### PR TITLE
[CONS-7706] Convert tls handshake logs from errors into debug

### DIFF
--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -20,7 +20,7 @@ import (
 
 func startServer(listener net.Listener, srv *http.Server, name string) {
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
-	logWriter, _ := pkglogsetup.NewLogWriter(5, log.ErrorLvl)
+	logWriter, _ := pkglogsetup.NewTLSHandshakeErrorWriter(5, log.ErrorLvl)
 
 	srv.ErrorLog = stdLog.New(logWriter, fmt.Sprintf("Error from the Agent HTTP server '%s': ", name), 0) // log errors to seelog
 


### PR DESCRIPTION
### What does this PR do?
Silence transient TLS errors during agent startup.

### Motivation
Reduce production log noise per [CONS-7706](https://datadoghq.atlassian.net/browse/CONS-7706).

### Describe how you validated your changes
Built a custom image with the change and observed TLS errors are now classified as `DEBUG`.

### Additional Notes
This is a pattern already established in the Cluster Agent API.

[CONS-7706]: https://datadoghq.atlassian.net/browse/CONS-7706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ