### PR TITLE
pkg/dyninst: Template snapshot support

### DIFF
--- a/pkg/dyninst/actuator/state_property_test.go
+++ b/pkg/dyninst/actuator/state_property_test.go
@@ -10,7 +10,6 @@ package actuator
 import (
 	"bytes"
 	"cmp"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -229,8 +228,8 @@ func (pts *propertyTestState) generateProcessUpdate() event {
 							Language: "go",
 						},
 						Template: "test log message",
-						Segments: []json.RawMessage{
-							json.RawMessage(`"test log message"`),
+						Segments: rcjson.SegmentList{
+							newStringSegment("test log message"),
 						},
 					},
 				}
@@ -375,4 +374,9 @@ func (pts *propertyTestState) completeRandomEffect() event {
 		panic(fmt.Sprintf("unknown effect: %T", eff))
 	}
 
+}
+
+func newStringSegment(value string) *rcjson.StringSegment {
+	s := rcjson.StringSegment(value)
+	return &s
 }

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6046]
-	PrepareEventRoot b8 00 00 00 09 00 00 00 
+	PrepareEventRoot c2 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6046.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6090]
-	PrepareEventRoot b9 00 00 00 09 00 00 00 
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 22 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 49 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6553]
-	PrepareEventRoot b0 00 00 00 09 00 00 00 
+	PrepareEventRoot ba 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4a65de]
-	PrepareEventRoot b1 00 00 00 00 00 00 00 
+	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@4a5e0e]
-	PrepareEventRoot b6 00 00 00 09 00 00 00 
+	PrepareEventRoot c0 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@4a642a]
-	PrepareEventRoot b6 00 00 00 09 00 00 00 
+	PrepareEventRoot c0 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4a646a]
-	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0x4a610a.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@4a628a]
-	PrepareEventRoot a7 00 00 00 19 00 00 00 
+	PrepareEventRoot b1 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@4a62d6]
-	PrepareEventRoot a8 00 00 00 00 00 00 00 
+	PrepareEventRoot b2 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 03 00 00 // ProcessType[[3]string]
+	Call eb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
-	PrepareEventRoot ad 00 00 00 31 00 00 00 
+	PrepareEventRoot b7 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 10 04 00 00 // ProcessType[[]int]
+	Call 37 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a620a]
-	PrepareEventRoot a5 00 00 00 19 00 00 00 
+	PrepareEventRoot af 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@4a624f]
-	PrepareEventRoot a6 00 00 00 00 00 00 00 
+	PrepareEventRoot b0 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 1c 05 00 00 // ProcessType[map[string]int]
+	Call 43 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a64ea]
-	PrepareEventRoot ae 00 00 00 09 00 00 00 
+	PrepareEventRoot b8 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@4a651f]
-	PrepareEventRoot af 00 00 00 00 00 00 00 
+	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@4a660a]
-	PrepareEventRoot b2 00 00 00 00 00 00 00 
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@4a6646]
-	PrepareEventRoot b3 00 00 00 00 00 00 00 
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a3 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 03 00 00 // ProcessType[[3]string]
+	Call eb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
-	PrepareEventRoot ab 00 00 00 31 00 00 00 
+	PrepareEventRoot b5 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@4a63d6]
-	PrepareEventRoot ac 00 00 00 00 00 00 00 
+	PrepareEventRoot b6 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	ExprPrepare 
@@ -158,311 +158,381 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2a 04 00 00 // ProcessType[[]string]
+	Call 51 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
-	PrepareEventRoot a9 00 00 00 19 00 00 00 
+	PrepareEventRoot b3 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@4a634f]
-	PrepareEventRoot aa 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
 	PrepareEventRoot b4 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot a5 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot a6 00 00 00 00 00 00 00 
+	Return 
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x30b: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot a7 00 00 00 11 00 00 00 
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot a8 00 00 00 00 00 00 00 
+	Return 
+// 0x324: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x346: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot a9 00 00 00 11 00 00 00 
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot aa 00 00 00 00 00 00 00 
+	Return 
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x381: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot ab 00 00 00 11 00 00 00 
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot ac 00 00 00 00 00 00 00 
+	Return 
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@4a618a]
+	PrepareEventRoot ad 00 00 00 11 00 00 00 
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
+	Return 
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
+	PrepareEventRoot ae 00 00 00 00 00 00 00 
+	Return 
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
+	Return 
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 55 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
-	PrepareEventRoot b5 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
+	PrepareEventRoot bf 00 00 00 09 00 00 00 
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x42d: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x30c: ProcessType[*bucket<string,int>]
+// 0x433: ProcessType[*bucket<string,int>]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x312: ProcessType[*bucket<string,main.bigStruct>]
+// 0x439: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 72 00 00 00 
 	Return 
-// 0x318: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x43f: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x31e: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x445: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x324: ProcessType[*error]
+// 0x44b: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x32a: ProcessType[*float32]
+// 0x451: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x330: ProcessType[*float64]
+// 0x457: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x336: ProcessType[*int]
+// 0x45d: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x33c: ProcessType[*int32]
+// 0x463: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x342: ProcessType[*int64]
+// 0x469: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x348: ProcessType[*main.bigStruct]
+// 0x46f: ProcessType[*main.bigStruct]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime._defer]
+// 0x475: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime._panic]
+// 0x47b: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.cgoCallers]
+// 0x481: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.coro]
+// 0x487: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.g]
+// 0x48d: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.m]
+// 0x493: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x372: ProcessType[*runtime.mapextra]
+// 0x499: ProcessType[*runtime.mapextra]
 	ProcessPointer 6d 00 00 00 
 	Return 
-// 0x378: ProcessType[*runtime.sudog]
+// 0x49f: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x37e: ProcessType[*runtime.timer]
+// 0x4a5: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x384: ProcessType[*runtime.traceBuf]
+// 0x4ab: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x38a: ProcessType[*string]
+// 0x4b1: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint]
+// 0x4b7: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint16]
+// 0x4bd: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint32]
+// 0x4c3: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint64]
+// 0x4c9: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uint8]
+// 0x4cf: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3ae: ProcessType[*uintptr]
+// 0x4d5: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3b4: ProcessType[[2]*runtime.traceBuf]
+// 0x4db: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 84 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call ab 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[[3]string]
+// 0x4eb: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x4fb: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 74 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 9b 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e0: ProcessType[[]bucket<string,int>.array]
+// 0x507: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7f 04 00 00 // ProcessType[bucket<string,int>]
+	Call a6 05 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ec: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x513: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 94 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call bb 05 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f8: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x51f: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a9 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d0 05 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x404: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x52b: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call be 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call e5 05 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x410: ProcessType[[]int]
+// 0x537: ProcessType[[]int]
 	ProcessSlice 86 00 00 00 08 00 00 00 
 	Return 
-// 0x41a: ProcessType[[]key<string>]
+// 0x541: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]string]
+// 0x551: ProcessType[[]string]
 	ProcessSlice 88 00 00 00 10 00 00 00 
 	Return 
-// 0x434: ProcessType[[]string.array]
+// 0x55b: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x440: ProcessType[[]uint8]
+// 0x567: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x44a: ProcessType[[]uintptr]
+// 0x571: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x454: ProcessType[[]val<main.bigStruct>]
+// 0x57b: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 48 03 00 00 // ProcessType[*main.bigStruct]
+	Call 6f 04 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x464: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x58b: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 16 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3d 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x474: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x59b: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 06 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 2d 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x47f: ProcessType[bucket<string,int>]
+// 0x5a6: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0c 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 33 04 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x494: ProcessType[bucket<string,main.bigStruct>]
+// 0x5bb: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
-	Call 54 04 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 12 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
+	Call 7b 05 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 39 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x4a9: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5d0: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
-	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 18 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
+	Call 8b 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 3f 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4be: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5e5: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 1e 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8b 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 45 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4ce: ProcessType[error]
+// 0x5f5: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x4d0: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x5f7: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9e 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x4de: ProcessType[hash<string,int>]
+// 0x605: ProcessType[hash<string,int>]
 	ProcessGoHmap 8d 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4ec: ProcessType[hash<string,main.bigStruct>]
+// 0x613: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 91 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4fa: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x621: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x508: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x62f: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 99 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x516: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x63d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x51c: ProcessType[map[string]int]
+// 0x643: ProcessType[map[string]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x522: ProcessType[map[string]main.bigStruct]
+// 0x649: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x528: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64f: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x52e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x655: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x534: ProcessType[runtime.g]
+// 0x65b: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime._panic]
+	Call 7b 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime._defer]
+	Call 75 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 40 04 00 00 // ProcessType[[]uint8]
+	Call 67 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 78 03 00 00 // ProcessType[*runtime.sudog]
+	Call 9f 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 7e 03 00 00 // ProcessType[*runtime.timer]
+	Call a5 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.coro]
+	Call 87 04 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x58f: ProcessType[runtime.m]
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+// 0x6b6: ProcessType[runtime.m]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 81 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ef 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call 16 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 05 00 00 // ProcessType[runtime.mTraceState]
+	Call 21 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x5ef: ProcessType[runtime.mLockProfile]
+// 0x716: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x5fa: ProcessType[runtime.mTraceState]
+// 0x721: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call db 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x60a: ProcessType[string]
+// 0x731: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -484,12 +554,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 768
-ID: 6 Len: 8 Enqueue: 936
+ID: 5 Len: 8 Enqueue: 1063
+ID: 6 Len: 8 Enqueue: 1231
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 942
+ID: 8 Len: 8 Enqueue: 1237
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1546
+ID: 10 Len: 16 Enqueue: 1841
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -497,18 +567,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1230
+ID: 18 Len: 16 Enqueue: 1525
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 828
-ID: 21 Len: 8 Enqueue: 924
-ID: 22 Len: 432 Enqueue: 1332
+ID: 20 Len: 8 Enqueue: 1123
+ID: 21 Len: 8 Enqueue: 1219
+ID: 22 Len: 432 Enqueue: 1627
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 852
+ID: 24 Len: 8 Enqueue: 1147
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 846
+ID: 26 Len: 8 Enqueue: 1141
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 876
-ID: 29 Len: 1760 Enqueue: 1423
+ID: 28 Len: 8 Enqueue: 1171
+ID: 29 Len: 1760 Enqueue: 1718
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -517,41 +587,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1088
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1383
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 888
+ID: 41 Len: 8 Enqueue: 1183
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1098
-ID: 44 Len: 8 Enqueue: 894
+ID: 43 Len: 24 Enqueue: 1393
+ID: 44 Len: 8 Enqueue: 1189
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 864
+ID: 47 Len: 8 Enqueue: 1159
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 870
+ID: 53 Len: 8 Enqueue: 1165
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 858
+ID: 60 Len: 8 Enqueue: 1153
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1519
+ID: 64 Len: 64 Enqueue: 1814
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1530
+ID: 69 Len: 32 Enqueue: 1825
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 948
-ID: 72 Len: 8 Enqueue: 900
+ID: 71 Len: 16 Enqueue: 1243
+ID: 72 Len: 8 Enqueue: 1195
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -567,46 +637,46 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 906
+ID: 88 Len: 8 Enqueue: 1201
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 816
-ID: 92 Len: 8 Enqueue: 834
-ID: 93 Len: 8 Enqueue: 822
-ID: 94 Len: 8 Enqueue: 930
-ID: 95 Len: 8 Enqueue: 804
-ID: 96 Len: 8 Enqueue: 810
-ID: 97 Len: 8 Enqueue: 912
-ID: 98 Len: 8 Enqueue: 918
-ID: 99 Len: 24 Enqueue: 1040
+ID: 91 Len: 8 Enqueue: 1111
+ID: 92 Len: 8 Enqueue: 1129
+ID: 93 Len: 8 Enqueue: 1117
+ID: 94 Len: 8 Enqueue: 1225
+ID: 95 Len: 8 Enqueue: 1099
+ID: 96 Len: 8 Enqueue: 1105
+ID: 97 Len: 8 Enqueue: 1207
+ID: 98 Len: 8 Enqueue: 1213
+ID: 99 Len: 24 Enqueue: 1335
 ID: 100 Len: 24 Enqueue: 0
-ID: 101 Len: 24 Enqueue: 1066
-ID: 102 Len: 48 Enqueue: 964
-ID: 103 Len: 8 Enqueue: 1308
+ID: 101 Len: 24 Enqueue: 1361
+ID: 102 Len: 48 Enqueue: 1259
+ID: 103 Len: 8 Enqueue: 1603
 ID: 104 Len: 8 Enqueue: 0
-ID: 105 Len: 48 Enqueue: 1246
-ID: 106 Len: 8 Enqueue: 780
-ID: 107 Len: 208 Enqueue: 1151
-ID: 108 Len: 8 Enqueue: 882
+ID: 105 Len: 48 Enqueue: 1541
+ID: 106 Len: 8 Enqueue: 1075
+ID: 107 Len: 208 Enqueue: 1446
+ID: 108 Len: 8 Enqueue: 1177
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 8 Enqueue: 1314
+ID: 110 Len: 8 Enqueue: 1609
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1260
-ID: 113 Len: 8 Enqueue: 786
-ID: 114 Len: 208 Enqueue: 1172
-ID: 115 Len: 8 Enqueue: 1326
+ID: 112 Len: 48 Enqueue: 1555
+ID: 113 Len: 8 Enqueue: 1081
+ID: 114 Len: 208 Enqueue: 1467
+ID: 115 Len: 8 Enqueue: 1621
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1288
-ID: 118 Len: 8 Enqueue: 798
-ID: 119 Len: 88 Enqueue: 1214
-ID: 120 Len: 8 Enqueue: 1320
+ID: 117 Len: 48 Enqueue: 1583
+ID: 118 Len: 8 Enqueue: 1093
+ID: 119 Len: 88 Enqueue: 1509
+ID: 120 Len: 8 Enqueue: 1615
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1274
-ID: 123 Len: 8 Enqueue: 792
-ID: 124 Len: 208 Enqueue: 1193
-ID: 125 Len: 8 Enqueue: 738
-ID: 126 Len: 8 Enqueue: 744
-ID: 127 Len: 8 Enqueue: 756
+ID: 122 Len: 48 Enqueue: 1569
+ID: 123 Len: 8 Enqueue: 1087
+ID: 124 Len: 208 Enqueue: 1488
+ID: 125 Len: 8 Enqueue: 1033
+ID: 126 Len: 8 Enqueue: 1039
+ID: 127 Len: 8 Enqueue: 1051
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -615,53 +685,63 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 16 Enqueue: 1076
+ID: 136 Len: 16 Enqueue: 1371
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 128 Enqueue: 1050
+ID: 139 Len: 128 Enqueue: 1345
 ID: 140 Len: 64 Enqueue: 0
-ID: 141 Len: 208 Enqueue: 992
-ID: 142 Len: 64 Enqueue: 1108
-ID: 143 Len: 8 Enqueue: 840
+ID: 141 Len: 208 Enqueue: 1287
+ID: 142 Len: 64 Enqueue: 1403
+ID: 143 Len: 8 Enqueue: 1135
 ID: 144 Len: 184 Enqueue: 0
-ID: 145 Len: 208 Enqueue: 1004
+ID: 145 Len: 208 Enqueue: 1299
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 64 Enqueue: 1124
-ID: 148 Len: 8 Enqueue: 1302
+ID: 147 Len: 64 Enqueue: 1419
+ID: 148 Len: 8 Enqueue: 1597
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 48 Enqueue: 1232
-ID: 151 Len: 8 Enqueue: 774
-ID: 152 Len: 144 Enqueue: 1140
-ID: 153 Len: 88 Enqueue: 1028
-ID: 154 Len: 208 Enqueue: 1016
+ID: 150 Len: 48 Enqueue: 1527
+ID: 151 Len: 8 Enqueue: 1069
+ID: 152 Len: 144 Enqueue: 1435
+ID: 153 Len: 88 Enqueue: 1323
+ID: 154 Len: 208 Enqueue: 1311
 ID: 155 Len: 64 Enqueue: 0
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 144 Enqueue: 980
-ID: 159 Len: 8 Enqueue: 750
+ID: 158 Len: 144 Enqueue: 1275
+ID: 159 Len: 8 Enqueue: 1045
 ID: 160 Len: 128 Enqueue: 0
 ID: 161 Len: 9 Enqueue: 0
 ID: 162 Len: 0 Enqueue: 0
 ID: 163 Len: 17 Enqueue: 0
 ID: 164 Len: 0 Enqueue: 0
-ID: 165 Len: 25 Enqueue: 0
+ID: 165 Len: 17 Enqueue: 0
 ID: 166 Len: 0 Enqueue: 0
-ID: 167 Len: 25 Enqueue: 0
+ID: 167 Len: 17 Enqueue: 0
 ID: 168 Len: 0 Enqueue: 0
-ID: 169 Len: 25 Enqueue: 0
+ID: 169 Len: 17 Enqueue: 0
 ID: 170 Len: 0 Enqueue: 0
-ID: 171 Len: 49 Enqueue: 0
+ID: 171 Len: 17 Enqueue: 0
 ID: 172 Len: 0 Enqueue: 0
-ID: 173 Len: 49 Enqueue: 0
-ID: 174 Len: 9 Enqueue: 0
-ID: 175 Len: 0 Enqueue: 0
-ID: 176 Len: 9 Enqueue: 0
-ID: 177 Len: 0 Enqueue: 0
+ID: 173 Len: 17 Enqueue: 0
+ID: 174 Len: 0 Enqueue: 0
+ID: 175 Len: 25 Enqueue: 0
+ID: 176 Len: 0 Enqueue: 0
+ID: 177 Len: 25 Enqueue: 0
 ID: 178 Len: 0 Enqueue: 0
-ID: 179 Len: 0 Enqueue: 0
+ID: 179 Len: 25 Enqueue: 0
 ID: 180 Len: 0 Enqueue: 0
-ID: 181 Len: 9 Enqueue: 0
-ID: 182 Len: 9 Enqueue: 0
-ID: 183 Len: 0 Enqueue: 0
+ID: 181 Len: 49 Enqueue: 0
+ID: 182 Len: 0 Enqueue: 0
+ID: 183 Len: 49 Enqueue: 0
 ID: 184 Len: 9 Enqueue: 0
-ID: 185 Len: 9 Enqueue: 0
+ID: 185 Len: 0 Enqueue: 0
+ID: 186 Len: 9 Enqueue: 0
+ID: 187 Len: 0 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
+ID: 189 Len: 0 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
+ID: 191 Len: 9 Enqueue: 0
+ID: 192 Len: 9 Enqueue: 0
+ID: 193 Len: 0 Enqueue: 0
+ID: 194 Len: 9 Enqueue: 0
+ID: 195 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8046]
-	PrepareEventRoot c9 00 00 00 09 00 00 00 
+	PrepareEventRoot d3 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8046.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8090.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8090]
-	PrepareEventRoot ca 00 00 00 09 00 00 00 
+	PrepareEventRoot d4 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8090.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d4 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call fb 05 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a8553]
-	PrepareEventRoot c1 00 00 00 09 00 00 00 
+	PrepareEventRoot cb 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a8553.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4a85de]
-	PrepareEventRoot c2 00 00 00 00 00 00 00 
+	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@4a7e0e]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
+	PrepareEventRoot d1 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@4a842a]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
+	PrepareEventRoot d1 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4a846a]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0x4a810a.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@4a828a]
-	PrepareEventRoot b8 00 00 00 19 00 00 00 
+	PrepareEventRoot c2 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a828a.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@4a82d6]
-	PrepareEventRoot b9 00 00 00 00 00 00 00 
+	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call f5 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8400]
-	PrepareEventRoot be 00 00 00 31 00 00 00 
+	PrepareEventRoot c8 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8400.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0e 04 00 00 // ProcessType[[]int]
+	Call 35 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a820a]
-	PrepareEventRoot b6 00 00 00 19 00 00 00 
+	PrepareEventRoot c0 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a820a.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@4a824f]
-	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ce 04 00 00 // ProcessType[map[string]int]
+	Call f5 05 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a84ea]
-	PrepareEventRoot bf 00 00 00 09 00 00 00 
+	PrepareEventRoot c9 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a84ea.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@4a851f]
-	PrepareEventRoot c0 00 00 00 00 00 00 00 
+	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@4a860a]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@4a8646]
-	PrepareEventRoot c4 00 00 00 00 00 00 00 
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b4 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call f5 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a838a]
-	PrepareEventRoot bc 00 00 00 31 00 00 00 
+	PrepareEventRoot c6 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a838a.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@4a83d6]
-	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	ExprPrepare 
@@ -158,345 +158,415 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 3c 04 00 00 // ProcessType[[]string]
+	Call 63 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a830a]
-	PrepareEventRoot ba 00 00 00 19 00 00 00 
+	PrepareEventRoot c4 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a830a.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@4a834f]
-	PrepareEventRoot bb 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot b6 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	Return 
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x30b: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot b8 00 00 00 11 00 00 00 
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot b9 00 00 00 00 00 00 00 
+	Return 
+// 0x324: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x346: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot ba 00 00 00 11 00 00 00 
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot bb 00 00 00 00 00 00 00 
+	Return 
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x381: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot bc 00 00 00 11 00 00 00 
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	Return 
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@4a818a]
+	PrepareEventRoot be 00 00 00 11 00 00 00 
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a818a.expr[0]]
+	Return 
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@4a81cf]
+	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	Return 
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8676]
+	PrepareEventRoot cf 00 00 00 00 00 00 00 
+	Return 
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call da 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 01 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
-	PrepareEventRoot c6 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
+	PrepareEventRoot d0 00 00 00 09 00 00 00 
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*error]
+// 0x42d: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float32]
+// 0x433: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x312: ProcessType[*float64]
+// 0x439: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x318: ProcessType[*int]
+// 0x43f: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int32]
+// 0x445: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x324: ProcessType[*int64]
+// 0x44b: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x32a: ProcessType[*main.bigStruct]
+// 0x451: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._defer]
+// 0x457: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime._panic]
+// 0x45d: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.cgoCallers]
+// 0x463: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.coro]
+// 0x469: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.g]
+// 0x46f: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.m]
+// 0x475: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.sudog]
+// 0x47b: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.synctestGroup]
+// 0x481: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.timer]
+// 0x487: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.traceBuf]
+// 0x48d: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*string]
+// 0x493: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x372: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x499: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<string,int>]
+// 0x49f: ProcessType[*table<string,int>]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,main.bigStruct>]
+// 0x4a5: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4ab: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9a 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint]
+// 0x4b1: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint16]
+// 0x4b7: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint32]
+// 0x4bd: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint64]
+// 0x4c3: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint8]
+// 0x4c9: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uintptr]
+// 0x4cf: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3ae: ProcessType[[2]*runtime.traceBuf]
+// 0x4d5: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 8d 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3be: ProcessType[[2][2]*runtime.traceBuf]
+// 0x4e5: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call d5 04 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3ce: ProcessType[[3]string]
+// 0x4f5: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3de: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x505: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 72 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 99 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ea: ProcessType[[]*table<string,int>.array]
+// 0x511: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<string,int>]
+	Call 9f 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f6: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x51d: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call a5 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x402: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x529: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ab 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x40e: ProcessType[[]int]
+// 0x535: ProcessType[[]int]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x418: ProcessType[[]noalg.map.group[string]int.array]
+// 0x53f: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 10 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 37 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x424: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x54b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 1b 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 42 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x430: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x557: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 26 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4d 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x43c: ProcessType[[]string]
+// 0x563: ProcessType[[]string]
 	ProcessSlice 86 00 00 00 10 00 00 00 
 	Return 
-// 0x446: ProcessType[[]string.array]
+// 0x56d: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 32 06 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x452: ProcessType[[]uint8]
+// 0x579: ProcessType[[]uint8]
 	ProcessSlice 80 00 00 00 01 00 00 00 
 	Return 
-// 0x45c: ProcessType[[]uintptr]
+// 0x583: ProcessType[[]uintptr]
 	ProcessSlice 82 00 00 00 08 00 00 00 
 	Return 
-// 0x466: ProcessType[error]
+// 0x58d: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x468: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x58f: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x474: ProcessType[groupReference<string,int>]
+// 0x59b: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 8f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x480: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5a7: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x48c: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5b3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x498: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x5bf: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ae 00 00 00 aa 00 00 00 10 18 
 	Return 
-// 0x4a4: ProcessType[map<string,int>]
+// 0x5cb: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8e 00 00 00 8b 00 00 00 10 18 
 	Return 
-// 0x4b0: ProcessType[map<string,main.bigStruct>]
+// 0x5d7: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 98 00 00 00 93 00 00 00 10 18 
 	Return 
-// 0x4bc: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5e3: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a5 00 00 00 9d 00 00 00 10 18 
 	Return 
-// 0x4c8: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x5ef: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a2 00 00 00 
 	Return 
-// 0x4ce: ProcessType[map[string]int]
+// 0x5f5: ProcessType[map[string]int]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x4d4: ProcessType[map[string]main.bigStruct]
+// 0x5fb: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x4da: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x601: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x4e0: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x607: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 31 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 58 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4f0: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x617: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 41 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 68 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x500: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x627: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 47 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 6e 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x510: ProcessType[noalg.map.group[string]int]
+// 0x637: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 17 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x51b: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x642: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call e0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 07 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x526: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64d: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 00 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 27 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x531: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 32 06 00 00 // ProcessType[string]
+// 0x658: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 59 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
+	Call 51 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x541: ProcessType[noalg.struct { key string; elem int }]
-	Call 32 06 00 00 // ProcessType[string]
+// 0x668: ProcessType[noalg.struct { key string; elem int }]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x547: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x66e: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call c8 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call ef 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x552: ProcessType[runtime.g]
+// 0x679: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime._panic]
+	Call 5d 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._defer]
+	Call 57 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 52 04 00 00 // ProcessType[[]uint8]
+	Call 79 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.sudog]
+	Call 7b 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.timer]
+	Call 87 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.coro]
+	Call 69 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 81 04 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x5b7: ProcessType[runtime.m]
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+// 0x6de: ProcessType[runtime.m]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 63 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 17 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 3e 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 22 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 49 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x617: ProcessType[runtime.mLockProfile]
+// 0x73e: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x622: ProcessType[runtime.mTraceState]
+// 0x749: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call be 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call e5 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x632: ProcessType[string]
+// 0x759: ProcessType[string]
 	ProcessString 7e 00 00 00 
 	Return 
-// 0x638: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x75f: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 68 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 8f 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x643: ProcessType[table<string,int>]
+// 0x76a: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 74 04 00 00 // ProcessType[groupReference<string,int>]
+	Call 9b 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x64e: ProcessType[table<string,main.bigStruct>]
+// 0x775: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 80 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call a7 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x659: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x780: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8c 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b3 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -517,31 +587,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 930
+ID: 5 Len: 8 Enqueue: 1225
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1586
+ID: 9 Len: 16 Enqueue: 1881
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 768
+ID: 11 Len: 8 Enqueue: 1063
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1126
+ID: 13 Len: 16 Enqueue: 1421
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 936
-ID: 20 Len: 8 Enqueue: 798
-ID: 21 Len: 8 Enqueue: 918
-ID: 22 Len: 440 Enqueue: 1362
+ID: 19 Len: 8 Enqueue: 1231
+ID: 20 Len: 8 Enqueue: 1093
+ID: 21 Len: 8 Enqueue: 1213
+ID: 22 Len: 440 Enqueue: 1657
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 822
+ID: 24 Len: 8 Enqueue: 1117
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 816
+ID: 26 Len: 8 Enqueue: 1111
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 846
-ID: 29 Len: 1808 Enqueue: 1463
+ID: 28 Len: 8 Enqueue: 1141
+ID: 29 Len: 1808 Enqueue: 1758
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -550,45 +620,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1106
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1401
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 852
+ID: 41 Len: 8 Enqueue: 1147
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1116
-ID: 44 Len: 8 Enqueue: 864
+ID: 43 Len: 24 Enqueue: 1411
+ID: 44 Len: 8 Enqueue: 1159
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 834
+ID: 47 Len: 8 Enqueue: 1129
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 858
+ID: 49 Len: 8 Enqueue: 1153
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 840
+ID: 55 Len: 8 Enqueue: 1135
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 828
+ID: 62 Len: 8 Enqueue: 1123
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1559
+ID: 67 Len: 64 Enqueue: 1854
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1570
+ID: 72 Len: 56 Enqueue: 1865
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 958
-ID: 75 Len: 16 Enqueue: 942
-ID: 76 Len: 8 Enqueue: 870
+ID: 74 Len: 32 Enqueue: 1253
+ID: 75 Len: 16 Enqueue: 1237
+ID: 76 Len: 8 Enqueue: 1165
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -605,39 +675,39 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 876
+ID: 93 Len: 8 Enqueue: 1171
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 786
-ID: 97 Len: 8 Enqueue: 804
-ID: 98 Len: 8 Enqueue: 792
-ID: 99 Len: 8 Enqueue: 924
-ID: 100 Len: 8 Enqueue: 774
-ID: 101 Len: 8 Enqueue: 780
-ID: 102 Len: 8 Enqueue: 906
-ID: 103 Len: 8 Enqueue: 912
-ID: 104 Len: 24 Enqueue: 1038
+ID: 96 Len: 8 Enqueue: 1081
+ID: 97 Len: 8 Enqueue: 1099
+ID: 98 Len: 8 Enqueue: 1087
+ID: 99 Len: 8 Enqueue: 1219
+ID: 100 Len: 8 Enqueue: 1069
+ID: 101 Len: 8 Enqueue: 1075
+ID: 102 Len: 8 Enqueue: 1201
+ID: 103 Len: 8 Enqueue: 1207
+ID: 104 Len: 24 Enqueue: 1333
 ID: 105 Len: 24 Enqueue: 0
-ID: 106 Len: 24 Enqueue: 1084
-ID: 107 Len: 48 Enqueue: 974
-ID: 108 Len: 8 Enqueue: 1230
+ID: 106 Len: 24 Enqueue: 1379
+ID: 107 Len: 48 Enqueue: 1269
+ID: 108 Len: 8 Enqueue: 1525
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 48 Enqueue: 1188
+ID: 110 Len: 48 Enqueue: 1483
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 8 Enqueue: 888
-ID: 113 Len: 8 Enqueue: 1236
+ID: 112 Len: 8 Enqueue: 1183
+ID: 113 Len: 8 Enqueue: 1531
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 48 Enqueue: 1200
+ID: 115 Len: 48 Enqueue: 1495
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 8 Enqueue: 894
-ID: 118 Len: 8 Enqueue: 1242
+ID: 117 Len: 8 Enqueue: 1189
+ID: 118 Len: 8 Enqueue: 1537
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 48 Enqueue: 1212
+ID: 120 Len: 48 Enqueue: 1507
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 8 Enqueue: 900
-ID: 123 Len: 8 Enqueue: 738
-ID: 124 Len: 8 Enqueue: 744
-ID: 125 Len: 8 Enqueue: 756
+ID: 122 Len: 8 Enqueue: 1195
+ID: 123 Len: 8 Enqueue: 1033
+ID: 124 Len: 8 Enqueue: 1039
+ID: 125 Len: 8 Enqueue: 1051
 ID: 126 Len: 1 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 1 Enqueue: 0
@@ -646,72 +716,82 @@ ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 16 Enqueue: 1094
+ID: 134 Len: 16 Enqueue: 1389
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 32 Enqueue: 1603
-ID: 137 Len: 16 Enqueue: 1140
+ID: 136 Len: 32 Enqueue: 1898
+ID: 137 Len: 16 Enqueue: 1435
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 200 Enqueue: 1296
-ID: 140 Len: 192 Enqueue: 1264
-ID: 141 Len: 24 Enqueue: 1345
-ID: 142 Len: 8 Enqueue: 1002
-ID: 143 Len: 200 Enqueue: 1048
-ID: 144 Len: 32 Enqueue: 1614
-ID: 145 Len: 16 Enqueue: 1152
+ID: 139 Len: 200 Enqueue: 1591
+ID: 140 Len: 192 Enqueue: 1559
+ID: 141 Len: 24 Enqueue: 1640
+ID: 142 Len: 8 Enqueue: 1297
+ID: 143 Len: 200 Enqueue: 1343
+ID: 144 Len: 32 Enqueue: 1909
+ID: 145 Len: 16 Enqueue: 1447
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 200 Enqueue: 1307
-ID: 148 Len: 192 Enqueue: 1248
-ID: 149 Len: 24 Enqueue: 1329
-ID: 150 Len: 8 Enqueue: 810
+ID: 147 Len: 200 Enqueue: 1602
+ID: 148 Len: 192 Enqueue: 1543
+ID: 149 Len: 24 Enqueue: 1624
+ID: 150 Len: 8 Enqueue: 1105
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 8 Enqueue: 1014
-ID: 153 Len: 200 Enqueue: 1060
-ID: 154 Len: 32 Enqueue: 1625
-ID: 155 Len: 16 Enqueue: 1164
+ID: 152 Len: 8 Enqueue: 1309
+ID: 153 Len: 200 Enqueue: 1355
+ID: 154 Len: 32 Enqueue: 1920
+ID: 155 Len: 16 Enqueue: 1459
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 136 Enqueue: 1318
-ID: 158 Len: 128 Enqueue: 1280
-ID: 159 Len: 16 Enqueue: 1351
-ID: 160 Len: 8 Enqueue: 1224
+ID: 157 Len: 136 Enqueue: 1613
+ID: 158 Len: 128 Enqueue: 1575
+ID: 159 Len: 16 Enqueue: 1646
+ID: 160 Len: 8 Enqueue: 1519
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 48 Enqueue: 1176
+ID: 162 Len: 48 Enqueue: 1471
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 882
-ID: 165 Len: 8 Enqueue: 1026
-ID: 166 Len: 136 Enqueue: 1072
-ID: 167 Len: 32 Enqueue: 1592
-ID: 168 Len: 16 Enqueue: 1128
+ID: 164 Len: 8 Enqueue: 1177
+ID: 165 Len: 8 Enqueue: 1321
+ID: 166 Len: 136 Enqueue: 1367
+ID: 167 Len: 32 Enqueue: 1887
+ID: 168 Len: 16 Enqueue: 1423
 ID: 169 Len: 8 Enqueue: 0
 ID: 170 Len: 136 Enqueue: 0
 ID: 171 Len: 128 Enqueue: 0
 ID: 172 Len: 16 Enqueue: 0
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 8 Enqueue: 990
+ID: 174 Len: 8 Enqueue: 1285
 ID: 175 Len: 136 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 750
+ID: 176 Len: 8 Enqueue: 1045
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 9 Enqueue: 0
 ID: 179 Len: 0 Enqueue: 0
 ID: 180 Len: 17 Enqueue: 0
 ID: 181 Len: 0 Enqueue: 0
-ID: 182 Len: 25 Enqueue: 0
+ID: 182 Len: 17 Enqueue: 0
 ID: 183 Len: 0 Enqueue: 0
-ID: 184 Len: 25 Enqueue: 0
+ID: 184 Len: 17 Enqueue: 0
 ID: 185 Len: 0 Enqueue: 0
-ID: 186 Len: 25 Enqueue: 0
+ID: 186 Len: 17 Enqueue: 0
 ID: 187 Len: 0 Enqueue: 0
-ID: 188 Len: 49 Enqueue: 0
+ID: 188 Len: 17 Enqueue: 0
 ID: 189 Len: 0 Enqueue: 0
-ID: 190 Len: 49 Enqueue: 0
-ID: 191 Len: 9 Enqueue: 0
-ID: 192 Len: 0 Enqueue: 0
-ID: 193 Len: 9 Enqueue: 0
-ID: 194 Len: 0 Enqueue: 0
+ID: 190 Len: 17 Enqueue: 0
+ID: 191 Len: 0 Enqueue: 0
+ID: 192 Len: 25 Enqueue: 0
+ID: 193 Len: 0 Enqueue: 0
+ID: 194 Len: 25 Enqueue: 0
 ID: 195 Len: 0 Enqueue: 0
-ID: 196 Len: 0 Enqueue: 0
+ID: 196 Len: 25 Enqueue: 0
 ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 9 Enqueue: 0
-ID: 199 Len: 9 Enqueue: 0
-ID: 200 Len: 0 Enqueue: 0
+ID: 198 Len: 49 Enqueue: 0
+ID: 199 Len: 0 Enqueue: 0
+ID: 200 Len: 49 Enqueue: 0
 ID: 201 Len: 9 Enqueue: 0
-ID: 202 Len: 9 Enqueue: 0
+ID: 202 Len: 0 Enqueue: 0
+ID: 203 Len: 9 Enqueue: 0
+ID: 204 Len: 0 Enqueue: 0
+ID: 205 Len: 0 Enqueue: 0
+ID: 206 Len: 0 Enqueue: 0
+ID: 207 Len: 0 Enqueue: 0
+ID: 208 Len: 9 Enqueue: 0
+ID: 209 Len: 9 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
+ID: 211 Len: 9 Enqueue: 0
+ID: 212 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae646]
-	PrepareEventRoot ce 00 00 00 09 00 00 00 
+	PrepareEventRoot d8 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae646.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae690.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae690]
-	PrepareEventRoot cf 00 00 00 09 00 00 00 
+	PrepareEventRoot d9 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae690.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f0 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 17 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeb53]
-	PrepareEventRoot c6 00 00 00 09 00 00 00 
+	PrepareEventRoot d0 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4aeb53.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4aebde]
-	PrepareEventRoot c7 00 00 00 00 00 00 00 
+	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@4ae40e]
-	PrepareEventRoot cc 00 00 00 09 00 00 00 
+	PrepareEventRoot d6 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@4aea2a]
-	PrepareEventRoot cc 00 00 00 09 00 00 00 
+	PrepareEventRoot d6 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4aea6a]
-	PrepareEventRoot cd 00 00 00 00 00 00 00 
+	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0x4ae70a.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@4ae88a]
-	PrepareEventRoot bd 00 00 00 19 00 00 00 
+	PrepareEventRoot c7 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae88a.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@4ae8d6]
-	PrepareEventRoot be 00 00 00 00 00 00 00 
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d4 03 00 00 // ProcessType[[3]string]
+	Call fb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4aea00]
-	PrepareEventRoot c3 00 00 00 31 00 00 00 
+	PrepareEventRoot cd 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4aea00.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2a 04 00 00 // ProcessType[[]int]
+	Call 51 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4ae80a]
-	PrepareEventRoot bb 00 00 00 19 00 00 00 
+	PrepareEventRoot c5 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae80a.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@4ae84f]
-	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ea 04 00 00 // ProcessType[map[string]int]
+	Call 11 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4aeaea]
-	PrepareEventRoot c4 00 00 00 09 00 00 00 
+	PrepareEventRoot ce 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aeaea.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@4aeb1f]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@4aec0a]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@4aec46]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d4 03 00 00 // ProcessType[[3]string]
+	Call fb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4ae98a]
-	PrepareEventRoot c1 00 00 00 31 00 00 00 
+	PrepareEventRoot cb 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae98a.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@4ae9d6]
-	PrepareEventRoot c2 00 00 00 00 00 00 00 
+	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	ExprPrepare 
@@ -158,358 +158,428 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 58 04 00 00 // ProcessType[[]string]
+	Call 7f 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4ae90a]
-	PrepareEventRoot bf 00 00 00 19 00 00 00 
+	PrepareEventRoot c9 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae90a.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@4ae94f]
-	PrepareEventRoot c0 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot bb 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	Return 
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x30b: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot bd 00 00 00 11 00 00 00 
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
+	Return 
+// 0x324: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x346: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot bf 00 00 00 11 00 00 00 
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
+	Return 
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x381: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot c1 00 00 00 11 00 00 00 
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
+	Return 
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@4ae78a]
+	PrepareEventRoot c3 00 00 00 11 00 00 00 
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae78a.expr[0]]
+	Return 
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@4ae7cf]
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
+	Return 
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aec76]
+	PrepareEventRoot d4 00 00 00 00 00 00 00 
+	Return 
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f6 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 1d 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
-	PrepareEventRoot cb 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
+	PrepareEventRoot d5 00 00 00 09 00 00 00 
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer b5 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*error]
+// 0x42d: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float32]
+// 0x433: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x312: ProcessType[*float64]
+// 0x439: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x318: ProcessType[*int]
+// 0x43f: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int32]
+// 0x445: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x324: ProcessType[*int64]
+// 0x44b: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x32a: ProcessType[*main.bigStruct]
+// 0x451: ProcessType[*main.bigStruct]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._defer]
+// 0x457: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime._panic]
+// 0x45d: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.cgoCallers]
+// 0x463: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.coro]
+// 0x469: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.g]
+// 0x46f: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.m]
+// 0x475: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.p]
+// 0x47b: ProcessType[*runtime.p]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.sudog]
+// 0x481: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.synctestBubble]
+// 0x487: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.timer]
+// 0x48d: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.traceBuf]
+// 0x493: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x372: ProcessType[*string]
+// 0x499: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x49f: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ac 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,int>]
+// 0x4a5: ProcessType[*table<string,int>]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<string,main.bigStruct>]
+// 0x4ab: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 95 00 00 00 
 	Return 
-// 0x38a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4b1: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint]
+// 0x4b7: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint16]
+// 0x4bd: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint32]
+// 0x4c3: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint64]
+// 0x4c9: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uint8]
+// 0x4cf: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3ae: ProcessType[*uintptr]
+// 0x4d5: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3b4: ProcessType[[2]*runtime.traceBuf]
+// 0x4db: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 93 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[[2][2]*runtime.traceBuf]
+// 0x4eb: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call db 04 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[3]string]
+// 0x4fb: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3e4: ProcessType[[]*runtime.p]
+// 0x50b: ProcessType[[]*runtime.p]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x3ee: ProcessType[[]*runtime.p.array]
+// 0x515: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 54 03 00 00 // ProcessType[*runtime.p]
+	Call 7b 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3fa: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x521: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 9f 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x406: ProcessType[[]*table<string,int>.array]
+// 0x52d: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,int>]
+	Call a5 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x412: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x539: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call ab 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x41e: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x545: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 8a 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b1 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]int]
+// 0x551: ProcessType[[]int]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x434: ProcessType[[]noalg.map.group[string]int.array]
+// 0x55b: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 2c 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 53 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x440: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x567: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 37 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 5e 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x44c: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x573: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 42 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 69 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x458: ProcessType[[]string]
+// 0x57f: ProcessType[[]string]
 	ProcessSlice 8b 00 00 00 10 00 00 00 
 	Return 
-// 0x462: ProcessType[[]string.array]
+// 0x589: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 58 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x46e: ProcessType[[]uint8]
+// 0x595: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x478: ProcessType[[]uintptr]
+// 0x59f: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x482: ProcessType[error]
+// 0x5a9: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x484: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5ab: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x490: ProcessType[groupReference<string,int>]
+// 0x5b7: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 94 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x49c: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5c3: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9e 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x4a8: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5cf: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ab 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x4b4: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x5db: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b3 00 00 00 af 00 00 00 10 18 
 	Return 
-// 0x4c0: ProcessType[map<string,int>]
+// 0x5e7: ProcessType[map<string,int>]
 	ProcessGoSwissMap 93 00 00 00 90 00 00 00 10 18 
 	Return 
-// 0x4cc: ProcessType[map<string,main.bigStruct>]
+// 0x5f3: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9d 00 00 00 98 00 00 00 10 18 
 	Return 
-// 0x4d8: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5ff: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap aa 00 00 00 a2 00 00 00 10 18 
 	Return 
-// 0x4e4: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x60b: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x4ea: ProcessType[map[string]int]
+// 0x611: ProcessType[map[string]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x4f0: ProcessType[map[string]main.bigStruct]
+// 0x617: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x4f6: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x61d: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x4fc: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x623: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 4d 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 74 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x50c: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x633: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 5d 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 84 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x51c: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x643: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 63 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 8a 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x52c: ProcessType[noalg.map.group[string]int]
+// 0x653: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0c 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 33 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x537: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x65e: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call fc 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 23 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x542: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x669: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1c 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 43 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x54d: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 58 06 00 00 // ProcessType[string]
+// 0x674: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
+	Call 51 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x55d: ProcessType[noalg.struct { key string; elem int }]
-	Call 58 06 00 00 // ProcessType[string]
+// 0x684: ProcessType[noalg.struct { key string; elem int }]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x563: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x68a: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call e4 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 0b 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x56e: ProcessType[runtime.g]
+// 0x695: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime._panic]
+	Call 5d 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._defer]
+	Call 57 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 6e 04 00 00 // ProcessType[[]uint8]
+	Call 95 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.sudog]
+	Call 81 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.timer]
+	Call 8d 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.coro]
+	Call 69 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 87 04 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x5d3: ProcessType[runtime.m]
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+// 0x6fa: ProcessType[runtime.m]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call e4 03 00 00 // ProcessType[[]*runtime.p]
+	Call 0b 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 63 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 3d 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 64 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 6f 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x63d: ProcessType[runtime.mLockProfile]
+// 0x764: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x648: ProcessType[runtime.mTraceState]
+// 0x76f: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call eb 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x658: ProcessType[string]
+// 0x77f: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
-// 0x65e: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x785: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 84 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call ab 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x669: ProcessType[table<string,int>]
+// 0x790: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 90 04 00 00 // ProcessType[groupReference<string,int>]
+	Call b7 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x674: ProcessType[table<string,main.bigStruct>]
+// 0x79b: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9c 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call c3 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x67f: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7a6: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a8 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call cf 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -530,31 +600,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 936
+ID: 5 Len: 8 Enqueue: 1231
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1624
+ID: 9 Len: 16 Enqueue: 1919
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 768
+ID: 11 Len: 8 Enqueue: 1063
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1154
+ID: 13 Len: 16 Enqueue: 1449
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 942
-ID: 20 Len: 8 Enqueue: 798
-ID: 21 Len: 8 Enqueue: 924
-ID: 22 Len: 440 Enqueue: 1390
+ID: 19 Len: 8 Enqueue: 1237
+ID: 20 Len: 8 Enqueue: 1093
+ID: 21 Len: 8 Enqueue: 1219
+ID: 22 Len: 440 Enqueue: 1685
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 822
+ID: 24 Len: 8 Enqueue: 1117
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 816
+ID: 26 Len: 8 Enqueue: 1111
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 846
-ID: 29 Len: 1816 Enqueue: 1491
+ID: 28 Len: 8 Enqueue: 1141
+ID: 29 Len: 1816 Enqueue: 1786
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -563,48 +633,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1134
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1429
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 858
+ID: 41 Len: 8 Enqueue: 1153
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1144
-ID: 44 Len: 8 Enqueue: 870
+ID: 43 Len: 24 Enqueue: 1439
+ID: 44 Len: 8 Enqueue: 1165
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 834
+ID: 47 Len: 8 Enqueue: 1129
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 864
+ID: 49 Len: 8 Enqueue: 1159
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 840
+ID: 55 Len: 8 Enqueue: 1135
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 996
+ID: 62 Len: 24 Enqueue: 1291
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 852
-ID: 65 Len: 8 Enqueue: 828
+ID: 64 Len: 8 Enqueue: 1147
+ID: 65 Len: 8 Enqueue: 1123
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1597
+ID: 70 Len: 56 Enqueue: 1892
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1608
+ID: 75 Len: 56 Enqueue: 1903
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 964
-ID: 78 Len: 16 Enqueue: 948
-ID: 79 Len: 8 Enqueue: 876
+ID: 77 Len: 32 Enqueue: 1259
+ID: 78 Len: 16 Enqueue: 1243
+ID: 79 Len: 8 Enqueue: 1171
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -620,39 +690,39 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 882
+ID: 95 Len: 8 Enqueue: 1177
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 786
-ID: 99 Len: 8 Enqueue: 792
-ID: 100 Len: 8 Enqueue: 804
-ID: 101 Len: 8 Enqueue: 930
-ID: 102 Len: 8 Enqueue: 774
-ID: 103 Len: 8 Enqueue: 780
-ID: 104 Len: 8 Enqueue: 912
-ID: 105 Len: 8 Enqueue: 918
-ID: 106 Len: 24 Enqueue: 1066
+ID: 98 Len: 8 Enqueue: 1081
+ID: 99 Len: 8 Enqueue: 1087
+ID: 100 Len: 8 Enqueue: 1099
+ID: 101 Len: 8 Enqueue: 1225
+ID: 102 Len: 8 Enqueue: 1069
+ID: 103 Len: 8 Enqueue: 1075
+ID: 104 Len: 8 Enqueue: 1207
+ID: 105 Len: 8 Enqueue: 1213
+ID: 106 Len: 24 Enqueue: 1361
 ID: 107 Len: 24 Enqueue: 0
-ID: 108 Len: 24 Enqueue: 1112
-ID: 109 Len: 48 Enqueue: 980
-ID: 110 Len: 8 Enqueue: 1258
+ID: 108 Len: 24 Enqueue: 1407
+ID: 109 Len: 48 Enqueue: 1275
+ID: 110 Len: 8 Enqueue: 1553
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1216
+ID: 112 Len: 48 Enqueue: 1511
 ID: 113 Len: 8 Enqueue: 0
-ID: 114 Len: 8 Enqueue: 894
-ID: 115 Len: 8 Enqueue: 1264
+ID: 114 Len: 8 Enqueue: 1189
+ID: 115 Len: 8 Enqueue: 1559
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1228
+ID: 117 Len: 48 Enqueue: 1523
 ID: 118 Len: 8 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 900
-ID: 120 Len: 8 Enqueue: 1270
+ID: 119 Len: 8 Enqueue: 1195
+ID: 120 Len: 8 Enqueue: 1565
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1240
+ID: 122 Len: 48 Enqueue: 1535
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 906
-ID: 125 Len: 8 Enqueue: 738
-ID: 126 Len: 8 Enqueue: 744
-ID: 127 Len: 8 Enqueue: 756
+ID: 124 Len: 8 Enqueue: 1201
+ID: 125 Len: 8 Enqueue: 1033
+ID: 126 Len: 8 Enqueue: 1039
+ID: 127 Len: 8 Enqueue: 1051
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -660,76 +730,86 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 1006
+ID: 135 Len: 8 Enqueue: 1301
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 16 Enqueue: 1122
+ID: 139 Len: 16 Enqueue: 1417
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 32 Enqueue: 1641
-ID: 142 Len: 16 Enqueue: 1168
+ID: 141 Len: 32 Enqueue: 1936
+ID: 142 Len: 16 Enqueue: 1463
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 200 Enqueue: 1324
-ID: 145 Len: 192 Enqueue: 1292
-ID: 146 Len: 24 Enqueue: 1373
-ID: 147 Len: 8 Enqueue: 1030
-ID: 148 Len: 200 Enqueue: 1076
-ID: 149 Len: 32 Enqueue: 1652
-ID: 150 Len: 16 Enqueue: 1180
+ID: 144 Len: 200 Enqueue: 1619
+ID: 145 Len: 192 Enqueue: 1587
+ID: 146 Len: 24 Enqueue: 1668
+ID: 147 Len: 8 Enqueue: 1325
+ID: 148 Len: 200 Enqueue: 1371
+ID: 149 Len: 32 Enqueue: 1947
+ID: 150 Len: 16 Enqueue: 1475
 ID: 151 Len: 8 Enqueue: 0
-ID: 152 Len: 200 Enqueue: 1335
-ID: 153 Len: 192 Enqueue: 1276
-ID: 154 Len: 24 Enqueue: 1357
-ID: 155 Len: 8 Enqueue: 810
+ID: 152 Len: 200 Enqueue: 1630
+ID: 153 Len: 192 Enqueue: 1571
+ID: 154 Len: 24 Enqueue: 1652
+ID: 155 Len: 8 Enqueue: 1105
 ID: 156 Len: 184 Enqueue: 0
-ID: 157 Len: 8 Enqueue: 1042
-ID: 158 Len: 200 Enqueue: 1088
-ID: 159 Len: 32 Enqueue: 1663
-ID: 160 Len: 16 Enqueue: 1192
+ID: 157 Len: 8 Enqueue: 1337
+ID: 158 Len: 200 Enqueue: 1383
+ID: 159 Len: 32 Enqueue: 1958
+ID: 160 Len: 16 Enqueue: 1487
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 136 Enqueue: 1346
-ID: 163 Len: 128 Enqueue: 1308
-ID: 164 Len: 16 Enqueue: 1379
-ID: 165 Len: 8 Enqueue: 1252
+ID: 162 Len: 136 Enqueue: 1641
+ID: 163 Len: 128 Enqueue: 1603
+ID: 164 Len: 16 Enqueue: 1674
+ID: 165 Len: 8 Enqueue: 1547
 ID: 166 Len: 8 Enqueue: 0
-ID: 167 Len: 48 Enqueue: 1204
+ID: 167 Len: 48 Enqueue: 1499
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 888
-ID: 170 Len: 8 Enqueue: 1054
-ID: 171 Len: 136 Enqueue: 1100
-ID: 172 Len: 32 Enqueue: 1630
-ID: 173 Len: 16 Enqueue: 1156
+ID: 169 Len: 8 Enqueue: 1183
+ID: 170 Len: 8 Enqueue: 1349
+ID: 171 Len: 136 Enqueue: 1395
+ID: 172 Len: 32 Enqueue: 1925
+ID: 173 Len: 16 Enqueue: 1451
 ID: 174 Len: 8 Enqueue: 0
 ID: 175 Len: 136 Enqueue: 0
 ID: 176 Len: 128 Enqueue: 0
 ID: 177 Len: 16 Enqueue: 0
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 8 Enqueue: 1018
+ID: 179 Len: 8 Enqueue: 1313
 ID: 180 Len: 136 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 750
+ID: 181 Len: 8 Enqueue: 1045
 ID: 182 Len: 128 Enqueue: 0
 ID: 183 Len: 9 Enqueue: 0
 ID: 184 Len: 0 Enqueue: 0
 ID: 185 Len: 17 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
-ID: 187 Len: 25 Enqueue: 0
+ID: 187 Len: 17 Enqueue: 0
 ID: 188 Len: 0 Enqueue: 0
-ID: 189 Len: 25 Enqueue: 0
+ID: 189 Len: 17 Enqueue: 0
 ID: 190 Len: 0 Enqueue: 0
-ID: 191 Len: 25 Enqueue: 0
+ID: 191 Len: 17 Enqueue: 0
 ID: 192 Len: 0 Enqueue: 0
-ID: 193 Len: 49 Enqueue: 0
+ID: 193 Len: 17 Enqueue: 0
 ID: 194 Len: 0 Enqueue: 0
-ID: 195 Len: 49 Enqueue: 0
-ID: 196 Len: 9 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 9 Enqueue: 0
-ID: 199 Len: 0 Enqueue: 0
+ID: 195 Len: 17 Enqueue: 0
+ID: 196 Len: 0 Enqueue: 0
+ID: 197 Len: 25 Enqueue: 0
+ID: 198 Len: 0 Enqueue: 0
+ID: 199 Len: 25 Enqueue: 0
 ID: 200 Len: 0 Enqueue: 0
-ID: 201 Len: 0 Enqueue: 0
+ID: 201 Len: 25 Enqueue: 0
 ID: 202 Len: 0 Enqueue: 0
-ID: 203 Len: 9 Enqueue: 0
-ID: 204 Len: 9 Enqueue: 0
-ID: 205 Len: 0 Enqueue: 0
+ID: 203 Len: 49 Enqueue: 0
+ID: 204 Len: 0 Enqueue: 0
+ID: 205 Len: 49 Enqueue: 0
 ID: 206 Len: 9 Enqueue: 0
-ID: 207 Len: 9 Enqueue: 0
+ID: 207 Len: 0 Enqueue: 0
+ID: 208 Len: 9 Enqueue: 0
+ID: 209 Len: 0 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
+ID: 211 Len: 0 Enqueue: 0
+ID: 212 Len: 0 Enqueue: 0
+ID: 213 Len: 9 Enqueue: 0
+ID: 214 Len: 9 Enqueue: 0
+ID: 215 Len: 0 Enqueue: 0
+ID: 216 Len: 9 Enqueue: 0
+ID: 217 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5388]
-	PrepareEventRoot b9 00 00 00 09 00 00 00 
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5388.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b53c0]
-	PrepareEventRoot ba 00 00 00 09 00 00 00 
+	PrepareEventRoot c4 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5880.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 22 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 49 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b5880]
-	PrepareEventRoot b1 00 00 00 09 00 00 00 
+	PrepareEventRoot bb 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5880.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b58f4]
-	PrepareEventRoot b2 00 00 00 00 00 00 00 
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@b519c]
-	PrepareEventRoot b7 00 00 00 09 00 00 00 
+	PrepareEventRoot c1 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@b5748]
-	PrepareEventRoot b7 00 00 00 09 00 00 00 
+	PrepareEventRoot c1 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b5780]
-	PrepareEventRoot b8 00 00 00 00 00 00 00 
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0xb5428.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@b55a8]
-	PrepareEventRoot a8 00 00 00 19 00 00 00 
+	PrepareEventRoot b2 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb55a8.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@b55ec]
-	PrepareEventRoot a9 00 00 00 00 00 00 00 
+	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 03 00 00 // ProcessType[[3]string]
+	Call eb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
-	PrepareEventRoot ae 00 00 00 31 00 00 00 
+	PrepareEventRoot b8 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 10 04 00 00 // ProcessType[[]int]
+	Call 37 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b5518]
-	PrepareEventRoot a6 00 00 00 19 00 00 00 
+	PrepareEventRoot b0 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@b5554]
-	PrepareEventRoot a7 00 00 00 00 00 00 00 
+	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 1c 05 00 00 // ProcessType[map[string]int]
+	Call 43 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5808]
-	PrepareEventRoot af 00 00 00 09 00 00 00 
+	PrepareEventRoot b9 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@b5838]
-	PrepareEventRoot b0 00 00 00 00 00 00 00 
+	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@b5938]
-	PrepareEventRoot b3 00 00 00 00 00 00 00 
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@b5970]
-	PrepareEventRoot b4 00 00 00 00 00 00 00 
+	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a4 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c4 03 00 00 // ProcessType[[3]string]
+	Call eb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b56b8]
-	PrepareEventRoot ac 00 00 00 31 00 00 00 
+	PrepareEventRoot b6 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb56b8.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@b56fc]
-	PrepareEventRoot ad 00 00 00 00 00 00 00 
+	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
 	ExprPrepare 
@@ -158,311 +158,381 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2a 04 00 00 // ProcessType[[]string]
+	Call 51 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b5628]
-	PrepareEventRoot aa 00 00 00 19 00 00 00 
+	PrepareEventRoot b4 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@b5664]
-	PrepareEventRoot ab 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot a6 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot a7 00 00 00 00 00 00 00 
+	Return 
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x30b: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot a8 00 00 00 11 00 00 00 
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot a9 00 00 00 00 00 00 00 
+	Return 
+// 0x324: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x346: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot aa 00 00 00 11 00 00 00 
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot ab 00 00 00 00 00 00 00 
+	Return 
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x381: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot ac 00 00 00 11 00 00 00 
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot ad 00 00 00 00 00 00 00 
+	Return 
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 31 07 00 00 // ProcessType[string]
+	Return 
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@b5498]
+	PrepareEventRoot ae 00 00 00 11 00 00 00 
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
+	Return 
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@b54d4]
+	PrepareEventRoot af 00 00 00 00 00 00 00 
+	Return 
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
+	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	Return 
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 55 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
-	PrepareEventRoot b6 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
+	PrepareEventRoot c0 00 00 00 09 00 00 00 
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x42d: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x30c: ProcessType[*bucket<string,int>]
+// 0x433: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x312: ProcessType[*bucket<string,main.bigStruct>]
+// 0x439: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x318: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x43f: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x31e: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x445: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x324: ProcessType[*error]
+// 0x44b: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x32a: ProcessType[*float32]
+// 0x451: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x330: ProcessType[*float64]
+// 0x457: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x336: ProcessType[*int]
+// 0x45d: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x33c: ProcessType[*int32]
+// 0x463: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x342: ProcessType[*int64]
+// 0x469: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x348: ProcessType[*main.bigStruct]
+// 0x46f: ProcessType[*main.bigStruct]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime._defer]
+// 0x475: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime._panic]
+// 0x47b: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.cgoCallers]
+// 0x481: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.coro]
+// 0x487: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.g]
+// 0x48d: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.m]
+// 0x493: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x372: ProcessType[*runtime.mapextra]
+// 0x499: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x378: ProcessType[*runtime.sudog]
+// 0x49f: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x37e: ProcessType[*runtime.timer]
+// 0x4a5: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x384: ProcessType[*runtime.traceBuf]
+// 0x4ab: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x38a: ProcessType[*string]
+// 0x4b1: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint]
+// 0x4b7: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint16]
+// 0x4bd: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint32]
+// 0x4c3: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint64]
+// 0x4c9: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uint8]
+// 0x4cf: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3ae: ProcessType[*uintptr]
+// 0x4d5: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3b4: ProcessType[[2]*runtime.traceBuf]
+// 0x4db: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 84 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call ab 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[[3]string]
+// 0x4eb: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x4fb: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 74 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 9b 05 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e0: ProcessType[[]bucket<string,int>.array]
+// 0x507: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7f 04 00 00 // ProcessType[bucket<string,int>]
+	Call a6 05 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ec: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x513: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 94 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call bb 05 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f8: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x51f: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a9 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d0 05 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x404: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x52b: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call be 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call e5 05 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x410: ProcessType[[]int]
+// 0x537: ProcessType[[]int]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x41a: ProcessType[[]key<string>]
+// 0x541: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]string]
+// 0x551: ProcessType[[]string]
 	ProcessSlice 89 00 00 00 10 00 00 00 
 	Return 
-// 0x434: ProcessType[[]string.array]
+// 0x55b: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x440: ProcessType[[]uint8]
+// 0x567: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x44a: ProcessType[[]uintptr]
+// 0x571: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x454: ProcessType[[]val<main.bigStruct>]
+// 0x57b: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 48 03 00 00 // ProcessType[*main.bigStruct]
+	Call 6f 04 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x464: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x58b: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 16 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3d 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x474: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x59b: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 06 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 2d 04 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x47f: ProcessType[bucket<string,int>]
+// 0x5a6: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0c 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 33 04 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x494: ProcessType[bucket<string,main.bigStruct>]
+// 0x5bb: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
-	Call 54 04 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 12 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
+	Call 7b 05 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 39 04 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x4a9: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5d0: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1a 04 00 00 // ProcessType[[]key<string>]
-	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 18 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 41 05 00 00 // ProcessType[[]key<string>]
+	Call 8b 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 3f 04 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4be: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5e5: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 1e 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8b 05 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 45 04 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4ce: ProcessType[error]
+// 0x5f5: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x4d0: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x5f7: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9f 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x4de: ProcessType[hash<string,int>]
+// 0x605: ProcessType[hash<string,int>]
 	ProcessGoHmap 8e 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4ec: ProcessType[hash<string,main.bigStruct>]
+// 0x613: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 92 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4fa: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x621: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9b 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x508: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x62f: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x516: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x63d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x51c: ProcessType[map[string]int]
+// 0x643: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x522: ProcessType[map[string]main.bigStruct]
+// 0x649: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x528: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64f: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x52e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x655: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x534: ProcessType[runtime.g]
+// 0x65b: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime._panic]
+	Call 7b 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime._defer]
+	Call 75 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 40 04 00 00 // ProcessType[[]uint8]
+	Call 67 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 78 03 00 00 // ProcessType[*runtime.sudog]
+	Call 9f 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 7e 03 00 00 // ProcessType[*runtime.timer]
+	Call a5 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.coro]
+	Call 87 04 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x58f: ProcessType[runtime.m]
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+// 0x6b6: ProcessType[runtime.m]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.g]
+	Call 8d 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 0a 06 00 00 // ProcessType[string]
+	Call 31 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 81 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ef 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call 16 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 05 00 00 // ProcessType[runtime.mTraceState]
+	Call 21 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x5ef: ProcessType[runtime.mLockProfile]
+// 0x716: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4a 04 00 00 // ProcessType[[]uintptr]
+	Call 71 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x5fa: ProcessType[runtime.mTraceState]
+// 0x721: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 6c 03 00 00 // ProcessType[*runtime.m]
+	Call db 04 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 93 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x60a: ProcessType[string]
+// 0x731: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -484,12 +554,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 768
-ID: 6 Len: 8 Enqueue: 936
+ID: 5 Len: 8 Enqueue: 1063
+ID: 6 Len: 8 Enqueue: 1231
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 942
+ID: 8 Len: 8 Enqueue: 1237
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1546
+ID: 10 Len: 16 Enqueue: 1841
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -497,18 +567,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1230
+ID: 18 Len: 16 Enqueue: 1525
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 828
-ID: 21 Len: 8 Enqueue: 924
-ID: 22 Len: 432 Enqueue: 1332
+ID: 20 Len: 8 Enqueue: 1123
+ID: 21 Len: 8 Enqueue: 1219
+ID: 22 Len: 432 Enqueue: 1627
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 852
+ID: 24 Len: 8 Enqueue: 1147
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 846
+ID: 26 Len: 8 Enqueue: 1141
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 876
-ID: 29 Len: 1760 Enqueue: 1423
+ID: 28 Len: 8 Enqueue: 1171
+ID: 29 Len: 1760 Enqueue: 1718
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -517,41 +587,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1088
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1383
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 888
+ID: 41 Len: 8 Enqueue: 1183
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1098
-ID: 44 Len: 8 Enqueue: 894
+ID: 43 Len: 24 Enqueue: 1393
+ID: 44 Len: 8 Enqueue: 1189
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 864
+ID: 47 Len: 8 Enqueue: 1159
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 870
+ID: 53 Len: 8 Enqueue: 1165
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 858
+ID: 60 Len: 8 Enqueue: 1153
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1519
+ID: 64 Len: 64 Enqueue: 1814
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1530
+ID: 69 Len: 32 Enqueue: 1825
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 948
-ID: 72 Len: 8 Enqueue: 900
+ID: 71 Len: 16 Enqueue: 1243
+ID: 72 Len: 8 Enqueue: 1195
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -567,47 +637,47 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 906
+ID: 88 Len: 8 Enqueue: 1201
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 816
-ID: 93 Len: 8 Enqueue: 834
-ID: 94 Len: 8 Enqueue: 822
-ID: 95 Len: 8 Enqueue: 930
-ID: 96 Len: 8 Enqueue: 804
-ID: 97 Len: 8 Enqueue: 810
-ID: 98 Len: 8 Enqueue: 912
-ID: 99 Len: 8 Enqueue: 918
-ID: 100 Len: 24 Enqueue: 1040
+ID: 92 Len: 8 Enqueue: 1111
+ID: 93 Len: 8 Enqueue: 1129
+ID: 94 Len: 8 Enqueue: 1117
+ID: 95 Len: 8 Enqueue: 1225
+ID: 96 Len: 8 Enqueue: 1099
+ID: 97 Len: 8 Enqueue: 1105
+ID: 98 Len: 8 Enqueue: 1207
+ID: 99 Len: 8 Enqueue: 1213
+ID: 100 Len: 24 Enqueue: 1335
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 1066
-ID: 103 Len: 48 Enqueue: 964
-ID: 104 Len: 8 Enqueue: 1308
+ID: 102 Len: 24 Enqueue: 1361
+ID: 103 Len: 48 Enqueue: 1259
+ID: 104 Len: 8 Enqueue: 1603
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 1246
-ID: 107 Len: 8 Enqueue: 780
-ID: 108 Len: 208 Enqueue: 1151
-ID: 109 Len: 8 Enqueue: 882
+ID: 106 Len: 48 Enqueue: 1541
+ID: 107 Len: 8 Enqueue: 1075
+ID: 108 Len: 208 Enqueue: 1446
+ID: 109 Len: 8 Enqueue: 1177
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 1314
+ID: 111 Len: 8 Enqueue: 1609
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1260
-ID: 114 Len: 8 Enqueue: 786
-ID: 115 Len: 208 Enqueue: 1172
-ID: 116 Len: 8 Enqueue: 1326
+ID: 113 Len: 48 Enqueue: 1555
+ID: 114 Len: 8 Enqueue: 1081
+ID: 115 Len: 208 Enqueue: 1467
+ID: 116 Len: 8 Enqueue: 1621
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1288
-ID: 119 Len: 8 Enqueue: 798
-ID: 120 Len: 88 Enqueue: 1214
-ID: 121 Len: 8 Enqueue: 1320
+ID: 118 Len: 48 Enqueue: 1583
+ID: 119 Len: 8 Enqueue: 1093
+ID: 120 Len: 88 Enqueue: 1509
+ID: 121 Len: 8 Enqueue: 1615
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1274
-ID: 124 Len: 8 Enqueue: 792
-ID: 125 Len: 208 Enqueue: 1193
-ID: 126 Len: 8 Enqueue: 738
-ID: 127 Len: 8 Enqueue: 744
-ID: 128 Len: 8 Enqueue: 756
+ID: 123 Len: 48 Enqueue: 1569
+ID: 124 Len: 8 Enqueue: 1087
+ID: 125 Len: 208 Enqueue: 1488
+ID: 126 Len: 8 Enqueue: 1033
+ID: 127 Len: 8 Enqueue: 1039
+ID: 128 Len: 8 Enqueue: 1051
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -616,53 +686,63 @@ ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 16 Enqueue: 1076
+ID: 137 Len: 16 Enqueue: 1371
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 128 Enqueue: 1050
+ID: 140 Len: 128 Enqueue: 1345
 ID: 141 Len: 64 Enqueue: 0
-ID: 142 Len: 208 Enqueue: 992
-ID: 143 Len: 64 Enqueue: 1108
-ID: 144 Len: 8 Enqueue: 840
+ID: 142 Len: 208 Enqueue: 1287
+ID: 143 Len: 64 Enqueue: 1403
+ID: 144 Len: 8 Enqueue: 1135
 ID: 145 Len: 184 Enqueue: 0
-ID: 146 Len: 208 Enqueue: 1004
+ID: 146 Len: 208 Enqueue: 1299
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 64 Enqueue: 1124
-ID: 149 Len: 8 Enqueue: 1302
+ID: 148 Len: 64 Enqueue: 1419
+ID: 149 Len: 8 Enqueue: 1597
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 48 Enqueue: 1232
-ID: 152 Len: 8 Enqueue: 774
-ID: 153 Len: 144 Enqueue: 1140
-ID: 154 Len: 88 Enqueue: 1028
-ID: 155 Len: 208 Enqueue: 1016
+ID: 151 Len: 48 Enqueue: 1527
+ID: 152 Len: 8 Enqueue: 1069
+ID: 153 Len: 144 Enqueue: 1435
+ID: 154 Len: 88 Enqueue: 1323
+ID: 155 Len: 208 Enqueue: 1311
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 64 Enqueue: 0
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 144 Enqueue: 980
-ID: 160 Len: 8 Enqueue: 750
+ID: 159 Len: 144 Enqueue: 1275
+ID: 160 Len: 8 Enqueue: 1045
 ID: 161 Len: 128 Enqueue: 0
 ID: 162 Len: 9 Enqueue: 0
 ID: 163 Len: 0 Enqueue: 0
 ID: 164 Len: 17 Enqueue: 0
 ID: 165 Len: 0 Enqueue: 0
-ID: 166 Len: 25 Enqueue: 0
+ID: 166 Len: 17 Enqueue: 0
 ID: 167 Len: 0 Enqueue: 0
-ID: 168 Len: 25 Enqueue: 0
+ID: 168 Len: 17 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0
-ID: 170 Len: 25 Enqueue: 0
+ID: 170 Len: 17 Enqueue: 0
 ID: 171 Len: 0 Enqueue: 0
-ID: 172 Len: 49 Enqueue: 0
+ID: 172 Len: 17 Enqueue: 0
 ID: 173 Len: 0 Enqueue: 0
-ID: 174 Len: 49 Enqueue: 0
-ID: 175 Len: 9 Enqueue: 0
-ID: 176 Len: 0 Enqueue: 0
-ID: 177 Len: 9 Enqueue: 0
-ID: 178 Len: 0 Enqueue: 0
+ID: 174 Len: 17 Enqueue: 0
+ID: 175 Len: 0 Enqueue: 0
+ID: 176 Len: 25 Enqueue: 0
+ID: 177 Len: 0 Enqueue: 0
+ID: 178 Len: 25 Enqueue: 0
 ID: 179 Len: 0 Enqueue: 0
-ID: 180 Len: 0 Enqueue: 0
+ID: 180 Len: 25 Enqueue: 0
 ID: 181 Len: 0 Enqueue: 0
-ID: 182 Len: 9 Enqueue: 0
-ID: 183 Len: 9 Enqueue: 0
-ID: 184 Len: 0 Enqueue: 0
+ID: 182 Len: 49 Enqueue: 0
+ID: 183 Len: 0 Enqueue: 0
+ID: 184 Len: 49 Enqueue: 0
 ID: 185 Len: 9 Enqueue: 0
-ID: 186 Len: 9 Enqueue: 0
+ID: 186 Len: 0 Enqueue: 0
+ID: 187 Len: 9 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
+ID: 189 Len: 0 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
+ID: 191 Len: 0 Enqueue: 0
+ID: 192 Len: 9 Enqueue: 0
+ID: 193 Len: 9 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 9 Enqueue: 0
+ID: 196 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b520c]
-	PrepareEventRoot ca 00 00 00 09 00 00 00 
+	PrepareEventRoot d4 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb520c.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5244.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5244]
-	PrepareEventRoot cb 00 00 00 09 00 00 00 
+	PrepareEventRoot d5 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5244.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb56f0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d4 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call fb 05 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b56f0]
-	PrepareEventRoot c2 00 00 00 09 00 00 00 
+	PrepareEventRoot cc 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb56f0.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b5764]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@b502c]
-	PrepareEventRoot c8 00 00 00 09 00 00 00 
+	PrepareEventRoot d2 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0xb55b8.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@b55b8]
-	PrepareEventRoot c8 00 00 00 09 00 00 00 
+	PrepareEventRoot d2 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb55b8.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b55f0]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0xb52b8.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@b5428]
-	PrepareEventRoot b9 00 00 00 19 00 00 00 
+	PrepareEventRoot c3 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5428.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@b546c]
-	PrepareEventRoot ba 00 00 00 00 00 00 00 
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call f5 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5590]
-	PrepareEventRoot bf 00 00 00 31 00 00 00 
+	PrepareEventRoot c9 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5590.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0xb53a8.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0e 04 00 00 // ProcessType[[]int]
+	Call 35 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b53a8]
-	PrepareEventRoot b7 00 00 00 19 00 00 00 
+	PrepareEventRoot c1 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb53a8.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@b53e4]
-	PrepareEventRoot b8 00 00 00 00 00 00 00 
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0xb5678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ce 04 00 00 // ProcessType[map[string]int]
+	Call f5 05 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5678]
-	PrepareEventRoot c0 00 00 00 09 00 00 00 
+	PrepareEventRoot ca 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5678.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@b56a8]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@b57a8]
-	PrepareEventRoot c4 00 00 00 00 00 00 00 
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@b57e0]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b5 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call f5 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b5528]
-	PrepareEventRoot bd 00 00 00 31 00 00 00 
+	PrepareEventRoot c7 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5528.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@b556c]
-	PrepareEventRoot be 00 00 00 00 00 00 00 
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0xb54a8.expr[0]]
 	ExprPrepare 
@@ -158,345 +158,415 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 3c 04 00 00 // ProcessType[[]string]
+	Call 63 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b54a8]
-	PrepareEventRoot bb 00 00 00 19 00 00 00 
+	PrepareEventRoot c5 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb54a8.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@b54e4]
-	PrepareEventRoot bc 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5820]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot b7 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot b8 00 00 00 00 00 00 00 
+	Return 
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x30b: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot b9 00 00 00 11 00 00 00 
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot ba 00 00 00 00 00 00 00 
+	Return 
+// 0x324: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x346: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot bb 00 00 00 11 00 00 00 
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	Return 
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x381: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot bd 00 00 00 11 00 00 00 
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
+	Return 
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 59 07 00 00 // ProcessType[string]
+	Return 
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@b5328]
+	PrepareEventRoot bf 00 00 00 11 00 00 00 
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5328.expr[0]]
+	Return 
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@b5364]
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
+	Return 
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b5820]
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
+	Return 
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call da 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 01 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
+	PrepareEventRoot d1 00 00 00 09 00 00 00 
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer b1 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*error]
+// 0x42d: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float32]
+// 0x433: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x312: ProcessType[*float64]
+// 0x439: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x318: ProcessType[*int]
+// 0x43f: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int32]
+// 0x445: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x324: ProcessType[*int64]
+// 0x44b: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x32a: ProcessType[*main.bigStruct]
+// 0x451: ProcessType[*main.bigStruct]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._defer]
+// 0x457: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime._panic]
+// 0x45d: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.cgoCallers]
+// 0x463: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.coro]
+// 0x469: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.g]
+// 0x46f: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.m]
+// 0x475: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.sudog]
+// 0x47b: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.synctestGroup]
+// 0x481: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.timer]
+// 0x487: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.traceBuf]
+// 0x48d: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*string]
+// 0x493: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x372: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x499: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<string,int>]
+// 0x49f: ProcessType[*table<string,int>]
 	ProcessPointer 89 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,main.bigStruct>]
+// 0x4a5: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4ab: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint]
+// 0x4b1: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint16]
+// 0x4b7: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint32]
+// 0x4bd: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint64]
+// 0x4c3: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint8]
+// 0x4c9: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uintptr]
+// 0x4cf: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3ae: ProcessType[[2]*runtime.traceBuf]
+// 0x4d5: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 8d 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3be: ProcessType[[2][2]*runtime.traceBuf]
+// 0x4e5: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call d5 04 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3ce: ProcessType[[3]string]
+// 0x4f5: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3de: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x505: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 72 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 99 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ea: ProcessType[[]*table<string,int>.array]
+// 0x511: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<string,int>]
+	Call 9f 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f6: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x51d: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call a5 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x402: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x529: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ab 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x40e: ProcessType[[]int]
+// 0x535: ProcessType[[]int]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x418: ProcessType[[]noalg.map.group[string]int.array]
+// 0x53f: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 10 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 37 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x424: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x54b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 1b 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 42 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x430: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x557: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 26 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4d 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x43c: ProcessType[[]string]
+// 0x563: ProcessType[[]string]
 	ProcessSlice 87 00 00 00 10 00 00 00 
 	Return 
-// 0x446: ProcessType[[]string.array]
+// 0x56d: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 32 06 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x452: ProcessType[[]uint8]
+// 0x579: ProcessType[[]uint8]
 	ProcessSlice 81 00 00 00 01 00 00 00 
 	Return 
-// 0x45c: ProcessType[[]uintptr]
+// 0x583: ProcessType[[]uintptr]
 	ProcessSlice 83 00 00 00 08 00 00 00 
 	Return 
-// 0x466: ProcessType[error]
+// 0x58d: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x468: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x58f: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x474: ProcessType[groupReference<string,int>]
+// 0x59b: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 90 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x480: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5a7: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x48c: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5b3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x498: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x5bf: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap af 00 00 00 ab 00 00 00 10 18 
 	Return 
-// 0x4a4: ProcessType[map<string,int>]
+// 0x5cb: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8f 00 00 00 8c 00 00 00 10 18 
 	Return 
-// 0x4b0: ProcessType[map<string,main.bigStruct>]
+// 0x5d7: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 99 00 00 00 94 00 00 00 10 18 
 	Return 
-// 0x4bc: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5e3: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a6 00 00 00 9e 00 00 00 10 18 
 	Return 
-// 0x4c8: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x5ef: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x4ce: ProcessType[map[string]int]
+// 0x5f5: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x4d4: ProcessType[map[string]main.bigStruct]
+// 0x5fb: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x4da: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x601: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x4e0: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x607: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 31 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 58 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4f0: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x617: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 41 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 68 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x500: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x627: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 47 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 6e 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x510: ProcessType[noalg.map.group[string]int]
+// 0x637: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 17 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x51b: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x642: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call e0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 07 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x526: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x64d: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 00 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 27 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x531: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 32 06 00 00 // ProcessType[string]
+// 0x658: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 59 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
+	Call 51 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x541: ProcessType[noalg.struct { key string; elem int }]
-	Call 32 06 00 00 // ProcessType[string]
+// 0x668: ProcessType[noalg.struct { key string; elem int }]
+	Call 59 07 00 00 // ProcessType[string]
 	Return 
-// 0x547: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x66e: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call c8 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call ef 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x552: ProcessType[runtime.g]
+// 0x679: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime._panic]
+	Call 5d 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._defer]
+	Call 57 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 52 04 00 00 // ProcessType[[]uint8]
+	Call 79 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.sudog]
+	Call 7b 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.timer]
+	Call 87 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.coro]
+	Call 69 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 81 04 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x5b7: ProcessType[runtime.m]
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+// 0x6de: ProcessType[runtime.m]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 32 06 00 00 // ProcessType[string]
+	Call 59 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 63 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 17 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 3e 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 22 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 49 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x617: ProcessType[runtime.mLockProfile]
+// 0x73e: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5c 04 00 00 // ProcessType[[]uintptr]
+	Call 83 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x622: ProcessType[runtime.mTraceState]
+// 0x749: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call be 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call e5 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x632: ProcessType[string]
+// 0x759: ProcessType[string]
 	ProcessString 7f 00 00 00 
 	Return 
-// 0x638: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x75f: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 68 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 8f 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x643: ProcessType[table<string,int>]
+// 0x76a: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 74 04 00 00 // ProcessType[groupReference<string,int>]
+	Call 9b 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x64e: ProcessType[table<string,main.bigStruct>]
+// 0x775: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 80 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call a7 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x659: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x780: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8c 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b3 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -517,31 +587,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 930
+ID: 5 Len: 8 Enqueue: 1225
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1586
+ID: 9 Len: 16 Enqueue: 1881
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 768
+ID: 11 Len: 8 Enqueue: 1063
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1126
+ID: 14 Len: 16 Enqueue: 1421
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 936
-ID: 20 Len: 8 Enqueue: 798
-ID: 21 Len: 8 Enqueue: 918
-ID: 22 Len: 440 Enqueue: 1362
+ID: 19 Len: 8 Enqueue: 1231
+ID: 20 Len: 8 Enqueue: 1093
+ID: 21 Len: 8 Enqueue: 1213
+ID: 22 Len: 440 Enqueue: 1657
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 822
+ID: 24 Len: 8 Enqueue: 1117
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 816
+ID: 26 Len: 8 Enqueue: 1111
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 846
-ID: 29 Len: 1808 Enqueue: 1463
+ID: 28 Len: 8 Enqueue: 1141
+ID: 29 Len: 1808 Enqueue: 1758
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -550,45 +620,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1106
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1401
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 852
+ID: 41 Len: 8 Enqueue: 1147
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1116
-ID: 44 Len: 8 Enqueue: 864
+ID: 43 Len: 24 Enqueue: 1411
+ID: 44 Len: 8 Enqueue: 1159
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 834
+ID: 47 Len: 8 Enqueue: 1129
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 858
+ID: 49 Len: 8 Enqueue: 1153
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 840
+ID: 55 Len: 8 Enqueue: 1135
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 828
+ID: 62 Len: 8 Enqueue: 1123
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1559
+ID: 67 Len: 64 Enqueue: 1854
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1570
+ID: 72 Len: 56 Enqueue: 1865
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 958
-ID: 75 Len: 16 Enqueue: 942
-ID: 76 Len: 8 Enqueue: 870
+ID: 74 Len: 32 Enqueue: 1253
+ID: 75 Len: 16 Enqueue: 1237
+ID: 76 Len: 8 Enqueue: 1165
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -605,40 +675,40 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 876
+ID: 93 Len: 8 Enqueue: 1171
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 786
-ID: 98 Len: 8 Enqueue: 804
-ID: 99 Len: 8 Enqueue: 792
-ID: 100 Len: 8 Enqueue: 924
-ID: 101 Len: 8 Enqueue: 774
-ID: 102 Len: 8 Enqueue: 780
-ID: 103 Len: 8 Enqueue: 906
-ID: 104 Len: 8 Enqueue: 912
-ID: 105 Len: 24 Enqueue: 1038
+ID: 97 Len: 8 Enqueue: 1081
+ID: 98 Len: 8 Enqueue: 1099
+ID: 99 Len: 8 Enqueue: 1087
+ID: 100 Len: 8 Enqueue: 1219
+ID: 101 Len: 8 Enqueue: 1069
+ID: 102 Len: 8 Enqueue: 1075
+ID: 103 Len: 8 Enqueue: 1201
+ID: 104 Len: 8 Enqueue: 1207
+ID: 105 Len: 24 Enqueue: 1333
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 1084
-ID: 108 Len: 48 Enqueue: 974
-ID: 109 Len: 8 Enqueue: 1230
+ID: 107 Len: 24 Enqueue: 1379
+ID: 108 Len: 48 Enqueue: 1269
+ID: 109 Len: 8 Enqueue: 1525
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 1188
+ID: 111 Len: 48 Enqueue: 1483
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 888
-ID: 114 Len: 8 Enqueue: 1236
+ID: 113 Len: 8 Enqueue: 1183
+ID: 114 Len: 8 Enqueue: 1531
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 1200
+ID: 116 Len: 48 Enqueue: 1495
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 894
-ID: 119 Len: 8 Enqueue: 1242
+ID: 118 Len: 8 Enqueue: 1189
+ID: 119 Len: 8 Enqueue: 1537
 ID: 120 Len: 8 Enqueue: 0
-ID: 121 Len: 48 Enqueue: 1212
+ID: 121 Len: 48 Enqueue: 1507
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 900
-ID: 124 Len: 8 Enqueue: 738
-ID: 125 Len: 8 Enqueue: 744
-ID: 126 Len: 8 Enqueue: 756
+ID: 123 Len: 8 Enqueue: 1195
+ID: 124 Len: 8 Enqueue: 1033
+ID: 125 Len: 8 Enqueue: 1039
+ID: 126 Len: 8 Enqueue: 1051
 ID: 127 Len: 1 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 1 Enqueue: 0
@@ -647,72 +717,82 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 16 Enqueue: 1094
+ID: 135 Len: 16 Enqueue: 1389
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 32 Enqueue: 1603
-ID: 138 Len: 16 Enqueue: 1140
+ID: 137 Len: 32 Enqueue: 1898
+ID: 138 Len: 16 Enqueue: 1435
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 200 Enqueue: 1296
-ID: 141 Len: 192 Enqueue: 1264
-ID: 142 Len: 24 Enqueue: 1345
-ID: 143 Len: 8 Enqueue: 1002
-ID: 144 Len: 200 Enqueue: 1048
-ID: 145 Len: 32 Enqueue: 1614
-ID: 146 Len: 16 Enqueue: 1152
+ID: 140 Len: 200 Enqueue: 1591
+ID: 141 Len: 192 Enqueue: 1559
+ID: 142 Len: 24 Enqueue: 1640
+ID: 143 Len: 8 Enqueue: 1297
+ID: 144 Len: 200 Enqueue: 1343
+ID: 145 Len: 32 Enqueue: 1909
+ID: 146 Len: 16 Enqueue: 1447
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 1307
-ID: 149 Len: 192 Enqueue: 1248
-ID: 150 Len: 24 Enqueue: 1329
-ID: 151 Len: 8 Enqueue: 810
+ID: 148 Len: 200 Enqueue: 1602
+ID: 149 Len: 192 Enqueue: 1543
+ID: 150 Len: 24 Enqueue: 1624
+ID: 151 Len: 8 Enqueue: 1105
 ID: 152 Len: 184 Enqueue: 0
-ID: 153 Len: 8 Enqueue: 1014
-ID: 154 Len: 200 Enqueue: 1060
-ID: 155 Len: 32 Enqueue: 1625
-ID: 156 Len: 16 Enqueue: 1164
+ID: 153 Len: 8 Enqueue: 1309
+ID: 154 Len: 200 Enqueue: 1355
+ID: 155 Len: 32 Enqueue: 1920
+ID: 156 Len: 16 Enqueue: 1459
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 136 Enqueue: 1318
-ID: 159 Len: 128 Enqueue: 1280
-ID: 160 Len: 16 Enqueue: 1351
-ID: 161 Len: 8 Enqueue: 1224
+ID: 158 Len: 136 Enqueue: 1613
+ID: 159 Len: 128 Enqueue: 1575
+ID: 160 Len: 16 Enqueue: 1646
+ID: 161 Len: 8 Enqueue: 1519
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 48 Enqueue: 1176
+ID: 163 Len: 48 Enqueue: 1471
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 8 Enqueue: 882
-ID: 166 Len: 8 Enqueue: 1026
-ID: 167 Len: 136 Enqueue: 1072
-ID: 168 Len: 32 Enqueue: 1592
-ID: 169 Len: 16 Enqueue: 1128
+ID: 165 Len: 8 Enqueue: 1177
+ID: 166 Len: 8 Enqueue: 1321
+ID: 167 Len: 136 Enqueue: 1367
+ID: 168 Len: 32 Enqueue: 1887
+ID: 169 Len: 16 Enqueue: 1423
 ID: 170 Len: 8 Enqueue: 0
 ID: 171 Len: 136 Enqueue: 0
 ID: 172 Len: 128 Enqueue: 0
 ID: 173 Len: 16 Enqueue: 0
 ID: 174 Len: 8 Enqueue: 0
-ID: 175 Len: 8 Enqueue: 990
+ID: 175 Len: 8 Enqueue: 1285
 ID: 176 Len: 136 Enqueue: 0
-ID: 177 Len: 8 Enqueue: 750
+ID: 177 Len: 8 Enqueue: 1045
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 9 Enqueue: 0
 ID: 180 Len: 0 Enqueue: 0
 ID: 181 Len: 17 Enqueue: 0
 ID: 182 Len: 0 Enqueue: 0
-ID: 183 Len: 25 Enqueue: 0
+ID: 183 Len: 17 Enqueue: 0
 ID: 184 Len: 0 Enqueue: 0
-ID: 185 Len: 25 Enqueue: 0
+ID: 185 Len: 17 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
-ID: 187 Len: 25 Enqueue: 0
+ID: 187 Len: 17 Enqueue: 0
 ID: 188 Len: 0 Enqueue: 0
-ID: 189 Len: 49 Enqueue: 0
+ID: 189 Len: 17 Enqueue: 0
 ID: 190 Len: 0 Enqueue: 0
-ID: 191 Len: 49 Enqueue: 0
-ID: 192 Len: 9 Enqueue: 0
-ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 9 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
+ID: 191 Len: 17 Enqueue: 0
+ID: 192 Len: 0 Enqueue: 0
+ID: 193 Len: 25 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 25 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
+ID: 197 Len: 25 Enqueue: 0
 ID: 198 Len: 0 Enqueue: 0
-ID: 199 Len: 9 Enqueue: 0
-ID: 200 Len: 9 Enqueue: 0
-ID: 201 Len: 0 Enqueue: 0
+ID: 199 Len: 49 Enqueue: 0
+ID: 200 Len: 0 Enqueue: 0
+ID: 201 Len: 49 Enqueue: 0
 ID: 202 Len: 9 Enqueue: 0
-ID: 203 Len: 9 Enqueue: 0
+ID: 203 Len: 0 Enqueue: 0
+ID: 204 Len: 9 Enqueue: 0
+ID: 205 Len: 0 Enqueue: 0
+ID: 206 Len: 0 Enqueue: 0
+ID: 207 Len: 0 Enqueue: 0
+ID: 208 Len: 0 Enqueue: 0
+ID: 209 Len: 9 Enqueue: 0
+ID: 210 Len: 9 Enqueue: 0
+ID: 211 Len: 0 Enqueue: 0
+ID: 212 Len: 9 Enqueue: 0
+ID: 213 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,34 +7,34 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 02 00 00 // ProcessType[*****int]
+	Call 09 04 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7da0]
-	PrepareEventRoot cf 00 00 00 09 00 00 00 
+	PrepareEventRoot d9 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7da0.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7dd4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 02 00 00 // ProcessType[**int]
+	Call 1b 04 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7dd4]
-	PrepareEventRoot d0 00 00 00 09 00 00 00 
+	PrepareEventRoot da 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7dd4.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb8240.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f0 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 17 06 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b8240]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
+	PrepareEventRoot d1 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8240.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b82b0]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@b7bc8]
-	PrepareEventRoot cd 00 00 00 09 00 00 00 
+	PrepareEventRoot d7 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0xb8108.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@b8108]
-	PrepareEventRoot cd 00 00 00 09 00 00 00 
+	PrepareEventRoot d7 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb8108.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b813c]
-	PrepareEventRoot ce 00 00 00 00 00 00 00 
+	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0xb7e38.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@b7f98]
-	PrepareEventRoot be 00 00 00 19 00 00 00 
+	PrepareEventRoot c8 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f98.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@b7fd8]
-	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d4 03 00 00 // ProcessType[[3]string]
+	Call fb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80e0]
-	PrepareEventRoot c4 00 00 00 31 00 00 00 
+	PrepareEventRoot ce 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80e0.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0xb7f18.expr[0]]
@@ -97,40 +97,40 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2a 04 00 00 // ProcessType[[]int]
+	Call 51 05 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b7f18]
-	PrepareEventRoot bc 00 00 00 19 00 00 00 
+	PrepareEventRoot c6 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7f18.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@b7f50]
-	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ea 04 00 00 // ProcessType[map[string]int]
+	Call 11 06 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b81c8]
-	PrepareEventRoot c5 00 00 00 09 00 00 00 
+	PrepareEventRoot cf 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb81c8.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@b81f4]
-	PrepareEventRoot c6 00 00 00 00 00 00 00 
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@b82e8]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@b831c]
-	PrepareEventRoot ca 00 00 00 00 00 00 00 
+	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot ba 00 00 00 11 00 00 00 
@@ -143,14 +143,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d4 03 00 00 // ProcessType[[3]string]
+	Call fb 04 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b8088]
-	PrepareEventRoot c2 00 00 00 31 00 00 00 
+	PrepareEventRoot cc 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8088.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@b80c8]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0xb8008.expr[0]]
 	ExprPrepare 
@@ -158,358 +158,428 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 58 04 00 00 // ProcessType[[]string]
+	Call 7f 05 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b8008]
-	PrepareEventRoot c0 00 00 00 19 00 00 00 
+	PrepareEventRoot ca 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8008.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@b8040]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
-	Return 
-// 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8360]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
+// 0x2ae: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x2d0: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot bc 00 00 00 11 00 00 00 
+	Call ae 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x2df: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	Return 
+// 0x2e9: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x30b: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot be 00 00 00 11 00 00 00 
+	Call e9 02 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x31a: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	Return 
+// 0x324: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x346: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot c0 00 00 00 11 00 00 00 
+	Call 24 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x355: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	Return 
+// 0x35f: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x381: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot c2 00 00 00 11 00 00 00 
+	Call 5f 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x390: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	Return 
+// 0x39a: ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 7f 07 00 00 // ProcessType[string]
+	Return 
+// 0x3bc: ProcessEvent[Probe[main.stringArg]@b7ea8]
+	PrepareEventRoot c4 00 00 00 11 00 00 00 
+	Call 9a 03 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7ea8.expr[0]]
+	Return 
+// 0x3cb: ProcessEvent[Probe[main.stringArg]Return@b7ee0]
+	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	Return 
+// 0x3d5: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b8360]
+	PrepareEventRoot d5 00 00 00 00 00 00 00 
+	Return 
+// 0x3df: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f6 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 1d 06 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
-	PrepareEventRoot cc 00 00 00 09 00 00 00 
-	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
+// 0x3fa: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
+	PrepareEventRoot d6 00 00 00 09 00 00 00 
+	Call df 03 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	Return 
-// 0x2e2: ProcessType[*****int]
+// 0x409: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2e8: ProcessType[****int]
+// 0x40f: ProcessType[****int]
 	ProcessPointer b6 00 00 00 
 	Return 
-// 0x2ee: ProcessType[***int]
+// 0x415: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x2f4: ProcessType[**int]
+// 0x41b: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
+// 0x421: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x300: ProcessType[*bool]
+// 0x427: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x306: ProcessType[*error]
+// 0x42d: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float32]
+// 0x433: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x312: ProcessType[*float64]
+// 0x439: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x318: ProcessType[*int]
+// 0x43f: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int32]
+// 0x445: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x324: ProcessType[*int64]
+// 0x44b: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x32a: ProcessType[*main.bigStruct]
+// 0x451: ProcessType[*main.bigStruct]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._defer]
+// 0x457: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime._panic]
+// 0x45d: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.cgoCallers]
+// 0x463: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.coro]
+// 0x469: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.g]
+// 0x46f: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.m]
+// 0x475: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.p]
+// 0x47b: ProcessType[*runtime.p]
 	ProcessPointer 87 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.sudog]
+// 0x481: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.synctestBubble]
+// 0x487: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.timer]
+// 0x48d: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.traceBuf]
+// 0x493: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x372: ProcessType[*string]
+// 0x499: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x49f: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ad 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,int>]
+// 0x4a5: ProcessType[*table<string,int>]
 	ProcessPointer 8e 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<string,main.bigStruct>]
+// 0x4ab: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x38a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4b1: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint]
+// 0x4b7: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint16]
+// 0x4bd: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint32]
+// 0x4c3: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint64]
+// 0x4c9: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uint8]
+// 0x4cf: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3ae: ProcessType[*uintptr]
+// 0x4d5: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3b4: ProcessType[[2]*runtime.traceBuf]
+// 0x4db: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 93 04 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3c4: ProcessType[[2][2]*runtime.traceBuf]
+// 0x4eb: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call db 04 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[3]string]
+// 0x4fb: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3e4: ProcessType[[]*runtime.p]
+// 0x50b: ProcessType[[]*runtime.p]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x3ee: ProcessType[[]*runtime.p.array]
+// 0x515: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 54 03 00 00 // ProcessType[*runtime.p]
+	Call 7b 04 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3fa: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x521: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 9f 04 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x406: ProcessType[[]*table<string,int>.array]
+// 0x52d: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,int>]
+	Call a5 04 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x412: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x539: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call ab 04 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x41e: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x545: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 8a 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b1 04 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]int]
+// 0x551: ProcessType[[]int]
 	ProcessSlice 8a 00 00 00 08 00 00 00 
 	Return 
-// 0x434: ProcessType[[]noalg.map.group[string]int.array]
+// 0x55b: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 2c 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 53 06 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x440: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x567: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 37 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 5e 06 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x44c: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x573: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 42 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 69 06 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x458: ProcessType[[]string]
+// 0x57f: ProcessType[[]string]
 	ProcessSlice 8c 00 00 00 10 00 00 00 
 	Return 
-// 0x462: ProcessType[[]string.array]
+// 0x589: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 58 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x46e: ProcessType[[]uint8]
+// 0x595: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x478: ProcessType[[]uintptr]
+// 0x59f: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x482: ProcessType[error]
+// 0x5a9: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x484: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x5ab: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b5 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x490: ProcessType[groupReference<string,int>]
+// 0x5b7: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 95 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x49c: ProcessType[groupReference<string,main.bigStruct>]
+// 0x5c3: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x4a8: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5cf: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ac 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x4b4: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x5db: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b4 00 00 00 b0 00 00 00 10 18 
 	Return 
-// 0x4c0: ProcessType[map<string,int>]
+// 0x5e7: ProcessType[map<string,int>]
 	ProcessGoSwissMap 94 00 00 00 91 00 00 00 10 18 
 	Return 
-// 0x4cc: ProcessType[map<string,main.bigStruct>]
+// 0x5f3: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9e 00 00 00 99 00 00 00 10 18 
 	Return 
-// 0x4d8: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x5ff: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ab 00 00 00 a3 00 00 00 10 18 
 	Return 
-// 0x4e4: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x60b: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x4ea: ProcessType[map[string]int]
+// 0x611: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x4f0: ProcessType[map[string]main.bigStruct]
+// 0x617: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x4f6: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x61d: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x4fc: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x623: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 4d 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 74 06 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x50c: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x633: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 5d 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 84 06 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x51c: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x643: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 63 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 8a 06 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x52c: ProcessType[noalg.map.group[string]int]
+// 0x653: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0c 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 33 06 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x537: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x65e: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call fc 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 23 06 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x542: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x669: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1c 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 43 06 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x54d: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 58 06 00 00 // ProcessType[string]
+// 0x674: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
+	Call 51 04 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x55d: ProcessType[noalg.struct { key string; elem int }]
-	Call 58 06 00 00 // ProcessType[string]
+// 0x684: ProcessType[noalg.struct { key string; elem int }]
+	Call 7f 07 00 00 // ProcessType[string]
 	Return 
-// 0x563: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x68a: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call e4 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 0b 06 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x56e: ProcessType[runtime.g]
+// 0x695: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime._panic]
+	Call 5d 04 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._defer]
+	Call 57 04 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 6e 04 00 00 // ProcessType[[]uint8]
+	Call 95 05 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 21 04 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.sudog]
+	Call 81 04 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.timer]
+	Call 8d 04 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.coro]
+	Call 69 04 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 87 04 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x5d3: ProcessType[runtime.m]
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+// 0x6fa: ProcessType[runtime.m]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.g]
+	Call 6f 04 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 58 06 00 00 // ProcessType[string]
+	Call 7f 07 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call e4 03 00 00 // ProcessType[[]*runtime.p]
+	Call 0b 05 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 63 04 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 3d 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 64 07 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 6f 07 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x63d: ProcessType[runtime.mLockProfile]
+// 0x764: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 78 04 00 00 // ProcessType[[]uintptr]
+	Call 9f 05 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x648: ProcessType[runtime.mTraceState]
+// 0x76f: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4e 03 00 00 // ProcessType[*runtime.m]
+	Call eb 04 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 75 04 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x658: ProcessType[string]
+// 0x77f: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
-// 0x65e: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x785: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 84 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call ab 05 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x669: ProcessType[table<string,int>]
+// 0x790: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 90 04 00 00 // ProcessType[groupReference<string,int>]
+	Call b7 05 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x674: ProcessType[table<string,main.bigStruct>]
+// 0x79b: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9c 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call c3 05 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x67f: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x7a6: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a8 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call cf 05 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -530,31 +600,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 936
+ID: 5 Len: 8 Enqueue: 1231
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1624
+ID: 9 Len: 16 Enqueue: 1919
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 768
+ID: 11 Len: 8 Enqueue: 1063
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1154
+ID: 14 Len: 16 Enqueue: 1449
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 942
-ID: 20 Len: 8 Enqueue: 798
-ID: 21 Len: 8 Enqueue: 924
-ID: 22 Len: 440 Enqueue: 1390
+ID: 19 Len: 8 Enqueue: 1237
+ID: 20 Len: 8 Enqueue: 1093
+ID: 21 Len: 8 Enqueue: 1219
+ID: 22 Len: 440 Enqueue: 1685
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 822
+ID: 24 Len: 8 Enqueue: 1117
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 816
+ID: 26 Len: 8 Enqueue: 1111
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 846
-ID: 29 Len: 1816 Enqueue: 1491
+ID: 28 Len: 8 Enqueue: 1141
+ID: 29 Len: 1816 Enqueue: 1786
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -563,48 +633,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1134
-ID: 39 Len: 8 Enqueue: 762
+ID: 38 Len: 24 Enqueue: 1429
+ID: 39 Len: 8 Enqueue: 1057
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 858
+ID: 41 Len: 8 Enqueue: 1153
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1144
-ID: 44 Len: 8 Enqueue: 870
+ID: 43 Len: 24 Enqueue: 1439
+ID: 44 Len: 8 Enqueue: 1165
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 834
+ID: 47 Len: 8 Enqueue: 1129
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 864
+ID: 49 Len: 8 Enqueue: 1159
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 840
+ID: 55 Len: 8 Enqueue: 1135
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 996
+ID: 62 Len: 24 Enqueue: 1291
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 852
-ID: 65 Len: 8 Enqueue: 828
+ID: 64 Len: 8 Enqueue: 1147
+ID: 65 Len: 8 Enqueue: 1123
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1597
+ID: 70 Len: 56 Enqueue: 1892
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1608
+ID: 75 Len: 56 Enqueue: 1903
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 964
-ID: 78 Len: 16 Enqueue: 948
-ID: 79 Len: 8 Enqueue: 876
+ID: 77 Len: 32 Enqueue: 1259
+ID: 78 Len: 16 Enqueue: 1243
+ID: 79 Len: 8 Enqueue: 1171
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -620,40 +690,40 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 882
+ID: 95 Len: 8 Enqueue: 1177
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 786
-ID: 100 Len: 8 Enqueue: 792
-ID: 101 Len: 8 Enqueue: 930
-ID: 102 Len: 8 Enqueue: 804
-ID: 103 Len: 8 Enqueue: 774
-ID: 104 Len: 8 Enqueue: 780
-ID: 105 Len: 8 Enqueue: 912
-ID: 106 Len: 8 Enqueue: 918
-ID: 107 Len: 24 Enqueue: 1066
+ID: 99 Len: 8 Enqueue: 1081
+ID: 100 Len: 8 Enqueue: 1087
+ID: 101 Len: 8 Enqueue: 1225
+ID: 102 Len: 8 Enqueue: 1099
+ID: 103 Len: 8 Enqueue: 1069
+ID: 104 Len: 8 Enqueue: 1075
+ID: 105 Len: 8 Enqueue: 1207
+ID: 106 Len: 8 Enqueue: 1213
+ID: 107 Len: 24 Enqueue: 1361
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 1112
-ID: 110 Len: 48 Enqueue: 980
-ID: 111 Len: 8 Enqueue: 1258
+ID: 109 Len: 24 Enqueue: 1407
+ID: 110 Len: 48 Enqueue: 1275
+ID: 111 Len: 8 Enqueue: 1553
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1216
+ID: 113 Len: 48 Enqueue: 1511
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 894
-ID: 116 Len: 8 Enqueue: 1264
+ID: 115 Len: 8 Enqueue: 1189
+ID: 116 Len: 8 Enqueue: 1559
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1228
+ID: 118 Len: 48 Enqueue: 1523
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 900
-ID: 121 Len: 8 Enqueue: 1270
+ID: 120 Len: 8 Enqueue: 1195
+ID: 121 Len: 8 Enqueue: 1565
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1240
+ID: 123 Len: 48 Enqueue: 1535
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 906
-ID: 126 Len: 8 Enqueue: 738
-ID: 127 Len: 8 Enqueue: 744
-ID: 128 Len: 8 Enqueue: 756
+ID: 125 Len: 8 Enqueue: 1201
+ID: 126 Len: 8 Enqueue: 1033
+ID: 127 Len: 8 Enqueue: 1039
+ID: 128 Len: 8 Enqueue: 1051
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -661,76 +731,86 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 1006
+ID: 136 Len: 8 Enqueue: 1301
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 16 Enqueue: 1122
+ID: 140 Len: 16 Enqueue: 1417
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 32 Enqueue: 1641
-ID: 143 Len: 16 Enqueue: 1168
+ID: 142 Len: 32 Enqueue: 1936
+ID: 143 Len: 16 Enqueue: 1463
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 200 Enqueue: 1324
-ID: 146 Len: 192 Enqueue: 1292
-ID: 147 Len: 24 Enqueue: 1373
-ID: 148 Len: 8 Enqueue: 1030
-ID: 149 Len: 200 Enqueue: 1076
-ID: 150 Len: 32 Enqueue: 1652
-ID: 151 Len: 16 Enqueue: 1180
+ID: 145 Len: 200 Enqueue: 1619
+ID: 146 Len: 192 Enqueue: 1587
+ID: 147 Len: 24 Enqueue: 1668
+ID: 148 Len: 8 Enqueue: 1325
+ID: 149 Len: 200 Enqueue: 1371
+ID: 150 Len: 32 Enqueue: 1947
+ID: 151 Len: 16 Enqueue: 1475
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 1335
-ID: 154 Len: 192 Enqueue: 1276
-ID: 155 Len: 24 Enqueue: 1357
-ID: 156 Len: 8 Enqueue: 810
+ID: 153 Len: 200 Enqueue: 1630
+ID: 154 Len: 192 Enqueue: 1571
+ID: 155 Len: 24 Enqueue: 1652
+ID: 156 Len: 8 Enqueue: 1105
 ID: 157 Len: 184 Enqueue: 0
-ID: 158 Len: 8 Enqueue: 1042
-ID: 159 Len: 200 Enqueue: 1088
-ID: 160 Len: 32 Enqueue: 1663
-ID: 161 Len: 16 Enqueue: 1192
+ID: 158 Len: 8 Enqueue: 1337
+ID: 159 Len: 200 Enqueue: 1383
+ID: 160 Len: 32 Enqueue: 1958
+ID: 161 Len: 16 Enqueue: 1487
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 136 Enqueue: 1346
-ID: 164 Len: 128 Enqueue: 1308
-ID: 165 Len: 16 Enqueue: 1379
-ID: 166 Len: 8 Enqueue: 1252
+ID: 163 Len: 136 Enqueue: 1641
+ID: 164 Len: 128 Enqueue: 1603
+ID: 165 Len: 16 Enqueue: 1674
+ID: 166 Len: 8 Enqueue: 1547
 ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 48 Enqueue: 1204
+ID: 168 Len: 48 Enqueue: 1499
 ID: 169 Len: 8 Enqueue: 0
-ID: 170 Len: 8 Enqueue: 888
-ID: 171 Len: 8 Enqueue: 1054
-ID: 172 Len: 136 Enqueue: 1100
-ID: 173 Len: 32 Enqueue: 1630
-ID: 174 Len: 16 Enqueue: 1156
+ID: 170 Len: 8 Enqueue: 1183
+ID: 171 Len: 8 Enqueue: 1349
+ID: 172 Len: 136 Enqueue: 1395
+ID: 173 Len: 32 Enqueue: 1925
+ID: 174 Len: 16 Enqueue: 1451
 ID: 175 Len: 8 Enqueue: 0
 ID: 176 Len: 136 Enqueue: 0
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 16 Enqueue: 0
 ID: 179 Len: 8 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 1018
+ID: 180 Len: 8 Enqueue: 1313
 ID: 181 Len: 136 Enqueue: 0
-ID: 182 Len: 8 Enqueue: 750
+ID: 182 Len: 8 Enqueue: 1045
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 9 Enqueue: 0
 ID: 185 Len: 0 Enqueue: 0
 ID: 186 Len: 17 Enqueue: 0
 ID: 187 Len: 0 Enqueue: 0
-ID: 188 Len: 25 Enqueue: 0
+ID: 188 Len: 17 Enqueue: 0
 ID: 189 Len: 0 Enqueue: 0
-ID: 190 Len: 25 Enqueue: 0
+ID: 190 Len: 17 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0
-ID: 192 Len: 25 Enqueue: 0
+ID: 192 Len: 17 Enqueue: 0
 ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 49 Enqueue: 0
+ID: 194 Len: 17 Enqueue: 0
 ID: 195 Len: 0 Enqueue: 0
-ID: 196 Len: 49 Enqueue: 0
-ID: 197 Len: 9 Enqueue: 0
-ID: 198 Len: 0 Enqueue: 0
-ID: 199 Len: 9 Enqueue: 0
-ID: 200 Len: 0 Enqueue: 0
+ID: 196 Len: 17 Enqueue: 0
+ID: 197 Len: 0 Enqueue: 0
+ID: 198 Len: 25 Enqueue: 0
+ID: 199 Len: 0 Enqueue: 0
+ID: 200 Len: 25 Enqueue: 0
 ID: 201 Len: 0 Enqueue: 0
-ID: 202 Len: 0 Enqueue: 0
+ID: 202 Len: 25 Enqueue: 0
 ID: 203 Len: 0 Enqueue: 0
-ID: 204 Len: 9 Enqueue: 0
-ID: 205 Len: 9 Enqueue: 0
-ID: 206 Len: 0 Enqueue: 0
+ID: 204 Len: 49 Enqueue: 0
+ID: 205 Len: 0 Enqueue: 0
+ID: 206 Len: 49 Enqueue: 0
 ID: 207 Len: 9 Enqueue: 0
-ID: 208 Len: 9 Enqueue: 0
+ID: 208 Len: 0 Enqueue: 0
+ID: 209 Len: 9 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
+ID: 211 Len: 0 Enqueue: 0
+ID: 212 Len: 0 Enqueue: 0
+ID: 213 Len: 0 Enqueue: 0
+ID: 214 Len: 9 Enqueue: 0
+ID: 215 Len: 9 Enqueue: 0
+ID: 216 Len: 0 Enqueue: 0
+ID: 217 Len: 9 Enqueue: 0
+ID: 218 Len: 9 Enqueue: 0

--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 	"unsafe"
@@ -158,7 +159,7 @@ var simpleStringArgExpected = map[string]any{
 
 func simpleStringArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	probe := slices.IndexFunc(irProg.Probes, func(p *ir.Probe) bool {
-		return p.GetID() == "stringArg"
+		return p.GetID() == "stringArg" || strings.HasPrefix(p.GetID(), "testTemplate")
 	})
 	require.NotEqual(t, -1, probe)
 	events := irProg.Probes[probe].Events
@@ -849,4 +850,68 @@ func TestDecoderFailsOnEvaluationErrorAndRetainsPassedBuffer(t *testing.T) {
 	require.Contains(t, string(out), "no decoder type found")
 	require.Equal(t, buf, []byte{1, 2, 3, 4, 5})
 
+}
+
+func TestDecoderWithTemplate(t *testing.T) {
+	testCases := []struct {
+		name             string
+		expectedInOutput string
+		expectedError    error
+		programName      string
+		probeName        string
+		eventGenerator   func(testing.TB, *ir.Program) []byte
+	}{
+		{
+			name:             "testTemplateStringSegment",
+			expectedInOutput: "hello",
+			programName:      "simple",
+			probeName:        "testTemplateStringSegment",
+			eventGenerator:   simpleStringArgEvent,
+		},
+		{
+			name:             "testTemplateMultipleStringSegments",
+			expectedInOutput: "hello world!",
+			programName:      "simple",
+			probeName:        "testTemplateMultipleStringSegments",
+			eventGenerator:   simpleStringArgEvent,
+		},
+		{
+			name:             "testTemplateStringAndDSLSegment",
+			expectedInOutput: "hello abcdefghijklmnop",
+			programName:      "simple",
+			probeName:        "testTemplateStringAndDSLSegment",
+			eventGenerator:   simpleStringArgEvent,
+		},
+		{
+			name:             "testTemplateMultipleDSLSegment",
+			expectedInOutput: "abcdefghijklmnopabcdefghijklmnop",
+			programName:      "simple",
+			probeName:        "testTemplateMultipleDSLSegment",
+			eventGenerator:   simpleStringArgEvent,
+		},
+		{
+			name:             "testTemplateDSLAndStringSegments",
+			expectedInOutput: "hello abcdefghijklmnop, and hello to abcdefghijklmnop",
+			programName:      "simple",
+			probeName:        "testTemplateDSLAndStringSegments",
+			eventGenerator:   simpleStringArgEvent,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			irProg := generateIrForProbes(t, tc.programName, tc.probeName)
+			decoder, err := NewDecoder(irProg, &noopTypeNameResolver{}, time.Now())
+			require.NoError(t, err)
+			input := tc.eventGenerator(t, irProg)
+			output, _, err := decoder.Decode(Event{
+				EntryOrLine: output.Event(input),
+				ServiceName: "foo"},
+				&noopSymbolicator{},
+				[]byte{},
+			)
+			require.Equal(t, tc.expectedError, err)
+			require.Contains(t, string(output), tc.expectedInOutput)
+		})
+	}
 }

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -2,14 +2,18 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
-
 //go:build linux_bpf
 
 package decode
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
@@ -37,6 +41,68 @@ type debuggerData struct {
 type evaluationError struct {
 	Expression string `json:"expr"`
 	Message    string `json:"message"`
+}
+
+type message struct {
+	probe            *ir.Probe
+	captureMap       map[ir.TypeID]*captureEvent
+	evaluationErrors *[]evaluationError
+}
+
+// MarshalJSONTo is used to marshal the expression template of the user specified probe
+// There are two types of segments in the template: string segments and json segments.
+// String segments are string literals and are written directly, while
+// JSON segments are formatted and the result is written to the encoder.
+// The following logic is followed, meant to emulate the behavior of %#v string format:
+//
+// Integers, floats, booleans, strings: Printed as literals in Go syntax.
+// Pointers: Printed as "0x" followed by the hexadecimal representation of the pointer address.
+// Structs: Printed as "typeName{field1: value1, field2: value2, ...}".
+// Arrays: Printed as "[numElements]typeName{element1, element2, ...}".
+// Slices: Printed as "[]slice{element1, element2, ...}".
+// Other types: Printed as "<type name>".
+func (m *message) MarshalJSONTo(enc *jsontext.Encoder) error {
+	var sb strings.Builder
+
+	// Go through each template segment, if its a string, write it directly to the encoder, if its a json segment, process the expression
+	// and write the result to the encoder.
+	for _, seg := range m.probe.Template.Segments {
+		switch segTyped := seg.(type) {
+		case ir.JSONSegment:
+			found := false
+			for k, v := range m.captureMap {
+				if _, ok := segTyped.RootTypeExpressionIndicies[k]; ok {
+					found = true
+					err := v.extractExpressionRawValue(&sb, segTyped.RootTypeExpressionIndicies[k])
+					if err != nil {
+						*v.evaluationErrors = append(*v.evaluationErrors, evaluationError{
+							Expression: segTyped.DSL,
+							Message:    err.Error(),
+						})
+						continue
+					}
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("no capture event found for segment %T", seg)
+			}
+		case ir.StringSegment:
+			if _, err := sb.WriteString(segTyped.Value); err != nil {
+				*m.evaluationErrors = append(*m.evaluationErrors, evaluationError{
+					Expression: segTyped.Value,
+					Message:    err.Error(),
+				})
+				continue
+			}
+		default:
+			*m.evaluationErrors = append(*m.evaluationErrors, evaluationError{
+				Expression: m.probe.Template.TemplateString,
+				Message:    fmt.Sprintf("unsupported segment type: %T", segTyped),
+			})
+		}
+	}
+	return enc.WriteToken(jsontext.String(sb.String()))
 }
 
 type snapshotData struct {
@@ -115,7 +181,7 @@ func (ce *captureEvent) clear() {
 }
 
 func (ce *captureEvent) init(
-	ev output.Event, types map[ir.TypeID]ir.Type, evalErrors *[]evaluationError,
+	ev output.Event, kind ir.EventKind, types map[ir.TypeID]ir.Type, evalErrors *[]evaluationError,
 ) error {
 	var rootType *ir.EventRootType
 	var rootData []byte
@@ -146,6 +212,7 @@ func (ce *captureEvent) init(
 	ce.rootType = rootType
 	ce.rootData = rootData
 	ce.skippedIndices.reset(len(rootType.Expressions))
+	ce.rootType.EventKind = kind
 	ce.evaluationErrors = evalErrors
 	return nil
 }
@@ -165,7 +232,7 @@ func (ce *captureEvent) processExpression(
 	enc *jsontext.Encoder,
 	expr *ir.RootExpression,
 	presenceBitSet bitset,
-	expressionIndex int,
+	expressionIndex int, // Index within the root type expressions
 ) error {
 	parameterType := expr.Expression.Type
 	parameterSize := parameterType.GetByteSize()
@@ -211,15 +278,379 @@ func (ce *captureEvent) processExpression(
 	return nil
 }
 
+// extractExpressionRawValue extracts the raw string value of an expression without JSON encoding
+func (ce *captureEvent) extractExpressionRawValue(sb *strings.Builder, expressionIndex int) error {
+	if expressionIndex >= len(ce.rootType.Expressions) {
+		return fmt.Errorf("expression index %d out of bounds", expressionIndex)
+	}
+	if ce.skippedIndices.get(expressionIndex) {
+		return fmt.Errorf("expression skipped")
+	}
+	expr := ce.rootType.Expressions[expressionIndex]
+	parameterType := expr.Expression.Type
+	parameterSize := parameterType.GetByteSize()
+	ub := expr.Offset + parameterSize
+	if int(ub) > len(ce.rootData) {
+		return fmt.Errorf("could not read parameter data from root data, length mismatch")
+	}
+
+	parameterData := ce.rootData[expr.Offset:ub]
+	presenceBitSet := bitset(ce.rootData[:ce.rootType.PresenceBitsetSize])
+	if !presenceBitSet.get(expressionIndex) && parameterSize != 0 {
+		return fmt.Errorf("expression not captured")
+	}
+
+	// Convert binary data to raw string value based on type
+	decoderType, ok := ce.encodingContext.typesByID[parameterType.GetID()]
+	if !ok {
+		return fmt.Errorf("no decoder type found for type %s", parameterType.GetName())
+	}
+
+	return extractRawValue(sb, decoderType, &ce.encodingContext, parameterData)
+}
+
+// extractRawValue converts binary data to raw string representation and writes it to the builder
+func extractRawValue(sb *strings.Builder, dt decoderType, c *encodingContext, data []byte) error {
+	switch t := dt.(type) {
+	case *baseType:
+		return extractBaseTypeValue(sb, t, data)
+	case *goStringHeaderType:
+		return extractStringValue(sb, t, c, data)
+	case *pointerType:
+		_, err := sb.WriteString("0x" + strconv.FormatUint(binary.NativeEndian.Uint64(data), 16))
+		return err
+	case *structureType:
+		// Format struct fields as readable string
+		return extractStructureTypeValue(sb, t, c, data)
+	case *arrayType:
+		// Format array elements as readable string
+		return extractArrayTypeValue(sb, t, c, data)
+	case *goSliceHeaderType:
+		// Format slice elements as readable string
+		return extractSliceTypeValue(sb, t, c, data)
+	default:
+		// Fallback: write type name for unsupported types
+		_, err := sb.WriteString("<" + dt.irType().GetName() + ">")
+		return err
+	}
+}
+
+func extractStructureTypeValue(sb *strings.Builder, s *structureType, c *encodingContext, data []byte) error {
+	structType := s.irType().(*ir.StructureType)
+	_, err := sb.WriteString(fmt.Sprintf("%s{", structType.GetName()))
+	if err != nil {
+		return err
+	}
+	for field := range structType.Fields() {
+		fieldEnd := field.Offset + field.Type.GetByteSize()
+		if fieldEnd > uint32(len(data)) {
+			// Field extends beyond available data - skip it
+			continue
+		}
+
+		fieldData := data[field.Offset:fieldEnd]
+
+		// Get the decoder type for this field
+		fieldDecoderType, ok := c.typesByID[field.Type.GetID()]
+		if !ok {
+			// Unknown field type - show type name
+			_, err = sb.WriteString(fmt.Sprintf("%s = <%s>", field.Name, field.Type.GetName()))
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Extract the raw value for this field
+		// Format as "fieldName = value"
+		_, err = sb.WriteString(fmt.Sprintf(" %s = ", field.Name))
+		if err != nil {
+			return err
+		}
+		err = extractRawValue(sb, fieldDecoderType, c, fieldData)
+		if err != nil {
+			// Error extracting field - show error
+			_, err = sb.WriteString(fmt.Sprintf("%s = <error: %v>", field.Name, err))
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+	}
+	_, err = sb.WriteString(" }")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// extractArrayTypeValue formats array elements as a readable string: "[element1, element2, ...]"
+func extractArrayTypeValue(sb *strings.Builder, a *arrayType, c *encodingContext, data []byte) error {
+	arrayType := a.irType().(*ir.ArrayType)
+	elementSize := int(arrayType.Element.GetByteSize())
+	numElements := int(arrayType.Count)
+
+	// Limit output for very large arrays
+	maxElementsToShow := 10
+	if numElements > maxElementsToShow {
+		numElements = maxElementsToShow
+	}
+
+	// Get the decoder type for array elements
+	elementDecoderType, ok := c.typesByID[arrayType.Element.GetID()]
+	if !ok {
+		_, err := sb.WriteString(fmt.Sprintf("[%d]<%s>", arrayType.Count, arrayType.Element.GetName()))
+		return err
+	}
+
+	_, err := sb.WriteString(fmt.Sprintf("[%d]%s{", arrayType.Count, arrayType.Element.GetName()))
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < numElements; i++ {
+		offset := i * elementSize
+		endIdx := offset + elementSize
+		if endIdx > len(data) {
+			break
+		}
+
+		elementData := data[offset:endIdx]
+		err = extractRawValue(sb, elementDecoderType, c, elementData)
+		if err != nil {
+			return err
+		}
+		if i < numElements-1 {
+			_, err = sb.WriteString(", ")
+			if err != nil {
+				return err
+			}
+		}
+	}
+	_, err = sb.WriteString("}")
+	return err
+}
+
+// extractSliceTypeValue formats slice elements as a readable string: "[element1, element2, ...]"
+func extractSliceTypeValue(sb *strings.Builder, s *goSliceHeaderType, c *encodingContext, data []byte) error {
+	sliceType := s.irType().(*ir.GoSliceHeaderType)
+	if len(data) < 16 {
+		return errors.New("data too short for slice")
+	}
+	// Extract slice header: pointer (8 bytes) + length (8 bytes) + capacity (8 bytes)
+	address := binary.NativeEndian.Uint64(data[0:8])
+	length := binary.NativeEndian.Uint64(data[8:16])
+
+	if address == 0 || length == 0 {
+		return errors.New("slice address or length is 0")
+	}
+
+	// Get the slice data
+	sliceDataItem, ok := c.dataItems[typeAndAddr{
+		irType: uint32(sliceType.Data.GetID()),
+		addr:   address,
+	}]
+	if !ok {
+		return fmt.Errorf("slice data item not found at address %#x with len %d", address, length)
+	}
+
+	sliceData, ok := sliceDataItem.Data()
+	if !ok {
+		return fmt.Errorf("slice data item marked as failed read")
+	}
+
+	elementSize := int(sliceType.Data.Element.GetByteSize())
+	sliceLength := int(len(sliceData)) / elementSize
+
+	// Limit output for very large slices
+	maxElementsToShow := 10
+	if sliceLength > maxElementsToShow {
+		sliceLength = maxElementsToShow
+	}
+
+	// Get the decoder type for slice elements
+	elementDecoderType, ok := c.typesByID[sliceType.Data.Element.GetID()]
+	if !ok {
+		return fmt.Errorf("no decoder type found for slice element type %s", sliceType.Data.Element.GetName())
+	}
+
+	_, err := sb.WriteString(fmt.Sprintf("[]%s{", sliceType.Data.Element.GetName()))
+	if err != nil {
+		return err
+	}
+	elementByteSize := int(sliceType.Data.Element.GetByteSize())
+	for i := 0; i < sliceLength; i++ {
+		elementData := sliceData[i*elementByteSize : (i+1)*elementByteSize]
+		err := extractRawValue(sb, elementDecoderType, c, elementData)
+		if err != nil {
+			return fmt.Errorf("error extracting raw value for slice element %d: %w", i, err)
+		}
+
+		if i < sliceLength-1 {
+			_, err = sb.WriteString(", ")
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	_, err = sb.WriteString("}")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// extractBaseTypeValue converts base type binary data to string
+func extractBaseTypeValue(sb *strings.Builder, b *baseType, data []byte) error {
+	kind, ok := (*ir.BaseType)(b).GetGoKind()
+	if !ok {
+		return fmt.Errorf("no go kind for type %s", (*ir.BaseType)(b).GetName())
+	}
+	var err error
+	switch kind {
+	case reflect.Bool:
+		if len(data) < 1 {
+			return errors.New("data too short for bool")
+		}
+		if data[0] == 1 {
+			_, err = sb.WriteString("true")
+			return err
+		}
+		_, err = sb.WriteString("false")
+		return err
+	case reflect.Int, reflect.Int64:
+		if len(data) < 8 {
+			return errors.New("data too short for int64")
+		}
+		val := int64(binary.NativeEndian.Uint64(data))
+		_, err = sb.WriteString(strconv.FormatInt(val, 10))
+		return err
+	case reflect.Int32:
+		if len(data) < 4 {
+			return errors.New("data too short for int32")
+		}
+		val := int32(binary.NativeEndian.Uint32(data))
+		_, err = sb.WriteString(strconv.FormatInt(int64(val), 10))
+		return err
+
+	case reflect.Int16:
+		if len(data) < 2 {
+			return errors.New("data too short for int16")
+		}
+		val := int16(binary.NativeEndian.Uint16(data))
+		_, err = sb.WriteString(strconv.FormatInt(int64(val), 10))
+		return err
+
+	case reflect.Int8:
+		if len(data) < 1 {
+			return errors.New("data too short for int8")
+		}
+		val := int8(data[0])
+		_, err = sb.WriteString(strconv.FormatInt(int64(val), 10))
+		return err
+
+	case reflect.Uint, reflect.Uint64:
+		if len(data) < 8 {
+			return errors.New("data too short for uint64")
+		}
+		val := binary.NativeEndian.Uint64(data)
+		_, err = sb.WriteString(strconv.FormatUint(val, 10))
+		return err
+
+	case reflect.Uint32:
+		if len(data) < 4 {
+			return errors.New("data too short for uint32")
+		}
+		val := binary.NativeEndian.Uint32(data)
+		_, err = sb.WriteString(strconv.FormatUint(uint64(val), 10))
+		return err
+
+	case reflect.Uint16:
+		if len(data) < 2 {
+			return errors.New("data too short for uint16")
+		}
+		val := binary.NativeEndian.Uint16(data)
+		_, err = sb.WriteString(strconv.FormatUint(uint64(val), 10))
+		return err
+
+	case reflect.Uint8:
+		if len(data) < 1 {
+			return errors.New("data too short for uint8")
+		}
+		_, err = sb.WriteString(strconv.FormatUint(uint64(data[0]), 10))
+		return err
+
+	case reflect.Float32:
+		if len(data) < 4 {
+			return errors.New("data too short for float32")
+		}
+		bits := binary.NativeEndian.Uint32(data)
+		val := math.Float32frombits(bits)
+		_, err = sb.WriteString(strconv.FormatFloat(float64(val), 'g', -1, 32))
+		return err
+
+	case reflect.Float64:
+		if len(data) < 8 {
+			return errors.New("data too short for float64")
+		}
+		bits := binary.NativeEndian.Uint64(data)
+		val := math.Float64frombits(bits)
+		_, err = sb.WriteString(strconv.FormatFloat(val, 'g', -1, 64))
+		return err
+
+	case reflect.String:
+		// Go strings are not stored as baseType, this shouldn't happen
+		_, err = sb.WriteString(string(data))
+		return err
+
+	default:
+		return fmt.Errorf("unsupported base type kind: %v", kind)
+	}
+}
+
+// extractStringValue extracts string value from Go string header
+func extractStringValue(sb *strings.Builder, s *goStringHeaderType, c *encodingContext, data []byte) error {
+	fieldEnd := s.strFieldOffset + uint32(s.strFieldSize)
+	if fieldEnd >= uint32(len(data)) {
+		return nil
+	}
+	strLen := binary.NativeEndian.Uint64(data[s.lenFieldOffset : s.lenFieldOffset+uint32(s.lenFieldSize)])
+	address := binary.NativeEndian.Uint64(data[s.strFieldOffset : s.strFieldOffset+uint32(s.strFieldSize)])
+	if address == 0 || strLen == 0 {
+		return nil
+	}
+	stringValue, ok := c.dataItems[typeAndAddr{
+		irType: uint32(s.GoStringHeaderType.Data.GetID()),
+		addr:   address,
+	}]
+	if !ok {
+		return nil
+	}
+	stringData, ok := stringValue.Data()
+	if !ok {
+		return nil
+	}
+	if len(stringData) < int(strLen) {
+		return nil
+	}
+
+	_, err := sb.WriteString(string(stringData[:strLen]))
+	return err
+}
+
 func (ce *captureEvent) MarshalJSONTo(enc *jsontext.Encoder) error {
+	if err := writeTokens(enc, jsontext.BeginObject); err != nil {
+		return err
+	}
+
 	if ce.rootType.PresenceBitsetSize > uint32(len(ce.rootData)) {
 		return errors.New("presence bitset is out of bounds")
 	}
 	presenceBitSet := ce.rootData[:ce.rootType.PresenceBitsetSize]
 
-	if err := writeTokens(enc, jsontext.BeginObject); err != nil {
-		return err
-	}
 	for _, kind := range []struct {
 		kind  ir.RootExpressionKind
 		token jsontext.Token
@@ -228,7 +659,7 @@ func (ce *captureEvent) MarshalJSONTo(enc *jsontext.Encoder) error {
 		{kind: ir.RootExpressionKindLocal, token: jsontext.String("locals")},
 	} {
 		// We iterate over the 'Expressions' of the EventRoot which contains
-		// metadata and raw bytes of the parameters of this function.
+		// metadata and raw bytes of the variables of this function.
 		var haveKind bool
 		for i, expr := range ce.rootType.Expressions {
 			if expr.Kind != kind.kind {
@@ -293,14 +724,15 @@ func (sd *stackData) MarshalJSONTo(enc *jsontext.Encoder) error {
 type stackLine gosym.GoLocation
 
 func (sl *stackLine) MarshalJSONTo(enc *jsontext.Encoder) error {
+	goLoc := (*gosym.GoLocation)(sl)
 	if err := writeTokens(enc,
 		jsontext.BeginObject,
 		jsontext.String("function"),
-		jsontext.String(sl.Function),
+		jsontext.String(goLoc.Function),
 		jsontext.String("fileName"),
-		jsontext.String(sl.File),
+		jsontext.String(goLoc.File),
 		jsontext.String("lineNumber"),
-		jsontext.Int(int64(sl.Line)),
+		jsontext.Int(int64(goLoc.Line)),
 		jsontext.EndObject,
 	); err != nil {
 		return err

--- a/pkg/dyninst/decode/marshal_test.go
+++ b/pkg/dyninst/decode/marshal_test.go
@@ -1,0 +1,536 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package decode
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+)
+
+// mockUnsupportedSegment embeds a JSONSegment but we'll cast it to a different type
+// to test the unsupported segment error path
+type mockUnsupportedSegment struct {
+	ir.JSONSegment
+}
+
+// createMockUnsupportedSegment creates a segment that will trigger the unsupported type error
+func createMockUnsupportedSegment() ir.TemplateSegment {
+	return &mockUnsupportedSegment{
+		JSONSegment: ir.JSONSegment{
+			RootTypeExpressionIndicies: map[ir.TypeID]int{
+				0: 0,
+			},
+		},
+	}
+}
+
+func TestMessageMarshalJSONToErrorPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupMessage    func() *message
+		expectedErrors  []string
+		shouldWriteJSON bool
+	}{
+		{
+			name: "extractExpressionRawValue_index_out_of_bounds",
+			setupMessage: func() *message {
+				evaluationErrors := make([]evaluationError, 0)
+				capEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						TypeCommon: ir.TypeCommon{
+							ID: 0,
+						},
+						Expressions: make([]*ir.RootExpression, 0), // empty expressions
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{RootTypeExpressionIndicies: map[ir.TypeID]int{0: 0}}, // index 0 but no expressions
+						},
+					},
+				}
+
+				return &message{
+					probe: probe,
+					captureMap: map[ir.TypeID]*captureEvent{
+						0: capEvent,
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+			},
+			expectedErrors:  []string{"expression index 0 out of bounds"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "extractExpressionRawValue_expression_skipped",
+			setupMessage: func() *message {
+				evaluationErrors := make([]evaluationError, 0)
+				capEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						TypeCommon: ir.TypeCommon{
+							ID: 0,
+						},
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:   1,
+											Name: "int",
+										},
+									},
+								},
+								Offset: 0,
+							},
+						},
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+				// Mark expression as skipped
+				capEvent.skippedIndices.reset(1)
+				capEvent.skippedIndices.set(0)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{RootTypeExpressionIndicies: map[ir.TypeID]int{0: 0}},
+						},
+					},
+				}
+
+				return &message{
+					probe:            probe,
+					captureMap:       map[ir.TypeID]*captureEvent{0: capEvent},
+					evaluationErrors: &evaluationErrors,
+				}
+			},
+			expectedErrors:  []string{"expression skipped"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "extractExpressionRawValue_length_mismatch",
+			setupMessage: func() *message {
+				evaluationErrors := make([]evaluationError, 0)
+				capEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						TypeCommon: ir.TypeCommon{
+							ID: 0,
+						},
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:       1,
+											Name:     "int64",
+											ByteSize: 8,
+										},
+									},
+								},
+								Offset: 10, // offset 10 + size 8 = 18, but rootData is only 5 bytes
+							},
+						},
+					},
+					rootData:         make([]byte, 5), // Not enough data
+					evaluationErrors: &evaluationErrors,
+				}
+				capEvent.skippedIndices.reset(1)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{RootTypeExpressionIndicies: map[ir.TypeID]int{0: 0}},
+						},
+					},
+				}
+
+				return &message{
+					probe:            probe,
+					captureMap:       map[ir.TypeID]*captureEvent{0: capEvent},
+					evaluationErrors: &evaluationErrors,
+				}
+			},
+			expectedErrors:  []string{"could not read parameter data from root data, length mismatch"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "extractExpressionRawValue_expression_not_captured",
+			setupMessage: func() *message {
+				evaluationErrors := make([]evaluationError, 0)
+				capEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						TypeCommon: ir.TypeCommon{
+							ID: 0,
+						},
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:       1,
+											Name:     "int64",
+											ByteSize: 8,
+										},
+									},
+								},
+								Offset: 8,
+							},
+						},
+						PresenceBitsetSize: 1,
+					},
+					rootData:         make([]byte, 16),
+					evaluationErrors: &evaluationErrors,
+				}
+				// Set presence bitset to indicate expression not captured (bit 0 = false)
+				capEvent.rootData[0] = 0x00
+				capEvent.skippedIndices.reset(1)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{RootTypeExpressionIndicies: map[ir.TypeID]int{0: 0}},
+						},
+					},
+				}
+
+				return &message{
+					probe: probe,
+					captureMap: map[ir.TypeID]*captureEvent{
+						0: capEvent,
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+			},
+			expectedErrors:  []string{"expression not captured"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "extractExpressionRawValue_no_decoder_type",
+			setupMessage: func() *message {
+				evaluationErrors := make([]evaluationError, 0)
+				capEvent := &captureEvent{
+					encodingContext: encodingContext{
+						typesByID: make(map[ir.TypeID]decoderType), // empty, so type won't be found
+					},
+					rootType: &ir.EventRootType{
+						TypeCommon: ir.TypeCommon{
+							ID: 0,
+						},
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:       999,
+											Name:     "unknown_type",
+											ByteSize: 8,
+										},
+									},
+								},
+								Offset: 8,
+							},
+						},
+						PresenceBitsetSize: 1,
+					},
+					rootData:         make([]byte, 16),
+					evaluationErrors: &evaluationErrors,
+				}
+				// Set presence bitset to indicate expression captured (bit 0 = true)
+				capEvent.rootData[0] = 0x01
+				capEvent.skippedIndices.reset(1)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{
+								RootTypeExpressionIndicies: map[ir.TypeID]int{0: 0},
+							},
+						},
+					},
+				}
+
+				return &message{
+					probe: probe,
+					captureMap: map[ir.TypeID]*captureEvent{
+						0: capEvent,
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+			},
+			expectedErrors:  []string{"no decoder type found for type unknown_type"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "string_segment_writestring_error",
+			setupMessage: func() *message {
+				evaluationErrors := make([]evaluationError, 0)
+				capEvent := &captureEvent{
+					evaluationErrors: &evaluationErrors,
+				}
+				// Create a string segment with a normal value since strings.Builder.WriteString rarely fails
+				// We're mainly testing that the error handling path works correctly
+				normalString := "test string value"
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.StringSegment{Value: normalString},
+						},
+					},
+				}
+
+				return &message{
+					probe: probe,
+					captureMap: map[ir.TypeID]*captureEvent{
+						0: capEvent,
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+			},
+			expectedErrors:  []string{}, // WriteString unlikely to fail, but test the path
+			shouldWriteJSON: true,
+		},
+		{
+			name: "unsupported_segment_type",
+			setupMessage: func() *message {
+				evaluationErrors := make([]evaluationError, 0)
+				capEvent := &captureEvent{
+					evaluationErrors: &evaluationErrors,
+				}
+
+				// We'll simulate the unsupported segment type error by creating a segment
+				// that satisfies the interface but gets handled as an unexpected type
+				// We'll create this in a helper that returns an interface{} cast to our mock type
+				mockSegment := createMockUnsupportedSegment()
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							mockSegment,
+						},
+					},
+				}
+
+				return &message{
+					probe: probe,
+					captureMap: map[ir.TypeID]*captureEvent{
+						0: capEvent,
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+			},
+			expectedErrors:  []string{"unsupported segment type: *decode.mockUnsupportedSegment"},
+			shouldWriteJSON: true,
+		},
+		{
+			name: "multiple_errors_mixed",
+			setupMessage: func() *message {
+				evaluationErrors := make([]evaluationError, 0)
+				capEvent := &captureEvent{
+					rootType: &ir.EventRootType{
+						TypeCommon: ir.TypeCommon{
+							ID: 0,
+						},
+						Expressions: []*ir.RootExpression{
+							{
+								Name: "arg1",
+								Expression: ir.Expression{
+									Type: &ir.BaseType{
+										TypeCommon: ir.TypeCommon{
+											ID:       1,
+											Name:     "int64",
+											ByteSize: 8,
+										},
+									},
+								},
+								Offset: 10, // Will cause length mismatch
+							},
+						},
+					},
+					rootData:         make([]byte, 5), // Not enough data
+					evaluationErrors: &evaluationErrors,
+				}
+				capEvent.skippedIndices.reset(1)
+
+				probe := &ir.Probe{
+					Template: &ir.Template{
+						Segments: []ir.TemplateSegment{
+							ir.JSONSegment{RootTypeExpressionIndicies: map[ir.TypeID]int{0: 0}}, // Will fail with length mismatch
+							ir.StringSegment{Value: "test"},                                     // Should succeed
+							createMockUnsupportedSegment(),                                      // Will fail with unsupported type
+							ir.JSONSegment{RootTypeExpressionIndicies: map[ir.TypeID]int{0: 1}}, // Will fail with out of bounds
+						},
+					},
+				}
+
+				return &message{
+					probe: probe,
+					captureMap: map[ir.TypeID]*captureEvent{
+						0: capEvent,
+					},
+					evaluationErrors: &evaluationErrors,
+				}
+			},
+			expectedErrors: []string{
+				"could not read parameter data from root data, length mismatch",
+				"unsupported segment type: *decode.mockUnsupportedSegment",
+				"expression index 1 out of bounds",
+			},
+			shouldWriteJSON: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			message := tt.setupMessage()
+
+			var buf strings.Builder
+			enc := jsontext.NewEncoder(&buf)
+
+			err := message.MarshalJSONTo(enc)
+
+			if tt.shouldWriteJSON {
+				// Should not return error - errors are added to evaluationErrors instead
+				assert.NoError(t, err, "MarshalJSONTo should not return error")
+			} else {
+				assert.Error(t, err, "Expected MarshalJSONTo to return error")
+			}
+
+			// Check that expected errors were added to evaluationErrors
+			require.NotNil(t, message.evaluationErrors)
+			actualErrors := *message.evaluationErrors
+
+			assert.Len(t, actualErrors, len(tt.expectedErrors), "Number of evaluation errors should match")
+			for i, expectedError := range tt.expectedErrors {
+				if i < len(actualErrors) {
+					assert.Contains(t, actualErrors[i].Message, expectedError, "Error message should contain expected text")
+				}
+			}
+
+			// Verify JSON was written (even with errors)
+			if tt.shouldWriteJSON {
+				jsonOutput := buf.String()
+				assert.NotEmpty(t, jsonOutput, "JSON should be written even with evaluation errors")
+
+				// The MarshalJSONTo method produces a JSON string token
+				// Expected format examples:
+				// - Empty string: "\"\"\n"
+				// - With content: "\"test string value\"\n"
+				assert.True(t, strings.HasPrefix(jsonOutput, `"`), "Should start with quote (JSON string)")
+				assert.True(t, strings.HasSuffix(jsonOutput, "\n"), "Should end with newline")
+
+				// The tests are working correctly - the main goal is to verify that
+				// evaluation errors are properly captured, not the exact JSON format
+			}
+		})
+	}
+}
+
+func TestMessageMarshalJSONToSuccessPath(t *testing.T) {
+	// Test successful marshaling to ensure our error tests don't break valid functionality
+	evaluationErrors := make([]evaluationError, 0)
+
+	// Create a working base type decoder
+	irBaseType := ir.BaseType{
+		TypeCommon: ir.TypeCommon{
+			ID:       1,
+			Name:     "int64",
+			ByteSize: 8,
+		},
+		GoTypeAttributes: ir.GoTypeAttributes{
+			GoKind: reflect.Int64,
+		},
+	}
+	baseTypeDecoder := (*baseType)(&irBaseType)
+
+	capEvent := &captureEvent{
+		encodingContext: encodingContext{
+			typesByID: map[ir.TypeID]decoderType{
+				1: baseTypeDecoder,
+			},
+		},
+		rootType: &ir.EventRootType{
+			TypeCommon: ir.TypeCommon{
+				ID: 1,
+			},
+			Expressions: []*ir.RootExpression{
+				{
+					Name: "arg1",
+					Expression: ir.Expression{
+						Type: &ir.BaseType{
+							TypeCommon: ir.TypeCommon{
+								ID:       1,
+								Name:     "int64",
+								ByteSize: 8,
+							},
+							GoTypeAttributes: ir.GoTypeAttributes{
+								GoKind: reflect.Int64,
+							},
+						},
+					},
+					Offset: 8,
+				},
+			},
+			PresenceBitsetSize: 1,
+		},
+		rootData:         make([]byte, 16),
+		evaluationErrors: &evaluationErrors,
+	}
+	// Set presence bitset to indicate expression captured (bit 0 = true)
+	capEvent.rootData[0] = 0x01
+	// Set the int64 value at offset 8 (little endian)
+	capEvent.rootData[8] = 42
+	capEvent.skippedIndices.reset(1)
+
+	probe := &ir.Probe{
+		Template: &ir.Template{
+			Segments: []ir.TemplateSegment{
+				ir.StringSegment{Value: "Value: "},
+				ir.JSONSegment{RootTypeExpressionIndicies: map[ir.TypeID]int{1: 0}},
+				ir.StringSegment{Value: " (end)"},
+			},
+		},
+	}
+
+	message := &message{
+		probe: probe,
+		captureMap: map[ir.TypeID]*captureEvent{
+			1: capEvent,
+		},
+		evaluationErrors: &evaluationErrors,
+	}
+
+	var buf strings.Builder
+	enc := jsontext.NewEncoder(&buf)
+
+	err := message.MarshalJSONTo(enc)
+	assert.NoError(t, err)
+
+	// Should have no evaluation errors for successful case
+	assert.Empty(t, evaluationErrors)
+
+	jsonOutput := buf.String()
+	assert.NotEmpty(t, jsonOutput)
+
+	// Should contain the template segments
+	// Note: The actual output format depends on extractRawValue implementation
+	assert.Contains(t, jsonOutput, "Value: ")
+	assert.Contains(t, jsonOutput, " (end)")
+}

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"unsafe"
 
-	"github.com/dustin/go-humanize"
 	"github.com/go-json-experiment/json/jsontext"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
@@ -31,6 +30,8 @@ import (
 // value types.
 type decoderType interface {
 	irType() ir.Type
+	// encodeValueFields is meant to encode the json fields of the type,
+	// including "value", "type", etc...
 	encodeValueFields(
 		c *encodingContext,
 		enc *jsontext.Encoder,
@@ -420,46 +421,55 @@ func (b *baseType) encodeValueFields(
 	); err != nil {
 		return err
 	}
-	kind, ok := b.GetGoKind()
+	kind, ok := (*ir.BaseType)(b).GetGoKind()
 	if !ok {
-		return fmt.Errorf("no go kind for type %s (ID: %d)", b.GetName(), b.GetID())
+		return fmt.Errorf("no go kind for type %s (ID: %d)", (*ir.BaseType)(b).GetName(), (*ir.BaseType)(b).GetID())
 	}
 	switch kind {
 	case reflect.Bool:
 		if len(data) < 1 {
 			return errors.New("passed data not long enough for bool")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatBool(data[0] == 1)))
+		if data[0] == 1 {
+			return writeTokens(enc, jsontext.String("true"))
+		}
+		return writeTokens(enc, jsontext.String("false"))
 	case reflect.Int:
 		if len(data) < 8 {
 			return errors.New("passed data not long enough for int")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatInt(int64(binary.NativeEndian.Uint64(data)), 10)))
+		val := int64(binary.NativeEndian.Uint64(data))
+		return writeTokens(enc, jsontext.String(strconv.FormatInt(val, 10)))
 	case reflect.Int8:
 		if len(data) < 1 {
 			return errors.New("passed data not long enough for int8")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatInt(int64(int8(data[0])), 10)))
+		val := int64(int8(data[0]))
+		return writeTokens(enc, jsontext.String(strconv.FormatInt(val, 10)))
 	case reflect.Int16:
 		if len(data) < 2 {
 			return errors.New("passed data not long enough for int16")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatInt(int64(int16(binary.NativeEndian.Uint16(data))), 10)))
+		val := int64(int16(binary.NativeEndian.Uint16(data)))
+		return writeTokens(enc, jsontext.String(strconv.FormatInt(val, 10)))
 	case reflect.Int32:
 		if len(data) != 4 {
 			return errors.New("passed data not long enough for int32")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatInt(int64(int32(binary.NativeEndian.Uint32(data))), 10)))
+		val := int64(int32(binary.NativeEndian.Uint32(data)))
+		return writeTokens(enc, jsontext.String(strconv.FormatInt(val, 10)))
 	case reflect.Int64:
 		if len(data) != 8 {
 			return errors.New("passed data not long enough for int64")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatInt(int64(binary.NativeEndian.Uint64(data)), 10)))
+		val := int64(binary.NativeEndian.Uint64(data))
+		return writeTokens(enc, jsontext.String(strconv.FormatInt(val, 10)))
 	case reflect.Uint:
 		if len(data) != 8 {
 			return errors.New("passed data not long enough for uint")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatUint(binary.NativeEndian.Uint64(data), 10)))
+		val := binary.NativeEndian.Uint64(data)
+		return writeTokens(enc, jsontext.String(strconv.FormatUint(val, 10)))
 	case reflect.Uint8:
 		if len(data) != 1 {
 			return errors.New("passed data not long enough for uint8")
@@ -469,32 +479,40 @@ func (b *baseType) encodeValueFields(
 		if len(data) != 2 {
 			return errors.New("passed data not long enough for uint16")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatUint(uint64(binary.NativeEndian.Uint16(data)), 10)))
+		val := uint64(binary.NativeEndian.Uint16(data))
+		return writeTokens(enc, jsontext.String(strconv.FormatUint(val, 10)))
 	case reflect.Uint32:
 		if len(data) != 4 {
 			return errors.New("passed data not long enough for uint32")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatUint(uint64(binary.NativeEndian.Uint32(data)), 10)))
+		val := uint64(binary.NativeEndian.Uint32(data))
+		return writeTokens(enc, jsontext.String(strconv.FormatUint(val, 10)))
 	case reflect.Uint64:
 		if len(data) != 8 {
 			return errors.New("passed data not long enough for uint64")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatUint(binary.NativeEndian.Uint64(data), 10)))
+		val := binary.NativeEndian.Uint64(data)
+		return writeTokens(enc, jsontext.String(strconv.FormatUint(val, 10)))
 	case reflect.Uintptr:
 		if len(data) != 8 {
 			return errors.New("passed data not long enough for uintptr")
 		}
-		return writeTokens(enc, jsontext.String("0x"+strconv.FormatUint(binary.NativeEndian.Uint64(data), 16)))
+		val := binary.NativeEndian.Uint64(data)
+		return writeTokens(enc, jsontext.String(strconv.FormatUint(val, 10)))
 	case reflect.Float32:
 		if len(data) != 4 {
 			return errors.New("passed data not long enough for float32")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatFloat(float64(math.Float32frombits(binary.NativeEndian.Uint32(data))), 'f', -1, 64)))
+		bits := binary.NativeEndian.Uint32(data)
+		val := math.Float32frombits(bits)
+		return writeTokens(enc, jsontext.String(strconv.FormatFloat(float64(val), 'g', -1, 32)))
 	case reflect.Float64:
 		if len(data) != 8 {
 			return errors.New("passed data not long enough for float64")
 		}
-		return writeTokens(enc, jsontext.String(strconv.FormatFloat(math.Float64frombits(binary.NativeEndian.Uint64(data)), 'f', -1, 64)))
+		bits := binary.NativeEndian.Uint64(data)
+		val := math.Float64frombits(bits)
+		return writeTokens(enc, jsontext.String(strconv.FormatFloat(val, 'g', -1, 64)))
 	case reflect.Complex64:
 		if len(data) != 8 {
 			return errors.New("passed data not long enough for complex64")
@@ -533,7 +551,7 @@ func (m *goMapType) encodeValueFields(
 	data []byte,
 ) error {
 	const encodeAddress = false
-	return encodePointer(c, data, encodeAddress, m.HeaderType.GetID(), enc)
+	return encodePointer(c, data, encodeAddress, (*ir.GoMapType)(m).HeaderType.GetID(), enc)
 }
 
 func (h *goHMapHeaderType) irType() ir.Type { return h.GoHMapHeaderType }
@@ -629,7 +647,7 @@ func encodeHMapBucket(
 	if upperBound > uint32(len(bucketData)) {
 		return encodedItems, fmt.Errorf(
 			"hmap bucket data for %q is too short to contain all fields: %d > %d",
-			h.Name, upperBound, len(bucketData),
+			h.GoHMapHeaderType.Name, upperBound, len(bucketData),
 		)
 	}
 	topHash := bucketData[h.tophashOfset : h.tophashOfset+topHashSize]
@@ -740,7 +758,7 @@ func (s *goSwissMapHeaderType) encodeValueFields(
 	} else {
 		// This is a 'large' swiss map where there are multiple groups of data/control words
 		// We need to collect the data items for the table pointers first.
-		tablePtrSliceDataItem, ok := c.getPtr(dirPtr, s.TablePtrSliceType.GetID())
+		tablePtrSliceDataItem, ok := c.getPtr(dirPtr, s.GoSwissMapHeaderType.TablePtrSliceType.GetID())
 		if !ok {
 			return writeTokens(enc,
 				tokenNotCapturedReason,
@@ -782,6 +800,7 @@ func (s *goSwissMapGroupsType) encodeValueFields(
 	enc *jsontext.Encoder,
 	_ []byte,
 ) error {
+	// Unimplemented as we encode based on the goSwissMapHeaderType
 	return writeTokens(enc,
 		tokenNotCapturedReason,
 		tokenNotCapturedReasonUnimplemented,
@@ -794,13 +813,15 @@ func (v *voidPointerType) encodeValueFields(
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
+	if err := writeTokens(enc,
+		jsontext.String("address"),
+	); err != nil {
+		return err
+	}
 	if len(data) != 8 {
 		return errors.New("passed data not long enough for void pointer")
 	}
-	return writeTokens(enc,
-		jsontext.String("address"),
-		jsontext.String("0x"+strconv.FormatUint(binary.NativeEndian.Uint64(data), 16)),
-	)
+	return writeTokens(enc, jsontext.String("0x"+strconv.FormatUint(binary.NativeEndian.Uint64(data), 16)))
 }
 
 func (p *pointerType) irType() ir.Type { return (*ir.PointerType)(p) }
@@ -815,9 +836,9 @@ func (p *pointerType) encodeValueFields(
 	//
 	// For things like map buckets or channel internals, which we encode as pointers, we won't
 	// find a go kind.
-	goKind, ok := p.Pointee.GetGoKind()
+	goKind, ok := (*ir.PointerType)(p).Pointee.GetGoKind()
 	writeAddress := ok && goKind != reflect.Pointer
-	return encodePointer(c, data, writeAddress, p.Pointee.GetID(), enc)
+	return encodePointer(c, data, writeAddress, (*ir.PointerType)(p).Pointee.GetID(), enc)
 }
 
 func encodePointer(
@@ -909,7 +930,10 @@ func (s *structureType) encodeValueFields(
 ) error {
 	if err := writeTokens(enc,
 		jsontext.String("fields"),
-		jsontext.BeginObject); err != nil {
+	); err != nil {
+		return err
+	}
+	if err := writeTokens(enc, jsontext.BeginObject); err != nil {
 		return err
 	}
 	for field := range s.irType().(*ir.StructureType).Fields() {
@@ -941,8 +965,8 @@ func (a *arrayType) encodeValueFields(
 	data []byte,
 ) error {
 	var err error
-	elementSize := int(a.Element.GetByteSize())
-	numElements := int(a.Count)
+	elementSize := int((*ir.ArrayType)(a).Element.GetByteSize())
+	numElements := int((*ir.ArrayType)(a).Count)
 	if err = writeTokens(enc,
 		jsontext.String("size"),
 		jsontext.String(strconv.FormatInt(int64(numElements), 10)),
@@ -952,8 +976,8 @@ func (a *arrayType) encodeValueFields(
 	}
 
 	var notCaptured = false
-	elementID := a.Element.GetID()
-	elementName := a.Element.GetName()
+	elementID := (*ir.ArrayType)(a).Element.GetID()
+	elementName := (*ir.ArrayType)(a).Element.GetName()
 	for i := range numElements {
 		offset := i * elementSize
 		endIdx := offset + elementSize
@@ -983,7 +1007,7 @@ func (s *goSliceHeaderType) irType() ir.Type { return (*ir.GoSliceHeaderType)(s)
 func (s *goSliceHeaderType) encodeValueFields(
 	c *encodingContext, enc *jsontext.Encoder, data []byte,
 ) error {
-	if len(data) < int(s.ByteSize) {
+	if len(data) < int((*ir.GoSliceHeaderType)(s).ByteSize) {
 		return writeTokens(enc,
 			tokenNotCapturedReason,
 			tokenNotCapturedReasonPruned,
@@ -1016,11 +1040,11 @@ func (s *goSliceHeaderType) encodeValueFields(
 		return err
 	}
 
-	elementSize := int(s.Data.Element.GetByteSize())
+	elementSize := int((*ir.GoSliceHeaderType)(s).Data.Element.GetByteSize())
 	var sliceData []byte
 	var sliceLength int
 	if elementSize > 0 {
-		sliceDataItem, ok := c.getPtr(address, s.Data.GetID())
+		sliceDataItem, ok := c.getPtr(address, (*ir.GoSliceHeaderType)(s).Data.GetID())
 		if !ok {
 			return writeTokens(enc,
 				tokenNotCapturedReason,
@@ -1043,9 +1067,9 @@ func (s *goSliceHeaderType) encodeValueFields(
 		jsontext.BeginArray); err != nil {
 		return err
 	}
-	elementByteSize := int(s.Data.Element.GetByteSize())
-	elementName := s.Data.Element.GetName()
-	elementID := s.Data.Element.GetID()
+	elementByteSize := int((*ir.GoSliceHeaderType)(s).Data.Element.GetByteSize())
+	elementName := (*ir.GoSliceHeaderType)(s).Data.Element.GetName()
+	elementID := (*ir.GoSliceHeaderType)(s).Data.Element.GetID()
 	for i := range int(sliceLength) {
 		var elementData []byte
 		if elementSize > 0 {
@@ -1055,8 +1079,8 @@ func (s *goSliceHeaderType) encodeValueFields(
 			c, enc, elementID, elementData, elementName,
 		); err != nil {
 			return fmt.Errorf(
-				"could not encode %s slice element of %s: %w",
-				humanize.Ordinal(i+1), elementName, err,
+				"could not encode slice element %d of %s: %w",
+				i+1, elementName, err,
 			)
 		}
 	}
@@ -1106,7 +1130,7 @@ func (s *goStringHeaderType) encodeValueFields(
 			jsontext.String(""),
 		)
 	}
-	stringValue, ok := c.getPtr(address, s.Data.GetID())
+	stringValue, ok := c.getPtr(address, s.GoStringHeaderType.Data.GetID())
 	if !ok {
 		return writeTokens(enc,
 			jsontext.String("size"),

--- a/pkg/dyninst/exprlang/exprlang.go
+++ b/pkg/dyninst/exprlang/exprlang.go
@@ -69,10 +69,10 @@ func Parse(dslJSON []byte) (Expr, error) {
 	}
 	pooled := getPooledDecoder(dslJSON)
 	defer pooled.put()
-	decoder := pooled.decoder
+	dec := pooled.decoder
 
 	// Ensure we have a JSON object
-	objStart, err := decoder.ReadToken()
+	objStart, err := dec.ReadToken()
 	if err != nil {
 		return nil, fmt.Errorf("parse error: failed to read token: %w", err)
 	}
@@ -81,7 +81,7 @@ func Parse(dslJSON []byte) (Expr, error) {
 	}
 
 	// Read the operation key
-	key, err := decoder.ReadToken()
+	key, err := dec.ReadToken()
 	if err != nil {
 		return nil, fmt.Errorf("parse error: failed to read operation key: %w", err)
 	}
@@ -92,32 +92,45 @@ func Parse(dslJSON []byte) (Expr, error) {
 	operation := key.String()
 	switch operation {
 	case "ref":
-		return parseRefExpr(decoder)
+		// Read the ref value
+		val, err := dec.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read ref value: %w", err)
+		}
+		if kind := val.Kind(); kind != '"' {
+			return nil, fmt.Errorf("parse error: malformed ref: got value token %v (%v), expected string", val, kind)
+		}
+
+		refValue := val.String()
+		if refValue == "" {
+			return nil, fmt.Errorf("parse error: ref value cannot be empty")
+		}
+
+		// Read the closing brace
+		endObj, err := dec.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
+		}
+		if kind := endObj.Kind(); kind != '}' {
+			return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected }", endObj, kind)
+		}
+
+		return &RefExpr{Ref: refValue}, nil
 	default:
 		// Read the argument for unsupported operations
-		arg, err := decoder.ReadToken()
+		arg, err := dec.ReadToken()
 		if err != nil {
 			return nil, fmt.Errorf("parse error: failed to read argument: %w", err)
 		}
 
-		// Extract the argument value before reading more tokens
-		var argument jsontext.Value
-		switch arg.Kind() {
-		case '"':
-			argument = jsontext.Value(arg.String())
-		case 'n':
-			argument = jsontext.Value(nil)
-		case 't', 'f':
-			argument = jsontext.Value(arg.String())
-		case '0':
-			// For numbers in unsupported expressions, store as string
-			argument = jsontext.Value(arg.String())
-		default:
-			argument = jsontext.Value(arg.String())
+		// Extract the argument value before the token gets voided
+		var argValue jsontext.Value
+		if arg.Kind() != 'n' { // not null
+			argValue = jsontext.Value(arg.String())
 		}
 
 		// Read the closing brace
-		endObj, err := decoder.ReadToken()
+		endObj, err := dec.ReadToken()
 		if err != nil {
 			return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
 		}
@@ -127,36 +140,9 @@ func Parse(dslJSON []byte) (Expr, error) {
 
 		return &UnsupportedExpr{
 			operation: operation,
-			argument:  argument,
+			argument:  argValue,
 		}, nil
 	}
-}
-
-func parseRefExpr(dec *jsontext.Decoder) (*RefExpr, error) {
-	// Read the value token
-	val, err := dec.ReadToken()
-	if err != nil {
-		return nil, fmt.Errorf("parse error: failed to read ref value: %w", err)
-	}
-	if kind := val.Kind(); kind != '"' {
-		return nil, fmt.Errorf("parse error: malformed ref: got value token %v (%v), expected string", val, kind)
-	}
-
-	refValue := val.String()
-	if refValue == "" {
-		return nil, fmt.Errorf("parse error: ref value cannot be empty")
-	}
-
-	// Read the closing brace
-	endObj, err := dec.ReadToken()
-	if err != nil {
-		return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
-	}
-	if kind := endObj.Kind(); kind != '}' {
-		return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected }", endObj, kind)
-	}
-
-	return &RefExpr{Ref: refValue}, nil
 }
 
 // IsSupported returns true if the expression uses only supported DSL features.

--- a/pkg/dyninst/exprlang/exprlang.go
+++ b/pkg/dyninst/exprlang/exprlang.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package exprlang provides utilities for parsing and working with expressions
+// in the expression language of the dynamic instrumentation and live debugger products.
+package exprlang
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// Expr represents an expression in the DSL.
+type Expr interface {
+	expr() // marker method
+}
+
+// RefExpr represents a reference to a variable.
+type RefExpr struct {
+	Ref string
+}
+
+func (re *RefExpr) expr() {}
+
+// UnsupportedExpr represents an expression type that is not yet supported.
+type UnsupportedExpr struct {
+	operation string
+	argument  jsontext.Value
+}
+
+func (ue *UnsupportedExpr) expr() {}
+
+// Parse parses a DSL JSON expression into a strongly-typed AST node.
+func Parse(dslJSON []byte) (Expr, error) {
+	if len(dslJSON) == 0 {
+		return nil, fmt.Errorf("parse error: empty DSL expression")
+	}
+	dec := jsontext.NewDecoder(bytes.NewReader(dslJSON))
+	// Ensure we have a JSON object
+	objStart, err := dec.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("parse error: failed to read token: %w", err)
+	}
+	if kind := objStart.Kind(); kind != '{' {
+		return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected {", objStart, kind)
+	}
+
+	// Read the operation key
+	key, err := dec.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("parse error: failed to read operation key: %w", err)
+	}
+	if kind := key.Kind(); kind != '"' {
+		return nil, fmt.Errorf("parse error: malformed DSL: got key token %v (%v), expected string", key, kind)
+	}
+
+	operation := key.String()
+	switch operation {
+	case "ref":
+		return parseRefExpr(dec)
+	default:
+		// Read the argument for unsupported operations
+		arg, err := dec.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read argument: %w", err)
+		}
+
+		// Extract the argument value before reading more tokens
+		var argument jsontext.Value
+		switch arg.Kind() {
+		case '"':
+			argument = jsontext.Value(arg.String())
+		case 'n':
+			argument = jsontext.Value(nil)
+		case 't', 'f':
+			argument = jsontext.Value(arg.String())
+		case '0':
+			// For numbers in unsupported expressions, store as string
+			argument = jsontext.Value(arg.String())
+		default:
+			argument = jsontext.Value(arg.String())
+		}
+
+		// Read the closing brace
+		endObj, err := dec.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
+		}
+		if kind := endObj.Kind(); kind != '}' {
+			return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected }", endObj, kind)
+		}
+
+		return &UnsupportedExpr{
+			operation: operation,
+			argument:  argument,
+		}, nil
+	}
+}
+
+func parseRefExpr(dec *jsontext.Decoder) (*RefExpr, error) {
+	// Read the value token
+	val, err := dec.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("parse error: failed to read ref value: %w", err)
+	}
+	if kind := val.Kind(); kind != '"' {
+		return nil, fmt.Errorf("parse error: malformed ref: got value token %v (%v), expected string", val, kind)
+	}
+
+	refValue := val.String()
+	if refValue == "" {
+		return nil, fmt.Errorf("parse error: ref value cannot be empty")
+	}
+
+	// Read the closing brace
+	endObj, err := dec.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
+	}
+	if kind := endObj.Kind(); kind != '}' {
+		return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected }", endObj, kind)
+	}
+
+	return &RefExpr{Ref: refValue}, nil
+}
+
+// IsSupported returns true if the expression uses only supported DSL features.
+func IsSupported(expr Expr) bool {
+	switch expr.(type) {
+	case *RefExpr:
+		return true
+	case *UnsupportedExpr:
+		return false
+	default:
+		return false
+	}
+}

--- a/pkg/dyninst/exprlang/exprlang_test.go
+++ b/pkg/dyninst/exprlang/exprlang_test.go
@@ -8,166 +8,254 @@
 package exprlang
 
 import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
+	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParse(t *testing.T) {
-	testCases := []struct {
-		name      string
-		input     string
-		wantExpr  Expr
-		wantError bool
-	}{
-		{
-			name:  "valid ref expression",
-			input: `{"ref": "s"}`,
-			wantExpr: &RefExpr{
-				Ref: "s",
-			},
-		},
-		{
-			name:  "valid ref with complex variable name",
-			input: `{"ref": "myVariable123"}`,
-			wantExpr: &RefExpr{
-				Ref: "myVariable123",
-			},
-		},
-		{
-			name:      "empty ref value",
-			input:     `{"ref": ""}`,
-			wantError: true,
-		},
-		{
-			name:  "unsupported instruction with string arg",
-			input: `{"foo": "bar"}`,
-			wantExpr: &UnsupportedExpr{
-				operation: "foo",
-				argument:  jsontext.Value("bar"),
-			},
-		},
-		{
-			name:  "unsupported instruction with number arg",
-			input: `{"add": 42}`,
-			wantExpr: &UnsupportedExpr{
-				operation: "add",
-				argument:  jsontext.Value("42"),
-			},
-		},
-		{
-			name:  "unsupported instruction with bool arg",
-			input: `{"enabled": true}`,
-			wantExpr: &UnsupportedExpr{
-				operation: "enabled",
-				argument:  jsontext.Value(jsontext.True.String()),
-			},
-		},
-		{
-			name:  "unsupported instruction with null arg",
-			input: `{"value": null}`,
-			wantExpr: &UnsupportedExpr{
-				operation: "value",
-				argument:  nil,
-			},
-		},
-		{
-			name:      "empty expression",
-			input:     `{}`,
-			wantError: true,
-		},
-		{
-			name:      "malformed JSON",
-			input:     `{"ref": "}`,
-			wantError: true,
-		},
-		{
-			name:      "not an object",
-			input:     `"ref"`,
-			wantError: true,
-		},
-		{
-			name:      "empty input",
-			input:     "",
-			wantError: true,
-		},
-		{
-			name:      "ref with non-string value",
-			input:     `{"ref": 123}`,
-			wantError: true,
-		},
+//go:embed testdata
+var testdataFS embed.FS
+
+var testCases = []struct {
+	name  string
+	input string
+}{
+	{
+		name:  "valid ref expression",
+		input: `{"ref": "s"}`,
+	},
+	{
+		name:  "valid ref with complex variable name",
+		input: `{"ref": "myVariable123"}`,
+	},
+	{
+		name:  "empty ref value",
+		input: `{"ref": ""}`,
+	},
+	{
+		name:  "unsupported instruction with string arg",
+		input: `{"foo": "bar"}`,
+	},
+	{
+		name:  "unsupported instruction with number arg",
+		input: `{"add": 42}`,
+	},
+	{
+		name:  "unsupported instruction with bool arg",
+		input: `{"enabled": true}`,
+	},
+	{
+		name:  "unsupported instruction with null arg",
+		input: `{"value": null}`,
+	},
+	{
+		name:  "empty expression",
+		input: `{}`,
+	},
+	{
+		name:  "malformed JSON",
+		input: `{"ref": "}`,
+	},
+	{
+		name:  "not an object",
+		input: `"ref"`,
+	},
+	{
+		name:  "empty input",
+		input: "",
+	},
+	{
+		name:  "ref with non-string value",
+		input: `{"ref": 123}`,
+	},
+	// Test simple references (supported)
+	{name: "ref hits", input: `{"ref": "hits"}`},
+	{name: "ref @it", input: `{"ref": "@it"}`},
+	{name: "ref @value", input: `{"ref": "@value"}`},
+	{name: "ref @key", input: `{"ref": "@key"}`},
+	// Test unsupported operations with simple values
+	{name: "isDefined", input: `{"isDefined": "foobar"}`},
+	{name: "not with bool", input: `{"not": true}`},
+	// Nested/complex structures (will fail to parse with current simple parser)
+	// The current parser only handles single-level {"operation": value} structures
+	{name: "len of ref", input: `{"len": {"ref": "payload"}}`},
+	{name: "len of getmember", input: `{"len": {"getmember": [{"ref": "self"}, "collectionField"]}}`},
+	{name: "getmember", input: `{"getmember": [{"ref": "self"}, "name"]}`},
+	{name: "nested getmember", input: `{"getmember": [{"getmember": [{"ref": "self"}, "field1"]}, "name"]}`},
+	{name: "index array", input: `{"index": [{"ref": "arr"}, 1]}`},
+	{name: "index dict", input: `{"index": [{"ref": "dict"}, "world"]}`},
+	{name: "contains", input: `{"contains": [{"ref": "payload"}, "hello"]}`},
+	{name: "eq with bool", input: `{"eq": [{"ref": "hits"}, true]}`},
+	{name: "eq with null", input: `{"eq": [{"ref": "hits"}, null]}`},
+	{name: "substring", input: `{"substring": [{"ref": "payload"}, 4, 7]}`},
+	{name: "any with isEmpty", input: `{"any": [{"ref": "collection"}, {"isEmpty": {"ref": "@it"}}]}`},
+	{name: "any with @value", input: `{"any": [{"ref": "coll"}, {"isEmpty": {"ref": "@value"}}]}`},
+	{name: "any with @key", input: `{"any": [{"ref": "coll"}, {"isEmpty": {"ref": "@key"}}]}`},
+	{name: "startsWith", input: `{"startsWith": [{"ref": "local_string"}, "hello"]}`},
+	{name: "filter", input: `{"filter": [{"ref": "collection"}, {"not": {"isEmpty": {"ref": "@it"}}}]}`},
+	{name: "matches", input: `{"matches": [{"ref": "payload"}, "[0-9]+"]}`},
+	{name: "or", input: `{"or": [{"ref": "bar"}, {"ref": "foo"}]}`},
+	{name: "and", input: `{"and": [{"ref": "bar"}, {"ref": "foo"}]}`},
+	{name: "instanceof", input: `{"instanceof": [{"ref": "bar"}, "int"]}`},
+	{name: "isEmpty", input: `{"isEmpty": {"ref": "empty_str"}}`},
+	{name: "ne", input: `{"ne": [1, 2]}`},
+	{name: "gt", input: `{"gt": [2, 1]}`},
+	{name: "ge", input: `{"ge": [2, 1]}`},
+	{name: "lt", input: `{"lt": [1, 2]}`},
+	{name: "le", input: `{"le": [1, 2]}`},
+	{name: "all", input: `{"all": [{"ref": "collection"}, {"not": {"isEmpty": {"ref": "@it"}}}]}`},
+	{name: "endsWith", input: `{"endsWith": [{"ref": "local_string"}, "world!"]}`},
+	{name: "len of filter", input: `{"len": {"filter": [{"ref": "collection"}, {"gt": [{"ref": "@it"}, 1]}]}}`},
+	{name: "deeply nested getmember", input: `{"getmember": [{"getmember": [{"getmember": [{"ref": "self"}, "field1"]}, "field2"]}, "name"]}`},
+	{name: "any with nested ops", input: `{"any": [{"getmember": [{"ref": "self"}, "collectionField"]}, {"startsWith": [{"getmember": [{"ref": "@it"}, "name"]}, "foo"]}]}`},
+	{name: "and with eq and gt", input: `{"and": [{"eq": [{"ref": "hits"}, 42]}, {"gt": [{"len": {"ref": "payload"}}, 5]}]}`},
+	{name: "index of filter", input: `{"index": [{"filter": [{"ref": "collection"}, {"gt": [{"ref": "@it"}, 2]}]}, 0]}`},
+	{name: "count", input: `{"count": {"ref": "payload"}}`},
+	{name: "substring negative", input: `{"substring": [{"ref": "s"}, -5, -1]}`},
+	{name: "nested filter with any", input: `{"len": {"filter": [{"ref": "collection"}, {"any": [{"ref": "@it"}, {"eq": [{"ref": "@it"}, 1]}]}]}}`},
+	// Test literal values (these should also fail - not objects)
+	{name: "literal int", input: `42`},
+	{name: "literal bool", input: `true`},
+}
+
+// exprResult represents the result of parsing an expression for storage in JSON.
+type exprResult struct {
+	Type      string          `json:"type"` // "ref", "unsupported", or "error"
+	Ref       string          `json:"ref"`  // Ref value (used for ref expressions)
+	Operation string          `json:"operation"`
+	Argument  json.RawMessage `json:"argument"` // Raw json argument (used for unsupported expressions)
+	Error     string          `json:"error"`
+}
+
+func exprToResult(expr Expr, err error) exprResult {
+	if err != nil {
+		return exprResult{Type: "error", Error: err.Error()}
 	}
+	switch e := expr.(type) {
+	case *RefExpr:
+		return exprResult{Type: "ref", Ref: e.Ref}
+	case *UnsupportedExpr:
+		return exprResult{Type: "unsupported", Operation: e.Operation, Argument: json.RawMessage(e.Argument)}
+	default:
+		return exprResult{Type: "error", Error: "unknown expression type"}
+	}
+}
+
+// sanitizeTestName converts a test name to a safe filename by replacing spaces
+// and special characters.
+func sanitizeTestName(testName string) string {
+	// Replace spaces with underscores
+	name := strings.ReplaceAll(testName, " ", "_")
+	// Replace @ with "at"
+	name = strings.ReplaceAll(name, "@", "at")
+	// Remove other special characters that might cause issues
+	name = strings.ReplaceAll(name, "/", "_")
+	name = strings.ReplaceAll(name, "\\", "_")
+	return name
+}
+
+func getExpectedOutputFilename(testName string) string {
+	return filepath.Join("testdata", sanitizeTestName(testName)+".json")
+}
+
+func loadExpectedOutput(testName string) (exprResult, error) {
+	filename := getExpectedOutputFilename(testName)
+	content, err := testdataFS.ReadFile(filename)
+	if err != nil {
+		return exprResult{}, fmt.Errorf("reading %s: %w", filename, err)
+	}
+	var result exprResult
+	if err := json.Unmarshal(content, &result); err != nil {
+		return exprResult{}, fmt.Errorf("unmarshalling %s: %w", filename, err)
+	}
+	return result, nil
+}
+
+func saveActualOutput(testName string, result exprResult) error {
+	filename := getExpectedOutputFilename(testName)
+	outputDir := filepath.Dir(filename)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("error creating testdata directory: %w", err)
+	}
+
+	marshaled, err := jsonv2.Marshal(
+		result,
+		jsontext.WithIndent("  "),
+		jsontext.EscapeForHTML(false),
+		jsontext.EscapeForJS(false),
+	)
+	if err != nil {
+		return fmt.Errorf("error marshalling result: %w", err)
+	}
+
+	baseName := filepath.Base(filename)
+	tmpFile, err := os.CreateTemp(outputDir, "."+baseName+".*.tmp.json")
+	if err != nil {
+		return fmt.Errorf("error creating temp output file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := io.Copy(tmpFile, bytes.NewReader(marshaled)); err != nil {
+		return fmt.Errorf("error writing temp output: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("error closing temp output: %w", err)
+	}
+	if err := os.Rename(tmpName, filename); err != nil {
+		return fmt.Errorf("error renaming temp output: %w", err)
+	}
+	return nil
+}
+
+func TestParse(t *testing.T) {
+	rewrite, _ := strconv.ParseBool(os.Getenv("REWRITE"))
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			expr, err := Parse([]byte(tc.input))
+			actualResult := exprToResult(expr, err)
 
-			if tc.wantError {
-				require.Error(t, err)
-				require.Nil(t, expr)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tc.wantExpr, expr)
+			if rewrite {
+				// In rewrite mode, save the actual output
+				if saveErr := saveActualOutput(tc.name, actualResult); saveErr != nil {
+					t.Logf("error saving actual output for test %s: %v", tc.name, saveErr)
+				} else {
+					t.Logf("output saved to: %s", getExpectedOutputFilename(tc.name))
+				}
+				return
+			}
+
+			// Load expected output from JSON and compare
+			expectedResult, loadErr := loadExpectedOutput(tc.name)
+			require.NoError(t, loadErr, "failed to load expected output for test %s", tc.name)
+
+			// Compare results
+			require.Equal(t, expectedResult.Type, actualResult.Type, "expression type mismatch")
+			require.Equal(t, expectedResult.Operation, actualResult.Operation, "operation mismatch")
+			require.Equal(t, expectedResult.Error, actualResult.Error, "error mismatch")
+			switch expr.(type) {
+			case *RefExpr:
+				require.Equal(t, expectedResult.Ref, actualResult.Ref, "ref value mismatch")
+			case *UnsupportedExpr:
+				require.JSONEq(t, string(expectedResult.Argument), string(actualResult.Argument), "argument mismatch")
 			}
 		})
 	}
 }
 
-func TestIsSupported(t *testing.T) {
-	testCases := []struct {
-		name          string
-		expr          Expr
-		wantSupported bool
-	}{
-		{
-			name:          "ref expression is supported",
-			expr:          &RefExpr{Ref: "s"},
-			wantSupported: true,
-		},
-		{
-			name:          "unsupported expression",
-			expr:          &UnsupportedExpr{operation: "foo", argument: jsontext.Value("bar")},
-			wantSupported: false,
-		},
-		{
-			name:          "nil expression",
-			expr:          nil,
-			wantSupported: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			supported := IsSupported(tc.expr)
-			require.Equal(t, tc.wantSupported, supported)
-		})
-	}
-}
-
 func BenchmarkParse(b *testing.B) {
-	testCases := []struct {
-		name  string
-		input string
-	}{
-		{
-			name:  "simple_ref",
-			input: `{"ref": "s"}`,
-		},
-		{
-			name:  "long_ref",
-			input: `{"ref": "thisIsAVeryLongVariableNameThatMightBeUsedInRealWorld"}`,
-		},
-		{
-			name:  "unsupported_string",
-			input: `{"add": "someValue"}`,
-		},
-		{
-			name:  "unsupported_number",
-			input: `{"multiply": 42}`,
-		},
-	}
-
 	for _, tc := range testCases {
 		input := []byte(tc.input)
 
@@ -180,40 +268,6 @@ func BenchmarkParse(b *testing.B) {
 				}
 				_ = expr
 			}
-		})
-	}
-}
-
-// BenchmarkParseParallel tests performance under concurrent load
-func BenchmarkParseParallel(b *testing.B) {
-	testCases := []struct {
-		name  string
-		input string
-	}{
-		{
-			name:  "simple_ref",
-			input: `{"ref": "s"}`,
-		},
-		{
-			name:  "unsupported_string",
-			input: `{"add": "someValue"}`,
-		},
-	}
-
-	for _, tc := range testCases {
-		input := []byte(tc.input)
-
-		b.Run(tc.name, func(b *testing.B) {
-			b.ReportAllocs()
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
-					expr, err := Parse(input)
-					if err != nil {
-						b.Fatal(err)
-					}
-					_ = expr
-				}
-			})
 		})
 	}
 }

--- a/pkg/dyninst/exprlang/exprlang_test.go
+++ b/pkg/dyninst/exprlang/exprlang_test.go
@@ -1,0 +1,219 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package exprlang
+
+import (
+	"testing"
+
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		wantExpr  Expr
+		wantError bool
+	}{
+		{
+			name:  "valid ref expression",
+			input: `{"ref": "s"}`,
+			wantExpr: &RefExpr{
+				Ref: "s",
+			},
+		},
+		{
+			name:  "valid ref with complex variable name",
+			input: `{"ref": "myVariable123"}`,
+			wantExpr: &RefExpr{
+				Ref: "myVariable123",
+			},
+		},
+		{
+			name:      "empty ref value",
+			input:     `{"ref": ""}`,
+			wantError: true,
+		},
+		{
+			name:  "unsupported instruction with string arg",
+			input: `{"foo": "bar"}`,
+			wantExpr: &UnsupportedExpr{
+				operation: "foo",
+				argument:  jsontext.Value("bar"),
+			},
+		},
+		{
+			name:  "unsupported instruction with number arg",
+			input: `{"add": 42}`,
+			wantExpr: &UnsupportedExpr{
+				operation: "add",
+				argument:  jsontext.Value("42"),
+			},
+		},
+		{
+			name:  "unsupported instruction with bool arg",
+			input: `{"enabled": true}`,
+			wantExpr: &UnsupportedExpr{
+				operation: "enabled",
+				argument:  jsontext.Value(jsontext.True.String()),
+			},
+		},
+		{
+			name:  "unsupported instruction with null arg",
+			input: `{"value": null}`,
+			wantExpr: &UnsupportedExpr{
+				operation: "value",
+				argument:  nil,
+			},
+		},
+		{
+			name:      "empty expression",
+			input:     `{}`,
+			wantError: true,
+		},
+		{
+			name:      "malformed JSON",
+			input:     `{"ref": "}`,
+			wantError: true,
+		},
+		{
+			name:      "not an object",
+			input:     `"ref"`,
+			wantError: true,
+		},
+		{
+			name:      "empty input",
+			input:     "",
+			wantError: true,
+		},
+		{
+			name:      "ref with non-string value",
+			input:     `{"ref": 123}`,
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := Parse([]byte(tc.input))
+
+			if tc.wantError {
+				require.Error(t, err)
+				require.Nil(t, expr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantExpr, expr)
+			}
+		})
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	testCases := []struct {
+		name          string
+		expr          Expr
+		wantSupported bool
+	}{
+		{
+			name:          "ref expression is supported",
+			expr:          &RefExpr{Ref: "s"},
+			wantSupported: true,
+		},
+		{
+			name:          "unsupported expression",
+			expr:          &UnsupportedExpr{operation: "foo", argument: jsontext.Value("bar")},
+			wantSupported: false,
+		},
+		{
+			name:          "nil expression",
+			expr:          nil,
+			wantSupported: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			supported := IsSupported(tc.expr)
+			require.Equal(t, tc.wantSupported, supported)
+		})
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "simple_ref",
+			input: `{"ref": "s"}`,
+		},
+		{
+			name:  "long_ref",
+			input: `{"ref": "thisIsAVeryLongVariableNameThatMightBeUsedInRealWorld"}`,
+		},
+		{
+			name:  "unsupported_string",
+			input: `{"add": "someValue"}`,
+		},
+		{
+			name:  "unsupported_number",
+			input: `{"multiply": 42}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		input := []byte(tc.input)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				expr, err := Parse(input)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = expr
+			}
+		})
+	}
+}
+
+// BenchmarkParseParallel tests performance under concurrent load
+func BenchmarkParseParallel(b *testing.B) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "simple_ref",
+			input: `{"ref": "s"}`,
+		},
+		{
+			name:  "unsupported_string",
+			input: `{"add": "someValue"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		input := []byte(tc.input)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					expr, err := Parse(input)
+					if err != nil {
+						b.Fatal(err)
+					}
+					_ = expr
+				}
+			})
+		})
+	}
+}

--- a/pkg/dyninst/exprlang/testdata/.gitkeep
+++ b/pkg/dyninst/exprlang/testdata/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the testdata directory is not empty
+

--- a/pkg/dyninst/exprlang/testdata/all.json
+++ b/pkg/dyninst/exprlang/testdata/all.json
@@ -1,0 +1,18 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "all",
+  "argument": [
+    {
+      "ref": "collection"
+    },
+    {
+      "not": {
+        "isEmpty": {
+          "ref": "@it"
+        }
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/and.json
+++ b/pkg/dyninst/exprlang/testdata/and.json
@@ -1,0 +1,14 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "and",
+  "argument": [
+    {
+      "ref": "bar"
+    },
+    {
+      "ref": "foo"
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/and_with_eq_and_gt.json
+++ b/pkg/dyninst/exprlang/testdata/and_with_eq_and_gt.json
@@ -1,0 +1,26 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "and",
+  "argument": [
+    {
+      "eq": [
+        {
+          "ref": "hits"
+        },
+        42
+      ]
+    },
+    {
+      "gt": [
+        {
+          "len": {
+            "ref": "payload"
+          }
+        },
+        5
+      ]
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/any_with_atkey.json
+++ b/pkg/dyninst/exprlang/testdata/any_with_atkey.json
@@ -1,0 +1,16 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "any",
+  "argument": [
+    {
+      "ref": "coll"
+    },
+    {
+      "isEmpty": {
+        "ref": "@key"
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/any_with_atvalue.json
+++ b/pkg/dyninst/exprlang/testdata/any_with_atvalue.json
@@ -1,0 +1,16 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "any",
+  "argument": [
+    {
+      "ref": "coll"
+    },
+    {
+      "isEmpty": {
+        "ref": "@value"
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/any_with_isEmpty.json
+++ b/pkg/dyninst/exprlang/testdata/any_with_isEmpty.json
@@ -1,0 +1,16 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "any",
+  "argument": [
+    {
+      "ref": "collection"
+    },
+    {
+      "isEmpty": {
+        "ref": "@it"
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/any_with_nested_ops.json
+++ b/pkg/dyninst/exprlang/testdata/any_with_nested_ops.json
@@ -1,0 +1,29 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "any",
+  "argument": [
+    {
+      "getmember": [
+        {
+          "ref": "self"
+        },
+        "collectionField"
+      ]
+    },
+    {
+      "startsWith": [
+        {
+          "getmember": [
+            {
+              "ref": "@it"
+            },
+            "name"
+          ]
+        },
+        "foo"
+      ]
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/contains.json
+++ b/pkg/dyninst/exprlang/testdata/contains.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "contains",
+  "argument": [
+    {
+      "ref": "payload"
+    },
+    "hello"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/count.json
+++ b/pkg/dyninst/exprlang/testdata/count.json
@@ -1,0 +1,9 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "count",
+  "argument": {
+    "ref": "payload"
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/deeply_nested_getmember.json
+++ b/pkg/dyninst/exprlang/testdata/deeply_nested_getmember.json
@@ -1,0 +1,22 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "getmember",
+  "argument": [
+    {
+      "getmember": [
+        {
+          "getmember": [
+            {
+              "ref": "self"
+            },
+            "field1"
+          ]
+        },
+        "field2"
+      ]
+    },
+    "name"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/empty_expression.json
+++ b/pkg/dyninst/exprlang/testdata/empty_expression.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "ref": "",
+  "operation": "",
+  "argument": null,
+  "error": "parse error: malformed DSL: got key token } (}), expected string"
+}

--- a/pkg/dyninst/exprlang/testdata/empty_input.json
+++ b/pkg/dyninst/exprlang/testdata/empty_input.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "ref": "",
+  "operation": "",
+  "argument": null,
+  "error": "parse error: empty DSL expression"
+}

--- a/pkg/dyninst/exprlang/testdata/empty_ref_value.json
+++ b/pkg/dyninst/exprlang/testdata/empty_ref_value.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "ref": "",
+  "operation": "",
+  "argument": null,
+  "error": "parse error: ref value cannot be empty"
+}

--- a/pkg/dyninst/exprlang/testdata/endsWith.json
+++ b/pkg/dyninst/exprlang/testdata/endsWith.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "endsWith",
+  "argument": [
+    {
+      "ref": "local_string"
+    },
+    "world!"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/eq_with_bool.json
+++ b/pkg/dyninst/exprlang/testdata/eq_with_bool.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "eq",
+  "argument": [
+    {
+      "ref": "hits"
+    },
+    true
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/eq_with_null.json
+++ b/pkg/dyninst/exprlang/testdata/eq_with_null.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "eq",
+  "argument": [
+    {
+      "ref": "hits"
+    },
+    null
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/filter.json
+++ b/pkg/dyninst/exprlang/testdata/filter.json
@@ -1,0 +1,18 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "filter",
+  "argument": [
+    {
+      "ref": "collection"
+    },
+    {
+      "not": {
+        "isEmpty": {
+          "ref": "@it"
+        }
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ge.json
+++ b/pkg/dyninst/exprlang/testdata/ge.json
@@ -1,0 +1,10 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "ge",
+  "argument": [
+    2,
+    1
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/getmember.json
+++ b/pkg/dyninst/exprlang/testdata/getmember.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "getmember",
+  "argument": [
+    {
+      "ref": "self"
+    },
+    "name"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/gt.json
+++ b/pkg/dyninst/exprlang/testdata/gt.json
@@ -1,0 +1,10 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "gt",
+  "argument": [
+    2,
+    1
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/index_array.json
+++ b/pkg/dyninst/exprlang/testdata/index_array.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "index",
+  "argument": [
+    {
+      "ref": "arr"
+    },
+    1
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/index_dict.json
+++ b/pkg/dyninst/exprlang/testdata/index_dict.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "index",
+  "argument": [
+    {
+      "ref": "dict"
+    },
+    "world"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/index_of_filter.json
+++ b/pkg/dyninst/exprlang/testdata/index_of_filter.json
@@ -1,0 +1,24 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "index",
+  "argument": [
+    {
+      "filter": [
+        {
+          "ref": "collection"
+        },
+        {
+          "gt": [
+            {
+              "ref": "@it"
+            },
+            2
+          ]
+        }
+      ]
+    },
+    0
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/instanceof.json
+++ b/pkg/dyninst/exprlang/testdata/instanceof.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "instanceof",
+  "argument": [
+    {
+      "ref": "bar"
+    },
+    "int"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/isDefined.json
+++ b/pkg/dyninst/exprlang/testdata/isDefined.json
@@ -1,0 +1,7 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "isDefined",
+  "argument": "foobar",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/isEmpty.json
+++ b/pkg/dyninst/exprlang/testdata/isEmpty.json
@@ -1,0 +1,9 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "isEmpty",
+  "argument": {
+    "ref": "empty_str"
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/le.json
+++ b/pkg/dyninst/exprlang/testdata/le.json
@@ -1,0 +1,10 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "le",
+  "argument": [
+    1,
+    2
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/len_of_filter.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_filter.json
@@ -1,0 +1,21 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "len",
+  "argument": {
+    "filter": [
+      {
+        "ref": "collection"
+      },
+      {
+        "gt": [
+          {
+            "ref": "@it"
+          },
+          1
+        ]
+      }
+    ]
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/len_of_getmember.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_getmember.json
@@ -1,0 +1,14 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "len",
+  "argument": {
+    "getmember": [
+      {
+        "ref": "self"
+      },
+      "collectionField"
+    ]
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/len_of_ref.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_ref.json
@@ -1,0 +1,9 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "len",
+  "argument": {
+    "ref": "payload"
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/literal_bool.json
+++ b/pkg/dyninst/exprlang/testdata/literal_bool.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "ref": "",
+  "operation": "",
+  "argument": null,
+  "error": "parse error: malformed DSL: got token true (true), expected {"
+}

--- a/pkg/dyninst/exprlang/testdata/literal_int.json
+++ b/pkg/dyninst/exprlang/testdata/literal_int.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "ref": "",
+  "operation": "",
+  "argument": null,
+  "error": "parse error: malformed DSL: got token 42 (number), expected {"
+}

--- a/pkg/dyninst/exprlang/testdata/lt.json
+++ b/pkg/dyninst/exprlang/testdata/lt.json
@@ -1,0 +1,10 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "lt",
+  "argument": [
+    1,
+    2
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/malformed_JSON.json
+++ b/pkg/dyninst/exprlang/testdata/malformed_JSON.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "ref": "",
+  "operation": "",
+  "argument": null,
+  "error": "parse error: failed to read ref value: jsontext: unexpected EOF within \"/ref\" after offset 10"
+}

--- a/pkg/dyninst/exprlang/testdata/matches.json
+++ b/pkg/dyninst/exprlang/testdata/matches.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "matches",
+  "argument": [
+    {
+      "ref": "payload"
+    },
+    "[0-9]+"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ne.json
+++ b/pkg/dyninst/exprlang/testdata/ne.json
@@ -1,0 +1,10 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "ne",
+  "argument": [
+    1,
+    2
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/nested_filter_with_any.json
+++ b/pkg/dyninst/exprlang/testdata/nested_filter_with_any.json
@@ -1,0 +1,28 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "len",
+  "argument": {
+    "filter": [
+      {
+        "ref": "collection"
+      },
+      {
+        "any": [
+          {
+            "ref": "@it"
+          },
+          {
+            "eq": [
+              {
+                "ref": "@it"
+              },
+              1
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/nested_getmember.json
+++ b/pkg/dyninst/exprlang/testdata/nested_getmember.json
@@ -1,0 +1,17 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "getmember",
+  "argument": [
+    {
+      "getmember": [
+        {
+          "ref": "self"
+        },
+        "field1"
+      ]
+    },
+    "name"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/not_an_object.json
+++ b/pkg/dyninst/exprlang/testdata/not_an_object.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "ref": "",
+  "operation": "",
+  "argument": null,
+  "error": "parse error: malformed DSL: got token ref (string), expected {"
+}

--- a/pkg/dyninst/exprlang/testdata/not_with_bool.json
+++ b/pkg/dyninst/exprlang/testdata/not_with_bool.json
@@ -1,0 +1,7 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "not",
+  "argument": true,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/or.json
+++ b/pkg/dyninst/exprlang/testdata/or.json
@@ -1,0 +1,14 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "or",
+  "argument": [
+    {
+      "ref": "bar"
+    },
+    {
+      "ref": "foo"
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_atit.json
+++ b/pkg/dyninst/exprlang/testdata/ref_atit.json
@@ -1,0 +1,7 @@
+{
+  "type": "ref",
+  "ref": "@it",
+  "operation": "",
+  "argument": null,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_atkey.json
+++ b/pkg/dyninst/exprlang/testdata/ref_atkey.json
@@ -1,0 +1,7 @@
+{
+  "type": "ref",
+  "ref": "@key",
+  "operation": "",
+  "argument": null,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_atvalue.json
+++ b/pkg/dyninst/exprlang/testdata/ref_atvalue.json
@@ -1,0 +1,7 @@
+{
+  "type": "ref",
+  "ref": "@value",
+  "operation": "",
+  "argument": null,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_hits.json
+++ b/pkg/dyninst/exprlang/testdata/ref_hits.json
@@ -1,0 +1,7 @@
+{
+  "type": "ref",
+  "ref": "hits",
+  "operation": "",
+  "argument": null,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_with_non-string_value.json
+++ b/pkg/dyninst/exprlang/testdata/ref_with_non-string_value.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "ref": "",
+  "operation": "",
+  "argument": null,
+  "error": "parse error: malformed ref: got value token 123 (number), expected string"
+}

--- a/pkg/dyninst/exprlang/testdata/startsWith.json
+++ b/pkg/dyninst/exprlang/testdata/startsWith.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "startsWith",
+  "argument": [
+    {
+      "ref": "local_string"
+    },
+    "hello"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/substring.json
+++ b/pkg/dyninst/exprlang/testdata/substring.json
@@ -1,0 +1,13 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "substring",
+  "argument": [
+    {
+      "ref": "payload"
+    },
+    4,
+    7
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/substring_negative.json
+++ b/pkg/dyninst/exprlang/testdata/substring_negative.json
@@ -1,0 +1,13 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "substring",
+  "argument": [
+    {
+      "ref": "s"
+    },
+    -5,
+    -1
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported instruction with null arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported instruction with null arg.json
@@ -1,0 +1,5 @@
+{
+  "type": "unsupported",
+  "operation": "value",
+  "argument": null
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_bool_arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_bool_arg.json
@@ -1,0 +1,7 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "enabled",
+  "argument": true,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_null_arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_null_arg.json
@@ -1,0 +1,7 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "value",
+  "argument": null,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_number_arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_number_arg.json
@@ -1,0 +1,7 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "add",
+  "argument": 42,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_string_arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_string_arg.json
@@ -1,0 +1,7 @@
+{
+  "type": "unsupported",
+  "ref": "",
+  "operation": "foo",
+  "argument": "bar",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/valid_ref_expression.json
+++ b/pkg/dyninst/exprlang/testdata/valid_ref_expression.json
@@ -1,0 +1,7 @@
+{
+  "type": "ref",
+  "ref": "s",
+  "operation": "",
+  "argument": null,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/valid_ref_with_complex_variable_name.json
+++ b/pkg/dyninst/exprlang/testdata/valid_ref_with_complex_variable_name.json
@@ -1,0 +1,7 @@
+{
+  "type": "ref",
+  "ref": "myVariable123",
+  "operation": "",
+  "argument": null,
+  "error": ""
+}

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -299,9 +299,8 @@ func runIntegrationTestSuite(
 	}
 	if rewrite {
 		t.Cleanup(func() {
-			if t.Failed() {
-				return
-			}
+			// Always save outputs in rewrite mode, even if test failed
+			// This allows updating golden files when the format changes
 			validateAndSaveOutputs(t, service, outputs.byTest)
 		})
 	}

--- a/pkg/dyninst/ir/probe_definition.go
+++ b/pkg/dyninst/ir/probe_definition.go
@@ -5,7 +5,11 @@
 
 package ir
 
-import "cmp"
+import (
+	"cmp"
+	"encoding/json"
+	"iter"
+)
 
 // ProbeIDer is an interface that allows for comparison of probe definitions.
 type ProbeIDer interface {
@@ -28,6 +32,8 @@ type ProbeDefinition interface {
 	GetCaptureConfig() CaptureConfig
 	// ThrottleConfig returns the throttle configuration of the probe.
 	GetThrottleConfig() ThrottleConfig
+	// GetTemplate returns the template definition of the probe.
+	GetTemplate() TemplateDefinition
 }
 
 // CompareProbeIDs compares two probe definitions by their ID and version.
@@ -41,6 +47,30 @@ func CompareProbeIDs[A, B ProbeIDer](a A, b B) int {
 // Where is a where clause of a probe.
 type Where interface {
 	Where() // marker method
+}
+
+// TemplateDefinition represents the configuration-time template definition
+type TemplateDefinition interface {
+	GetTemplateString() string
+	GetSegments() iter.Seq[TemplateSegmentDefinition]
+}
+
+// TemplateSegmentDefinition represents a configuration-time template segment
+type TemplateSegmentDefinition interface {
+	TemplateSegment() // marker method
+}
+
+// TemplateSegmentString represents a string literal segment in configuration
+type TemplateSegmentString interface {
+	TemplateSegmentDefinition
+	GetString() string
+}
+
+// TemplateSegmentExpression represents an expression segment in configuration
+type TemplateSegmentExpression interface {
+	TemplateSegmentDefinition
+	GetDSL() string
+	GetJSON() json.RawMessage
 }
 
 // FunctionWhere is a where clause of a probe that is a function.

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -7,7 +7,10 @@
 
 package ir
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // ProgramID is a ID corresponding to an instance of a Program.  It is used to
 // identify messages from this program as they are communicated over the ring
@@ -151,9 +154,44 @@ type Probe struct {
 	Subprogram *Subprogram
 	// The events that trigger the probe.
 	Events []*Event
-	// TODO: Add template support:
-	//	TemplateSegments []TemplateSegment
+	// Template contains the concrete template structure for this probe
+	Template *Template
 }
+
+// Template represents the concrete template structure for a probe (IR side)
+type Template struct {
+	// TemplateString is the complete template string
+	TemplateString string
+	// Segments are the ordered parts of the template
+	Segments []TemplateSegment
+}
+
+// TemplateSegment represents a concrete part of the template (IR side)
+type TemplateSegment interface {
+	templateSegment() // marker method
+}
+
+// StringSegment is a string literal in the template (IR side)
+type StringSegment struct {
+	Value string
+	Index int
+}
+
+func (s StringSegment) templateSegment() {}
+
+// JSONSegment is an expression segment in the template (IR side)
+type JSONSegment struct {
+	// JSON is the AST of the DSL segment.
+	JSON json.RawMessage
+	// DSL is the raw expression language segment.
+	DSL string
+	// ExpressionIndex is the index of the root expression that corresponds to this segment.
+	RootTypeExpressionIndicies map[TypeID]int
+	// ExpressionKind is the kind of expression that corresponds to this segment.
+	ExpressionKind EventKind
+}
+
+func (s JSONSegment) templateSegment() {}
 
 // Event corresponds to an action that will occur when a PC is hit.
 type Event struct {

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -2440,26 +2440,32 @@ func newProbe(
 	}
 	segments := []ir.TemplateSegment{}
 	probeTemplate := probeCfg.GetTemplate()
-	for seg := range probeTemplate.GetSegments() {
-		switch s := seg.(type) {
-		case rcjson.StringSegment:
-			segments = append(segments, ir.StringSegment{Value: s.GetString()})
-		case rcjson.JSONSegment:
-			segments = append(segments, ir.JSONSegment{
-				JSON:                       s.GetJSON(),
-				DSL:                        s.GetDSL(),
-				RootTypeExpressionIndicies: make(map[ir.TypeID]int),
-			})
-		default:
-			return nil, ir.Issue{
-				Kind:    ir.IssueKindInvalidProbeDefinition,
-				Message: fmt.Sprintf("invalid template segment: %T", seg),
-			}, nil
+	if probeTemplate != nil {
+		for seg := range probeTemplate.GetSegments() {
+			switch s := seg.(type) {
+			case rcjson.StringSegment:
+				segments = append(segments, ir.StringSegment{Value: s.GetString()})
+			case rcjson.JSONSegment:
+				segments = append(segments, ir.JSONSegment{
+					JSON:                       s.GetJSON(),
+					DSL:                        s.GetDSL(),
+					RootTypeExpressionIndicies: make(map[ir.TypeID]int),
+				})
+			default:
+				return nil, ir.Issue{
+					Kind:    ir.IssueKindInvalidProbeDefinition,
+					Message: fmt.Sprintf("invalid template segment: %T", seg),
+				}, nil
+			}
 		}
 	}
 
+	var templateString string
+	if probeTemplate != nil {
+		templateString = probeTemplate.GetTemplateString()
+	}
 	template := &ir.Template{
-		TemplateString: probeCfg.GetTemplate().GetTemplateString(),
+		TemplateString: templateString,
 		Segments:       segments,
 	}
 	probe := &ir.Probe{

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -25,6 +25,7 @@ import (
 	"cmp"
 	"container/heap"
 	"debug/dwarf"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -45,9 +46,11 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/loclist"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/exprlang"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcjson"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
@@ -1757,8 +1760,14 @@ func populateEventExpressions(
 	typeCatalog *typeCatalog,
 ) ir.Issue {
 	id := typeCatalog.idAlloc.next()
-	var expressions []*ir.RootExpression
+	var (
+		expressions           []*ir.RootExpression
+		variableExpressionSet = make(map[string]int)
+	)
 	for _, variable := range probe.Subprogram.Variables {
+		if _, ok := variableExpressionSet[variable.Name]; ok {
+			continue
+		}
 		var variableKind ir.RootExpressionKind
 		switch event.Kind {
 		case ir.EventKindEntry:
@@ -1794,24 +1803,46 @@ func populateEventExpressions(
 		default:
 			panic(fmt.Sprintf("unexpected event kind: %v", event.Kind))
 		}
-		variableSize := variable.Type.GetByteSize()
-		expr := &ir.RootExpression{
-			Name:   variable.Name,
-			Offset: uint32(0),
-			Kind:   variableKind,
-			Expression: ir.Expression{
-				Type: variable.Type,
-				Operations: []ir.ExpressionOp{
-					&ir.LocationOp{
-						Variable: variable,
-						Offset:   0,
-						ByteSize: uint32(variableSize),
-					},
-				},
-			},
-		}
+		expr := createVariableExpression(variable, variableKind)
 		expressions = append(expressions, expr)
+		variableExpressionSet[variable.Name] = len(expressions) - 1
 	}
+
+	// Collect segment variables and add generated expressions for them if needed
+	// before calculating sizes
+	for i := range probe.Template.Segments {
+		segment, ok := (probe.Template.Segments[i]).(ir.JSONSegment)
+		if !ok {
+			continue
+		}
+		relevantVariables, err := collectSegmentVariables(segment.JSON, probe.Subprogram)
+		if err != nil {
+			return ir.Issue{
+				Kind:    ir.IssueKindUnsupportedFeature,
+				Message: fmt.Sprintf("failed to collect segment variables: %v", err),
+			}
+		}
+		for _, variable := range relevantVariables {
+			if _, ok := variableExpressionSet[variable.Name]; !ok {
+				var variableKind ir.RootExpressionKind
+				if variable.Role == ir.VariableRoleParameter {
+					if event.Kind != ir.EventKindEntry {
+						continue
+					}
+					variableKind = ir.RootExpressionKindArgument
+				} else {
+					if event.Kind != ir.EventKindReturn && event.Kind != ir.EventKindLine {
+						continue
+					}
+					variableKind = ir.RootExpressionKindLocal
+				}
+				expr := createVariableExpression(variable, variableKind)
+				expressions = append(expressions, expr)
+				variableExpressionSet[variable.Name] = len(expressions) - 1
+			}
+		}
+	}
+
 	presenceBitsetSize := uint32((len(expressions) + 7) / 8)
 	byteSize := uint64(presenceBitsetSize)
 	for _, e := range expressions {
@@ -1838,6 +1869,27 @@ func populateEventExpressions(
 		Expressions:        expressions,
 	}
 	typeCatalog.typesByID[event.Type.ID] = event.Type
+
+	// map segments to their expression indices
+	for i := range probe.Template.Segments {
+		segment, ok := (probe.Template.Segments[i]).(ir.JSONSegment)
+		if !ok {
+			continue
+		}
+		relevantVariables, err := collectSegmentVariables(segment.JSON, probe.Subprogram)
+		if err != nil {
+			return ir.Issue{
+				Kind:    ir.IssueKindUnsupportedFeature,
+				Message: fmt.Sprintf("failed to collect segment variables: %v", err),
+			}
+		}
+		for _, variable := range relevantVariables {
+			if expressionIndex, ok := variableExpressionSet[variable.Name]; ok {
+				segment.RootTypeExpressionIndicies[event.Type.ID] = expressionIndex
+			}
+			probe.Template.Segments[i] = segment
+		}
+	}
 	return ir.Issue{}
 }
 
@@ -1854,6 +1906,25 @@ func (c concreteSubprogramRef) cmpByOffset(b concreteSubprogramRef) int {
 		cmp.Compare(c.offset, b.offset),
 		cmp.Compare(c.abstractOrigin, b.abstractOrigin),
 	)
+}
+
+func createVariableExpression(variable *ir.Variable, variableKind ir.RootExpressionKind) *ir.RootExpression {
+	variableSize := variable.Type.GetByteSize()
+	return &ir.RootExpression{
+		Name:   variable.Name,
+		Offset: uint32(0),
+		Kind:   variableKind,
+		Expression: ir.Expression{
+			Type: variable.Type,
+			Operations: []ir.ExpressionOp{
+				&ir.LocationOp{
+					Variable: variable,
+					Offset:   0,
+					ByteSize: uint32(variableSize),
+				},
+			},
+		},
+	}
 }
 
 type rootVisitor struct {
@@ -2367,11 +2438,35 @@ func newProbe(
 	if returnEvent != nil {
 		events = append(events, returnEvent)
 	}
+	segments := []ir.TemplateSegment{}
+	probeTemplate := probeCfg.GetTemplate()
+	for seg := range probeTemplate.GetSegments() {
+		switch s := seg.(type) {
+		case rcjson.StringSegment:
+			segments = append(segments, ir.StringSegment{Value: s.GetString()})
+		case rcjson.JSONSegment:
+			segments = append(segments, ir.JSONSegment{
+				JSON:                       s.GetJSON(),
+				DSL:                        s.GetDSL(),
+				RootTypeExpressionIndicies: make(map[ir.TypeID]int),
+			})
+		default:
+			return nil, ir.Issue{
+				Kind:    ir.IssueKindInvalidProbeDefinition,
+				Message: fmt.Sprintf("invalid template segment: %T", seg),
+			}, nil
+		}
+	}
 
+	template := &ir.Template{
+		TemplateString: probeCfg.GetTemplate().GetTemplateString(),
+		Segments:       segments,
+	}
 	probe := &ir.Probe{
 		ProbeDefinition: probeCfg,
 		Subprogram:      subprogram,
 		Events:          events,
+		Template:        template,
 	}
 	return probe, ir.Issue{}, nil
 }
@@ -3100,4 +3195,40 @@ func compileUnitFromName(name string) string {
 		return runtimePackageName
 	}
 	return name[:packageNameEnd]
+}
+
+// collectSegmentVariables collects the variables used in an expression.
+func collectSegmentVariables(msg json.RawMessage, subprogram *ir.Subprogram) ([]*ir.Variable, error) {
+	if len(msg) == 0 {
+		return nil, nil
+	}
+	expr, err := exprlang.Parse(msg)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := expr.(*exprlang.UnsupportedExpr); ok {
+		return nil, fmt.Errorf("expression is not supported")
+	}
+	switch e := expr.(type) {
+	case *exprlang.RefExpr:
+		// Validate that the referenced variable exists as a parameter in the subprogram
+		varIndex := variableExistsInSubprogram(e.Ref, subprogram)
+		if varIndex == -1 {
+			return nil, fmt.Errorf("referenced variable '%s' is not in the subprogram", e.Ref)
+		}
+		return []*ir.Variable{subprogram.Variables[varIndex]}, nil
+	default:
+		return nil, nil
+	}
+}
+
+// variableExistsInSubprogram checks if a referenced variable exists as a parameter
+// in the given subprogram.
+func variableExistsInSubprogram(varName string, subprogram *ir.Subprogram) int {
+	for i, variable := range subprogram.Variables {
+		if variable.Name == varName {
+			return i
+		}
+	}
+	return -1
 }

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -5,8 +5,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.HandleHTTP}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -29,8 +29,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.LookAtTheRequest}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: test log message
+      segments: [test log message]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -5,19 +5,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
+      message: stackC
       template: ""
-      segments: []
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.stackC]
+          Type: 1314 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd0a46a", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1313 EventRootType Probe[main.stackC]Return
+          Type: 1315 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd0a4a5", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,8 +26,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -45,8 +47,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -64,19 +67,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1286 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xd08f2e", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1287 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08fe2", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -84,8 +88,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -99,8 +104,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -114,8 +120,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -129,8 +136,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -144,8 +152,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -158,8 +167,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -173,8 +183,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -193,8 +204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -208,8 +220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -223,8 +236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
+      message: '{c}'
       template: ""
-      segments: []
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -238,8 +252,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
+      message: '{w}, {x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -253,8 +276,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
+      message: '{t}'
       template: ""
-      segments: []
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -268,8 +292,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -283,8 +308,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -298,8 +324,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -313,8 +340,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -328,8 +356,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -343,8 +372,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -358,14 +388,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1301 EventRootType Probe[main.testEmptySlice]
+          Type: 1303 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd0a000", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -373,14 +404,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1306 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -389,14 +426,15 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptyString]
+          Type: 1325 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,28 +442,30 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testEmptyStruct]
+          Type: 1331 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd0a9e0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1332 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd0aa00", Frameless: true}]
           Condition: null
     - id: testError
@@ -433,8 +473,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -448,8 +489,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -468,8 +510,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -488,8 +531,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -508,8 +552,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -531,8 +576,9 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -546,8 +592,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -566,8 +613,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
+      message: '{x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -586,8 +639,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -606,14 +660,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
+      message: testInlinedBBB
       template: ""
-      segments: []
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testInlinedBBB]
+          Type: 1336 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -621,8 +676,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
+      message: testInlinedBC
       template: ""
-      segments: []
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -641,14 +697,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testInlinedBCA]
+          Type: 1337 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -659,14 +716,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1338 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -674,14 +732,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testInlinedBCB]
+          Type: 1339 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -692,14 +751,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1340 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -708,14 +768,15 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInlinedPrint]
+          Type: 1333 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0460a"
               Frameless: false
@@ -728,9 +789,9 @@ Probes:
             - PC: "0xd0492f"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1334 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -741,14 +802,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1335 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -766,14 +828,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testInlinedSq]
+          Type: 1341 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -784,14 +847,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1340 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1342 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -800,14 +864,15 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1343 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04b05"
               Frameless: false
@@ -819,8 +884,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -834,8 +900,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -849,8 +916,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -864,8 +932,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -879,8 +948,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -894,8 +964,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -908,19 +979,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1284 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xd08dae", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1285 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08ef3", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -928,8 +1000,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -946,8 +1019,9 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -964,8 +1038,9 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -982,8 +1057,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -996,19 +1077,46 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1290 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xd09253", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1291 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xd09462", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1016,8 +1124,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -1031,8 +1140,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -1046,8 +1156,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -1061,8 +1172,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -1076,8 +1188,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1091,8 +1204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1106,8 +1220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1121,8 +1236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1136,8 +1252,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1151,8 +1270,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1166,8 +1288,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1181,8 +1304,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1196,8 +1320,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1211,8 +1336,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1226,8 +1352,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1241,8 +1368,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1256,8 +1384,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1271,8 +1400,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1286,8 +1416,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1301,8 +1432,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1316,14 +1450,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testMassiveString]
+          Type: 1322 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1332,90 +1467,131 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testMassiveString]
+          Type: 1323 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1292 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xd094f3", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1293 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xd0972b", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1296 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xd0986e", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1297 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xd09936", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
+      message: '{s1}, {s2}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1288 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xd0900e", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1289 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xd0922a", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1250 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1251 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1423,8 +1599,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
+      message: '{a}, {b}, {c}, {d}, {e}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1437,8 +1628,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1452,13 +1644,45 @@ Probes:
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd08395", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1248 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd0832a", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1249 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd08395", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
+      message: '{z}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1472,14 +1696,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1308 EventRootType Probe[main.testNilSlice]
+          Type: 1310 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1487,14 +1712,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1307 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1502,14 +1733,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
+      message: '{a}, {s}, {x}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1309 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1517,14 +1757,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1321 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd0a540", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1532,8 +1773,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1547,8 +1789,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1562,8 +1805,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1577,8 +1821,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1605,8 +1850,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}, {failed}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1632,114 +1883,120 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
+      message: testReturnsArray
       template: ""
-      segments: []
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1260 EventRootType Probe[main.testReturnsArray]
+          Type: 1262 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xd0884a", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1261 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1263 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xd088ad", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
+      message: testReturnsArrayOne
       template: ""
-      segments: []
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1264 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xd088ca", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1265 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xd0890b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
+      message: testReturnsArrayZero
       template: ""
-      segments: []
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1266 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xd0892a", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1267 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xd08966", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
+      message: testReturnsBacktrackInt
       template: ""
-      segments: []
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1270 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xd08a0e", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1271 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xd08a8a", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
+      message: testReturnsBoolAndUintptr
       template: ""
-      segments: []
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1282 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xd08d4a", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1283 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xd08d90", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
+      message: testReturnsComplex
       template: ""
-      segments: []
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1256 EventRootType Probe[main.testReturnsComplex]
+          Type: 1258 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xd0870a", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1259 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xd08766", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1747,8 +2004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{failed}'
       template: ""
-      segments: []
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1770,8 +2028,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1789,8 +2048,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1808,8 +2068,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1828,8 +2089,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1851,171 +2113,180 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
+      message: testReturnsLargeStruct
       template: ""
-      segments: []
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1260 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xd0878e", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1261 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xd08813", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
+      message: testReturnsManyFloats
       template: ""
-      segments: []
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1256 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xd0860e", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1257 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xd086e5", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
+      message: testReturnsMixed
       template: ""
-      segments: []
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1272 EventRootType Probe[main.testReturnsMixed]
+          Type: 1274 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xd08b6a", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1275 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xd08bcc", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
+      message: testReturnsMixedStruct
       template: ""
-      segments: []
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1268 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xd0898a", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1269 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xd089d8", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
+      message: testReturnsMultipleFloats
       template: ""
-      segments: []
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1280 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xd08cca", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1281 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xd08d16", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
+      message: testReturnsOnlyFloat
       template: ""
-      segments: []
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1278 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xd08c6a", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1279 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xd08cae", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
+      message: testReturnsPrimitives
       template: ""
-      segments: []
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1254 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xd0858a", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1255 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xd085f1", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
+      message: testReturnsStructWithArray
       template: ""
-      segments: []
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1276 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xd08bea", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1277 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xd08c4d", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
+      message: testReturnsWideStruct
       template: ""
-      segments: []
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1272 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xd08aae", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1273 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xd08b34", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2023,8 +2294,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -2038,8 +2310,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -2053,8 +2326,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -2068,8 +2342,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -2083,8 +2358,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -2098,8 +2374,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -2113,8 +2390,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2128,8 +2406,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -2143,8 +2422,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -2158,8 +2438,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2173,8 +2454,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2188,14 +2470,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testSingleString]
+          Type: 1316 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd0a4c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2203,8 +2486,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2218,8 +2502,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2233,8 +2518,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2248,8 +2534,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2263,8 +2550,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2278,14 +2566,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1313 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2293,14 +2582,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1302 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1304 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2308,8 +2598,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2322,38 +2613,40 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1252 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd084ae", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1253 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0854e", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1294 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xd097ca", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1295 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xd0983c", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2361,8 +2654,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2376,8 +2670,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
+      message: '{z}'
       template: ""
-      segments: []
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2391,14 +2686,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1306 EventRootType Probe[main.testStringSlice]
+          Type: 1308 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2406,8 +2702,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2421,8 +2718,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2436,19 +2734,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testStruct]
+          Type: 1329 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd0a860", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1328 EventRootType Probe[main.testStruct]Return
+          Type: 1330 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd0a882", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2456,14 +2755,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1303 EventRootType Probe[main.testStructSlice]
+          Type: 1305 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2471,8 +2776,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2485,52 +2791,55 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1298 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xd0996e", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1299 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xd09a1a", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1327 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd0a720", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1328 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd0a73e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1326 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd0a700", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2538,8 +2847,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2553,14 +2863,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
+      message: '{x}, {y}, {z}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testThreeStrings]
+          Type: 1317 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd0a4e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2568,19 +2887,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1318 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd0a500", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1319 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a51e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2588,14 +2908,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1320 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a520", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2603,8 +2924,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2618,8 +2940,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2633,8 +2956,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2648,8 +2972,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2663,8 +2988,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2678,8 +3004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2693,8 +3020,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +3036,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1300 EventRootType Probe[main.testUintSlice]
+          Type: 1302 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd09fe0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2723,14 +3052,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testUnitializedString]
+          Type: 1324 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2738,8 +3068,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2753,8 +3084,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2768,14 +3100,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1311 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2783,33 +3116,40 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1312 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1300 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xd09a4e", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1301 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09acc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -8962,10 +9302,10 @@ Types:
       GoKind: 22
       Pointee: 671 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1312
+      ID: 1314
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1313
+      ID: 1315
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9045,7 +9385,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1284
+      ID: 1286
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9061,7 +9401,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1285
+      ID: 1287
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9388,7 +9728,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1304
+      ID: 1306
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9414,7 +9754,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1301
+      ID: 1303
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9430,7 +9770,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1323
+      ID: 1325
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9446,7 +9786,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1332
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9462,7 +9802,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
+      ID: 1331
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9660,7 +10000,7 @@ Types:
       ID: 1182
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1334
+      ID: 1336
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1179
@@ -9692,16 +10032,16 @@ Types:
       ID: 1180
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1337
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1336
+      ID: 1338
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1337
+      ID: 1339
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1338
+      ID: 1340
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1183
@@ -9710,7 +10050,7 @@ Types:
       ID: 1184
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1333
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9726,7 +10066,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1335
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9742,10 +10082,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1334
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1341
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9761,7 +10101,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1342
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9777,7 +10117,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1343
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -9889,7 +10229,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1282
+      ID: 1284
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -9905,7 +10245,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1283
+      ID: 1285
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -9992,7 +10332,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1288
+      ID: 1290
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10088,7 +10428,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1289
+      ID: 1291
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10424,7 +10764,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1322
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10440,7 +10780,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1321
+      ID: 1323
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10456,7 +10796,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1290
+      ID: 1292
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10552,7 +10892,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1291
+      ID: 1293
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10568,7 +10908,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1294
+      ID: 1296
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10594,7 +10934,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1295
+      ID: 1297
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10620,7 +10960,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1286
+      ID: 1288
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10646,7 +10986,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1287
+      ID: 1289
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10662,7 +11002,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1248
+      ID: 1250
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10678,7 +11018,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1251
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10776,7 +11116,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1247
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1249
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10818,7 +11190,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1307
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10844,7 +11216,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1309
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -10880,7 +11252,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1310
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10896,7 +11268,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1321
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11044,10 +11416,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1262
+      ID: 1264
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1263
+      ID: 1265
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11063,10 +11435,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1266
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1265
+      ID: 1267
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11082,10 +11454,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1260
+      ID: 1262
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1261
+      ID: 1263
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11101,10 +11473,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1268
+      ID: 1270
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1269
+      ID: 1271
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11200,10 +11572,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1280
+      ID: 1282
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1281
+      ID: 1283
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11229,10 +11601,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1258
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1257
+      ID: 1259
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11428,10 +11800,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1258
+      ID: 1260
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1259
+      ID: 1261
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11447,10 +11819,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1254
+      ID: 1256
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1255
+      ID: 1257
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11626,10 +11998,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1268
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1267
+      ID: 1269
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11645,10 +12017,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1272
+      ID: 1274
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1273
+      ID: 1275
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11704,10 +12076,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1278
+      ID: 1280
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1279
+      ID: 1281
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11733,10 +12105,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1276
+      ID: 1278
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1277
+      ID: 1279
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11752,10 +12124,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1254
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1253
+      ID: 1255
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -11841,10 +12213,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1274
+      ID: 1276
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1275
+      ID: 1277
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11860,10 +12232,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1270
+      ID: 1272
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1271
+      ID: 1273
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12055,7 +12427,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1314
+      ID: 1316
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12151,7 +12523,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1313
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12167,7 +12539,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1302
+      ID: 1304
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12199,7 +12571,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1250
+      ID: 1252
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12215,7 +12587,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1251
+      ID: 1253
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12251,7 +12623,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1292
+      ID: 1294
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12267,7 +12639,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1293
+      ID: 1295
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12335,7 +12707,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1308
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12383,7 +12755,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
+      ID: 1305
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12425,7 +12797,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1296
+      ID: 1298
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12441,7 +12813,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1297
+      ID: 1299
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12467,7 +12839,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1325
+      ID: 1327
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12483,10 +12855,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1326
+      ID: 1328
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1324
+      ID: 1326
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12518,7 +12890,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1329
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12534,10 +12906,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1328
+      ID: 1330
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1318
+      ID: 1320
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12553,7 +12925,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1318
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12569,10 +12941,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1317
+      ID: 1319
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1315
+      ID: 1317
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12720,7 +13092,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1300
+      ID: 1302
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12736,7 +13108,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1322
+      ID: 1324
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12784,7 +13156,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1309
+      ID: 1311
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12800,7 +13172,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1310
+      ID: 1312
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12816,7 +13188,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1298
+      ID: 1300
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12842,7 +13214,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1299
+      ID: 1301
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -19894,7 +20266,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1341
+MaxTypeID: 1343
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x175c760", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -5,19 +5,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
+      message: stackC
       template: ""
-      segments: []
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1487 EventRootType Probe[main.stackC]
+          Type: 1489 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcdb8aa", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1488 EventRootType Probe[main.stackC]Return
+          Type: 1490 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcdb8e5", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,8 +26,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -45,8 +47,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -64,19 +67,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1461 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcda36e", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1462 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda422", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -84,8 +88,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -99,8 +104,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -114,8 +120,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -129,8 +136,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -144,8 +152,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -158,8 +167,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -173,8 +183,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -193,8 +204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -208,8 +220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -223,8 +236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
+      message: '{c}'
       template: ""
-      segments: []
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -238,8 +252,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
+      message: '{w}, {x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -253,8 +276,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
+      message: '{t}'
       template: ""
-      segments: []
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -268,8 +292,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -283,8 +308,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -298,8 +324,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -313,8 +340,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -328,8 +356,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -343,8 +372,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -358,14 +388,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testEmptySlice]
+          Type: 1478 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdb440", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -373,14 +404,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1481 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -389,14 +426,15 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptyString]
+          Type: 1500 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,28 +442,30 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1504 EventRootType Probe[main.testEmptyStruct]
+          Type: 1506 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcdbe20", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1507 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcdbe40", Frameless: true}]
           Condition: null
     - id: testError
@@ -433,8 +473,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -448,8 +489,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -468,8 +510,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -488,8 +531,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -508,8 +552,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -531,8 +576,9 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -546,8 +592,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -566,8 +613,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
+      message: '{x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -586,8 +639,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -606,14 +660,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
+      message: testInlinedBBB
       template: ""
-      segments: []
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1509 EventRootType Probe[main.testInlinedBBB]
+          Type: 1511 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -621,8 +676,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
+      message: testInlinedBC
       template: ""
-      segments: []
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -641,14 +697,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1510 EventRootType Probe[main.testInlinedBCA]
+          Type: 1512 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -659,14 +716,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1513 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -674,14 +732,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1512 EventRootType Probe[main.testInlinedBCB]
+          Type: 1514 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -692,14 +751,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1515 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -708,14 +768,15 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1506 EventRootType Probe[main.testInlinedPrint]
+          Type: 1508 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd592a"
               Frameless: false
@@ -728,9 +789,9 @@ Probes:
             - PC: "0xcd5c4f"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1509 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -741,14 +802,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1510 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -766,14 +828,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1514 EventRootType Probe[main.testInlinedSq]
+          Type: 1516 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -784,14 +847,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1515 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1517 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -800,14 +864,15 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1516 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1518 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5e25"
               Frameless: false
@@ -819,8 +884,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -834,8 +900,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -849,8 +916,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -864,8 +932,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -879,8 +948,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -894,8 +964,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -908,19 +979,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1459 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcda1ce", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1460 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda333", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -928,8 +1000,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -946,8 +1019,9 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -964,8 +1038,9 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -982,8 +1057,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -996,19 +1077,46 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1465 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcda693", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1466 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcda8a2", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1016,8 +1124,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -1031,8 +1140,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -1046,8 +1156,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -1061,8 +1172,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -1076,8 +1188,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1091,8 +1204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1106,8 +1220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1121,8 +1236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1136,8 +1252,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1151,8 +1270,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1166,8 +1288,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1181,8 +1304,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1196,8 +1320,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1211,8 +1336,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1226,8 +1352,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1241,8 +1368,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1256,8 +1384,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1271,8 +1400,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1286,8 +1416,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1301,8 +1432,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1316,14 +1450,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMassiveString]
+          Type: 1497 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1332,90 +1467,131 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1496 EventRootType Probe[main.testMassiveString]
+          Type: 1498 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1467 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcda933", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1468 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdab6b", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1471 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdacae", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1472 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdad7e", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
+      message: '{s1}, {s2}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1463 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1464 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcda66a", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1423,8 +1599,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
+      message: '{a}, {b}, {c}, {d}, {e}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1437,8 +1628,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1452,13 +1644,45 @@ Probes:
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1423 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd974a", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1424 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
+      message: '{z}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1472,14 +1696,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1483 EventRootType Probe[main.testNilSlice]
+          Type: 1485 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1487,14 +1712,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1482 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1502,14 +1733,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
+      message: '{a}, {s}, {x}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1484 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1517,14 +1757,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1496 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdb980", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1532,8 +1773,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1547,8 +1789,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1562,8 +1805,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1577,8 +1821,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1605,8 +1850,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}, {failed}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1632,114 +1883,120 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
+      message: testReturnsArray
       template: ""
-      segments: []
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsArray]
+          Type: 1437 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcd9c6a", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1438 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcd9ccd", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
+      message: testReturnsArrayOne
       template: ""
-      segments: []
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1439 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcd9cea", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1440 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcd9d2b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
+      message: testReturnsArrayZero
       template: ""
-      segments: []
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1441 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcd9d4a", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1442 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcd9d86", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
+      message: testReturnsBacktrackInt
       template: ""
-      segments: []
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1445 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcd9e2e", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1446 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcd9eaa", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
+      message: testReturnsBoolAndUintptr
       template: ""
-      segments: []
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1457 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcda16a", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1458 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcda1b0", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
+      message: testReturnsComplex
       template: ""
-      segments: []
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsComplex]
+          Type: 1433 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcd9b2a", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1434 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1747,8 +2004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{failed}'
       template: ""
-      segments: []
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1770,8 +2028,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1789,8 +2048,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1808,8 +2068,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1828,8 +2089,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1851,171 +2113,180 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
+      message: testReturnsLargeStruct
       template: ""
-      segments: []
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1435 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1436 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcd9c33", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
+      message: testReturnsManyFloats
       template: ""
-      segments: []
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1431 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcd9a2e", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1432 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcd9b07", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
+      message: testReturnsMixed
       template: ""
-      segments: []
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsMixed]
+          Type: 1449 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcd9f8a", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1450 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcd9fec", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
+      message: testReturnsMixedStruct
       template: ""
-      segments: []
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1443 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcd9daa", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1444 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcd9df8", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
+      message: testReturnsMultipleFloats
       template: ""
-      segments: []
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1455 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcda0ea", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1456 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcda136", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
+      message: testReturnsOnlyFloat
       template: ""
-      segments: []
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1453 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcda08a", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1454 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcda0ce", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
+      message: testReturnsPrimitives
       template: ""
-      segments: []
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1429 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcd99aa", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1430 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcd9a11", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
+      message: testReturnsStructWithArray
       template: ""
-      segments: []
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1451 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcda00a", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1452 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcda06d", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
+      message: testReturnsWideStruct
       template: ""
-      segments: []
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1447 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcd9ece", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1448 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcd9f54", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2023,8 +2294,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -2038,8 +2310,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -2053,8 +2326,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -2068,8 +2342,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -2083,8 +2358,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -2098,8 +2374,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -2113,8 +2390,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2128,8 +2406,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -2143,8 +2422,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -2158,8 +2438,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2173,8 +2454,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2188,14 +2470,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1489 EventRootType Probe[main.testSingleString]
+          Type: 1491 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdb900", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2203,8 +2486,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2218,8 +2502,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2233,8 +2518,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2248,8 +2534,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2263,8 +2550,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2278,14 +2566,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1488 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2293,14 +2582,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1477 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1479 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2308,8 +2598,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2322,38 +2613,40 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1427 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd98ce", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1428 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd996b", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1469 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdac0a", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1470 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdac7c", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2361,8 +2654,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2376,8 +2670,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
+      message: '{z}'
       template: ""
-      segments: []
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2391,14 +2686,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1481 EventRootType Probe[main.testStringSlice]
+          Type: 1483 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2406,8 +2702,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2421,8 +2718,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2436,19 +2734,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1502 EventRootType Probe[main.testStruct]
+          Type: 1504 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcdbca0", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1503 EventRootType Probe[main.testStruct]Return
+          Type: 1505 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcdbcc2", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2456,14 +2755,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testStructSlice]
+          Type: 1480 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2471,8 +2776,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2485,52 +2791,55 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1473 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdadae", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1474 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdae5a", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1502 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcdbb60", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1503 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcdbb7e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1501 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcdbb40", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2538,8 +2847,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2553,14 +2863,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
+      message: '{x}, {y}, {z}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1490 EventRootType Probe[main.testThreeStrings]
+          Type: 1492 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdb920", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2568,19 +2887,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1493 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdb940", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1494 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdb95e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2588,14 +2908,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1495 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdb960", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2603,8 +2924,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2618,8 +2940,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2633,8 +2956,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2648,8 +2972,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2663,8 +2988,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2678,8 +3004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2693,8 +3020,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +3036,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1475 EventRootType Probe[main.testUintSlice]
+          Type: 1477 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdb420", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2723,14 +3052,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1497 EventRootType Probe[main.testUnitializedString]
+          Type: 1499 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2738,8 +3068,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2753,8 +3084,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2768,14 +3100,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1486 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2783,33 +3116,40 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1487 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1475 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdae8e", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1476 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdaf0c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9267,10 +9607,10 @@ Types:
       GoKind: 22
       Pointee: 808 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9350,7 +9690,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9366,7 +9706,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9693,7 +10033,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9719,7 +10059,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9735,7 +10075,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9751,7 +10091,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9767,7 +10107,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9965,7 +10305,7 @@ Types:
       ID: 1357
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1354
@@ -9997,16 +10337,16 @@ Types:
       ID: 1355
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1358
@@ -10015,7 +10355,7 @@ Types:
       ID: 1359
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10031,7 +10371,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10047,10 +10387,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10066,7 +10406,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10082,7 +10422,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10194,7 +10534,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10210,7 +10550,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10297,7 +10637,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10393,7 +10733,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10729,7 +11069,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10745,7 +11085,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10761,7 +11101,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10857,7 +11197,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10873,7 +11213,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10899,7 +11239,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10925,7 +11265,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10951,7 +11291,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10967,7 +11307,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10983,7 +11323,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11081,7 +11421,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1422
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1424
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11123,7 +11495,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11149,7 +11521,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11185,7 +11557,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11201,7 +11573,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11349,10 +11721,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1437
+      ID: 1439
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1438
+      ID: 1440
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11368,10 +11740,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1441
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11387,10 +11759,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1435
+      ID: 1437
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1436
+      ID: 1438
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11406,10 +11778,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11505,10 +11877,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1455
+      ID: 1457
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11534,10 +11906,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1432
+      ID: 1434
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11733,10 +12105,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1433
+      ID: 1435
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1434
+      ID: 1436
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11752,10 +12124,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11931,10 +12303,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11950,10 +12322,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12009,10 +12381,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12038,10 +12410,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12057,10 +12429,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12146,10 +12518,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12165,10 +12537,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12360,7 +12732,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12456,7 +12828,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12472,7 +12844,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12504,7 +12876,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12520,7 +12892,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12556,7 +12928,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12572,7 +12944,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12640,7 +13012,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12688,7 +13060,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12730,7 +13102,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12746,7 +13118,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12772,7 +13144,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12788,10 +13160,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12823,7 +13195,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12839,10 +13211,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12858,7 +13230,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12874,10 +13246,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13025,7 +13397,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13041,7 +13413,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13089,7 +13461,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13105,7 +13477,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13121,7 +13493,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13147,7 +13519,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -21654,7 +22026,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1516
+MaxTypeID: 1518
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18003a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -5,19 +5,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
+      message: stackC
       template: ""
-      segments: []
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1506 EventRootType Probe[main.stackC]
+          Type: 1508 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xce00ca", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1507 EventRootType Probe[main.stackC]Return
+          Type: 1509 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xce0105", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,8 +26,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -45,8 +47,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -64,19 +67,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcdebae", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1481 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdec62", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -84,8 +88,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -99,8 +104,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -114,8 +120,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -129,8 +136,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -144,8 +152,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -158,8 +167,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -173,8 +183,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -193,8 +204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -208,8 +220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -223,8 +236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
+      message: '{c}'
       template: ""
-      segments: []
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -238,8 +252,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
+      message: '{w}, {x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -253,8 +276,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
+      message: '{t}'
       template: ""
-      segments: []
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -268,8 +292,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -283,8 +308,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -298,8 +324,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -313,8 +340,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -328,8 +356,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -343,8 +372,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -358,14 +388,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          Type: 1497 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -373,14 +404,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1500 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -389,14 +426,15 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptyString]
+          Type: 1519 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,28 +442,30 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1523 EventRootType Probe[main.testEmptyStruct]
+          Type: 1525 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xce0640", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1526 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xce0660", Frameless: true}]
           Condition: null
     - id: testError
@@ -433,8 +473,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -448,8 +489,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -468,8 +510,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -488,8 +531,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -508,8 +552,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -531,8 +576,9 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -546,8 +592,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -566,8 +613,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
+      message: '{x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -586,8 +639,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -606,14 +660,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
+      message: testInlinedBBB
       template: ""
-      segments: []
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1528 EventRootType Probe[main.testInlinedBBB]
+          Type: 1530 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -621,8 +676,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
+      message: testInlinedBC
       template: ""
-      segments: []
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -641,14 +697,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1529 EventRootType Probe[main.testInlinedBCA]
+          Type: 1531 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -659,14 +716,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1532 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -674,14 +732,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1531 EventRootType Probe[main.testInlinedBCB]
+          Type: 1533 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -692,14 +751,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1534 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -708,14 +768,15 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1525 EventRootType Probe[main.testInlinedPrint]
+          Type: 1527 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda20a"
               Frameless: false
@@ -728,9 +789,9 @@ Probes:
             - PC: "0xcda52f"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1528 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -741,14 +802,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1529 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -766,14 +828,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1533 EventRootType Probe[main.testInlinedSq]
+          Type: 1535 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -784,14 +847,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1534 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1536 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -800,14 +864,15 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1535 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1537 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda705"
               Frameless: false
@@ -819,8 +884,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -834,8 +900,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -849,8 +916,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -864,8 +932,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -879,8 +948,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -894,8 +964,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -908,19 +979,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcdea0e", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1479 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdeb73", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -928,8 +1000,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -946,8 +1019,9 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -964,8 +1038,9 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -982,8 +1057,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -996,19 +1077,46 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcdeed3", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1485 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcdf0e2", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1016,8 +1124,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -1031,8 +1140,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -1046,8 +1156,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -1061,8 +1172,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -1076,8 +1188,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1091,8 +1204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1106,8 +1220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1121,8 +1236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1136,8 +1252,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1151,8 +1270,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1166,8 +1288,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1181,8 +1304,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1196,8 +1320,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1211,8 +1336,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1226,8 +1352,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1241,8 +1368,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1256,8 +1384,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1271,8 +1400,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1286,8 +1416,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1301,8 +1432,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1316,14 +1450,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1514 EventRootType Probe[main.testMassiveString]
+          Type: 1516 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1332,90 +1467,131 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1515 EventRootType Probe[main.testMassiveString]
+          Type: 1517 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcdf173", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1487 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdf3ab", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdf4ee", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1491 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdf5bf", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
+      message: '{s1}, {s2}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcdec8e", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1483 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcdeeaa", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1444 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1445 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1423,8 +1599,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
+      message: '{a}, {b}, {c}, {d}, {e}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1437,8 +1628,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1452,13 +1644,45 @@ Probes:
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1442 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcddf8a", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1443 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
+      message: '{z}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1472,14 +1696,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
+          Type: 1504 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1487,14 +1712,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1501 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1502,14 +1733,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
+      message: '{a}, {s}, {x}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1503 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1517,14 +1757,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1515 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xce01a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1532,8 +1773,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1547,8 +1789,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1562,8 +1805,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1577,8 +1821,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1605,8 +1850,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}, {failed}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1632,114 +1883,120 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
+      message: testReturnsArray
       template: ""
-      segments: []
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          Type: 1456 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcde4aa", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1457 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcde50d", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
+      message: testReturnsArrayOne
       template: ""
-      segments: []
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1458 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcde52a", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1459 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcde56b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
+      message: testReturnsArrayZero
       template: ""
-      segments: []
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1460 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcde58a", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1461 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcde5c6", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
+      message: testReturnsBacktrackInt
       template: ""
-      segments: []
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcde66e", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1465 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcde6ea", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
+      message: testReturnsBoolAndUintptr
       template: ""
-      segments: []
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcde9aa", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1477 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcde9f0", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
+      message: testReturnsComplex
       template: ""
-      segments: []
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          Type: 1452 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcde36a", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1453 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcde3c6", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1747,8 +2004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{failed}'
       template: ""
-      segments: []
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1770,8 +2028,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1789,8 +2048,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1808,8 +2068,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1828,8 +2089,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1851,171 +2113,180 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
+      message: testReturnsLargeStruct
       template: ""
-      segments: []
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcde3ee", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1455 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcde473", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
+      message: testReturnsManyFloats
       template: ""
-      segments: []
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1450 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcde26e", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1451 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcde347", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
+      message: testReturnsMixed
       template: ""
-      segments: []
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          Type: 1468 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcde7ca", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1469 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcde82c", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
+      message: testReturnsMixedStruct
       template: ""
-      segments: []
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcde5ea", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1463 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcde638", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
+      message: testReturnsMultipleFloats
       template: ""
-      segments: []
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcde92a", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1475 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcde976", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
+      message: testReturnsOnlyFloat
       template: ""
-      segments: []
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcde8ca", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1473 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcde90e", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
+      message: testReturnsPrimitives
       template: ""
-      segments: []
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1448 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcde1ea", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1449 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcde251", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
+      message: testReturnsStructWithArray
       template: ""
-      segments: []
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcde84a", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1471 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcde8ad", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
+      message: testReturnsWideStruct
       template: ""
-      segments: []
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1466 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcde70e", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1467 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcde794", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2023,8 +2294,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -2038,8 +2310,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -2053,8 +2326,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -2068,8 +2342,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -2083,8 +2358,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -2098,8 +2374,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -2113,8 +2390,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2128,8 +2406,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -2143,8 +2422,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -2158,8 +2438,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2173,8 +2454,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2188,14 +2470,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1508 EventRootType Probe[main.testSingleString]
+          Type: 1510 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xce0120", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2203,8 +2486,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2218,8 +2502,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2233,8 +2518,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2248,8 +2534,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2263,8 +2550,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2278,14 +2566,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1507 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2293,14 +2582,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1498 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2308,8 +2598,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2322,38 +2613,40 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1446 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcde10e", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1447 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcde1ad", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1488 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdf44a", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1489 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdf4bc", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2361,8 +2654,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2376,8 +2670,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
+      message: '{z}'
       template: ""
-      segments: []
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2391,14 +2686,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
+          Type: 1502 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2406,8 +2702,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2421,8 +2718,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2436,19 +2734,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1521 EventRootType Probe[main.testStruct]
+          Type: 1523 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xce04c0", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1522 EventRootType Probe[main.testStruct]Return
+          Type: 1524 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xce04e2", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2456,14 +2755,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
+          Type: 1499 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2471,8 +2776,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2485,52 +2791,55 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1492 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdf5ee", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1493 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdf69c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1521 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xce0380", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1522 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xce039e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1520 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xce0360", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2538,8 +2847,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2553,14 +2863,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
+      message: '{x}, {y}, {z}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStrings]
+          Type: 1511 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xce0140", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2568,19 +2887,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xce0160", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce017e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2588,14 +2908,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0180", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2603,8 +2924,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2618,8 +2940,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2633,8 +2956,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2648,8 +2972,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2663,8 +2988,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2678,8 +3004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2693,8 +3020,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +3036,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
+          Type: 1496 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2723,14 +3052,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1516 EventRootType Probe[main.testUnitializedString]
+          Type: 1518 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2738,8 +3068,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2753,8 +3084,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2768,14 +3100,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2783,33 +3116,40 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1506 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdf6ce", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1495 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdf74c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9334,10 +9674,10 @@ Types:
       GoKind: 22
       Pointee: 821 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9417,7 +9757,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9433,7 +9773,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9760,7 +10100,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9786,7 +10126,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9802,7 +10142,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9818,7 +10158,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9834,7 +10174,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10032,7 +10372,7 @@ Types:
       ID: 1376
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1373
@@ -10064,16 +10404,16 @@ Types:
       ID: 1374
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1377
@@ -10082,7 +10422,7 @@ Types:
       ID: 1378
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10098,7 +10438,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10114,10 +10454,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10133,7 +10473,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10149,7 +10489,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10261,7 +10601,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10277,7 +10617,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10364,7 +10704,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10460,7 +10800,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10796,7 +11136,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10812,7 +11152,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10828,7 +11168,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10924,7 +11264,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10940,7 +11280,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10966,7 +11306,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10992,7 +11332,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11018,7 +11358,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11034,7 +11374,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11050,7 +11390,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11148,7 +11488,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1441
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1443
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11190,7 +11562,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11216,7 +11588,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11252,7 +11624,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11268,7 +11640,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11416,10 +11788,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11435,10 +11807,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11454,10 +11826,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1457
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11473,10 +11845,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11572,10 +11944,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11601,10 +11973,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11800,10 +12172,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11819,10 +12191,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11998,10 +12370,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12017,10 +12389,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12076,10 +12448,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12105,10 +12477,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12124,10 +12496,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12213,10 +12585,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12232,10 +12604,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12427,7 +12799,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12523,7 +12895,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12539,7 +12911,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12571,7 +12943,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12587,7 +12959,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12623,7 +12995,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12639,7 +13011,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12707,7 +13079,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12755,7 +13127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12797,7 +13169,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12813,7 +13185,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12839,7 +13211,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12855,10 +13227,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12890,7 +13262,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12906,10 +13278,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12925,7 +13297,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12941,10 +13313,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13092,7 +13464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13108,7 +13480,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13156,7 +13528,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13172,7 +13544,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13188,7 +13560,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13214,7 +13586,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -21881,7 +22253,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1535
+MaxTypeID: 1537
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -5,19 +5,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
+      message: stackC
       template: ""
-      segments: []
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.stackC]
+          Type: 1314 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x892858", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1313 EventRootType Probe[main.stackC]Return
+          Type: 1315 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x89288c", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,8 +26,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -45,8 +47,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -64,19 +67,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1286 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x89160c", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1287 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x8916a4", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -84,8 +88,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -99,8 +104,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -114,8 +120,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -129,8 +136,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -144,8 +152,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -158,8 +167,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -173,8 +183,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -193,8 +204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -208,8 +220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -223,8 +236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
+      message: '{c}'
       template: ""
-      segments: []
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -238,8 +252,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
+      message: '{w}, {x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -253,8 +276,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
+      message: '{t}'
       template: ""
-      segments: []
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -268,8 +292,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -283,8 +308,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -298,8 +324,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -313,8 +340,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -328,8 +356,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -343,8 +372,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -358,14 +388,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1301 EventRootType Probe[main.testEmptySlice]
+          Type: 1303 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x8924d0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -373,14 +404,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1306 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x892500", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -389,14 +426,15 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptyString]
+          Type: 1325 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x892930", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,28 +442,30 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testEmptyStruct]
+          Type: 1331 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x892c80", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1332 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x892c90", Frameless: true}]
           Condition: null
     - id: testError
@@ -433,8 +473,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -448,8 +489,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -468,8 +510,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -488,8 +531,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -508,8 +552,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -531,8 +576,9 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -546,8 +592,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -566,8 +613,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
+      message: '{x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -586,8 +639,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -606,14 +660,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
+      message: testInlinedBBB
       template: ""
-      segments: []
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testInlinedBBB]
+          Type: 1336 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d878", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -621,8 +676,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
+      message: testInlinedBC
       template: ""
-      segments: []
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -641,14 +697,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testInlinedBCA]
+          Type: 1337 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -659,14 +716,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1338 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -674,14 +732,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testInlinedBCB]
+          Type: 1339 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -692,14 +751,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1340 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -708,14 +768,15 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInlinedPrint]
+          Type: 1333 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -728,9 +789,9 @@ Probes:
             - PC: "0x88d8fc"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1334 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d630", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -741,14 +802,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1335 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -766,14 +828,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testInlinedSq]
+          Type: 1341 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -784,14 +847,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1340 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1342 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -800,14 +864,15 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1343 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88dab4"
               Frameless: false
@@ -819,8 +884,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -834,8 +900,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -849,8 +916,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -864,8 +932,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -879,8 +948,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -894,8 +964,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -908,19 +979,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1284 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x891430", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1285 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x891588", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -928,8 +1000,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -946,8 +1019,9 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -964,8 +1038,9 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -982,8 +1057,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -996,19 +1077,46 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1290 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x89193c", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1291 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x891aac", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1016,8 +1124,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -1031,8 +1140,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -1046,8 +1156,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -1061,8 +1172,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -1076,8 +1188,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1091,8 +1204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1106,8 +1220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1121,8 +1236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1136,8 +1252,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1151,8 +1270,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1166,8 +1288,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1181,8 +1304,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1196,8 +1320,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1211,8 +1336,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1226,8 +1352,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1241,8 +1368,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1256,8 +1384,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1271,8 +1400,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1286,8 +1416,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1301,8 +1432,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1316,14 +1450,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testMassiveString]
+          Type: 1322 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1332,90 +1467,131 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testMassiveString]
+          Type: 1323 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1292 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x891b30", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1293 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x891ce0", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1296 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x891e0c", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1297 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x891eb0", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
+      message: '{s1}, {s2}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1288 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x8916e0", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1289 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x8918b0", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1250 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1251 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1423,8 +1599,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
+      message: '{a}, {b}, {c}, {d}, {e}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1437,8 +1628,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1452,13 +1644,45 @@ Probes:
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1248 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x890958", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1249 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
+      message: '{z}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1472,14 +1696,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1308 EventRootType Probe[main.testNilSlice]
+          Type: 1310 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1487,14 +1712,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1307 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x892510", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1502,14 +1733,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
+      message: '{a}, {s}, {x}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1309 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1517,14 +1757,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1321 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x892900", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1532,8 +1773,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1547,8 +1789,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1562,8 +1805,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1577,8 +1821,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1605,8 +1850,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}, {failed}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1632,114 +1883,120 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
+      message: testReturnsArray
       template: ""
-      segments: []
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1260 EventRootType Probe[main.testReturnsArray]
+          Type: 1262 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x890e3c", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1261 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1263 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x890e90", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
+      message: testReturnsArrayOne
       template: ""
-      segments: []
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1264 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x890ec8", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1265 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x890f04", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
+      message: testReturnsArrayZero
       template: ""
-      segments: []
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1266 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x890f38", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1267 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x890f70", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
+      message: testReturnsBacktrackInt
       template: ""
-      segments: []
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1270 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x891028", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1271 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x89108c", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
+      message: testReturnsBoolAndUintptr
       template: ""
-      segments: []
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1282 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x8913b8", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1283 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x8913f8", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
+      message: testReturnsComplex
       template: ""
-      segments: []
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1256 EventRootType Probe[main.testReturnsComplex]
+          Type: 1258 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x890ce8", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1259 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x890d34", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1747,8 +2004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{failed}'
       template: ""
-      segments: []
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1770,8 +2028,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1789,8 +2048,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1808,8 +2068,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1828,8 +2089,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1851,171 +2113,180 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
+      message: testReturnsLargeStruct
       template: ""
-      segments: []
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1260 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x890d70", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1261 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x890e04", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
+      message: testReturnsManyFloats
       template: ""
-      segments: []
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1256 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x890c28", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1257 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x890cac", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
+      message: testReturnsMixed
       template: ""
-      segments: []
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1272 EventRootType Probe[main.testReturnsMixed]
+          Type: 1274 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x8911a8", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1275 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x891200", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
+      message: testReturnsMixedStruct
       template: ""
-      segments: []
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1268 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x890fa8", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1269 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x890ff0", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
+      message: testReturnsMultipleFloats
       template: ""
-      segments: []
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1280 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x891338", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1281 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x89137c", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
+      message: testReturnsOnlyFloat
       template: ""
-      segments: []
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1278 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x8912c8", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1279 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x891308", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
+      message: testReturnsPrimitives
       template: ""
-      segments: []
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1254 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x890b98", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1255 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x890bf0", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
+      message: testReturnsStructWithArray
       template: ""
-      segments: []
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1276 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x89123c", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1277 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x891290", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
+      message: testReturnsWideStruct
       template: ""
-      segments: []
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1272 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x8910d0", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1273 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x891174", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2023,8 +2294,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -2038,8 +2310,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -2053,8 +2326,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -2068,8 +2342,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -2083,8 +2358,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -2098,8 +2374,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -2113,8 +2390,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2128,8 +2406,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -2143,8 +2422,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -2158,8 +2438,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2173,8 +2454,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2188,14 +2470,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testSingleString]
+          Type: 1316 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x8928b0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2203,8 +2486,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2218,8 +2502,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2233,8 +2518,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2248,8 +2534,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2263,8 +2550,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2278,14 +2566,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1313 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2293,14 +2582,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1302 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1304 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x8924e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2308,8 +2598,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2322,38 +2613,40 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1252 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x890ac8", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1253 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890b54", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1294 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x891d68", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1295 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2361,8 +2654,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2376,8 +2670,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
+      message: '{z}'
       template: ""
-      segments: []
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2391,14 +2686,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1306 EventRootType Probe[main.testStringSlice]
+          Type: 1308 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2406,8 +2702,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2421,8 +2718,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2436,19 +2734,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testStruct]
+          Type: 1329 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x892b80", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1328 EventRootType Probe[main.testStruct]Return
+          Type: 1330 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x892b9c", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2456,14 +2755,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1303 EventRootType Probe[main.testStructSlice]
+          Type: 1305 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x8924f0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2471,8 +2776,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2485,52 +2791,55 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1298 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x891eec", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1299 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x891f7c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1327 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x892a90", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1328 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x892aa8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1326 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x892a80", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2538,8 +2847,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2553,14 +2863,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
+      message: '{x}, {y}, {z}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testThreeStrings]
+          Type: 1317 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x8928c0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2568,19 +2887,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1318 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x8928d0", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1319 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x8928e8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2588,14 +2908,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1320 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8928f0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2603,8 +2924,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2618,8 +2940,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2633,8 +2956,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2648,8 +2972,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2663,8 +2988,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2678,8 +3004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2693,8 +3020,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +3036,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1300 EventRootType Probe[main.testUintSlice]
+          Type: 1302 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x8924c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2723,14 +3052,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testUnitializedString]
+          Type: 1324 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x892920", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2738,8 +3068,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2753,8 +3084,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2768,14 +3100,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1311 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2783,33 +3116,40 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1312 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1300 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x891fb8", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1301 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x892024", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9198,10 +9538,10 @@ Types:
       GoKind: 22
       Pointee: 671 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1312
+      ID: 1314
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1313
+      ID: 1315
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9281,7 +9621,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1284
+      ID: 1286
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9297,7 +9637,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1285
+      ID: 1287
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9624,7 +9964,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1304
+      ID: 1306
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9650,7 +9990,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1301
+      ID: 1303
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9666,7 +10006,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1323
+      ID: 1325
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9682,7 +10022,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1332
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9698,7 +10038,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
+      ID: 1331
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9896,7 +10236,7 @@ Types:
       ID: 1182
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1334
+      ID: 1336
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1179
@@ -9928,16 +10268,16 @@ Types:
       ID: 1180
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1337
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1336
+      ID: 1338
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1337
+      ID: 1339
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1338
+      ID: 1340
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1183
@@ -9946,7 +10286,7 @@ Types:
       ID: 1184
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1333
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9962,7 +10302,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1335
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9978,10 +10318,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1334
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1341
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9997,7 +10337,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1342
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10013,7 +10353,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1343
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10125,7 +10465,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1282
+      ID: 1284
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10141,7 +10481,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1283
+      ID: 1285
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10228,7 +10568,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1288
+      ID: 1290
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10324,7 +10664,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1289
+      ID: 1291
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10660,7 +11000,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1322
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10676,7 +11016,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1321
+      ID: 1323
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10692,7 +11032,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1290
+      ID: 1292
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10788,7 +11128,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1291
+      ID: 1293
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10804,7 +11144,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1294
+      ID: 1296
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10830,7 +11170,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1295
+      ID: 1297
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10856,7 +11196,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1286
+      ID: 1288
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10882,7 +11222,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1287
+      ID: 1289
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10898,7 +11238,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1248
+      ID: 1250
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10914,7 +11254,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1251
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11012,7 +11352,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1247
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1249
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11054,7 +11426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1307
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11080,7 +11452,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1309
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11116,7 +11488,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1310
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11132,7 +11504,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1321
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11280,10 +11652,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1262
+      ID: 1264
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1263
+      ID: 1265
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11299,10 +11671,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1266
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1265
+      ID: 1267
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11318,10 +11690,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1260
+      ID: 1262
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1261
+      ID: 1263
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11337,10 +11709,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1268
+      ID: 1270
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1269
+      ID: 1271
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11436,10 +11808,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1280
+      ID: 1282
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1281
+      ID: 1283
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11465,10 +11837,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1258
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1257
+      ID: 1259
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11664,10 +12036,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1258
+      ID: 1260
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1259
+      ID: 1261
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11683,10 +12055,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1254
+      ID: 1256
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1255
+      ID: 1257
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11862,10 +12234,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1268
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1267
+      ID: 1269
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11881,10 +12253,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1272
+      ID: 1274
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1273
+      ID: 1275
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11940,10 +12312,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1278
+      ID: 1280
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1279
+      ID: 1281
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11969,10 +12341,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1276
+      ID: 1278
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1277
+      ID: 1279
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11988,10 +12360,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1254
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1253
+      ID: 1255
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12077,10 +12449,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1274
+      ID: 1276
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1275
+      ID: 1277
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12096,10 +12468,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1270
+      ID: 1272
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1271
+      ID: 1273
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12291,7 +12663,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1314
+      ID: 1316
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12387,7 +12759,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1313
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12403,7 +12775,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1302
+      ID: 1304
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12435,7 +12807,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1250
+      ID: 1252
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12451,7 +12823,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1251
+      ID: 1253
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12487,7 +12859,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1292
+      ID: 1294
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12503,7 +12875,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1293
+      ID: 1295
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12571,7 +12943,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1308
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12619,7 +12991,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
+      ID: 1305
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12661,7 +13033,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1296
+      ID: 1298
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12677,7 +13049,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1297
+      ID: 1299
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12703,7 +13075,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1325
+      ID: 1327
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12719,10 +13091,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1326
+      ID: 1328
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1324
+      ID: 1326
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12754,7 +13126,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1329
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12770,10 +13142,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1328
+      ID: 1330
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1318
+      ID: 1320
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12789,7 +13161,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1318
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12805,10 +13177,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1317
+      ID: 1319
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1315
+      ID: 1317
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12956,7 +13328,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1300
+      ID: 1302
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12972,7 +13344,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1322
+      ID: 1324
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13020,7 +13392,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1309
+      ID: 1311
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13036,7 +13408,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1310
+      ID: 1312
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13052,7 +13424,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1298
+      ID: 1300
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13078,7 +13450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1299
+      ID: 1301
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -20130,7 +20502,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1341
+MaxTypeID: 1343
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -5,19 +5,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
+      message: stackC
       template: ""
-      segments: []
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1487 EventRootType Probe[main.stackC]
+          Type: 1489 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84fe58", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1488 EventRootType Probe[main.stackC]Return
+          Type: 1490 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84fe8c", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,8 +26,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -45,8 +47,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -64,19 +67,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1461 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x84ecac", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1462 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ed44", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -84,8 +88,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -99,8 +104,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -114,8 +120,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -129,8 +136,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -144,8 +152,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -158,8 +167,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -173,8 +183,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -193,8 +204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -208,8 +220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -223,8 +236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
+      message: '{c}'
       template: ""
-      segments: []
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -238,8 +252,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
+      message: '{w}, {x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -253,8 +276,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
+      message: '{t}'
       template: ""
-      segments: []
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -268,8 +292,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -283,8 +308,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -298,8 +324,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -313,8 +340,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -328,8 +356,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -343,8 +372,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -358,14 +388,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testEmptySlice]
+          Type: 1478 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84fad0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -373,14 +404,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1481 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84fb00", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -389,14 +426,15 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptyString]
+          Type: 1500 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ff30", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,28 +442,30 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1504 EventRootType Probe[main.testEmptyStruct]
+          Type: 1506 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x850280", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1507 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x850290", Frameless: true}]
           Condition: null
     - id: testError
@@ -433,8 +473,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -448,8 +489,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -468,8 +510,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -488,8 +531,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -508,8 +552,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -531,8 +576,9 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -546,8 +592,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -566,8 +613,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
+      message: '{x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -586,8 +639,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -606,14 +660,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
+      message: testInlinedBBB
       template: ""
-      segments: []
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1509 EventRootType Probe[main.testInlinedBBB]
+          Type: 1511 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -621,8 +676,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
+      message: testInlinedBC
       template: ""
-      segments: []
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -641,14 +697,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1510 EventRootType Probe[main.testInlinedBCA]
+          Type: 1512 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -659,14 +716,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1513 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -674,14 +732,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1512 EventRootType Probe[main.testInlinedBCB]
+          Type: 1514 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -692,14 +751,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1515 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -708,14 +768,15 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1506 EventRootType Probe[main.testInlinedPrint]
+          Type: 1508 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -728,9 +789,9 @@ Probes:
             - PC: "0x84b00c"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1509 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -741,14 +802,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1510 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -766,14 +828,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1514 EventRootType Probe[main.testInlinedSq]
+          Type: 1516 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -784,14 +847,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1515 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1517 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -800,14 +864,15 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1516 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1518 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1c4"
               Frameless: false
@@ -819,8 +884,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -834,8 +900,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -849,8 +916,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -864,8 +932,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -879,8 +948,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -894,8 +964,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -908,19 +979,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1459 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x84eaf0", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1460 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ec48", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -928,8 +1000,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -946,8 +1019,9 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -964,8 +1038,9 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -982,8 +1057,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -996,19 +1077,46 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1465 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x84efac", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1466 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x84f118", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1016,8 +1124,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -1031,8 +1140,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -1046,8 +1156,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -1061,8 +1172,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -1076,8 +1188,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1091,8 +1204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1106,8 +1220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1121,8 +1236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1136,8 +1252,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1151,8 +1270,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1166,8 +1288,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1181,8 +1304,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1196,8 +1320,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1211,8 +1336,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1226,8 +1352,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1241,8 +1368,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1256,8 +1384,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1271,8 +1400,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1286,8 +1416,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1301,8 +1432,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1316,14 +1450,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMassiveString]
+          Type: 1497 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1332,90 +1467,131 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1496 EventRootType Probe[main.testMassiveString]
+          Type: 1498 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1467 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x84f180", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1468 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x84f32c", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1471 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1472 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x84f4d4", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
+      message: '{s1}, {s2}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1463 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x84ed80", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1464 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x84ef50", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1423,8 +1599,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
+      message: '{a}, {b}, {c}, {d}, {e}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1437,8 +1628,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1452,13 +1644,45 @@ Probes:
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e088", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1423 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84e028", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1424 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e088", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
+      message: '{z}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1472,14 +1696,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1483 EventRootType Probe[main.testNilSlice]
+          Type: 1485 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1487,14 +1712,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1482 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1502,14 +1733,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
+      message: '{a}, {s}, {x}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1484 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1517,14 +1757,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1496 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ff00", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1532,8 +1773,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1547,8 +1789,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1562,8 +1805,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1577,8 +1821,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1605,8 +1850,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}, {failed}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1632,114 +1883,120 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
+      message: testReturnsArray
       template: ""
-      segments: []
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsArray]
+          Type: 1437 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x84e4fc", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1438 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x84e550", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
+      message: testReturnsArrayOne
       template: ""
-      segments: []
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1439 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x84e588", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1440 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x84e5c4", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
+      message: testReturnsArrayZero
       template: ""
-      segments: []
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1441 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x84e5f8", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1442 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x84e630", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
+      message: testReturnsBacktrackInt
       template: ""
-      segments: []
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1445 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x84e6e8", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1446 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x84e74c", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
+      message: testReturnsBoolAndUintptr
       template: ""
-      segments: []
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1457 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x84ea78", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1458 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x84eab8", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
+      message: testReturnsComplex
       template: ""
-      segments: []
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsComplex]
+          Type: 1433 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x84e3a8", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1434 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x84e3f4", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1747,8 +2004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{failed}'
       template: ""
-      segments: []
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1770,8 +2028,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1789,8 +2048,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1808,8 +2068,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1828,8 +2089,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1851,171 +2113,180 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
+      message: testReturnsLargeStruct
       template: ""
-      segments: []
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1435 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x84e430", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1436 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x84e4c4", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
+      message: testReturnsManyFloats
       template: ""
-      segments: []
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1431 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x84e2e8", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1432 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x84e36c", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
+      message: testReturnsMixed
       template: ""
-      segments: []
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsMixed]
+          Type: 1449 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x84e868", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1450 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x84e8c0", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
+      message: testReturnsMixedStruct
       template: ""
-      segments: []
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1443 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x84e668", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1444 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x84e6b0", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
+      message: testReturnsMultipleFloats
       template: ""
-      segments: []
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1455 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x84e9f8", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1456 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x84ea3c", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
+      message: testReturnsOnlyFloat
       template: ""
-      segments: []
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1453 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x84e988", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1454 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x84e9c8", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
+      message: testReturnsPrimitives
       template: ""
-      segments: []
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1429 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x84e258", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1430 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x84e2b0", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
+      message: testReturnsStructWithArray
       template: ""
-      segments: []
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1451 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x84e8fc", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1452 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x84e950", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
+      message: testReturnsWideStruct
       template: ""
-      segments: []
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1447 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x84e790", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1448 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x84e834", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2023,8 +2294,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -2038,8 +2310,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -2053,8 +2326,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -2068,8 +2342,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -2083,8 +2358,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -2098,8 +2374,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -2113,8 +2390,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2128,8 +2406,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -2143,8 +2422,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -2158,8 +2438,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2173,8 +2454,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2188,14 +2470,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1489 EventRootType Probe[main.testSingleString]
+          Type: 1491 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84feb0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2203,8 +2486,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2218,8 +2502,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2233,8 +2518,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2248,8 +2534,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2263,8 +2550,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2278,14 +2566,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1488 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2293,14 +2582,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1477 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1479 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84fae0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2308,8 +2598,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2322,38 +2613,40 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1427 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84e198", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1428 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84e220", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1469 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x84f388", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1470 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x84f3ec", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2361,8 +2654,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2376,8 +2670,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
+      message: '{z}'
       template: ""
-      segments: []
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2391,14 +2686,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1481 EventRootType Probe[main.testStringSlice]
+          Type: 1483 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2406,8 +2702,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2421,8 +2718,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2436,19 +2734,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1502 EventRootType Probe[main.testStruct]
+          Type: 1504 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x850180", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1503 EventRootType Probe[main.testStruct]Return
+          Type: 1505 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x85019c", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2456,14 +2755,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testStructSlice]
+          Type: 1480 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84faf0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2471,8 +2776,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2485,52 +2791,55 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1473 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x84f50c", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1474 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x84f59c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1502 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x850090", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1503 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x8500a8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1501 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x850080", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2538,8 +2847,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2553,14 +2863,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
+      message: '{x}, {y}, {z}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1490 EventRootType Probe[main.testThreeStrings]
+          Type: 1492 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84fec0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2568,19 +2887,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1493 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84fed0", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1494 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84fee8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2588,14 +2908,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1495 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84fef0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2603,8 +2924,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2618,8 +2940,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2633,8 +2956,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2648,8 +2972,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2663,8 +2988,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2678,8 +3004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2693,8 +3020,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +3036,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1475 EventRootType Probe[main.testUintSlice]
+          Type: 1477 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84fac0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2723,14 +3052,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1497 EventRootType Probe[main.testUnitializedString]
+          Type: 1499 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ff20", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2738,8 +3068,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2753,8 +3084,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2768,14 +3100,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1486 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2783,33 +3116,40 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1487 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1475 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1476 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84f640", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9503,10 +9843,10 @@ Types:
       GoKind: 22
       Pointee: 808 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9586,7 +9926,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9602,7 +9942,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9929,7 +10269,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9955,7 +10295,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9971,7 +10311,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9987,7 +10327,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10003,7 +10343,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10201,7 +10541,7 @@ Types:
       ID: 1357
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1354
@@ -10233,16 +10573,16 @@ Types:
       ID: 1355
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1358
@@ -10251,7 +10591,7 @@ Types:
       ID: 1359
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10267,7 +10607,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10283,10 +10623,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10302,7 +10642,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10318,7 +10658,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10430,7 +10770,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10446,7 +10786,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10533,7 +10873,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10629,7 +10969,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10965,7 +11305,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10981,7 +11321,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10997,7 +11337,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11093,7 +11433,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11109,7 +11449,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -11135,7 +11475,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11161,7 +11501,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11187,7 +11527,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11203,7 +11543,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11219,7 +11559,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11317,7 +11657,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1422
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1424
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11359,7 +11731,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11385,7 +11757,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11421,7 +11793,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11437,7 +11809,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11585,10 +11957,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1437
+      ID: 1439
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1438
+      ID: 1440
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11604,10 +11976,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1441
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11623,10 +11995,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1435
+      ID: 1437
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1436
+      ID: 1438
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11642,10 +12014,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11741,10 +12113,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1455
+      ID: 1457
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11770,10 +12142,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1432
+      ID: 1434
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11969,10 +12341,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1433
+      ID: 1435
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1434
+      ID: 1436
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11988,10 +12360,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -12167,10 +12539,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12186,10 +12558,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12245,10 +12617,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12274,10 +12646,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12293,10 +12665,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12382,10 +12754,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12401,10 +12773,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12596,7 +12968,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12692,7 +13064,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12708,7 +13080,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12740,7 +13112,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12756,7 +13128,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12792,7 +13164,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12808,7 +13180,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12876,7 +13248,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12924,7 +13296,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12966,7 +13338,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12982,7 +13354,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13008,7 +13380,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13024,10 +13396,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -13059,7 +13431,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -13075,10 +13447,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13094,7 +13466,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13110,10 +13482,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13261,7 +13633,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13277,7 +13649,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13325,7 +13697,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13341,7 +13713,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13357,7 +13729,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13383,7 +13755,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -21890,7 +22262,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1516
+MaxTypeID: 1518
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -5,19 +5,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
+      message: stackC
       template: ""
-      segments: []
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
+        - ID: 192
           Kind: Entry
-          Type: 1506 EventRootType Probe[main.stackC]
+          Type: 1508 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80c2e8", Frameless: false}]
           Condition: null
-        - ID: 189
+        - ID: 191
           Kind: Return
-          Type: 1507 EventRootType Probe[main.stackC]Return
+          Type: 1509 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80c318", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,8 +26,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -45,8 +47,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -64,19 +67,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
+        - ID: 164
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1480 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x80b24c", Frameless: false}]
           Condition: null
-        - ID: 161
+        - ID: 163
           Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1481 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b2d8", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -84,8 +88,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -99,8 +104,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -114,8 +120,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -129,8 +136,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -144,8 +152,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -158,8 +167,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -173,8 +183,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -193,8 +204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -208,8 +220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -223,8 +236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
+      message: '{c}'
       template: ""
-      segments: []
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -238,8 +252,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
+      message: '{w}, {x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -253,8 +276,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
+      message: '{t}'
       template: ""
-      segments: []
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -268,8 +292,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -283,8 +308,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -298,8 +324,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -313,8 +340,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -328,8 +356,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -343,8 +372,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -358,14 +388,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
+        - ID: 180
           Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          Type: 1497 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80bf90", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -373,14 +404,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
+        - ID: 183
           Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1500 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80bfc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -389,14 +426,15 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
+        - ID: 202
           Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptyString]
+          Type: 1519 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -404,28 +442,30 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
+        - ID: 208
           Kind: Entry
-          Type: 1523 EventRootType Probe[main.testEmptyStruct]
+          Type: 1525 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
+        - ID: 209
           Kind: Entry
-          Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1526 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
     - id: testError
@@ -433,8 +473,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -448,8 +489,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -468,8 +510,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
+      message: '{e}'
       template: ""
-      segments: []
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -488,8 +531,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -508,8 +552,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -531,8 +576,9 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -546,8 +592,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -566,8 +613,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
+      message: '{x}, {y}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -586,8 +639,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -606,14 +660,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
+      message: testInlinedBBB
       template: ""
-      segments: []
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
+        - ID: 213
           Kind: Entry
-          Type: 1528 EventRootType Probe[main.testInlinedBBB]
+          Type: 1530 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -621,8 +676,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
+      message: testInlinedBC
       template: ""
-      segments: []
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -641,14 +697,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
+        - ID: 214
           Kind: Entry
-          Type: 1529 EventRootType Probe[main.testInlinedBCA]
+          Type: 1531 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -659,14 +716,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCA
       template: ""
-      segments: []
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
+        - ID: 215
           Kind: Line
-          Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1532 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -674,14 +732,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
+        - ID: 216
           Kind: Entry
-          Type: 1531 EventRootType Probe[main.testInlinedBCB]
+          Type: 1533 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -692,14 +751,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
+      message: testInlinedBCB
       template: ""
-      segments: []
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
+        - ID: 217
           Kind: Line
-          Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1534 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -708,14 +768,15 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
+        - ID: 211
           Kind: Entry
-          Type: 1525 EventRootType Probe[main.testInlinedPrint]
+          Type: 1527 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -728,9 +789,9 @@ Probes:
             - PC: "0x80781c"
               Frameless: false
           Condition: null
-        - ID: 208
+        - ID: 210
           Kind: Return
-          Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1528 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -741,14 +802,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
+        - ID: 212
           Kind: Line
-          Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1529 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -766,14 +828,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
+        - ID: 218
           Kind: Entry
-          Type: 1533 EventRootType Probe[main.testInlinedSq]
+          Type: 1535 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -784,14 +847,15 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
+        - ID: 219
           Kind: Line
-          Type: 1534 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1536 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -800,14 +864,15 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
+        - ID: 220
           Kind: Entry
-          Type: 1535 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1537 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8079b4"
               Frameless: false
@@ -819,8 +884,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -834,8 +900,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -849,8 +916,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -864,8 +932,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -879,8 +948,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -894,8 +964,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{b}'
       template: ""
-      segments: []
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -908,19 +979,20 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
+        - ID: 162
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1478 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x80b0c0", Frameless: false}]
           Condition: null
-        - ID: 159
+        - ID: 161
           Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1479 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b1e8", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -928,8 +1000,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -946,8 +1019,9 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -964,8 +1038,9 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
+      message: testLongFunctionWithChangingState
       template: ""
-      segments: []
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -982,8 +1057,14 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
+      message: '{a} and {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -996,19 +1077,46 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
+        - ID: 168
           Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1484 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x80b51c", Frameless: false}]
           Condition: null
-        - ID: 165
+        - ID: 167
           Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1485 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x80b65c", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -1016,8 +1124,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -1031,8 +1140,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -1046,8 +1156,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -1061,8 +1172,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -1076,8 +1188,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1091,8 +1204,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1106,8 +1220,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1121,8 +1236,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1136,8 +1252,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1151,8 +1270,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1166,8 +1288,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1181,8 +1304,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1196,8 +1320,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1211,8 +1336,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1226,8 +1352,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1241,8 +1368,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1256,8 +1384,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1271,8 +1400,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1286,8 +1416,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1301,8 +1432,11 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
+      message: '{redactMyEntries}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1316,14 +1450,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
+        - ID: 199
           Kind: Entry
-          Type: 1514 EventRootType Probe[main.testMassiveString]
+          Type: 1516 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1332,90 +1467,131 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
+        - ID: 200
           Kind: Entry
-          Type: 1515 EventRootType Probe[main.testMassiveString]
+          Type: 1517 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
+      message: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
+        - ID: 170
           Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1486 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x80b6c0", Frameless: false}]
           Condition: null
-        - ID: 167
+        - ID: 169
           Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1487 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x80b848", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
+        - ID: 174
           Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1490 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x80b93c", Frameless: false}]
           Condition: null
-        - ID: 171
+        - ID: 173
           Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1491 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x80b9d4", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
+      message: '{s1}, {s2}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
+        - ID: 166
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1482 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x80b310", Frameless: false}]
           Condition: null
-        - ID: 163
+        - ID: 165
           Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1483 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x80b4b4", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
+        - ID: 128
           Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1444 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a718", Frameless: false}]
           Condition: null
-        - ID: 125
+        - ID: 127
           Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1445 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1423,8 +1599,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
+      message: '{a}, {b}, {c}, {d}, {e}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1437,8 +1628,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1452,13 +1644,45 @@ Probes:
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      message: Parameter {i} * 2 = result {result}
+      template: ""
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 126
+          Kind: Entry
+          Type: 1442 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a688", Frameless: false}]
+          Condition: null
+        - ID: 125
+          Kind: Return
+          Type: 1443 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
+      message: '{z}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1472,14 +1696,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
+        - ID: 187
           Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
+          Type: 1504 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1487,14 +1712,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
+        - ID: 184
           Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1501 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1502,14 +1733,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
+      message: '{a}, {s}, {x}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
+        - ID: 186
           Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1503 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1517,14 +1757,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
+        - ID: 198
           Kind: Entry
-          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1515 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80c370", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1532,8 +1773,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1547,8 +1789,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1562,8 +1805,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1577,8 +1821,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1605,8 +1850,14 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}, {failed}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1632,114 +1883,120 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
+      message: testReturnsArray
       template: ""
-      segments: []
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
+        - ID: 140
           Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          Type: 1456 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x80ab1c", Frameless: false}]
           Condition: null
-        - ID: 137
+        - ID: 139
           Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1457 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x80ab68", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
+      message: testReturnsArrayOne
       template: ""
-      segments: []
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
+        - ID: 142
           Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1458 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x80ab98", Frameless: false}]
           Condition: null
-        - ID: 139
+        - ID: 141
           Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1459 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x80abd0", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
+      message: testReturnsArrayZero
       template: ""
-      segments: []
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
+        - ID: 144
           Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1460 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x80ac08", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 143
           Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1461 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x80ac3c", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
+      message: testReturnsBacktrackInt
       template: ""
-      segments: []
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
+        - ID: 148
           Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1464 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x80acf8", Frameless: false}]
           Condition: null
-        - ID: 145
+        - ID: 147
           Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1465 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
+      message: testReturnsBoolAndUintptr
       template: ""
-      segments: []
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
+        - ID: 160
           Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1476 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x80b048", Frameless: false}]
           Condition: null
-        - ID: 157
+        - ID: 159
           Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1477 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x80b084", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
+      message: testReturnsComplex
       template: ""
-      segments: []
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
+        - ID: 136
           Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          Type: 1452 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x80a9d8", Frameless: false}]
           Condition: null
-        - ID: 133
+        - ID: 135
           Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1453 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x80aa20", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1747,8 +2004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
+      message: '{failed}'
       template: ""
-      segments: []
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1770,8 +2028,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1789,8 +2048,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1808,8 +2068,9 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1828,8 +2089,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
+      message: '{v}'
       template: ""
-      segments: []
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1851,171 +2113,180 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
+      message: testReturnsLargeStruct
       template: ""
-      segments: []
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
+        - ID: 138
           Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1454 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x80aa60", Frameless: false}]
           Condition: null
-        - ID: 135
+        - ID: 137
           Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1455 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x80aadc", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
+      message: testReturnsManyFloats
       template: ""
-      segments: []
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
+        - ID: 134
           Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1450 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x80a928", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 133
           Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1451 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x80a9a8", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
+      message: testReturnsMixed
       template: ""
-      segments: []
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
+        - ID: 152
           Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          Type: 1468 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
           Condition: null
-        - ID: 149
+        - ID: 151
           Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1469 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80aeac", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
+      message: testReturnsMixedStruct
       template: ""
-      segments: []
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
+        - ID: 146
           Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1462 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x80ac78", Frameless: false}]
           Condition: null
-        - ID: 143
+        - ID: 145
           Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1463 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80acbc", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
+      message: testReturnsMultipleFloats
       template: ""
-      segments: []
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
+        - ID: 158
           Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1474 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x80afd8", Frameless: false}]
           Condition: null
-        - ID: 155
+        - ID: 157
           Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1475 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x80b018", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
+      message: testReturnsOnlyFloat
       template: ""
-      segments: []
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
+        - ID: 156
           Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1472 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x80af68", Frameless: false}]
           Condition: null
-        - ID: 153
+        - ID: 155
           Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1473 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x80afa4", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
+      message: testReturnsPrimitives
       template: ""
-      segments: []
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
+        - ID: 132
           Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1448 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x80a898", Frameless: false}]
           Condition: null
-        - ID: 129
+        - ID: 131
           Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1449 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80a8ec", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
+      message: testReturnsStructWithArray
       template: ""
-      segments: []
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
+        - ID: 154
           Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1470 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x80aeec", Frameless: false}]
           Condition: null
-        - ID: 151
+        - ID: 153
           Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1471 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x80af38", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
+      message: testReturnsWideStruct
       template: ""
-      segments: []
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
+        - ID: 150
           Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1466 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x80ad90", Frameless: false}]
           Condition: null
-        - ID: 147
+        - ID: 149
           Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1467 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x80ae1c", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -2023,8 +2294,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -2038,8 +2310,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -2053,8 +2326,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -2068,8 +2342,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -2083,8 +2358,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -2098,8 +2374,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -2113,8 +2390,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -2128,8 +2406,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -2143,8 +2422,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -2158,8 +2438,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
+      message: parameter = {x}
       template: ""
-      segments: []
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2173,8 +2454,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2188,14 +2470,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
+        - ID: 193
           Kind: Entry
-          Type: 1508 EventRootType Probe[main.testSingleString]
+          Type: 1510 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80c330", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2203,8 +2486,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2218,8 +2502,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2233,8 +2518,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2248,8 +2534,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2263,8 +2550,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2278,14 +2566,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
+        - ID: 190
           Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1507 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2293,14 +2582,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
+        - ID: 181
           Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1498 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80bfa0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2308,8 +2598,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
+      message: '{m}'
       template: ""
-      segments: []
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2322,38 +2613,40 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
+      message: '{i}'
       template: ""
-      segments: []
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
+        - ID: 130
           Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1446 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a7d8", Frameless: false}]
           Condition: null
-        - ID: 127
+        - ID: 129
           Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1447 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a85c", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
+        - ID: 172
           Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1488 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x80b8a8", Frameless: false}]
           Condition: null
-        - ID: 169
+        - ID: 171
           Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1489 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x80b900", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2361,8 +2654,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2376,8 +2670,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
+      message: '{z}'
       template: ""
-      segments: []
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2391,14 +2686,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
+        - ID: 185
           Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
+          Type: 1502 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2406,8 +2702,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2421,8 +2718,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2436,19 +2734,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
+        - ID: 207
           Kind: Entry
-          Type: 1521 EventRootType Probe[main.testStruct]
+          Type: 1523 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
           Condition: null
-        - ID: 204
+        - ID: 206
           Kind: Return
-          Type: 1522 EventRootType Probe[main.testStruct]Return
+          Type: 1524 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2456,14 +2755,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
+      message: '{xs}, {a}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
+        - ID: 182
           Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
+          Type: 1499 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80bfb0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2471,8 +2776,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2485,52 +2791,55 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
+      message: '{arg}'
       template: ""
-      segments: []
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
+        - ID: 176
           Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1492 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x80ba0c", Frameless: false}]
           Condition: null
-        - ID: 173
+        - ID: 175
           Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1493 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x80ba90", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
+        - ID: 205
           Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1521 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80c4f0", Frameless: true}]
           Condition: null
-        - ID: 202
+        - ID: 204
           Kind: Return
-          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1522 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80c4fc", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
+        - ID: 203
           Kind: Entry
-          Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1520 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80c4e0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2538,8 +2847,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
+      message: '{s}'
       template: ""
-      segments: []
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2553,14 +2863,23 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
+      message: '{x}, {y}, {z}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
+        - ID: 194
           Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStrings]
+          Type: 1511 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80c340", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2568,19 +2887,20 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
+        - ID: 196
           Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80c350", Frameless: true}]
           Condition: null
-        - ID: 193
+        - ID: 195
           Kind: Return
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c35c", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2588,14 +2908,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
+        - ID: 197
           Kind: Entry
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c360", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2603,8 +2924,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2618,8 +2940,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2633,8 +2956,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2648,8 +2972,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2663,8 +2988,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2678,8 +3004,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2693,8 +3020,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2708,14 +3036,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
+      message: '{u}'
       template: ""
-      segments: []
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
+        - ID: 179
           Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
+          Type: 1496 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80bf80", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2723,14 +3052,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
+        - ID: 201
           Kind: Entry
-          Type: 1516 EventRootType Probe[main.testUnitializedString]
+          Type: 1518 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80c390", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2738,8 +3068,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
+      message: '{x}'
       template: ""
-      segments: []
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2753,8 +3084,9 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
+      message: '{a}'
       template: ""
-      segments: []
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2768,14 +3100,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
+        - ID: 188
           Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1505 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2783,33 +3116,40 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
+      message: '{xs}'
       template: ""
-      segments: []
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
+        - ID: 189
           Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1506 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
+      message: '{a}, {b}'
       template: ""
-      segments: []
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
+        - ID: 178
           Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1494 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
           Condition: null
-        - ID: 175
+        - ID: 177
           Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1495 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80bb28", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9604,10 +9944,10 @@ Types:
       GoKind: 22
       Pointee: 821 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9687,7 +10027,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9703,7 +10043,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10030,7 +10370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10056,7 +10396,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10072,7 +10412,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10088,7 +10428,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10104,7 +10444,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10302,7 +10642,7 @@ Types:
       ID: 1376
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1373
@@ -10334,16 +10674,16 @@ Types:
       ID: 1374
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1377
@@ -10352,7 +10692,7 @@ Types:
       ID: 1378
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10368,7 +10708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10384,10 +10724,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10403,7 +10743,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10419,7 +10759,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10531,7 +10871,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10547,7 +10887,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10634,7 +10974,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10730,7 +11070,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11066,7 +11406,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11082,7 +11422,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11098,7 +11438,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11194,7 +11534,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11210,7 +11550,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -11236,7 +11576,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11262,7 +11602,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11288,7 +11628,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11304,7 +11644,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11320,7 +11660,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11418,7 +11758,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1441
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1443
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11460,7 +11832,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11486,7 +11858,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11522,7 +11894,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11538,7 +11910,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11686,10 +12058,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11705,10 +12077,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11724,10 +12096,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1457
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11743,10 +12115,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11842,10 +12214,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11871,10 +12243,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12070,10 +12442,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12089,10 +12461,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -12268,10 +12640,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12287,10 +12659,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12346,10 +12718,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12375,10 +12747,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12394,10 +12766,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12483,10 +12855,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12502,10 +12874,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12697,7 +13069,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12793,7 +13165,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12809,7 +13181,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12841,7 +13213,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12857,7 +13229,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12893,7 +13265,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12909,7 +13281,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12977,7 +13349,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13025,7 +13397,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13067,7 +13439,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13083,7 +13455,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13109,7 +13481,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13125,10 +13497,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -13160,7 +13532,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -13176,10 +13548,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13195,7 +13567,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13211,10 +13583,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13362,7 +13734,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13378,7 +13750,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13426,7 +13798,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13442,7 +13814,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13458,7 +13830,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13484,7 +13856,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -22151,7 +22523,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1535
+MaxTypeID: 1537
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 184 EventRootType Probe[main.PointerChainArg]
+          Type: 194 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 185 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 195 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6090", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 176 EventRootType Probe[main.bigMapArg]
+          Type: 186 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 177 EventRootType Probe[main.bigMapArg]Return
+          Type: 187 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a65de", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 182 EventRootType Probe[main.inlined]
+          Type: 192 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5e0e"
               Frameless: false
             - PC: "0x4a642a"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 183 EventRootType Probe[main.inlined]Return
+          Type: 193 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a646a", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 167 EventRootType Probe[main.intArrayArg]
+          Type: 177 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 168 EventRootType Probe[main.intArrayArg]Return
+          Type: 178 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a62d6", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 173 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 183 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a6400", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 165 EventRootType Probe[main.intSliceArg]
+          Type: 175 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 166 EventRootType Probe[main.intSliceArg]Return
+          Type: 176 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a624f", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 174 EventRootType Probe[main.mapArg]
+          Type: 184 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 175 EventRootType Probe[main.mapArg]Return
+          Type: 185 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a651f", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 178 EventRootType Probe[main.noArgs]
+          Type: 188 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a660a", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 179 EventRootType Probe[main.noArgs]Return
+          Type: 189 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a6646", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 171 EventRootType Probe[main.stringArrayArg]
+          Type: 181 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 172 EventRootType Probe[main.stringArrayArg]Return
+          Type: 182 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a63d6", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,130 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 179 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 180 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 165 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 166 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 167 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 168 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: ['hello ', world, '!']
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 169 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
+          Type: 169 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 170 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
+          Type: 170 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 171 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 172 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [hello]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 173 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 174 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 180 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 190 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a6676", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 191 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a682e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -729,7 +844,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 184
+      ID: 194
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -745,7 +860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 185
+      ID: 195
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -761,7 +876,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 176
+      ID: 186
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -777,10 +892,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 177
+      ID: 187
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 182
+      ID: 192
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -796,7 +911,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 183
+      ID: 193
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 161
@@ -818,7 +933,7 @@ Types:
       ID: 162
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 167
+      ID: 177
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -834,10 +949,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 168
+      ID: 178
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 165
+      ID: 175
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -853,10 +968,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 166
+      ID: 176
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 174
+      ID: 184
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -872,13 +987,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 175
+      ID: 185
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 178
+      ID: 188
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 179
+      ID: 189
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 163
@@ -897,10 +1012,105 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 165
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 167
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 169
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 171
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 173
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 164
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 173
+      ID: 166
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 168
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 170
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 172
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 174
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 183
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -916,7 +1126,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 171
+      ID: 181
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -932,10 +1142,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 172
+      ID: 182
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 169
+      ID: 179
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -951,13 +1161,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 170
+      ID: 180
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 180
+      ID: 190
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 181
+      ID: 191
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2570,7 +2780,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39264
       GoKind: 26
-MaxTypeID: 185
+MaxTypeID: 195
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x573240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 201 EventRootType Probe[main.PointerChainArg]
+          Type: 211 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 202 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 212 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8090", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 193 EventRootType Probe[main.bigMapArg]
+          Type: 203 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a8553", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 194 EventRootType Probe[main.bigMapArg]Return
+          Type: 204 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a85de", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 199 EventRootType Probe[main.inlined]
+          Type: 209 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a7e0e"
               Frameless: false
             - PC: "0x4a842a"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 200 EventRootType Probe[main.inlined]Return
+          Type: 210 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a846a", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 184 EventRootType Probe[main.intArrayArg]
+          Type: 194 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a828a", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 185 EventRootType Probe[main.intArrayArg]Return
+          Type: 195 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a82d6", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 190 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 200 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a8400", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 182 EventRootType Probe[main.intSliceArg]
+          Type: 192 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a820a", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 183 EventRootType Probe[main.intSliceArg]Return
+          Type: 193 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a824f", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 191 EventRootType Probe[main.mapArg]
+          Type: 201 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a84ea", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 192 EventRootType Probe[main.mapArg]Return
+          Type: 202 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a851f", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 195 EventRootType Probe[main.noArgs]
+          Type: 205 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a860a", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 196 EventRootType Probe[main.noArgs]Return
+          Type: 206 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a8646", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 188 EventRootType Probe[main.stringArrayArg]
+          Type: 198 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a838a", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 189 EventRootType Probe[main.stringArrayArg]Return
+          Type: 199 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a83d6", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,130 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 196 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 197 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0x4a834f", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 182 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 183 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 184 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 185 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: ['hello ', world, '!']
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 186 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
+          Type: 186 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 187 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4a834f", Frameless: false}]
+          Type: 187 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 188 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 189 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [hello]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 190 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 191 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 197 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 207 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 208 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a883c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -755,7 +870,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -771,7 +886,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -787,7 +902,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 193
+      ID: 203
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -803,10 +918,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 194
+      ID: 204
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 199
+      ID: 209
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -822,7 +937,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 200
+      ID: 210
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 178
@@ -844,7 +959,7 @@ Types:
       ID: 179
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 184
+      ID: 194
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -860,10 +975,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 185
+      ID: 195
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 182
+      ID: 192
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -879,10 +994,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 183
+      ID: 193
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 191
+      ID: 201
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -898,13 +1013,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 192
+      ID: 202
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 195
+      ID: 205
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 196
+      ID: 206
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 180
@@ -923,10 +1038,105 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 182
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 184
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 186
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 188
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 190
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 181
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 183
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 185
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 187
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 189
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 191
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 200
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -942,7 +1152,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -958,10 +1168,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 186
+      ID: 196
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -977,13 +1187,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 187
+      ID: 197
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 197
+      ID: 207
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 198
+      ID: 208
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2754,7 +2964,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43264
       GoKind: 26
-MaxTypeID: 202
+MaxTypeID: 212
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x57e340", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 206 EventRootType Probe[main.PointerChainArg]
+          Type: 216 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae646", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 207 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 217 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae690", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 198 EventRootType Probe[main.bigMapArg]
+          Type: 208 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4aeb53", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 199 EventRootType Probe[main.bigMapArg]Return
+          Type: 209 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4aebde", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 204 EventRootType Probe[main.inlined]
+          Type: 214 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae40e"
               Frameless: false
             - PC: "0x4aea2a"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 205 EventRootType Probe[main.inlined]Return
+          Type: 215 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4aea6a", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 189 EventRootType Probe[main.intArrayArg]
+          Type: 199 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4ae88a", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 190 EventRootType Probe[main.intArrayArg]Return
+          Type: 200 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4ae8d6", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 195 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 205 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4aea00", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 187 EventRootType Probe[main.intSliceArg]
+          Type: 197 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4ae80a", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 188 EventRootType Probe[main.intSliceArg]Return
+          Type: 198 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4ae84f", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 196 EventRootType Probe[main.mapArg]
+          Type: 206 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4aeaea", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 197 EventRootType Probe[main.mapArg]Return
+          Type: 207 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4aeb1f", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 200 EventRootType Probe[main.noArgs]
+          Type: 210 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4aec0a", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 201 EventRootType Probe[main.noArgs]Return
+          Type: 211 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4aec46", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 193 EventRootType Probe[main.stringArrayArg]
+          Type: 203 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4ae98a", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 194 EventRootType Probe[main.stringArrayArg]Return
+          Type: 204 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4ae9d6", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,130 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 201 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 202 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0x4ae94f", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 187 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 188 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 189 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 190 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: ['hello ', world, '!']
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 191 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
+          Type: 191 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 192 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4ae94f", Frameless: false}]
+          Type: 192 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 193 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 194 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [hello]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 195 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 196 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 202 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 212 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aec76", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 213 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4aee44", Frameless: false}]
           Condition: null
 Subprograms:
@@ -773,7 +888,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 206
+      ID: 216
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -789,7 +904,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 217
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -805,7 +920,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 198
+      ID: 208
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -821,10 +936,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 199
+      ID: 209
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 204
+      ID: 214
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -840,7 +955,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 205
+      ID: 215
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 183
@@ -862,7 +977,7 @@ Types:
       ID: 184
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -878,10 +993,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 190
+      ID: 200
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 187
+      ID: 197
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -897,10 +1012,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 196
+      ID: 206
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -916,13 +1031,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 197
+      ID: 207
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 200
+      ID: 210
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 185
@@ -941,10 +1056,105 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 187
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 189
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 191
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 193
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 195
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 186
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 195
+      ID: 188
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 190
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 192
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 194
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 196
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 205
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -960,7 +1170,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 193
+      ID: 203
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -976,10 +1186,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 194
+      ID: 204
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 191
+      ID: 201
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -995,13 +1205,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 192
+      ID: 202
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 203
+      ID: 213
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2807,7 +3017,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 44672
       GoKind: 26
-MaxTypeID: 207
+MaxTypeID: 217
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x58d3a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 185 EventRootType Probe[main.PointerChainArg]
+          Type: 195 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5388", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 186 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 196 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb53c0", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 177 EventRootType Probe[main.bigMapArg]
+          Type: 187 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb5880", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 178 EventRootType Probe[main.bigMapArg]Return
+          Type: 188 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb58f4", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 183 EventRootType Probe[main.inlined]
+          Type: 193 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb519c"
               Frameless: false
             - PC: "0xb5748"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 184 EventRootType Probe[main.inlined]Return
+          Type: 194 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb5780", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 168 EventRootType Probe[main.intArrayArg]
+          Type: 178 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb55a8", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 169 EventRootType Probe[main.intArrayArg]Return
+          Type: 179 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb55ec", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 174 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 184 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5720", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 166 EventRootType Probe[main.intSliceArg]
+          Type: 176 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5518", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 167 EventRootType Probe[main.intSliceArg]Return
+          Type: 177 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5554", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 175 EventRootType Probe[main.mapArg]
+          Type: 185 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5808", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 176 EventRootType Probe[main.mapArg]Return
+          Type: 186 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb5838", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 179 EventRootType Probe[main.noArgs]
+          Type: 189 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb5938", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 180 EventRootType Probe[main.noArgs]Return
+          Type: 190 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb5970", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 172 EventRootType Probe[main.stringArrayArg]
+          Type: 182 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb56b8", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 173 EventRootType Probe[main.stringArrayArg]Return
+          Type: 183 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb56fc", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,130 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 180 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb5628", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 181 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0xb5664", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 166 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 167 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 168 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 169 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: ['hello ', world, '!']
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 170 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb5628", Frameless: false}]
+          Type: 170 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 171 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb5664", Frameless: false}]
+          Type: 171 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 172 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 173 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [hello]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 174 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5498", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 175 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 191 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb59b0", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 182 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 192 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb5b24", Frameless: false}]
           Condition: null
 Subprograms:
@@ -729,7 +844,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 185
+      ID: 195
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -745,7 +860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 186
+      ID: 196
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -761,7 +876,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 177
+      ID: 187
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -777,10 +892,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 178
+      ID: 188
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 183
+      ID: 193
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -796,7 +911,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 184
+      ID: 194
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 162
@@ -818,7 +933,7 @@ Types:
       ID: 163
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 168
+      ID: 178
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -834,10 +949,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 169
+      ID: 179
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 166
+      ID: 176
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -853,10 +968,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 167
+      ID: 177
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 175
+      ID: 185
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -872,13 +987,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 176
+      ID: 186
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 179
+      ID: 189
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 180
+      ID: 190
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 164
@@ -897,10 +1012,105 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 166
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 168
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 170
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 172
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 174
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 165
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 174
+      ID: 167
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 169
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 171
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 173
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 175
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 184
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -916,7 +1126,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 172
+      ID: 182
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -932,10 +1142,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 173
+      ID: 183
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 170
+      ID: 180
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -951,13 +1161,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 171
+      ID: 181
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 181
+      ID: 191
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 182
+      ID: 192
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2576,7 +2786,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39232
       GoKind: 26
-MaxTypeID: 186
+MaxTypeID: 196
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 202 EventRootType Probe[main.PointerChainArg]
+          Type: 212 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb520c", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 203 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 213 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb5244", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 194 EventRootType Probe[main.bigMapArg]
+          Type: 204 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb56f0", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 195 EventRootType Probe[main.bigMapArg]Return
+          Type: 205 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb5764", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 200 EventRootType Probe[main.inlined]
+          Type: 210 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb502c"
               Frameless: false
             - PC: "0xb55b8"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 201 EventRootType Probe[main.inlined]Return
+          Type: 211 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb55f0", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 185 EventRootType Probe[main.intArrayArg]
+          Type: 195 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 186 EventRootType Probe[main.intArrayArg]Return
+          Type: 196 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb546c", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 191 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 201 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5590", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 183 EventRootType Probe[main.intSliceArg]
+          Type: 193 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb53a8", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 184 EventRootType Probe[main.intSliceArg]Return
+          Type: 194 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb53e4", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 192 EventRootType Probe[main.mapArg]
+          Type: 202 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5678", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 193 EventRootType Probe[main.mapArg]Return
+          Type: 203 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb56a8", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 196 EventRootType Probe[main.noArgs]
+          Type: 206 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb57a8", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 197 EventRootType Probe[main.noArgs]Return
+          Type: 207 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb57e0", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 189 EventRootType Probe[main.stringArrayArg]
+          Type: 199 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb5528", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 190 EventRootType Probe[main.stringArrayArg]Return
+          Type: 200 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb556c", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,130 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 197 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb54a8", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 198 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0xb54e4", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 183 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 184 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 185 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 186 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: ['hello ', world, '!']
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 187 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb54a8", Frameless: false}]
+          Type: 187 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 188 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb54e4", Frameless: false}]
+          Type: 188 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 189 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 190 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [hello]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 191 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb5328", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 192 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb5364", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 208 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb5820", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 199 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 209 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb59a0", Frameless: false}]
           Condition: null
 Subprograms:
@@ -755,7 +870,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -771,7 +886,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 203
+      ID: 213
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -787,7 +902,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 194
+      ID: 204
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -803,10 +918,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 195
+      ID: 205
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 200
+      ID: 210
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -822,7 +937,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 179
@@ -844,7 +959,7 @@ Types:
       ID: 180
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 185
+      ID: 195
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -860,10 +975,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 186
+      ID: 196
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 183
+      ID: 193
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -879,10 +994,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 184
+      ID: 194
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 202
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -898,13 +1013,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 193
+      ID: 203
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 196
+      ID: 206
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 197
+      ID: 207
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 181
@@ -923,10 +1038,105 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 183
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 185
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 187
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 189
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 191
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 182
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 191
+      ID: 184
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 186
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 188
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 190
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 192
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 201
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -942,7 +1152,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -958,10 +1168,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 190
+      ID: 200
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 187
+      ID: 197
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -977,13 +1187,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 198
+      ID: 208
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 199
+      ID: 209
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2760,7 +2970,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43232
       GoKind: 26
-MaxTypeID: 203
+MaxTypeID: 213
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191340", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,9 +10,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
+        - ID: 34
           Kind: Entry
-          Type: 207 EventRootType Probe[main.PointerChainArg]
+          Type: 217 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7da0", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -25,9 +25,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
+        - ID: 35
           Kind: Entry
-          Type: 208 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 218 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7dd4", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -39,14 +39,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
+        - ID: 27
           Kind: Entry
-          Type: 199 EventRootType Probe[main.bigMapArg]
+          Type: 209 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb8240", Frameless: false}]
           Condition: null
-        - ID: 16
+        - ID: 26
           Kind: Return
-          Type: 200 EventRootType Probe[main.bigMapArg]Return
+          Type: 210 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb82b0", Frameless: false}]
           Condition: null
     - id: inlined
@@ -59,18 +59,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
+        - ID: 33
           Kind: Entry
-          Type: 205 EventRootType Probe[main.inlined]
+          Type: 215 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb7bc8"
               Frameless: false
             - PC: "0xb8108"
               Frameless: false
           Condition: null
-        - ID: 22
+        - ID: 32
           Kind: Return
-          Type: 206 EventRootType Probe[main.inlined]Return
+          Type: 216 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb813c", Frameless: false}]
           Condition: null
     - id: intArg
@@ -101,14 +101,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
+        - ID: 18
           Kind: Entry
-          Type: 190 EventRootType Probe[main.intArrayArg]
+          Type: 200 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb7f98", Frameless: false}]
           Condition: null
-        - ID: 7
+        - ID: 17
           Kind: Return
-          Type: 191 EventRootType Probe[main.intArrayArg]Return
+          Type: 201 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb7fd8", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -120,9 +120,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
+        - ID: 23
           Kind: Entry
-          Type: 196 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 206 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb80e0", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -134,14 +134,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
+        - ID: 16
           Kind: Entry
-          Type: 188 EventRootType Probe[main.intSliceArg]
+          Type: 198 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb7f18", Frameless: false}]
           Condition: null
-        - ID: 5
+        - ID: 15
           Kind: Return
-          Type: 189 EventRootType Probe[main.intSliceArg]Return
+          Type: 199 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb7f50", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -153,14 +153,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
+        - ID: 25
           Kind: Entry
-          Type: 197 EventRootType Probe[main.mapArg]
+          Type: 207 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb81c8", Frameless: false}]
           Condition: null
-        - ID: 14
+        - ID: 24
           Kind: Return
-          Type: 198 EventRootType Probe[main.mapArg]Return
+          Type: 208 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb81f4", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -172,14 +172,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
+        - ID: 29
           Kind: Entry
-          Type: 201 EventRootType Probe[main.noArgs]
+          Type: 211 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb82e8", Frameless: false}]
           Condition: null
-        - ID: 18
+        - ID: 28
           Kind: Return
-          Type: 202 EventRootType Probe[main.noArgs]Return
+          Type: 212 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb831c", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -210,14 +210,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
+        - ID: 22
           Kind: Entry
-          Type: 194 EventRootType Probe[main.stringArrayArg]
+          Type: 204 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb8088", Frameless: false}]
           Condition: null
-        - ID: 11
+        - ID: 21
           Kind: Return
-          Type: 195 EventRootType Probe[main.stringArrayArg]Return
+          Type: 205 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb80c8", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -229,15 +229,130 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
+        - ID: 20
+          Kind: Entry
+          Type: 202 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0xb8008", Frameless: false}]
+          Condition: null
+        - ID: 19
+          Kind: Return
+          Type: 203 EventRootType Probe[main.stringSliceArg]Return
+          InjectionPoints: [{PC: "0xb8040", Frameless: false}]
+          Condition: null
+    - id: testTemplateDSLAndStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}, and hello to {s}
+      template: ""
+      segments:
+        - 'hello '
+        - json: {ref: s}
+          dsl: s
+        - ', and hello to '
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 6
+          Kind: Entry
+          Type: 188 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          Condition: null
+        - ID: 5
+          Kind: Return
+          Type: 189 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: '{s}{s}'
+      template: ""
+      segments:
+        - json: {ref: s}
+          dsl: s
+        - json: {ref: s}
+          dsl: s
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 8
+          Kind: Entry
+          Type: 190 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          Condition: null
+        - ID: 7
+          Kind: Return
+          Type: 191 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
+          Condition: null
+    - id: testTemplateMultipleStringSegments
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello world!
+      template: ""
+      segments: ['hello ', world, '!']
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
         - ID: 10
           Kind: Entry
-          Type: 192 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb8008", Frameless: false}]
+          Type: 192 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 193 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb8040", Frameless: false}]
+          Type: 193 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringAndDSLSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello {s}
+      template: ""
+      segments: ['hello ', {json: {ref: s}, dsl: s}]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 12
+          Kind: Entry
+          Type: 194 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          Condition: null
+        - ID: 11
+          Kind: Return
+          Type: 195 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
+          Condition: null
+    - id: testTemplateStringSegment
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      tags: ['foo:bar']
+      message: hello
+      template: ""
+      segments: [hello]
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 14
+          Kind: Entry
+          Type: 196 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          Condition: null
+        - ID: 13
+          Kind: Return
+          Type: 197 EventRootType Probe[main.stringArg]Return
+          InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -249,14 +364,14 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
+        - ID: 31
           Kind: Entry
-          Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 213 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb8360", Frameless: false}]
           Condition: null
-        - ID: 20
+        - ID: 30
           Kind: Return
-          Type: 204 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 214 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb84d8", Frameless: false}]
           Condition: null
 Subprograms:
@@ -773,7 +888,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 207
+      ID: 217
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -789,7 +904,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 208
+      ID: 218
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -805,7 +920,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 199
+      ID: 209
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -821,10 +936,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 200
+      ID: 210
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 205
+      ID: 215
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -840,7 +955,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 206
+      ID: 216
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 184
@@ -862,7 +977,7 @@ Types:
       ID: 185
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 200
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -878,10 +993,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 191
+      ID: 201
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -897,10 +1012,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 197
+      ID: 207
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -916,13 +1031,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 198
+      ID: 208
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
       ID: 186
@@ -941,10 +1056,105 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
+      ID: 188
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 190
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 192
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 194
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 196
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
       ID: 187
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 196
+      ID: 189
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 191
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 193
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 195
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 197
+      Name: Probe[main.stringArg]Return
+    - __kind: EventRootType
+      ID: 206
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -960,7 +1170,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 194
+      ID: 204
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -976,10 +1186,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 195
+      ID: 205
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 202
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -995,13 +1205,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 193
+      ID: 203
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 213
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 204
+      ID: 214
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2813,7 +3023,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 44640
       GoKind: 26
-MaxTypeID: 208
+MaxTypeID: 218
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1a13a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/json_redaction_test.go
+++ b/pkg/dyninst/json_redaction_test.go
@@ -200,6 +200,7 @@ var defaultRedactors = []jsonRedactor{
 		matchRegexp(`/debugger/snapshot/stack/[[:digit:]]+$`),
 		replacerFunc(redactStackFrame),
 	),
+
 	redactor(
 		exactMatcher(`/debugger/snapshot/id`),
 		replacement(`"[id]"`),
@@ -211,6 +212,13 @@ var defaultRedactors = []jsonRedactor{
 	redactor(
 		exactMatcher(`/timestamp`),
 		replacement(`"[ts]"`),
+	),
+	redactor(
+		exactMatcher(`/message`),
+		regexpStringReplacer(
+			`0x[[:xdigit:]]+`,
+			`0x[addr]`,
+		),
 	),
 	redactor(
 		exactMatcher(`/duration`),

--- a/pkg/dyninst/rcjson/rcjson.go
+++ b/pkg/dyninst/rcjson/rcjson.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"math"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
@@ -50,8 +51,8 @@ func UnmarshalProbe(data []byte) (Probe, error) {
 	}
 	if err := json.Unmarshal(data, v); err != nil {
 		return nil, fmt.Errorf(
-			"UnmarshalProbe: id: %s, kind: %v: failed to parse json: %w",
-			c.ID, v.GetKind(), err,
+			"UnmarshalProbe: id: %s, type: %s: failed to parse json: %w",
+			c.ID, c.Type, err,
 		)
 	}
 	return v, nil
@@ -194,6 +195,12 @@ func (m *MetricProbe) GetThrottleConfig() ir.ThrottleConfig {
 // GetKind returns the kind of the probe.
 func (m *MetricProbe) GetKind() ir.ProbeKind { return ir.ProbeKindMetric }
 
+// GetTemplate returns the template of the probe.
+func (m *MetricProbe) GetTemplate() ir.TemplateDefinition { return nil }
+
+// GetSegments returns the segments of the probe template.
+func (m *MetricProbe) GetSegments() []ir.TemplateSegmentDefinition { return nil }
+
 // LogProbeCommon groups the configuration fields that are shared between
 // LogProbe and SnapshotProbe.
 //
@@ -213,8 +220,87 @@ type LogProbeCommon struct {
 	// Template is the message template of the log to emit.
 	Template string `json:"template"`
 	// Segments are the segments of the log message template.
-	Segments []json.RawMessage `json:"segments"`
+	Segments SegmentList `json:"segments"`
 }
+
+// TemplateSegment is a segment of a probe template.
+type TemplateSegment interface {
+	TemplateSegment() // marker method
+}
+
+// SegmentList is a list of Segments which can each be either a StringSegment or a JSONSegment
+type SegmentList []TemplateSegment
+
+// UnmarshalJSON implements custom JSON unmarshaling for SegmentList
+func (sl *SegmentList) UnmarshalJSON(data []byte) error {
+	var segmentData []json.RawMessage
+	if err := json.Unmarshal(data, &segmentData); err != nil {
+		return err
+	}
+
+	*sl = make([]TemplateSegment, len(segmentData))
+	for i, data := range segmentData {
+		var str StringSegment
+		if err := json.Unmarshal(data, &str); err == nil {
+			(*sl)[i] = str
+			continue
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("failed to unmarshal segment %d: %w", i, err)
+		}
+
+		if strData, hasStr := raw["str"]; hasStr {
+			var str StringSegment
+			if err := json.Unmarshal(strData, &str); err != nil {
+				return fmt.Errorf("failed to unmarshal string segment %d: %w", i, err)
+			}
+			(*sl)[i] = str
+		} else if _, hasDSL := raw["json"]; hasDSL {
+			var jsonSeg JSONSegment
+			if err := json.Unmarshal(data, &jsonSeg); err != nil {
+				return fmt.Errorf("failed to unmarshal JSON segment %d: %w", i, err)
+			}
+			(*sl)[i] = jsonSeg
+		} else {
+			return fmt.Errorf("unknown segment type at index %d: %s", i, string(data))
+		}
+	}
+	return nil
+}
+
+// StringSegment is a string literal to be used as a segment of a probe template.
+type StringSegment string
+
+// GetString implements the ir.TemplateSegmentString interface
+func (s StringSegment) GetString() string {
+	return string(s)
+}
+
+// TemplateSegment implements the TemplateSegment interface.
+func (s StringSegment) TemplateSegment() {}
+
+// JSONSegment is a JSON object to be used as a segment of a probe template.
+type JSONSegment struct {
+	// JSON is the AST of the DSL segment.
+	JSON json.RawMessage `json:"json"`
+	// DSL is the raw expression language segment.
+	DSL string `json:"dsl"`
+}
+
+// GetDSL implements the ir.TemplateSegmentExpression interface
+func (s JSONSegment) GetDSL() string {
+	return s.DSL
+}
+
+// GetJSON implements the ir.TemplateSegmentExpression interface
+func (s JSONSegment) GetJSON() json.RawMessage {
+	return s.JSON
+}
+
+// TemplateSegment implements the TemplateSegment interface.
+func (s JSONSegment) TemplateSegment() {}
 
 // GetCaptureConfig returns the capture configuration of the probe.
 func (l *LogProbeCommon) GetCaptureConfig() ir.CaptureConfig {
@@ -249,6 +335,11 @@ func (l *LogProbe) GetThrottleConfig() ir.ThrottleConfig {
 // GetKind returns the kind of the probe.
 func (l *LogProbe) GetKind() ir.ProbeKind { return ir.ProbeKindLog }
 
+// GetTemplate returns the template of the probe.
+func (l *LogProbe) GetTemplate() ir.TemplateDefinition {
+	return &logProbeTemplate{template: l.Template, segments: l.Segments}
+}
+
 // SnapshotProbe represents a probe that captures a complete snapshot of the
 // local variables and object graph when it is triggered. It behaves similarly
 // to a log probe with `captureSnapshot=true`, but it is treated as a distinct
@@ -278,6 +369,11 @@ func (l *SnapshotProbe) GetThrottleConfig() ir.ThrottleConfig {
 	return (*snapshotThrottleConfig)(l.Sampling)
 }
 
+// GetTemplate returns the template of the probe.
+func (l *SnapshotProbe) GetTemplate() ir.TemplateDefinition {
+	return &logProbeTemplate{template: l.Template, segments: l.Segments}
+}
+
 // SpanProbe is a probe that decorates a span.
 type SpanProbe struct {
 	ProbeCommon
@@ -298,6 +394,12 @@ func (s *SpanProbe) GetKind() ir.ProbeKind { return ir.ProbeKindSpan }
 
 // GetThrottleConfig returns the throttle configuration of the probe.
 func (s *SpanProbe) GetThrottleConfig() ir.ThrottleConfig { return infiniteThrottleConfig{} }
+
+// GetTemplate returns the template of the probe.
+func (s *SpanProbe) GetTemplate() ir.TemplateDefinition { return nil }
+
+// GetSegments returns the segments of the probe template.
+func (s *SpanProbe) GetSegments() []ir.TemplateSegmentDefinition { return nil }
 
 // Exists so that we can make accessors infallible. In practice, valid
 // probes won't return this.
@@ -404,6 +506,29 @@ var _ ir.ThrottleConfig = infiniteThrottleConfig{}
 
 func (infiniteThrottleConfig) GetThrottlePeriodMs() uint32 { return 1000 }
 func (infiniteThrottleConfig) GetThrottleBudget() int64    { return math.MaxInt64 }
+
+// logProbeTemplate implements ir.TemplateDefinition for LogProbe
+type logProbeTemplate struct {
+	template string
+	segments []TemplateSegment
+}
+
+func (l *logProbeTemplate) GetTemplateString() string {
+	return l.template
+}
+
+func (l *logProbeTemplate) GetSegments() iter.Seq[ir.TemplateSegmentDefinition] {
+	return func(yield func(ir.TemplateSegmentDefinition) bool) {
+		if l.segments == nil {
+			return
+		}
+		for _, seg := range l.segments {
+			if !yield(seg) {
+				return
+			}
+		}
+	}
+}
 
 func validateWhere(where *Where) error {
 	if where == nil {

--- a/pkg/dyninst/rcjson/rcjson_test.go
+++ b/pkg/dyninst/rcjson/rcjson_test.go
@@ -80,13 +80,14 @@ var testCases = []testCase{
 					SnapshotsPerSecond: 1.0,
 				},
 				Template: "Hello {name}",
-				Segments: []json.RawMessage{
-					json.RawMessage(`{"str": "Hello "}`),
-					json.RawMessage(`{"dsl": "name", "json": {"ref": "name"}}`),
+				Segments: SegmentList{
+					newStringSegment("Hello "),
+					newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
 				},
 			},
 		},
 	},
+
 	{
 		name: "log probe with file and multiple lines",
 		input: `{
@@ -136,9 +137,9 @@ var testCases = []testCase{
 					SnapshotsPerSecond: 1.0,
 				},
 				Template: "Hello {name}",
-				Segments: []json.RawMessage{
-					json.RawMessage(`{"str": "Hello "}`),
-					json.RawMessage(`{"dsl": "name", "json": {"ref": "name"}}`),
+				Segments: SegmentList{
+					newStringSegment("Hello "),
+					newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
 				},
 			},
 		},
@@ -193,9 +194,9 @@ var testCases = []testCase{
 					SnapshotsPerSecond: 1.0,
 				},
 				Template: "Hello {name}",
-				Segments: []json.RawMessage{
-					json.RawMessage(`{"str": "Hello "}`),
-					json.RawMessage(`{"dsl": "name", "json": {"ref": "name"}}`),
+				Segments: SegmentList{
+					newStringSegment("Hello "),
+					newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
 				},
 			},
 		},
@@ -253,6 +254,38 @@ var testCases = []testCase{
 			}`,
 		unmarshalErr: `failed to parse json: invalid config type: INVALID_TYPE`,
 	},
+	{
+		name: "log probe with mixed segment types including plain strings",
+		input: `{
+				"id": "log-probe-mixed",
+				"type": "LOG_PROBE",
+				"version": 1,
+				"where": {
+					"methodName": "MyMethod"
+				},
+				"template": "Hello {name} world",
+				"segments": ["Hello ", {"dsl": "name", "json": {"ref": "name"}}, " world"],
+				"captureSnapshot": false
+			}`,
+		want: &LogProbe{
+			LogProbeCommon: LogProbeCommon{
+				ProbeCommon: ProbeCommon{
+					ID:      "log-probe-mixed",
+					Version: 1,
+					Type:    TypeLogProbe.String(),
+					Where: &Where{
+						MethodName: "MyMethod",
+					},
+				},
+				Template: "Hello {name} world",
+				Segments: SegmentList{
+					newStringSegment("Hello "),
+					newJSONSegment(json.RawMessage(`{"ref": "name"}`), "name"),
+					newStringSegment(" world"),
+				},
+			},
+		},
+	},
 }
 
 func TestUnmarshalProbe(t *testing.T) {
@@ -274,5 +307,17 @@ func TestUnmarshalProbe(t *testing.T) {
 				assert.NoError(t, validationErr)
 			}
 		})
+	}
+}
+
+func newStringSegment(value string) StringSegment {
+	s := StringSegment(value)
+	return s
+}
+
+func newJSONSegment(json json.RawMessage, dsl string) JSONSegment {
+	return JSONSegment{
+		JSON: json,
+		DSL:  dsl,
 	}
 }

--- a/pkg/dyninst/rcscrape/probe_definition.go
+++ b/pkg/dyninst/rcscrape/probe_definition.go
@@ -23,18 +23,24 @@ import (
 
 type probeDefinitionV1 struct{ probeDefinition }
 
-func (r probeDefinitionV1) GetID() string      { return rcProbeIDV1 }
-func (r probeDefinitionV1) GetWhere() ir.Where { return probeWhereV1{} }
+func (r probeDefinitionV1) GetID() string                               { return rcProbeIDV1 }
+func (r probeDefinitionV1) GetWhere() ir.Where                          { return probeWhereV1{} }
+func (r probeDefinitionV1) GetSegments() []ir.TemplateSegmentDefinition { return nil }
+func (r probeDefinitionV1) GetTemplate() ir.TemplateDefinition          { return nil }
 
 type probeDefinitionV2 struct{ probeDefinition }
 
-func (r probeDefinitionV2) GetID() string      { return rcProbeIDV2 }
-func (r probeDefinitionV2) GetWhere() ir.Where { return probeWhereV2{} }
+func (r probeDefinitionV2) GetID() string                               { return rcProbeIDV2 }
+func (r probeDefinitionV2) GetWhere() ir.Where                          { return probeWhereV2{} }
+func (r probeDefinitionV2) GetSegments() []ir.TemplateSegmentDefinition { return nil }
+func (r probeDefinitionV2) GetTemplate() ir.TemplateDefinition          { return nil }
 
 type symdbProbeDefinition struct{ probeDefinition }
 
-func (r symdbProbeDefinition) GetID() string      { return rcProbeIDSymdb }
-func (r symdbProbeDefinition) GetWhere() ir.Where { return probeWhereSymdb{} }
+func (r symdbProbeDefinition) GetID() string                               { return rcProbeIDSymdb }
+func (r symdbProbeDefinition) GetWhere() ir.Where                          { return probeWhereSymdb{} }
+func (r symdbProbeDefinition) GetSegments() []ir.TemplateSegmentDefinition { return nil }
+func (r symdbProbeDefinition) GetTemplate() ir.TemplateDefinition          { return nil }
 
 type probeDefinition struct{}
 

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -96,10 +96,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [382:439] injectible: [382-389], [391-395], [397-399], [401-403], [406-420], [426-428], [432-439]
+		Var: &v: *main.firstBehavior (declared at line 391, available: [382-439])
+		Var: &fortyTwo: *int (declared at line 394, available: [395-395])
+		Var: .autotmp_8: [0]int (declared at line 437, available: [382-439])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -206,9 +206,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [288:293] injectible: [288-293]
+		Arg: arg: [3]int (declared at line 288, available: [288-293])
+		Arg: ~r0: [3]int (declared at line 288, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -375,9 +375,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [272:282] injectible: [272-282]
+		Arg: arg: main.largeStruct (declared at line 272, available: [272-282])
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -386,17 +386,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [319:321] injectible: [319-321]
+		Arg: a: int (declared at line 319, available: [319-321])
+		Arg: b: int (declared at line 319, available: [319-321])
+		Arg: c: int (declared at line 319, available: [319-321])
+		Arg: d: int (declared at line 319, available: [319-321])
+		Arg: e: int (declared at line 319, available: [319-321])
+		Arg: f: int (declared at line 319, available: [319-321])
+		Arg: g: int (declared at line 319, available: [319-321])
+		Arg: h: int (declared at line 319, available: [319-321])
+		Arg: i: int (declared at line 319, available: [319-321])
+		Arg: ~r0: [2]int (declared at line 319, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -437,30 +437,30 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:340] injectible: [328-340]
+		Arg: a: int (declared at line 328, available: [328-340])
+		Arg: b: int (declared at line 328, available: [328-340])
+		Arg: c: int (declared at line 328, available: [328-340])
+		Arg: d: int (declared at line 328, available: [328-340])
+		Arg: e: int (declared at line 328, available: [328-340])
+		Arg: f: int (declared at line 328, available: [328-340])
+		Arg: g: int (declared at line 328, available: [328-340])
+		Arg: h: int (declared at line 328, available: [328-340])
+		Arg: s: string (declared at line 328, available: [328-340])
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:357] injectible: [355-357]
+		Arg: a: [2]int (declared at line 355, available: [355-357])
+		Arg: b: [3]int (declared at line 355, available: [355-357])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: [2]int (declared at line 355, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [299:311] injectible: [299-311]
+		Arg: s1: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: s2: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -476,6 +476,9 @@ Package: main
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturnAndChangesToParams (main.testNamedReturnAndChangesToParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [112:113] injectible: [112-113]
+		Arg: i: int (declared at line 109, available: [112-113])
+		Arg: j: int (declared at line 109, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -578,28 +581,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-53])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [3]int (declared at line 165, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [1]int (declared at line 173, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [181:183] injectible: [181-183]
+		Arg: ~r0: [0]int (declared at line 181, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [204:206] injectible: [204-206]
+		Arg: ~r0: int (declared at line 204, available: )
+		Arg: ~r1: int (declared at line 204, available: )
+		Arg: ~r2: int (declared at line 204, available: )
+		Arg: ~r3: int (declared at line 204, available: )
+		Arg: ~r4: int (declared at line 204, available: )
+		Arg: ~r5: int (declared at line 204, available: )
+		Arg: ~r6: int (declared at line 204, available: )
+		Arg: ~r7: int (declared at line 204, available: )
+		Arg: ~r8: string (declared at line 204, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [261:263] injectible: [261-263]
+		Arg: ~r0: bool (declared at line 261, available: )
+		Arg: ~r1: uintptr (declared at line 261, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [146:148] injectible: [146-148]
+		Arg: ~r0: complex64 (declared at line 146, available: )
+		Arg: ~r1: complex128 (declared at line 146, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -621,52 +624,52 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-78])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:140] injectible: [128-128], [138-140]
+		Arg: ~r0: float64 (declared at line 129, available: )
+		Arg: ~r1: float64 (declared at line 129, available: )
+		Arg: ~r2: float64 (declared at line 129, available: )
+		Arg: ~r3: float64 (declared at line 129, available: )
+		Arg: ~r4: float64 (declared at line 129, available: )
+		Arg: ~r5: float64 (declared at line 129, available: )
+		Arg: ~r6: float64 (declared at line 129, available: )
+		Arg: ~r7: float64 (declared at line 130, available: )
+		Arg: ~r8: float64 (declared at line 130, available: )
+		Arg: ~r9: float64 (declared at line 130, available: )
+		Arg: ~r10: float64 (declared at line 130, available: )
+		Arg: ~r11: float64 (declared at line 130, available: )
+		Arg: ~r12: float64 (declared at line 130, available: )
+		Arg: ~r13: float64 (declared at line 130, available: )
+		Arg: ~r14: float64 (declared at line 131, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 134, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 136, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [224:226] injectible: [224-226]
+		Arg: ~r0: int (declared at line 224, available: )
+		Arg: ~r1: float64 (declared at line 224, available: )
+		Arg: ~r2: int (declared at line 224, available: )
+		Arg: ~r3: float64 (declared at line 224, available: )
+		Arg: ~r4: string (declared at line 224, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [194:196] injectible: [194-196]
+		Arg: ~r0: main.mixedStruct (declared at line 194, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: float32 (declared at line 253, available: )
+		Arg: ~r1: float64 (declared at line 253, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float64 (declared at line 245, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [119:121] injectible: [119-121]
+		Arg: ~r0: int8 (declared at line 119, available: )
+		Arg: ~r1: int16 (declared at line 119, available: )
+		Arg: ~r2: int32 (declared at line 119, available: )
+		Arg: ~r3: int64 (declared at line 119, available: )
+		Arg: ~r4: uint8 (declared at line 119, available: )
+		Arg: ~r5: uint16 (declared at line 119, available: )
+		Arg: ~r6: uint32 (declared at line 119, available: )
+		Arg: ~r7: uint64 (declared at line 119, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [236:238] injectible: [236-238]
+		Arg: ~r0: main.structWithArray (declared at line 236, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -712,11 +715,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: arg: [5]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: int (declared at line 347, available: )
+		Arg: ~r2: int (declared at line 347, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -751,11 +754,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [363:370] injectible: [363-365], [367-368], [370-370]
+		Arg: arg: main.structWithArray (declared at line 363, available: [363-370])
+		Arg: ~r0: int (declared at line 363, available: )
+		Arg: ~r1: main.structWithArray (declared at line 363, available: )
+		Var: x: int (declared at line 365, available: [363-370])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -808,11 +811,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [376:379] injectible: [376-379]
+		Arg: a: [0]int (declared at line 376, available: )
+		Arg: b: int (declared at line 376, available: [376-379])
+		Arg: ~r0: int (declared at line 376, available: )
+		Arg: ~r1: [0]int (declared at line 376, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -85,10 +85,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [382:439] injectible: [382-389], [391-395], [397-399], [401-403], [406-420], [426-428], [432-439]
+		Var: &v: *main.firstBehavior (declared at line 391, available: [382-439])
+		Var: &fortyTwo: *int (declared at line 394, available: [395-395])
+		Var: .autotmp_8: [0]int (declared at line 437, available: [382-439])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -195,9 +195,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [288:293] injectible: [288-293]
+		Arg: arg: [3]int (declared at line 288, available: [288-293])
+		Arg: ~r0: [3]int (declared at line 288, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -364,9 +364,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [272:282] injectible: [272-282]
+		Arg: arg: main.largeStruct (declared at line 272, available: [272-282])
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -375,17 +375,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [319:321] injectible: [319-321]
+		Arg: a: int (declared at line 319, available: [319-321])
+		Arg: b: int (declared at line 319, available: [319-321])
+		Arg: c: int (declared at line 319, available: [319-321])
+		Arg: d: int (declared at line 319, available: [319-321])
+		Arg: e: int (declared at line 319, available: [319-321])
+		Arg: f: int (declared at line 319, available: [319-321])
+		Arg: g: int (declared at line 319, available: [319-321])
+		Arg: h: int (declared at line 319, available: [319-321])
+		Arg: i: int (declared at line 319, available: [319-321])
+		Arg: ~r0: [2]int (declared at line 319, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -426,30 +426,30 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:340] injectible: [328-340]
+		Arg: a: int (declared at line 328, available: [328-340])
+		Arg: b: int (declared at line 328, available: [328-340])
+		Arg: c: int (declared at line 328, available: [328-340])
+		Arg: d: int (declared at line 328, available: [328-340])
+		Arg: e: int (declared at line 328, available: [328-340])
+		Arg: f: int (declared at line 328, available: [328-340])
+		Arg: g: int (declared at line 328, available: [328-340])
+		Arg: h: int (declared at line 328, available: [328-340])
+		Arg: s: string (declared at line 328, available: [328-340])
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:357] injectible: [355-357]
+		Arg: a: [2]int (declared at line 355, available: [355-357])
+		Arg: b: [3]int (declared at line 355, available: [355-357])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: [2]int (declared at line 355, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [299:311] injectible: [299-311]
+		Arg: s1: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: s2: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -465,6 +465,9 @@ Package: main
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturnAndChangesToParams (main.testNamedReturnAndChangesToParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [112:113] injectible: [112-113]
+		Arg: i: int (declared at line 109, available: [112-113])
+		Arg: j: int (declared at line 109, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -567,28 +570,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [3]int (declared at line 165, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [1]int (declared at line 173, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [181:183] injectible: [181-183]
+		Arg: ~r0: [0]int (declared at line 181, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [204:206] injectible: [204-206]
+		Arg: ~r0: int (declared at line 204, available: )
+		Arg: ~r1: int (declared at line 204, available: )
+		Arg: ~r2: int (declared at line 204, available: )
+		Arg: ~r3: int (declared at line 204, available: )
+		Arg: ~r4: int (declared at line 204, available: )
+		Arg: ~r5: int (declared at line 204, available: )
+		Arg: ~r6: int (declared at line 204, available: )
+		Arg: ~r7: int (declared at line 204, available: )
+		Arg: ~r8: string (declared at line 204, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [261:263] injectible: [261-263]
+		Arg: ~r0: bool (declared at line 261, available: )
+		Arg: ~r1: uintptr (declared at line 261, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [146:148] injectible: [146-148]
+		Arg: ~r0: complex64 (declared at line 146, available: )
+		Arg: ~r1: complex128 (declared at line 146, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -610,52 +613,52 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-78])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:140] injectible: [128-128], [138-140]
+		Arg: ~r0: float64 (declared at line 129, available: )
+		Arg: ~r1: float64 (declared at line 129, available: )
+		Arg: ~r2: float64 (declared at line 129, available: )
+		Arg: ~r3: float64 (declared at line 129, available: )
+		Arg: ~r4: float64 (declared at line 129, available: )
+		Arg: ~r5: float64 (declared at line 129, available: )
+		Arg: ~r6: float64 (declared at line 129, available: )
+		Arg: ~r7: float64 (declared at line 130, available: )
+		Arg: ~r8: float64 (declared at line 130, available: )
+		Arg: ~r9: float64 (declared at line 130, available: )
+		Arg: ~r10: float64 (declared at line 130, available: )
+		Arg: ~r11: float64 (declared at line 130, available: )
+		Arg: ~r12: float64 (declared at line 130, available: )
+		Arg: ~r13: float64 (declared at line 130, available: )
+		Arg: ~r14: float64 (declared at line 131, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 134, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 136, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [224:226] injectible: [224-226]
+		Arg: ~r0: int (declared at line 224, available: )
+		Arg: ~r1: float64 (declared at line 224, available: )
+		Arg: ~r2: int (declared at line 224, available: )
+		Arg: ~r3: float64 (declared at line 224, available: )
+		Arg: ~r4: string (declared at line 224, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [194:196] injectible: [194-196]
+		Arg: ~r0: main.mixedStruct (declared at line 194, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: float32 (declared at line 253, available: )
+		Arg: ~r1: float64 (declared at line 253, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float64 (declared at line 245, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [119:121] injectible: [119-121]
+		Arg: ~r0: int8 (declared at line 119, available: )
+		Arg: ~r1: int16 (declared at line 119, available: )
+		Arg: ~r2: int32 (declared at line 119, available: )
+		Arg: ~r3: int64 (declared at line 119, available: )
+		Arg: ~r4: uint8 (declared at line 119, available: )
+		Arg: ~r5: uint16 (declared at line 119, available: )
+		Arg: ~r6: uint32 (declared at line 119, available: )
+		Arg: ~r7: uint64 (declared at line 119, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [236:238] injectible: [236-238]
+		Arg: ~r0: main.structWithArray (declared at line 236, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -701,11 +704,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: arg: [5]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: int (declared at line 347, available: )
+		Arg: ~r2: int (declared at line 347, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -740,11 +743,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [363:370] injectible: [363-365], [367-368], [370-370]
+		Arg: arg: main.structWithArray (declared at line 363, available: [363-370])
+		Arg: ~r0: int (declared at line 363, available: )
+		Arg: ~r1: main.structWithArray (declared at line 363, available: )
+		Var: x: int (declared at line 365, available: [363-370])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -797,11 +800,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [376:379] injectible: [376-379]
+		Arg: a: [0]int (declared at line 376, available: )
+		Arg: b: int (declared at line 376, available: [376-379])
+		Arg: ~r0: int (declared at line 376, available: )
+		Arg: ~r1: [0]int (declared at line 376, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -84,10 +84,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [382:439] injectible: [382-389], [391-395], [397-399], [401-403], [406-420], [426-428], [432-439]
+		Var: &v: *main.firstBehavior (declared at line 391, available: [382-439])
+		Var: &fortyTwo: *int (declared at line 394, available: [395-395])
+		Var: .autotmp_8: [0]int (declared at line 437, available: [382-439])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -194,9 +194,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [288:293] injectible: [288-293]
+		Arg: arg: [3]int (declared at line 288, available: [288-293])
+		Arg: ~r0: [3]int (declared at line 288, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -363,9 +363,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [272:282] injectible: [272-282]
+		Arg: arg: main.largeStruct (declared at line 272, available: [272-282])
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -374,17 +374,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [319:321] injectible: [319-321]
+		Arg: a: int (declared at line 319, available: [319-321])
+		Arg: b: int (declared at line 319, available: [319-321])
+		Arg: c: int (declared at line 319, available: [319-321])
+		Arg: d: int (declared at line 319, available: [319-321])
+		Arg: e: int (declared at line 319, available: [319-321])
+		Arg: f: int (declared at line 319, available: [319-321])
+		Arg: g: int (declared at line 319, available: [319-321])
+		Arg: h: int (declared at line 319, available: [319-321])
+		Arg: i: int (declared at line 319, available: [319-321])
+		Arg: ~r0: [2]int (declared at line 319, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -425,30 +425,30 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:340] injectible: [328-340]
+		Arg: a: int (declared at line 328, available: [328-340])
+		Arg: b: int (declared at line 328, available: [328-340])
+		Arg: c: int (declared at line 328, available: [328-340])
+		Arg: d: int (declared at line 328, available: [328-340])
+		Arg: e: int (declared at line 328, available: [328-340])
+		Arg: f: int (declared at line 328, available: [328-340])
+		Arg: g: int (declared at line 328, available: [328-340])
+		Arg: h: int (declared at line 328, available: [328-340])
+		Arg: s: string (declared at line 328, available: [328-340])
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:357] injectible: [355-357]
+		Arg: a: [2]int (declared at line 355, available: [355-357])
+		Arg: b: [3]int (declared at line 355, available: [355-357])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: [2]int (declared at line 355, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [299:311] injectible: [299-311]
+		Arg: s1: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: s2: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -464,6 +464,9 @@ Package: main
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturnAndChangesToParams (main.testNamedReturnAndChangesToParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [112:113] injectible: [112-113]
+		Arg: i: int (declared at line 109, available: [112-113])
+		Arg: j: int (declared at line 109, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -566,28 +569,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [3]int (declared at line 165, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [1]int (declared at line 173, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [181:183] injectible: [181-183]
+		Arg: ~r0: [0]int (declared at line 181, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [204:206] injectible: [204-206]
+		Arg: ~r0: int (declared at line 204, available: )
+		Arg: ~r1: int (declared at line 204, available: )
+		Arg: ~r2: int (declared at line 204, available: )
+		Arg: ~r3: int (declared at line 204, available: )
+		Arg: ~r4: int (declared at line 204, available: )
+		Arg: ~r5: int (declared at line 204, available: )
+		Arg: ~r6: int (declared at line 204, available: )
+		Arg: ~r7: int (declared at line 204, available: )
+		Arg: ~r8: string (declared at line 204, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [261:263] injectible: [261-263]
+		Arg: ~r0: bool (declared at line 261, available: )
+		Arg: ~r1: uintptr (declared at line 261, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [146:148] injectible: [146-148]
+		Arg: ~r0: complex64 (declared at line 146, available: )
+		Arg: ~r1: complex128 (declared at line 146, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -609,52 +612,52 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-78])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:140] injectible: [128-128], [138-140]
+		Arg: ~r0: float64 (declared at line 129, available: )
+		Arg: ~r1: float64 (declared at line 129, available: )
+		Arg: ~r2: float64 (declared at line 129, available: )
+		Arg: ~r3: float64 (declared at line 129, available: )
+		Arg: ~r4: float64 (declared at line 129, available: )
+		Arg: ~r5: float64 (declared at line 129, available: )
+		Arg: ~r6: float64 (declared at line 129, available: )
+		Arg: ~r7: float64 (declared at line 130, available: )
+		Arg: ~r8: float64 (declared at line 130, available: )
+		Arg: ~r9: float64 (declared at line 130, available: )
+		Arg: ~r10: float64 (declared at line 130, available: )
+		Arg: ~r11: float64 (declared at line 130, available: )
+		Arg: ~r12: float64 (declared at line 130, available: )
+		Arg: ~r13: float64 (declared at line 130, available: )
+		Arg: ~r14: float64 (declared at line 131, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 134, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 136, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [224:226] injectible: [224-226]
+		Arg: ~r0: int (declared at line 224, available: )
+		Arg: ~r1: float64 (declared at line 224, available: )
+		Arg: ~r2: int (declared at line 224, available: )
+		Arg: ~r3: float64 (declared at line 224, available: )
+		Arg: ~r4: string (declared at line 224, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [194:196] injectible: [194-196]
+		Arg: ~r0: main.mixedStruct (declared at line 194, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: float32 (declared at line 253, available: )
+		Arg: ~r1: float64 (declared at line 253, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float64 (declared at line 245, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [119:121] injectible: [119-121]
+		Arg: ~r0: int8 (declared at line 119, available: )
+		Arg: ~r1: int16 (declared at line 119, available: )
+		Arg: ~r2: int32 (declared at line 119, available: )
+		Arg: ~r3: int64 (declared at line 119, available: )
+		Arg: ~r4: uint8 (declared at line 119, available: )
+		Arg: ~r5: uint16 (declared at line 119, available: )
+		Arg: ~r6: uint32 (declared at line 119, available: )
+		Arg: ~r7: uint64 (declared at line 119, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [236:238] injectible: [236-238]
+		Arg: ~r0: main.structWithArray (declared at line 236, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -700,11 +703,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: arg: [5]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: int (declared at line 347, available: )
+		Arg: ~r2: int (declared at line 347, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -739,11 +742,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [363:370] injectible: [363-365], [367-368], [370-370]
+		Arg: arg: main.structWithArray (declared at line 363, available: [363-370])
+		Arg: ~r0: int (declared at line 363, available: )
+		Arg: ~r1: main.structWithArray (declared at line 363, available: )
+		Var: x: int (declared at line 365, available: [363-370])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -796,11 +799,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [376:379] injectible: [376-379]
+		Arg: a: [0]int (declared at line 376, available: )
+		Arg: b: int (declared at line 376, available: [376-379])
+		Arg: ~r0: int (declared at line 376, available: )
+		Arg: ~r1: [0]int (declared at line 376, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -96,10 +96,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [382:439] injectible: [382-389], [391-395], [397-399], [401-403], [406-420], [426-428], [432-439]
+		Var: &v: *main.firstBehavior (declared at line 391, available: [382-439])
+		Var: &fortyTwo: *int (declared at line 394, available: [395-395])
+		Var: .autotmp_8: [0]int (declared at line 437, available: [382-439])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -206,9 +206,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [288:293] injectible: [288-293]
+		Arg: arg: [3]int (declared at line 288, available: [288-293])
+		Arg: ~r0: [3]int (declared at line 288, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -375,10 +375,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [272:282] injectible: [272-282]
+		Arg: arg: main.largeStruct (declared at line 272, available: [272-273])
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -387,17 +387,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [319:321] injectible: [319-321]
+		Arg: a: int (declared at line 319, available: [319-321])
+		Arg: b: int (declared at line 319, available: [319-321])
+		Arg: c: int (declared at line 319, available: [319-321])
+		Arg: d: int (declared at line 319, available: [319-321])
+		Arg: e: int (declared at line 319, available: [319-321])
+		Arg: f: int (declared at line 319, available: [319-321])
+		Arg: g: int (declared at line 319, available: [319-321])
+		Arg: h: int (declared at line 319, available: [319-321])
+		Arg: i: int (declared at line 319, available: [319-321])
+		Arg: ~r0: [2]int (declared at line 319, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -438,32 +438,32 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:340] injectible: [328-340]
+		Arg: a: int (declared at line 328, available: [328-340])
+		Arg: b: int (declared at line 328, available: [328-340])
+		Arg: c: int (declared at line 328, available: [328-340])
+		Arg: d: int (declared at line 328, available: [328-340])
+		Arg: e: int (declared at line 328, available: [328-340])
+		Arg: f: int (declared at line 328, available: [328-340])
+		Arg: g: int (declared at line 328, available: [328-340])
+		Arg: h: int (declared at line 328, available: [328-340])
+		Arg: s: string (declared at line 328, available: [328-340])
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:357] injectible: [355-357]
+		Arg: a: [2]int (declared at line 355, available: [355-357])
+		Arg: b: [3]int (declared at line 355, available: [355-357])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: [2]int (declared at line 355, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [299:311] injectible: [299-311]
+		Arg: s1: main.largeStruct (declared at line 299, available: [299-300])
+		Arg: s2: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -479,6 +479,9 @@ Package: main
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturnAndChangesToParams (main.testNamedReturnAndChangesToParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [110:113] injectible: [110-113]
+		Arg: i: int (declared at line 109, available: [110-113])
+		Arg: j: int (declared at line 109, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -581,28 +584,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-53])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [3]int (declared at line 165, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [1]int (declared at line 173, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [181:183] injectible: [181-183]
+		Arg: ~r0: [0]int (declared at line 181, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [204:206] injectible: [204-206]
+		Arg: ~r0: int (declared at line 204, available: )
+		Arg: ~r1: int (declared at line 204, available: )
+		Arg: ~r2: int (declared at line 204, available: )
+		Arg: ~r3: int (declared at line 204, available: )
+		Arg: ~r4: int (declared at line 204, available: )
+		Arg: ~r5: int (declared at line 204, available: )
+		Arg: ~r6: int (declared at line 204, available: )
+		Arg: ~r7: int (declared at line 204, available: )
+		Arg: ~r8: string (declared at line 204, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [261:263] injectible: [261-263]
+		Arg: ~r0: bool (declared at line 261, available: )
+		Arg: ~r1: uintptr (declared at line 261, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [146:148] injectible: [146-148]
+		Arg: ~r0: complex64 (declared at line 146, available: )
+		Arg: ~r1: complex128 (declared at line 146, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -624,54 +627,54 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-79])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:140] injectible: [128-128], [138-140]
+		Arg: ~r0: float64 (declared at line 129, available: )
+		Arg: ~r1: float64 (declared at line 129, available: )
+		Arg: ~r2: float64 (declared at line 129, available: )
+		Arg: ~r3: float64 (declared at line 129, available: )
+		Arg: ~r4: float64 (declared at line 129, available: )
+		Arg: ~r5: float64 (declared at line 129, available: )
+		Arg: ~r6: float64 (declared at line 129, available: )
+		Arg: ~r7: float64 (declared at line 130, available: )
+		Arg: ~r8: float64 (declared at line 130, available: )
+		Arg: ~r9: float64 (declared at line 130, available: )
+		Arg: ~r10: float64 (declared at line 130, available: )
+		Arg: ~r11: float64 (declared at line 130, available: )
+		Arg: ~r12: float64 (declared at line 130, available: )
+		Arg: ~r13: float64 (declared at line 130, available: )
+		Arg: ~r14: float64 (declared at line 131, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 134, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 136, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [224:226] injectible: [224-226]
+		Arg: ~r0: int (declared at line 224, available: )
+		Arg: ~r1: float64 (declared at line 224, available: )
+		Arg: ~r2: int (declared at line 224, available: )
+		Arg: ~r3: float64 (declared at line 224, available: )
+		Arg: ~r4: string (declared at line 224, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [194:196] injectible: [194-196]
+		Arg: ~r0: main.mixedStruct (declared at line 194, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: float32 (declared at line 253, available: )
+		Arg: ~r1: float64 (declared at line 253, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float64 (declared at line 245, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [119:121] injectible: [119-121]
+		Arg: ~r0: int8 (declared at line 119, available: )
+		Arg: ~r1: int16 (declared at line 119, available: )
+		Arg: ~r2: int32 (declared at line 119, available: )
+		Arg: ~r3: int64 (declared at line 119, available: )
+		Arg: ~r4: uint8 (declared at line 119, available: )
+		Arg: ~r5: uint16 (declared at line 119, available: )
+		Arg: ~r6: uint32 (declared at line 119, available: )
+		Arg: ~r7: uint64 (declared at line 119, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [236:238] injectible: [236-238]
+		Arg: ~r0: main.structWithArray (declared at line 236, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -717,11 +720,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: arg: [5]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: int (declared at line 347, available: )
+		Arg: ~r2: int (declared at line 347, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -756,11 +759,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [363:370] injectible: [363-365], [367-368], [370-370]
+		Arg: arg: main.structWithArray (declared at line 363, available: [363-370])
+		Arg: ~r0: int (declared at line 363, available: )
+		Arg: ~r1: main.structWithArray (declared at line 363, available: )
+		Var: x: int (declared at line 365, available: [363-370])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -813,11 +816,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [376:379] injectible: [376-379]
+		Arg: a: [0]int (declared at line 376, available: )
+		Arg: b: int (declared at line 376, available: [376-379])
+		Arg: ~r0: int (declared at line 376, available: )
+		Arg: ~r1: [0]int (declared at line 376, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -85,10 +85,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [382:439] injectible: [382-389], [391-395], [397-399], [401-403], [406-420], [426-428], [432-439]
+		Var: &v: *main.firstBehavior (declared at line 391, available: [382-439])
+		Var: &fortyTwo: *int (declared at line 394, available: [395-395])
+		Var: .autotmp_8: [0]int (declared at line 437, available: [382-439])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -195,9 +195,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [288:293] injectible: [288-293]
+		Arg: arg: [3]int (declared at line 288, available: [288-293])
+		Arg: ~r0: [3]int (declared at line 288, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -364,10 +364,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [272:282] injectible: [272-282]
+		Arg: arg: main.largeStruct (declared at line 272, available: [272-273])
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -376,17 +376,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [319:321] injectible: [319-321]
+		Arg: a: int (declared at line 319, available: [319-321])
+		Arg: b: int (declared at line 319, available: [319-321])
+		Arg: c: int (declared at line 319, available: [319-321])
+		Arg: d: int (declared at line 319, available: [319-321])
+		Arg: e: int (declared at line 319, available: [319-321])
+		Arg: f: int (declared at line 319, available: [319-321])
+		Arg: g: int (declared at line 319, available: [319-321])
+		Arg: h: int (declared at line 319, available: [319-321])
+		Arg: i: int (declared at line 319, available: [319-321])
+		Arg: ~r0: [2]int (declared at line 319, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -427,32 +427,32 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:340] injectible: [328-340]
+		Arg: a: int (declared at line 328, available: [328-340])
+		Arg: b: int (declared at line 328, available: [328-340])
+		Arg: c: int (declared at line 328, available: [328-340])
+		Arg: d: int (declared at line 328, available: [328-340])
+		Arg: e: int (declared at line 328, available: [328-340])
+		Arg: f: int (declared at line 328, available: [328-340])
+		Arg: g: int (declared at line 328, available: [328-340])
+		Arg: h: int (declared at line 328, available: [328-340])
+		Arg: s: string (declared at line 328, available: [328-340])
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:357] injectible: [355-357]
+		Arg: a: [2]int (declared at line 355, available: [355-357])
+		Arg: b: [3]int (declared at line 355, available: [355-357])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: [2]int (declared at line 355, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [299:311] injectible: [299-311]
+		Arg: s1: main.largeStruct (declared at line 299, available: [299-300])
+		Arg: s2: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -468,6 +468,10 @@ Package: main
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturnAndChangesToParams (main.testNamedReturnAndChangesToParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [110:113] injectible: [110-113]
+		Arg: i: int (declared at line 109, available: [110-113])
+		Arg: j: int (declared at line 109, available: )
+		Var: q: int (declared at line 111, available: [112-113])
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -570,28 +574,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [3]int (declared at line 165, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [1]int (declared at line 173, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [181:183] injectible: [181-183]
+		Arg: ~r0: [0]int (declared at line 181, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [204:206] injectible: [204-206]
+		Arg: ~r0: int (declared at line 204, available: )
+		Arg: ~r1: int (declared at line 204, available: )
+		Arg: ~r2: int (declared at line 204, available: )
+		Arg: ~r3: int (declared at line 204, available: )
+		Arg: ~r4: int (declared at line 204, available: )
+		Arg: ~r5: int (declared at line 204, available: )
+		Arg: ~r6: int (declared at line 204, available: )
+		Arg: ~r7: int (declared at line 204, available: )
+		Arg: ~r8: string (declared at line 204, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [261:263] injectible: [261-263]
+		Arg: ~r0: bool (declared at line 261, available: )
+		Arg: ~r1: uintptr (declared at line 261, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [146:148] injectible: [146-148]
+		Arg: ~r0: complex64 (declared at line 146, available: )
+		Arg: ~r1: complex128 (declared at line 146, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -613,54 +617,54 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-79])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:140] injectible: [128-128], [138-140]
+		Arg: ~r0: float64 (declared at line 129, available: )
+		Arg: ~r1: float64 (declared at line 129, available: )
+		Arg: ~r2: float64 (declared at line 129, available: )
+		Arg: ~r3: float64 (declared at line 129, available: )
+		Arg: ~r4: float64 (declared at line 129, available: )
+		Arg: ~r5: float64 (declared at line 129, available: )
+		Arg: ~r6: float64 (declared at line 129, available: )
+		Arg: ~r7: float64 (declared at line 130, available: )
+		Arg: ~r8: float64 (declared at line 130, available: )
+		Arg: ~r9: float64 (declared at line 130, available: )
+		Arg: ~r10: float64 (declared at line 130, available: )
+		Arg: ~r11: float64 (declared at line 130, available: )
+		Arg: ~r12: float64 (declared at line 130, available: )
+		Arg: ~r13: float64 (declared at line 130, available: )
+		Arg: ~r14: float64 (declared at line 131, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 134, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 136, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [224:226] injectible: [224-226]
+		Arg: ~r0: int (declared at line 224, available: )
+		Arg: ~r1: float64 (declared at line 224, available: )
+		Arg: ~r2: int (declared at line 224, available: )
+		Arg: ~r3: float64 (declared at line 224, available: )
+		Arg: ~r4: string (declared at line 224, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [194:196] injectible: [194-196]
+		Arg: ~r0: main.mixedStruct (declared at line 194, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: float32 (declared at line 253, available: )
+		Arg: ~r1: float64 (declared at line 253, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float64 (declared at line 245, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [119:121] injectible: [119-121]
+		Arg: ~r0: int8 (declared at line 119, available: )
+		Arg: ~r1: int16 (declared at line 119, available: )
+		Arg: ~r2: int32 (declared at line 119, available: )
+		Arg: ~r3: int64 (declared at line 119, available: )
+		Arg: ~r4: uint8 (declared at line 119, available: )
+		Arg: ~r5: uint16 (declared at line 119, available: )
+		Arg: ~r6: uint32 (declared at line 119, available: )
+		Arg: ~r7: uint64 (declared at line 119, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [236:238] injectible: [236-238]
+		Arg: ~r0: main.structWithArray (declared at line 236, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -706,11 +710,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: arg: [5]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: int (declared at line 347, available: )
+		Arg: ~r2: int (declared at line 347, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -745,11 +749,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [363:370] injectible: [363-365], [367-368], [370-370]
+		Arg: arg: main.structWithArray (declared at line 363, available: [363-370])
+		Arg: ~r0: int (declared at line 363, available: )
+		Arg: ~r1: main.structWithArray (declared at line 363, available: )
+		Var: x: int (declared at line 365, available: [363-370])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -802,11 +806,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [376:379] injectible: [376-379]
+		Arg: a: [0]int (declared at line 376, available: )
+		Arg: b: int (declared at line 376, available: [376-379])
+		Arg: ~r0: int (declared at line 376, available: )
+		Arg: ~r1: [0]int (declared at line 376, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -84,10 +84,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
-		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
-		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
-		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [382:439] injectible: [382-389], [391-395], [397-399], [401-403], [406-420], [426-428], [432-439]
+		Var: &v: *main.firstBehavior (declared at line 391, available: [382-439])
+		Var: &fortyTwo: *int (declared at line 394, available: [395-395])
+		Var: .autotmp_8: [0]int (declared at line 437, available: [382-439])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -194,9 +194,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
-		Arg: arg: [3]int (declared at line 280, available: [280-285])
-		Arg: ~r0: [3]int (declared at line 280, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [288:293] injectible: [288-293]
+		Arg: arg: [3]int (declared at line 288, available: [288-293])
+		Arg: ~r0: [3]int (declared at line 288, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -363,10 +363,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
-		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
-		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [272:282] injectible: [272-282]
+		Arg: arg: main.largeStruct (declared at line 272, available: [272-273])
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
+		Arg: ~r0: main.largeStruct (declared at line 272, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -375,17 +375,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
-		Arg: a: int (declared at line 311, available: [311-313])
-		Arg: b: int (declared at line 311, available: [311-313])
-		Arg: c: int (declared at line 311, available: [311-313])
-		Arg: d: int (declared at line 311, available: [311-313])
-		Arg: e: int (declared at line 311, available: [311-313])
-		Arg: f: int (declared at line 311, available: [311-313])
-		Arg: g: int (declared at line 311, available: [311-313])
-		Arg: h: int (declared at line 311, available: [311-313])
-		Arg: i: int (declared at line 311, available: [311-313])
-		Arg: ~r0: [2]int (declared at line 311, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [319:321] injectible: [319-321]
+		Arg: a: int (declared at line 319, available: [319-321])
+		Arg: b: int (declared at line 319, available: [319-321])
+		Arg: c: int (declared at line 319, available: [319-321])
+		Arg: d: int (declared at line 319, available: [319-321])
+		Arg: e: int (declared at line 319, available: [319-321])
+		Arg: f: int (declared at line 319, available: [319-321])
+		Arg: g: int (declared at line 319, available: [319-321])
+		Arg: h: int (declared at line 319, available: [319-321])
+		Arg: i: int (declared at line 319, available: [319-321])
+		Arg: ~r0: [2]int (declared at line 319, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -426,32 +426,32 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-330], [332-332]
-		Arg: a: int (declared at line 320, available: [320-332])
-		Arg: b: int (declared at line 320, available: [320-332])
-		Arg: c: int (declared at line 320, available: [320-332])
-		Arg: d: int (declared at line 320, available: [320-332])
-		Arg: e: int (declared at line 320, available: [320-332])
-		Arg: f: int (declared at line 320, available: [320-332])
-		Arg: g: int (declared at line 320, available: [320-332])
-		Arg: h: int (declared at line 320, available: [320-332])
-		Arg: s: string (declared at line 320, available: [320-332])
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-		Arg: ~r0: main.largeStruct (declared at line 320, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
-		Arg: a: [2]int (declared at line 347, available: [347-349])
-		Arg: b: [3]int (declared at line 347, available: [347-349])
-		Arg: ~r0: int (declared at line 347, available: )
-		Arg: ~r1: [2]int (declared at line 347, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:340] injectible: [328-338], [340-340]
+		Arg: a: int (declared at line 328, available: [328-340])
+		Arg: b: int (declared at line 328, available: [328-340])
+		Arg: c: int (declared at line 328, available: [328-340])
+		Arg: d: int (declared at line 328, available: [328-340])
+		Arg: e: int (declared at line 328, available: [328-340])
+		Arg: f: int (declared at line 328, available: [328-340])
+		Arg: g: int (declared at line 328, available: [328-340])
+		Arg: h: int (declared at line 328, available: [328-340])
+		Arg: s: string (declared at line 328, available: [328-340])
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+		Arg: ~r0: main.largeStruct (declared at line 328, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:357] injectible: [355-357]
+		Arg: a: [2]int (declared at line 355, available: [355-357])
+		Arg: b: [3]int (declared at line 355, available: [355-357])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: [2]int (declared at line 355, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
-		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
-		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
-		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [299:311] injectible: [299-311]
+		Arg: s1: main.largeStruct (declared at line 299, available: [299-300])
+		Arg: s2: main.largeStruct (declared at line 299, available: [299-311])
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
+		Arg: ~r0: main.largeStruct (declared at line 299, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -467,6 +467,10 @@ Package: main
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
+	Function: testNamedReturnAndChangesToParams (main.testNamedReturnAndChangesToParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [110:113] injectible: [110-113]
+		Arg: i: int (declared at line 109, available: [110-113])
+		Arg: j: int (declared at line 109, available: )
+		Var: q: int (declared at line 111, available: [112-113])
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -569,28 +573,28 @@ Package: main
 			Var: val: string (declared at line 52, available: )
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
-		Arg: ~r0: [3]int (declared at line 157, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
-		Arg: ~r0: [1]int (declared at line 165, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
-		Arg: ~r0: [0]int (declared at line 173, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
-		Arg: ~r0: int (declared at line 196, available: )
-		Arg: ~r1: int (declared at line 196, available: )
-		Arg: ~r2: int (declared at line 196, available: )
-		Arg: ~r3: int (declared at line 196, available: )
-		Arg: ~r4: int (declared at line 196, available: )
-		Arg: ~r5: int (declared at line 196, available: )
-		Arg: ~r6: int (declared at line 196, available: )
-		Arg: ~r7: int (declared at line 196, available: )
-		Arg: ~r8: string (declared at line 196, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
-		Arg: ~r0: bool (declared at line 253, available: )
-		Arg: ~r1: uintptr (declared at line 253, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
-		Arg: ~r0: complex64 (declared at line 138, available: )
-		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [3]int (declared at line 165, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [1]int (declared at line 173, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [181:183] injectible: [181-183]
+		Arg: ~r0: [0]int (declared at line 181, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [204:206] injectible: [204-206]
+		Arg: ~r0: int (declared at line 204, available: )
+		Arg: ~r1: int (declared at line 204, available: )
+		Arg: ~r2: int (declared at line 204, available: )
+		Arg: ~r3: int (declared at line 204, available: )
+		Arg: ~r4: int (declared at line 204, available: )
+		Arg: ~r5: int (declared at line 204, available: )
+		Arg: ~r6: int (declared at line 204, available: )
+		Arg: ~r7: int (declared at line 204, available: )
+		Arg: ~r8: string (declared at line 204, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [261:263] injectible: [261-263]
+		Arg: ~r0: bool (declared at line 261, available: )
+		Arg: ~r1: uintptr (declared at line 261, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [146:148] injectible: [146-148]
+		Arg: ~r0: complex64 (declared at line 146, available: )
+		Arg: ~r1: complex128 (declared at line 146, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -612,54 +616,54 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-79])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-		Arg: ~r0: main.largeStruct (declared at line 149, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
-		Arg: ~r0: float64 (declared at line 121, available: )
-		Arg: ~r1: float64 (declared at line 121, available: )
-		Arg: ~r2: float64 (declared at line 121, available: )
-		Arg: ~r3: float64 (declared at line 121, available: )
-		Arg: ~r4: float64 (declared at line 121, available: )
-		Arg: ~r5: float64 (declared at line 121, available: )
-		Arg: ~r6: float64 (declared at line 121, available: )
-		Arg: ~r7: float64 (declared at line 122, available: )
-		Arg: ~r8: float64 (declared at line 122, available: )
-		Arg: ~r9: float64 (declared at line 122, available: )
-		Arg: ~r10: float64 (declared at line 122, available: )
-		Arg: ~r11: float64 (declared at line 122, available: )
-		Arg: ~r12: float64 (declared at line 122, available: )
-		Arg: ~r13: float64 (declared at line 122, available: )
-		Arg: ~r14: float64 (declared at line 123, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
-		Arg: ~r0: int (declared at line 216, available: )
-		Arg: ~r1: float64 (declared at line 216, available: )
-		Arg: ~r2: int (declared at line 216, available: )
-		Arg: ~r3: float64 (declared at line 216, available: )
-		Arg: ~r4: string (declared at line 216, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
-		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
-		Arg: ~r0: float32 (declared at line 245, available: )
-		Arg: ~r1: float64 (declared at line 245, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
-		Arg: ~r0: float64 (declared at line 237, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
-		Arg: ~r0: int8 (declared at line 111, available: )
-		Arg: ~r1: int16 (declared at line 111, available: )
-		Arg: ~r2: int32 (declared at line 111, available: )
-		Arg: ~r3: int64 (declared at line 111, available: )
-		Arg: ~r4: uint8 (declared at line 111, available: )
-		Arg: ~r5: uint16 (declared at line 111, available: )
-		Arg: ~r6: uint32 (declared at line 111, available: )
-		Arg: ~r7: uint64 (declared at line 111, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
-		Arg: ~r0: main.structWithArray (declared at line 228, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
-		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+		Arg: ~r0: main.largeStruct (declared at line 157, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:140] injectible: [128-128], [138-140]
+		Arg: ~r0: float64 (declared at line 129, available: )
+		Arg: ~r1: float64 (declared at line 129, available: )
+		Arg: ~r2: float64 (declared at line 129, available: )
+		Arg: ~r3: float64 (declared at line 129, available: )
+		Arg: ~r4: float64 (declared at line 129, available: )
+		Arg: ~r5: float64 (declared at line 129, available: )
+		Arg: ~r6: float64 (declared at line 129, available: )
+		Arg: ~r7: float64 (declared at line 130, available: )
+		Arg: ~r8: float64 (declared at line 130, available: )
+		Arg: ~r9: float64 (declared at line 130, available: )
+		Arg: ~r10: float64 (declared at line 130, available: )
+		Arg: ~r11: float64 (declared at line 130, available: )
+		Arg: ~r12: float64 (declared at line 130, available: )
+		Arg: ~r13: float64 (declared at line 130, available: )
+		Arg: ~r14: float64 (declared at line 131, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 134, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 136, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [224:226] injectible: [224-226]
+		Arg: ~r0: int (declared at line 224, available: )
+		Arg: ~r1: float64 (declared at line 224, available: )
+		Arg: ~r2: int (declared at line 224, available: )
+		Arg: ~r3: float64 (declared at line 224, available: )
+		Arg: ~r4: string (declared at line 224, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [194:196] injectible: [194-196]
+		Arg: ~r0: main.mixedStruct (declared at line 194, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: float32 (declared at line 253, available: )
+		Arg: ~r1: float64 (declared at line 253, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float64 (declared at line 245, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [119:121] injectible: [119-121]
+		Arg: ~r0: int8 (declared at line 119, available: )
+		Arg: ~r1: int16 (declared at line 119, available: )
+		Arg: ~r2: int32 (declared at line 119, available: )
+		Arg: ~r3: int64 (declared at line 119, available: )
+		Arg: ~r4: uint8 (declared at line 119, available: )
+		Arg: ~r5: uint16 (declared at line 119, available: )
+		Arg: ~r6: uint32 (declared at line 119, available: )
+		Arg: ~r7: uint64 (declared at line 119, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [236:238] injectible: [236-238]
+		Arg: ~r0: main.structWithArray (declared at line 236, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
+		Arg: ~r0: main.wideStruct (declared at line 216, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -705,11 +709,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
-		Arg: arg: [5]int (declared at line 339, available: [339-341])
-		Arg: ~r0: int (declared at line 339, available: )
-		Arg: ~r1: int (declared at line 339, available: )
-		Arg: ~r2: int (declared at line 339, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: arg: [5]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: int (declared at line 347, available: )
+		Arg: ~r2: int (declared at line 347, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -744,11 +748,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
-		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
-		Arg: ~r0: int (declared at line 355, available: )
-		Arg: ~r1: main.structWithArray (declared at line 355, available: )
-		Var: x: int (declared at line 357, available: [355-362])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [363:370] injectible: [363-365], [367-368], [370-370]
+		Arg: arg: main.structWithArray (declared at line 363, available: [363-370])
+		Arg: ~r0: int (declared at line 363, available: )
+		Arg: ~r1: main.structWithArray (declared at line 363, available: )
+		Var: x: int (declared at line 365, available: [363-370])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -801,11 +805,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
-		Arg: a: [0]int (declared at line 368, available: )
-		Arg: b: int (declared at line 368, available: [368-371])
-		Arg: ~r0: int (declared at line 368, available: )
-		Arg: ~r1: [0]int (declared at line 368, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [376:379] injectible: [376-379]
+		Arg: a: [0]int (declared at line 376, available: )
+		Arg: b: int (declared at line 376, available: [376-379])
+		Arg: ~r0: int (declared at line 376, available: )
+		Arg: ~r1: [0]int (declared at line 376, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string

--- a/pkg/dyninst/testdata/decoded/fault/callMe.json
+++ b/pkg/dyninst/testdata/decoded/fault/callMe.json
@@ -65,6 +65,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -70,6 +70,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "stackC"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -73,7 +73,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -149,7 +150,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -225,7 +227,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -301,7 +304,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -377,7 +381,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -453,7 +458,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -528,7 +534,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -604,7 +611,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -681,7 +689,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -757,6 +766,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -68,7 +68,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "0x[addr]"
   },
   {
     "service": "sample",
@@ -144,7 +145,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "0x[addr]"
   },
   {
     "service": "sample",
@@ -221,7 +223,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "0x[addr]"
   },
   {
     "service": "sample",
@@ -298,7 +301,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "0x[addr]"
   },
   {
     "service": "sample",
@@ -381,7 +385,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "0x[addr]"
   },
   {
     "service": "sample",
@@ -470,6 +475,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -96,6 +96,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "[3]int{11, 12, 13}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]struct {}{struct {}{ }, struct {}{ }}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -89,6 +89,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2][2]int{[2]int{1, 2}, [2]int{3, 4}}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -129,6 +129,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2][2][2]int{[2][2]int{[2]int{1, 2}, [2]int{3, 4}}, [2][2]int{[2]int{5, 6}, [2]int{7, 8}}}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -113,6 +113,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]map[string]int{<map[string]int>, <map[string]int>}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]string{first, second}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
@@ -87,6 +87,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]main.nestedStruct{main.nestedStruct{ anotherInt = 42 anotherString = foo }, main.nestedStruct{ anotherInt = 24 anotherString = bar }}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -85,6 +85,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]bool{true, true}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]uint8{1, 1}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<chan bool>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -67,6 +67,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "2, 3, "
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -76,6 +76,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "main.deepMap1{ a = <map[int]*main.deepMap2> }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -101,6 +101,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -70,6 +70,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -82,6 +82,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -82,6 +82,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -100,6 +100,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -63,6 +63,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ", 2"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -59,7 +59,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "sample",
@@ -121,6 +122,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "main.emptyStruct{ }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
@@ -60,6 +60,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -70,6 +70,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<error>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -131,6 +131,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -92,6 +92,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "main.esotericStack{ _valid = 77 c = <chan struct {}> val = <interface {}> work = <main.something> foo = <func()> }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -68,6 +68,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "10"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -90,6 +90,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "[5]int{1, 2, 3, 4, 5}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -89,6 +89,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[5]int{1, 2, 3, 4, 5}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
@@ -65,6 +65,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "10"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "10, 15"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
@@ -70,6 +70,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "150"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -60,6 +60,7 @@
         "captures": {}
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testInlinedBBB"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -56,6 +56,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testInlinedBC"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -60,6 +60,7 @@
         "captures": {}
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testInlinedBCA"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
@@ -66,6 +66,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testInlinedBCA"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -60,6 +60,7 @@
         "captures": {}
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testInlinedBCB"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
@@ -66,6 +66,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testInlinedBCB"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -64,7 +64,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "25"
   },
   {
     "service": "sample",
@@ -136,7 +137,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "3"
   },
   {
     "service": "sample",
@@ -208,7 +210,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "150"
   },
   {
     "service": "sample",
@@ -285,7 +288,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "150"
   },
   {
     "service": "sample",
@@ -353,6 +357,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "1"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
@@ -68,7 +68,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "25"
   },
   {
     "service": "sample",
@@ -144,7 +145,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "3"
   },
   {
     "service": "sample",
@@ -220,7 +222,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "150"
   },
   {
     "service": "sample",
@@ -301,7 +304,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "150"
   },
   {
     "service": "sample",
@@ -372,6 +376,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "1"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -64,6 +64,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "10"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
@@ -68,6 +68,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "10"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -81,7 +81,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[5]int{1, 2, 3, 4, 5}"
   },
   {
     "service": "sample",
@@ -170,6 +171,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[5]int{1, 2, 3, 4, 5}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]int16{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]int32{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]int64{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]int8{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]int{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -69,7 +69,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<main.behavior>"
   },
   {
     "service": "sample",
@@ -142,7 +143,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<main.behavior>"
   },
   {
     "service": "sample",
@@ -214,7 +216,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<main.behavior>"
   },
   {
     "service": "sample",
@@ -287,7 +290,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<main.behavior>"
   },
   {
     "service": "sample",
@@ -354,7 +358,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<main.behavior>"
   },
   {
     "service": "sample",
@@ -420,6 +425,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<main.behavior>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -150,6 +150,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "main.largeStruct{ a = 1 b = 2 c = 3 d = 4 e = 5 f = 6 g = 7 h = 8 i = 9 j = 10 }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -88,6 +88,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -56,6 +56,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -67,7 +67,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -137,7 +138,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -207,7 +209,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -277,7 +280,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -347,7 +351,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -417,7 +422,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -487,7 +493,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -557,7 +564,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -627,7 +635,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   },
   {
     "service": "sample",
@@ -697,6 +706,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "testLongFunctionWithChangingState"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -67,7 +67,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -137,7 +138,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -207,7 +209,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -277,7 +280,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -347,7 +351,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -417,7 +422,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -487,7 +493,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -557,7 +564,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -627,7 +635,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   },
   {
     "service": "sample",
@@ -697,6 +706,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "55 and 89"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -110,6 +110,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "21, 22, 23, 24, 25, 26, 27, 28, 29"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -175,6 +175,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[[4]string][2]int>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -646,6 +646,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[string][]main.structWithMap>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -71,6 +71,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[struct {}]int>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -71,6 +71,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[struct {}]struct {}>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -71,6 +71,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[int]struct {}>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[int]int>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -521,6 +521,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[[4]int][4]int>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -145,6 +145,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[[4]int]uint8>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[string][]main.structWithMap>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[string][]main.structWithMap>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -145,6 +145,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[uint8][4]int>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[uint8]uint8>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[string]int>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -101,6 +101,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[string][]string>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -99,6 +99,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[string]main.nestedStruct>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -270,6 +270,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[bool]main.node>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[uint8]uint8>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -2611,6 +2611,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[uint8]uint8>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -161,6 +161,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[int]uint8>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[int]uint8>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
@@ -61,6 +61,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -141,6 +141,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "31, 32, 33, 34, 35, 36, 37, 38, overflow"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -110,6 +110,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "[2]int{51, 52}, [3]int{63, 64, 65}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -195,6 +195,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "main.largeStruct{ a = 101 b = 102 c = 103 d = 104 e = 105 f = 106 g = 107 h = 108 i = 109 j = 110 }, main.largeStruct{ a = 111 b = 112 c = 113 d = 114 e = 115 f = 116 g = 117 h = 118 i = 119 j = 120 }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -72,6 +72,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "41"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -75,6 +75,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "false, 42, 122, 1337, xyz"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -68,6 +68,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "40"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnAndChangesToParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnAndChangesToParams.json
@@ -1,0 +1,78 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testNamedReturnAndChangesToParams",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testNamedReturnAndChangesToParams",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 113
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 438
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testNamedReturnAndChangesToParams",
+          "location": {
+            "method": "main.testNamedReturnAndChangesToParams"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "int",
+                "value": "1"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "j": {
+                "type": "int",
+                "value": "113"
+              },
+              "q": {
+                "type": "int",
+                "value": "112"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "1, 112, 113"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -1,0 +1,74 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testNamedReturn",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testNamedReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 91
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 393
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testNamedReturnWithTemplate",
+          "location": {
+            "method": "main.testNamedReturn"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "int",
+                "value": "40"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "result": {
+                "type": "int",
+                "value": "80"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "Parameter 40 * 2 = result 80"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -63,6 +63,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -63,6 +63,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ", 5"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -67,6 +67,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "1, , 5"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -65,6 +65,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -70,6 +70,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -82,6 +82,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -76,7 +76,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -157,7 +158,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -240,6 +242,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -96,7 +96,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>, true"
   },
   {
     "service": "sample",
@@ -189,6 +190,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>, false"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -74,6 +74,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsArray"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -66,6 +66,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsArrayOne"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -61,6 +61,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsArrayZero"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -92,6 +92,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsBacktrackInt"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -56,7 +56,7 @@
               },
               "~r1": {
                 "type": "uintptr",
-                "value": "0x1234"
+                "value": "4660"
               }
             }
           }
@@ -64,6 +64,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsBoolAndUintptr"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -64,6 +64,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsComplex"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -79,7 +79,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "true"
   },
   {
     "service": "sample",
@@ -154,6 +155,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "false"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -68,6 +68,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "42"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -72,6 +72,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "42"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "42"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -77,7 +77,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -168,7 +169,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   },
   {
     "service": "sample",
@@ -260,6 +262,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "<interface {}>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -101,6 +101,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsLargeStruct"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -121,6 +121,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsManyFloats"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -76,6 +76,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsMixed"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -60,6 +60,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsMixedStruct"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -64,6 +64,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsMultipleFloats"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -60,6 +60,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsOnlyFloat"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -88,6 +88,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsPrimitives"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -79,6 +79,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsStructWithArray"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -105,6 +105,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "testReturnsWideStruct"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]int32{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "true"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "97"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "-1512"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "parameter = -16"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "-32"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "-64"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "parameter = -8"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "1"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "abc"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "1512"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "16"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "32"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "64"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "8"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -103,6 +103,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[][]uint{[]uint{4}, []uint{5, 6}, []uint{7, 8, 9}}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -81,6 +81,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<map[string]int>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -76,6 +76,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "42"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -98,6 +98,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "[5]int{41, 42, 43, 44, 45}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]string{one, two}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -60,6 +60,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -73,6 +73,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[]string{abc, xyz, 123}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -60,6 +60,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct.json
@@ -86,6 +86,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "main.aStruct{ aBool = true aString = one aNumber = 2 nested = main.nestedStruct{ anotherInt = 3 anotherString = four } }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -91,6 +91,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[]main.structWithNoStrings{main.structWithNoStrings{ aUint8 = 42 aBool = true }, main.structWithNoStrings{ aUint8 = 24 aBool = true }}, 3"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -79,6 +79,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "main.structWithAny{ a = <interface {}> }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -110,6 +110,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "main.structWithArray{ arr = [2]int{71, 72} x = 73 }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
@@ -85,6 +85,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "main.structWithCyclicMaps{ m1 = <map[struct {}]main.structWithCyclicMaps> m2 = <map[struct {}]map[struct {}]main.structWithCyclicMaps> m3 = <map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps> m4 = <map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps> m5 = <map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps> m6 = <map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps> }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -472,6 +472,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "main.structWithCyclicSlices{ s1 = []main.structWithCyclicSlices{main.structWithCyclicSlices{ s1 = s1 = <error: slice address or length is 0> s2 = s2 = <error: slice address or length is 0> s3 = s3 = <error: slice address or length is 0> s4 = s4 = <error: slice address or length is 0> s5 = s5 = <error: slice address or length is 0> s6 = s6 = <error: slice address or length is 0> }} s2 = [][]main.structWithCyclicSlices{s2 = <error: error extracting raw value for slice element 0: slice address or length is 0> s3 = [][][]main.structWithCyclicSlices{s3 = <error: error extracting raw value for slice element 0: slice address or length is 0> s4 = [][][][]main.structWithCyclicSlices{s4 = <error: error extracting raw value for slice element 0: slice address or length is 0> s5 = [][][][][]main.structWithCyclicSlices{s5 = <error: error extracting raw value for slice element 0: slice address or length is 0> s6 = [][][][][][]main.structWithCyclicSlices{s6 = <error: error extracting raw value for slice element 0: slice address or length is 0> }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -76,6 +76,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "main.structWithMap{ m = <map[int]int> }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -67,6 +67,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "abc, def, ghi"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
@@ -73,6 +73,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "main.threeStringStruct{ a = abc b = def c = ghi }"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -73,6 +73,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "3"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]uint16{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]uint32{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]uint64{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]uint8{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -69,6 +69,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[2]uint{1, 2}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -60,6 +60,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "0x[addr]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -73,6 +73,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[]uint{1, 2, 3}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -59,6 +59,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "<unsafe.Pointer>"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -461,6 +461,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[100]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -318,6 +318,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[]uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
@@ -318,6 +318,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": "[]uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -78,6 +78,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "[0]int{}, 82"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -54,6 +54,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -55,6 +55,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -615,6 +615,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -54,7 +54,8 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   },
   {
     "service": "simple",
@@ -117,6 +118,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -55,6 +55,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -68,6 +68,7 @@
         }
       }
     },
-    "timestamp": "[ts]"
+    "timestamp": "[ts]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/mapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapArg.json
@@ -67,6 +67,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/noArgs.json
+++ b/pkg/dyninst/testdata/decoded/simple/noArgs.json
@@ -46,6 +46,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArg.json
@@ -55,6 +55,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -69,6 +69,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateDSLAndStringSegments.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateDSLAndStringSegments.json
@@ -1,0 +1,61 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.stringArg",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.stringArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 51
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 20
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testTemplateDSLAndStringSegments",
+          "location": {
+            "method": "main.stringArg"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "value": "d"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "hello d, and hello to d"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleDSLSegment.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleDSLSegment.json
@@ -1,0 +1,61 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.stringArg",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.stringArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 51
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 20
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testTemplateMultipleDSLSegment",
+          "location": {
+            "method": "main.stringArg"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "value": "d"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "dd"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleStringSegments.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateMultipleStringSegments.json
@@ -1,0 +1,61 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.stringArg",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.stringArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 51
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 20
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testTemplateMultipleStringSegments",
+          "location": {
+            "method": "main.stringArg"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "value": "d"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "hello world!"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateStringAndDSLSegment.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateStringAndDSLSegment.json
@@ -1,0 +1,61 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.stringArg",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.stringArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 51
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 20
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testTemplateStringAndDSLSegment",
+          "location": {
+            "method": "main.stringArg"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "value": "d"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "hello d"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/testTemplateStringSegment.json
+++ b/pkg/dyninst/testdata/decoded/simple/testTemplateStringSegment.json
@@ -1,0 +1,61 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.stringArg",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.stringArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 51
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 20
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testTemplateStringSegment",
+          "location": {
+            "method": "main.stringArg"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "value": "d"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "hello"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -84,6 +84,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": ""
   }
 ]

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -34,7 +34,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -233,7 +234,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -270,7 +272,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -469,7 +472,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -506,7 +510,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -705,6 +710,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   }
 ]

--- a/pkg/dyninst/testdata/e2e/rc_tester_v1.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester_v1.json
@@ -34,7 +34,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -233,7 +234,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -270,7 +272,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -469,7 +472,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -506,7 +510,8 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   },
   {
     "service": "rc_tester",
@@ -705,6 +710,7 @@
       }
     },
     "timestamp": "[ts]",
-    "duration": "[duration]"
+    "duration": "[duration]",
+    "message": "test log message"
   }
 ]

--- a/pkg/dyninst/testprogs/progs/sample/returns.go
+++ b/pkg/dyninst/testprogs/progs/sample/returns.go
@@ -105,6 +105,14 @@ func testSomeNamedReturn(i int) (_ int, result2 int, _ int) {
 	return i * 10, i * 20, i * 30
 }
 
+//go:noinline
+func testNamedReturnAndChangesToParams(i int) (j int) {
+	i += 55
+	q := i * 2
+	j = q + 1
+	return j
+}
+
 // Primitive types - exercise all basic types.
 //
 //go:noinline
@@ -427,4 +435,5 @@ func executeReturns() {
 	testMultipleArrayArgs([2]int{51, 52}, [3]int{63, 64, 65})
 	testStructWithArrayArg(structWithArray{arr: [2]int{71, 72}, x: 73})
 	testZeroSizeArgAndReturn([0]int{}, 82)
+	testNamedReturnAndChangesToParams(1)
 }

--- a/pkg/dyninst/testprogs/testdata/probes/fault.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/fault.yaml
@@ -7,3 +7,5 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: ""
+    segments:

--- a/pkg/dyninst/testprogs/testdata/probes/rc_tester.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/rc_tester.yaml
@@ -7,6 +7,9 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: "test log message"
+    segments:
+      - str: "test log message"
   - id: http_handler
     type: LOG_PROBE
     where:
@@ -14,3 +17,6 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: "test log message"
+    segments:
+      - str: "test log message"

--- a/pkg/dyninst/testprogs/testdata/probes/rc_tester_v1.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/rc_tester_v1.yaml
@@ -7,6 +7,9 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: "test log message"
+    segments:
+      - str: "test log message"
   - id: http_handler
     type: LOG_PROBE
     where:
@@ -14,3 +17,7 @@ probes:
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
+    template: "test log message"
+    segments:
+      - str: "test log message"
+

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -1572,11 +1572,33 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testReturnsInt
-    message: "{i}"
+    message: "{i} + {j}"
     segments:
       - json: 
           ref: "i"
         dsl: "i"
+      - str: " + "
+      - dsl: "j"
+        json:
+          ref: "j"
+    captureSnapshot: true
+  - id: testNamedReturnAndChangesToParams
+    type: LOG_PROBE
+    where:
+      methodName: main.testNamedReturnAndChangesToParams
+    message: "{i}, {q}, {j}"
+    segments:
+      - json: 
+          ref: "i"
+        dsl: "i"
+      - str: ", "
+      - json: 
+          ref: "q"
+        dsl: "q"
+      - str: ", "
+      - dsl: "j"
+        json:
+          ref: "j"
     captureSnapshot: true
   - id: testReturnsIntPointer
     type: LOG_PROBE

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -6,6 +6,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleByte
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleRune
     type: LOG_PROBE
@@ -13,6 +18,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleRune
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleBool
     type: LOG_PROBE
@@ -20,6 +30,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleBool
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt
     type: LOG_PROBE
@@ -27,6 +42,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt8
     type: LOG_PROBE
@@ -34,6 +54,12 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt8
+    message: "parameter = {x}"
+    segments:
+      - str: "parameter = "
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt16
     type: LOG_PROBE
@@ -41,6 +67,12 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt16
+    message: "parameter = {x}"
+    segments:
+      - str: "parameter = "
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt32
     type: LOG_PROBE
@@ -48,6 +80,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt32
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt64
     type: LOG_PROBE
@@ -55,6 +92,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt64
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint
     type: LOG_PROBE
@@ -62,6 +104,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint8
     type: LOG_PROBE
@@ -69,6 +116,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint8
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint16
     type: LOG_PROBE
@@ -76,6 +128,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint16
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint32
     type: LOG_PROBE
@@ -83,6 +140,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint32
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint64
     type: LOG_PROBE
@@ -90,6 +152,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint64
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleFloat32
     type: LOG_PROBE
@@ -97,6 +164,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleFloat32
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleFloat64
     type: LOG_PROBE
@@ -104,6 +176,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleFloat64
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testTypeAlias
     type: LOG_PROBE
@@ -111,6 +188,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testTypeAlias
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleString
     type: LOG_PROBE
@@ -119,12 +201,22 @@ probes:
     where:
       methodName: main.testSingleString
     captureSnapshot: true
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"  
   - id: testUnitializedString
     type: LOG_PROBE
     tags:
       - "foo:bar"
     where:
       methodName: main.testUnitializedString
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testMassiveString
     type: LOG_PROBE
@@ -132,6 +224,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMassiveString
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testMassiveStringWithSizeLimit
     type: LOG_PROBE
@@ -139,6 +236,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMassiveString
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     capture:
       maxLength: 11
@@ -148,6 +250,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEmptyString
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -157,6 +264,19 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testThreeStrings
+    message: "{x}, {y}, {z}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
+      - str: ", "
+      - json: 
+          ref: "y"
+        dsl: "y"
+      - str: ", "
+      - json: 
+          ref: "z"
+        dsl: "z"
     captureSnapshot: true
   - id: testThreeStringsInStruct
     type: LOG_PROBE
@@ -164,6 +284,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testThreeStringsInStruct
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testUnsafePointer
     type: LOG_PROBE
@@ -171,6 +296,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUnsafePointer
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testThreeStringsInStructPointer
     type: LOG_PROBE
@@ -178,6 +308,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testThreeStringsInStructPointer
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testOneStringInStructPointer
     type: LOG_PROBE
@@ -185,6 +320,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testOneStringInStructPointer
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testByteArray
     type: LOG_PROBE
@@ -192,6 +332,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testByteArray
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testRuneArray
     type: LOG_PROBE
@@ -199,6 +344,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testRuneArray
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testStringArray
     type: LOG_PROBE
@@ -206,6 +356,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStringArray
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testBoolArray
     type: LOG_PROBE
@@ -214,12 +369,22 @@ probes:
     where:
       methodName: main.testBoolArray
     captureSnapshot: true
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
   - id: testIntArray
     type: LOG_PROBE
     tags:
       - "foo:bar"
     where:
       methodName: main.testIntArray
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInt8Array
     type: LOG_PROBE
@@ -227,6 +392,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInt8Array
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInt16Array
     type: LOG_PROBE
@@ -234,6 +404,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInt16Array
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInt32Array
     type: LOG_PROBE
@@ -241,6 +416,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInt32Array
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInt64Array
     type: LOG_PROBE
@@ -248,6 +428,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInt64Array
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUintArray
     type: LOG_PROBE
@@ -255,6 +440,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUintArray
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUint8Array
     type: LOG_PROBE
@@ -262,6 +452,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUint8Array
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUint16Array
     type: LOG_PROBE
@@ -269,6 +464,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUint16Array
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUint32Array
     type: LOG_PROBE
@@ -276,6 +476,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUint32Array
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUint64Array
     type: LOG_PROBE
@@ -283,6 +488,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUint64Array
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testArrayOfArrays
     type: LOG_PROBE
@@ -290,6 +500,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayOfArrays
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testArrayOfStrings
     type: LOG_PROBE
@@ -297,6 +512,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayOfStrings
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testArrayOfArraysOfArrays
     type: LOG_PROBE
@@ -304,11 +524,21 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayOfArraysOfArrays
+    message: "{b}"
+    segments:
+      - json: 
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true
   - id: testArrayOfStructs
     type: LOG_PROBE
     where:
       methodName: main.testArrayOfStructs
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testArrayEmptyStructs
     type: LOG_PROBE
@@ -316,6 +546,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayEmptyStructs
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testUintSlice
     type: LOG_PROBE
@@ -324,12 +559,22 @@ probes:
     where:
       methodName: main.testUintSlice
     captureSnapshot: true
+    message: "{u}"
+    segments:
+      - json: 
+          ref: "u"
+        dsl: "u"
   - id: testVeryLargeSlice
     type: LOG_PROBE
     tags:
       - "foo:bar"
     where:
       methodName: main.testVeryLargeSlice
+    message: "{xs}"
+    segments:
+      - json: 
+          ref: "xs"
+        dsl: "xs"
     captureSnapshot: true
   - id: testVeryLargeSliceWithSizeLimit
     type: LOG_PROBE
@@ -337,6 +582,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testVeryLargeSlice
+    message: "{xs}"
+    segments:
+      - json: 
+          ref: "xs"
+        dsl: "xs"
     captureSnapshot: true
     capture:
       collectionSizeLimit: 12
@@ -346,6 +596,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testVeryLargeArray
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testEmptySlice
     type: LOG_PROBE
@@ -353,6 +608,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEmptySlice
+    message: "{u}"
+    segments:
+      - json: 
+          ref: "u"
+        dsl: "u"
     captureSnapshot: true
   - id: testSliceOfSlices
     type: LOG_PROBE
@@ -360,6 +620,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSliceOfSlices
+    message: "{u}"
+    segments:
+      - json: 
+          ref: "u"
+        dsl: "u"
     captureSnapshot: true
   - id: testStructSlice
     type: LOG_PROBE
@@ -367,6 +632,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStructSlice
+    message: "{xs}, {a}"
+    segments:
+      - json: 
+          ref: "xs"
+        dsl: "xs"
+      - str: ", "
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testEmptySliceOfStructs
     type: LOG_PROBE
@@ -374,6 +648,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEmptySliceOfStructs
+    message: "{xs}, {a}"
+    segments:
+      - json: 
+          ref: "xs"
+        dsl: "xs"
+      - str: ", "
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testNilSliceOfStructs
     type: LOG_PROBE
@@ -381,6 +664,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testNilSliceOfStructs
+    message: "{xs}, {a}"
+    segments:
+      - json: 
+          ref: "xs"
+        dsl: "xs"
+      - str: ", "
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testStringSlice
     type: LOG_PROBE
@@ -388,6 +680,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStringSlice
+    message: "{s}"
+    segments:
+      - json: 
+          ref: "s"
+        dsl: "s"
     captureSnapshot: true
   - id: testNilSliceWithOtherParams
     type: LOG_PROBE
@@ -395,6 +692,19 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testNilSliceWithOtherParams
+    message: "{a}, {s}, {x}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json: 
+          ref: "s"
+        dsl: "s"
+      - str: ", "
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testNilSlice
     type: LOG_PROBE
@@ -402,6 +712,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testNilSlice
+    message: "{xs}"
+    segments:
+      - json: 
+          ref: "xs"
+        dsl: "xs"
     captureSnapshot: true
   - id: testSliceEmptyStructs
     type: LOG_PROBE
@@ -409,6 +724,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSliceEmptyStructs
+    message: "{xs}"
+    segments:
+      - json: 
+          ref: "xs"
+        dsl: "xs"
     captureSnapshot: true
   - id: testStruct
     type: LOG_PROBE
@@ -416,6 +736,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStruct
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testEmptyStruct
     type: LOG_PROBE
@@ -424,6 +749,11 @@ probes:
     where:
       methodName: main.testEmptyStruct
     captureSnapshot: true
+    message: "{e}"
+    segments:
+      - json: 
+          ref: "e"
+        dsl: "e"
   - id: testUintPointer
     type: LOG_PROBE
     tags:
@@ -431,12 +761,22 @@ probes:
     where:
       methodName: main.testUintPointer
     captureSnapshot: true
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
   - id: testStringPointer
     type: LOG_PROBE
     tags:
       - "foo:bar"
     where:
       methodName: main.testStringPointer
+    message: "{z}"
+    segments:
+      - json: 
+          ref: "z"
+        dsl: "z"
     captureSnapshot: true
   - id: testNilPointer
     type: LOG_PROBE
@@ -444,6 +784,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testNilPointer
+    message: "{z}, {a}"
+    segments:
+      - json: 
+          ref: "z"
+        dsl: "z"
+      - str: ", "
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testCombinedByte
     type: LOG_PROBE
@@ -451,6 +800,19 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testCombinedByte
+    message: "{w}, {x}, {y}"
+    segments:
+      - json: 
+          ref: "w"
+        dsl: "w"
+      - str: ", "
+      - json: 
+          ref: "x"
+        dsl: "x"
+      - str: ", "
+      - json: 
+          ref: "y"
+        dsl: "y"
     captureSnapshot: true
   - id: testMultipleSimpleParams
     type: LOG_PROBE
@@ -458,11 +820,37 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMultipleSimpleParams
+    message: "{a}, {b}, {c}, {d}, {e}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json: 
+          ref: "b"
+        dsl: "b"
+      - str: ", "
+      - json: 
+          ref: "c"
+        dsl: "c"
+      - str: ", "
+      - json: 
+          ref: "d"
+        dsl: "d"
+      - str: ", "
+      - json: 
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testInterface
     type: LOG_PROBE
     where:
       methodName: main.testInterface
+    message: "{b}"
+    segments:
+      - json: 
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -470,6 +858,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testAny
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -479,6 +872,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testError
+    message: "{e}"
+    segments:
+      - json: 
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testBigStruct
     type: LOG_PROBE
@@ -486,6 +884,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testBigStruct
+    message: "{b}"
+    segments:
+      - json: 
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true
   - id: stackC
     type: LOG_PROBE
@@ -493,6 +896,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.stackC
+    message: "stackC"
+    segments:
+      - str: "stackC"
     captureSnapshot: true
   - id: testChannel
     type: LOG_PROBE
@@ -500,6 +906,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testChannel
+    message: "{c}"
+    segments:
+      - json: 
+          ref: "c"
+        dsl: "c"
     captureSnapshot: true
   - id: testLinkedList
     type: LOG_PROBE
@@ -507,6 +918,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testLinkedList
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testPointerLoop
     type: LOG_PROBE
@@ -514,6 +930,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testPointerLoop
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testCycle
     type: LOG_PROBE
@@ -521,6 +942,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testCycle
+    message: "{t}"
+    segments:
+      - json: 
+          ref: "t"
+        dsl: "t"
     captureSnapshot: true
   - id: testPointerToSimpleStruct
     type: LOG_PROBE
@@ -528,6 +954,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testPointerToSimpleStruct
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testEsotericStack
     type: LOG_PROBE
@@ -535,6 +966,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEsotericStack
+    message: "{e}"
+    segments:
+      - json: 
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testEsotericHeap
     type: LOG_PROBE
@@ -542,6 +978,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEsotericHeap
+    message: "{e}"
+    segments:
+      - json: 
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testSmallMap
     type: LOG_PROBE
@@ -549,6 +990,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSmallMap
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapIntToInt
     type: LOG_PROBE
@@ -556,6 +1002,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapIntToInt
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapStringToInt
     type: LOG_PROBE
@@ -563,6 +1014,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapStringToInt
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapStringToSlice
     type: LOG_PROBE
@@ -570,6 +1026,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapStringToSlice
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapArrayToArray
     type: LOG_PROBE
@@ -577,6 +1038,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapArrayToArray
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapStringToStruct
     type: LOG_PROBE
@@ -584,6 +1050,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapStringToStruct
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapMassive
     type: LOG_PROBE
@@ -591,6 +1062,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapMassive
+    message: "{redactMyEntries}"
+    segments:
+      - json: 
+          ref: "redactMyEntries"
+        dsl: "redactMyEntries"
     captureSnapshot: true
   - id: testMapMassiveWithSizeLimit
     type: LOG_PROBE
@@ -598,6 +1074,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapMassive
+    message: "{redactMyEntries}"
+    segments:
+      - json: 
+          ref: "redactMyEntries"
+        dsl: "redactMyEntries"
     captureSnapshot: true
     capture:
       collectionSizeLimit: 3
@@ -607,6 +1088,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapEmbeddedMaps
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapWithLinkedList
     type: LOG_PROBE
@@ -614,6 +1100,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithLinkedList
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapWithSmallValue
     type: LOG_PROBE
@@ -621,6 +1112,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithSmallValue
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapWithSmallValueMassive
     type: LOG_PROBE
@@ -628,6 +1124,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithSmallValueMassive
+    message: "{redactMyEntries}"
+    segments:
+      - json: 
+          ref: "redactMyEntries"
+        dsl: "redactMyEntries"
     captureSnapshot: true
   - id: testMapWithSmallKeyAndValue
     type: LOG_PROBE
@@ -635,6 +1136,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithSmallKeyAndValue
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapWithSmallKeyAndValueMassive
     type: LOG_PROBE
@@ -642,6 +1148,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithSmallKeyAndValueMassive
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapSmallKeySmallValue
     type: LOG_PROBE
@@ -649,6 +1160,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapSmallKeySmallValue
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapSmallKeyLargeValue
     type: LOG_PROBE
@@ -656,6 +1172,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapSmallKeyLargeValue
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapLargeKeySmallValue
     type: LOG_PROBE
@@ -663,6 +1184,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapLargeKeySmallValue
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapLargeKeyLargeValue
     type: LOG_PROBE
@@ -670,6 +1196,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapLargeKeyLargeValue
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapEmptyKey
     type: LOG_PROBE
@@ -677,6 +1208,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapEmptyKey
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapEmptyValue
     type: LOG_PROBE
@@ -684,6 +1220,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapEmptyValue
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapEmptyKeyAndValue
     type: LOG_PROBE
@@ -691,6 +1232,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapEmptyKeyAndValue
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testStructWithMap
     type: LOG_PROBE
@@ -698,6 +1244,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStructWithMap
+    message: "{s}"
+    segments:
+      - json: 
+          ref: "s"
+        dsl: "s"
     captureSnapshot: true
   - id: testArrayOfMaps
     type: LOG_PROBE
@@ -705,6 +1256,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayOfMaps
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testPointerToMap
     type: LOG_PROBE
@@ -712,6 +1268,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testPointerToMap
+    message: "{m}"
+    segments:
+      - json: 
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testInlinedPrint
     type: LOG_PROBE
@@ -719,6 +1280,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedPrint
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -728,6 +1294,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedSumArray
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -737,6 +1308,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedSq
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInlinedBA
     type: LOG_PROBE
@@ -744,6 +1320,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBA
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInlinedBB
     type: LOG_PROBE
@@ -751,6 +1332,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBB
+    message: "{x}, {y}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
+      - str: ", "
+      - json: 
+          ref: "y"
+        dsl: "y"
     captureSnapshot: true
   - id: testInlinedBBA
     type: LOG_PROBE
@@ -758,6 +1348,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBBA
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInlinedBBB
     type: LOG_PROBE
@@ -765,6 +1360,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBBB
+    message: "testInlinedBBB"
+    segments:
+      - str: "testInlinedBBB"
     captureSnapshot: true
   - id: testInlinedBC
     type: LOG_PROBE
@@ -772,6 +1370,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBC
+    message: "testInlinedBC"
+    segments:
+      - str: "testInlinedBC"
     captureSnapshot: true
   - id: testInlinedBCA
     type: LOG_PROBE
@@ -779,6 +1380,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBCA
+    message: "testInlinedBCA"
+    segments:
+      - str: "testInlinedBCA"
     captureSnapshot: true
   - id: testInlinedBCB
     type: LOG_PROBE
@@ -786,6 +1390,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBCB
+    message: "testInlinedBCB"
+    segments:
+      - str: "testInlinedBCB"
     captureSnapshot: true
   - id: testFrameless
     type: LOG_PROBE
@@ -793,6 +1400,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testFrameless
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testFramelessArray
     type: LOG_PROBE
@@ -800,11 +1412,21 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testFramelessArray
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testDeepPtr1
     type: LOG_PROBE
     where:
       methodName: main.testDeepPtr1
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -812,6 +1434,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepPtr7
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 5
@@ -819,6 +1446,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepSlice1
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -826,6 +1458,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepSlice7
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 5
@@ -833,6 +1470,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepMap1
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -840,6 +1482,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepMap7
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 5
@@ -847,6 +1494,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testStringType1
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -854,6 +1506,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testStringType2
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -861,11 +1518,21 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testEmptyStructPointer
+    message: "{e}"
+    segments:
+      - json: 
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testAnyPtr
     type: LOG_PROBE
     where:
       methodName: main.testAnyPtr
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -873,6 +1540,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testStructWithAny
+    message: "{s}"
+    segments:
+      - json: 
+          ref: "s"
+        dsl: "s"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -880,31 +1552,61 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testStructWithCyclicSlices
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testStructWithCyclicMaps
     type: LOG_PROBE
     where:
       methodName: main.testStructWithCyclicMaps
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testReturnsInt
     type: LOG_PROBE
     where:
       methodName: main.testReturnsInt
+    message: "{i}"
+    segments:
+      - json: 
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testReturnsIntPointer
     type: LOG_PROBE
     where:
       methodName: main.testReturnsIntPointer
+    message: "{i}"
+    segments:
+      - json: 
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testReturnsIntAndFloat
     type: LOG_PROBE
     where:
       methodName: main.testReturnsIntAndFloat
+    message: "{i}"
+    segments:
+      - json: 
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testReturnsError
     type: LOG_PROBE
     where:
       methodName: main.testReturnsError
+    message: "{failed}"
+    segments:
+      - json: 
+          ref: "failed"
+        dsl: "failed"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -912,6 +1614,15 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testReturnsAnyAndError
+    message: "{v}, {failed}"
+    segments:
+      - json: 
+          ref: "v"
+        dsl: "v"
+      - str: ", "
+      - json: 
+          ref: "failed"
+        dsl: "failed"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -919,6 +1630,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testReturnsAny
+    message: "{v}"
+    segments:
+      - json: 
+          ref: "v"
+        dsl: "v"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -926,6 +1642,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testReturnsInterface
+    message: "{v}"
+    segments:
+      - json: 
+          ref: "v"
+        dsl: "v"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -933,16 +1654,46 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testNamedReturn
+    message: "{i}"
+    segments:
+      - json: 
+          ref: "i"
+        dsl: "i"
+    captureSnapshot: true
+  - id: testNamedReturnWithTemplate
+    type: LOG_PROBE
+    where:
+      methodName: main.testNamedReturn
+    message: "Parameter {i} * 2 = result {result}"
+    segments:
+      - str: "Parameter "
+      - dsl: "i"
+        json:
+          ref: "i"
+      - str: " * 2 = result "
+      - dsl: "result"
+        json:
+          ref: "result"
     captureSnapshot: true
   - id: testMultipleNamedReturn
     type: LOG_PROBE
     where:
       methodName: main.testMultipleNamedReturn
+    message: "{i}"
+    segments:
+      - json: 
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testSomeNamedReturn
     type: LOG_PROBE
     where:
       methodName: main.testSomeNamedReturn
+    message: "{i}"
+    segments:
+      - json: 
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testInlinedPrintLine
     type: LOG_PROBE
@@ -951,6 +1702,11 @@ probes:
       sourceFile: inlined.go
       lines:
         - "14"
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -961,6 +1717,9 @@ probes:
       sourceFile: inlined.go
       lines:
         - "63"
+    message: "testInlinedBCA"
+    segments:
+      - str: "testInlinedBCA"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -971,6 +1730,9 @@ probes:
       sourceFile: inlined.go
       lines:
         - "67"
+    message: "testInlinedBCB"
+    segments:
+      - str: "testInlinedBCB"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -981,6 +1743,11 @@ probes:
       sourceFile: inlined.go
       lines:
         - "75"
+    message: "{x}"
+    segments:
+      - json: 
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -991,6 +1758,11 @@ probes:
       sourceFile: inlined.go
       lines:
         - "93"
+    message: "{a}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -1001,6 +1773,9 @@ probes:
       sourceFile: complex.go
       lines:
         - "208"
+    message: "testLongFunctionWithChangingState"
+    segments:
+      - str: "testLongFunctionWithChangingState"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -1011,6 +1786,9 @@ probes:
       sourceFile: complex.go
       lines:
         - "215"
+    message: "testLongFunctionWithChangingState"
+    segments:
+      - str: "testLongFunctionWithChangingState"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -1024,123 +1802,298 @@ probes:
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
+    message: "{a} and {b}"
+    segments:
+      - dsl: "a"
+        json:
+          ref: "a"
+      - str: " and "
+      - dsl: "b"
+        json:
+          ref: "b"
   - id: testReturnsPrimitives
     type: LOG_PROBE
     where:
       methodName: main.testReturnsPrimitives
+    message: "testReturnsPrimitives"
+    segments:
+      - str: "testReturnsPrimitives"
     captureSnapshot: true
   - id: testReturnsManyFloats
     type: LOG_PROBE
     where:
       methodName: main.testReturnsManyFloats
+    message: "testReturnsManyFloats"
+    segments:
+      - str: "testReturnsManyFloats"
     captureSnapshot: true
   - id: testReturnsComplex
     type: LOG_PROBE
     where:
       methodName: main.testReturnsComplex
+    message: "testReturnsComplex"
+    segments:
+      - str: "testReturnsComplex"
     captureSnapshot: true
   - id: testReturnsLargeStruct
     type: LOG_PROBE
     where:
       methodName: main.testReturnsLargeStruct
+    message: "testReturnsLargeStruct"
+    segments:
+      - str: "testReturnsLargeStruct"
     captureSnapshot: true
   - id: testReturnsArray
     type: LOG_PROBE
     where:
       methodName: main.testReturnsArray
+    message: "testReturnsArray"
+    segments:
+      - str: "testReturnsArray"
     captureSnapshot: true
   - id: testReturnsArrayOne
     type: LOG_PROBE
     where:
       methodName: main.testReturnsArrayOne
+    message: "testReturnsArrayOne"
+    segments:
+      - str: "testReturnsArrayOne"
     captureSnapshot: true
   - id: testReturnsArrayZero
     type: LOG_PROBE
     where:
       methodName: main.testReturnsArrayZero
+    message: "testReturnsArrayZero"
+    segments:
+      - str: "testReturnsArrayZero"
     captureSnapshot: true
   - id: testReturnsMixedStruct
     type: LOG_PROBE
     where:
       methodName: main.testReturnsMixedStruct
+    message: "testReturnsMixedStruct"
+    segments:
+      - str: "testReturnsMixedStruct"
     captureSnapshot: true
   - id: testReturnsBacktrackInt
     type: LOG_PROBE
     where:
       methodName: main.testReturnsBacktrackInt
+    message: "testReturnsBacktrackInt"
+    segments:
+      - str: "testReturnsBacktrackInt"
     captureSnapshot: true
   - id: testReturnsWideStruct
     type: LOG_PROBE
     where:
       methodName: main.testReturnsWideStruct
+    message: "testReturnsWideStruct"
+    segments:
+      - str: "testReturnsWideStruct"
     captureSnapshot: true
   - id: testReturnsMixed
     type: LOG_PROBE
     where:
       methodName: main.testReturnsMixed
+    message: "testReturnsMixed"
+    segments:
+      - str: "testReturnsMixed"
     captureSnapshot: true
   - id: testReturnsStructWithArray
     type: LOG_PROBE
     where:
       methodName: main.testReturnsStructWithArray
+    message: "testReturnsStructWithArray"
+    segments:
+      - str: "testReturnsStructWithArray"
     captureSnapshot: true
   - id: testReturnsOnlyFloat
     type: LOG_PROBE
     where:
       methodName: main.testReturnsOnlyFloat
+    message: "testReturnsOnlyFloat"
+    segments:
+      - str: "testReturnsOnlyFloat"
     captureSnapshot: true
   - id: testReturnsMultipleFloats
     type: LOG_PROBE
     where:
       methodName: main.testReturnsMultipleFloats
+    message: "testReturnsMultipleFloats"
+    segments:
+      - str: "testReturnsMultipleFloats"
     captureSnapshot: true
   - id: testReturnsBoolAndUintptr
     type: LOG_PROBE
     where:
       methodName: main.testReturnsBoolAndUintptr
+    message: "testReturnsBoolAndUintptr"
+    segments:
+      - str: "testReturnsBoolAndUintptr"
     captureSnapshot: true
   - id: testLargeArgAndReturn
     type: LOG_PROBE
     where:
       methodName: main.testLargeArgAndReturn
+    message: "{arg}"
+    segments:
+      - json: 
+          ref: "arg"
+        dsl: "arg"
     captureSnapshot: true
   - id: testArrayArgAndReturn
     type: LOG_PROBE
     where:
       methodName: main.testArrayArgAndReturn
+    message: "{arg}"
+    segments:
+      - json: 
+          ref: "arg"
+        dsl: "arg"
     captureSnapshot: true
   - id: testMultipleLargeArgs
     type: LOG_PROBE
     where:
       methodName: main.testMultipleLargeArgs
+    message: "{s1}, {s2}"
+    segments:
+      - json: 
+          ref: "s1"
+        dsl: "s1"
+      - str: ", "
+      - json: 
+          ref: "s2"
+        dsl: "s2"
     captureSnapshot: true
   - id: testManyArgsArrayReturn
     type: LOG_PROBE
     where:
       methodName: main.testManyArgsArrayReturn
+    message: "{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json: 
+          ref: "b"
+        dsl: "b"
+      - str: ", "
+      - json: 
+          ref: "c"
+        dsl: "c"
+      - str: ", "
+      - json: 
+          ref: "d"
+        dsl: "d"
+      - str: ", "
+      - json: 
+          ref: "e"
+        dsl: "e"
+      - str: ", "
+      - json: 
+          ref: "f"
+        dsl: "f"
+      - str: ", "
+      - json: 
+          ref: "g"
+        dsl: "g"
+      - str: ", "
+      - json: 
+          ref: "h"
+        dsl: "h"
+      - str: ", "
+      - json: 
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testMixedArgsStackReturn
     type: LOG_PROBE
     where:
       methodName: main.testMixedArgsStackReturn
+    message: "{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json: 
+          ref: "b"
+        dsl: "b"
+      - str: ", "
+      - json: 
+          ref: "c"
+        dsl: "c"
+      - str: ", "
+      - json: 
+          ref: "d"
+        dsl: "d"
+      - str: ", "
+      - json: 
+          ref: "e"
+        dsl: "e"
+      - str: ", "
+      - json: 
+          ref: "f"
+        dsl: "f"
+      - str: ", "
+      - json: 
+          ref: "g"
+        dsl: "g"
+      - str: ", "
+      - json: 
+          ref: "h"
+        dsl: "h"
+      - str: ", "
+      - json: 
+          ref: "s"
+        dsl: "s"
     captureSnapshot: true
   - id: testStackArgRegReturns
     type: LOG_PROBE
     where:
       methodName: main.testStackArgRegReturns
+    message: "{arg}"
+    segments:
+      - json: 
+          ref: "arg"
+        dsl: "arg"
     captureSnapshot: true
   - id: testMultipleArrayArgs
     type: LOG_PROBE
     where:
       methodName: main.testMultipleArrayArgs
+    message: "{a}, {b}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json: 
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true
   - id: testStructWithArrayArg
     type: LOG_PROBE
     where:
       methodName: main.testStructWithArrayArg
+    message: "{arg}"
+    segments:
+      - json: 
+          ref: "arg"
+        dsl: "arg"
     captureSnapshot: true
   - id: testZeroSizeArgAndReturn
     type: LOG_PROBE
     where:
       methodName: main.testZeroSizeArgAndReturn
+    message: "{a}, {b}"
+    segments:
+      - json: 
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json: 
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -77,3 +77,70 @@ probes:
   captureSnapshot: true
   where:
     methodName: main.usesMapsOfMapsThatDoNotAppearAsArguments
+- id: testTemplateStringSegment
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "hello"
+  segments:
+    - str: "hello"
+- id: testTemplateMultipleStringSegments
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "hello world!"
+  segments:
+    - str: "hello "
+    - str: "world"
+    - str: "!"
+- id: testTemplateStringAndDSLSegment
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "hello {s}"
+  segments:
+    - str: "hello "
+    - dsl: "s"
+      json:
+        ref: "s"
+- id: testTemplateMultipleDSLSegment
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "{s}{s}"
+  segments:
+    - dsl: "s"
+      json:
+        ref: "s"
+    - dsl: "s"
+      json:
+        ref: "s"
+- id: testTemplateDSLAndStringSegments
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.stringArg
+  captureSnapshot: true
+  message: "hello {s}, and hello to {s}"
+  segments:
+    - str: "hello "
+    - dsl: "s"
+      json:
+        ref: "s"
+    - str: ", and hello to "
+    - dsl: "s"
+      json:
+        ref: "s"


### PR DESCRIPTION
### What does this PR do?

Adds support for templates in ir, irgen, rcjson, and decoding packages.

### Motivation

Allowing users to specify templates in Go DI/LD using the expression language. For now just variable referencing would be supported.

### Describe how you validated your changes

Added test cases to integration tests.

### Additional Notes
