### PR TITLE
config/remote/service: clarify locking behaviors

### DIFF
--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -19,9 +19,9 @@ type client struct {
 	pbClient *pbgo.Client
 }
 
-type cacheBypassClients struct {
-	clock    clock.Clock
-	requests chan chan struct{}
+// rateLimiter limits the number of requests that can be made in a given window.
+type rateLimiter struct {
+	clock clock.Clock
 
 	// Fixed window rate limiting
 	// It allows client requests spikes while limiting the global amount of request
@@ -31,7 +31,7 @@ type cacheBypassClients struct {
 	allowance      int
 }
 
-func (c *cacheBypassClients) Limit() bool {
+func (c *rateLimiter) Limit() bool {
 	now := c.clock.Now()
 	window := now.Truncate(c.windowDuration)
 

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -39,9 +39,8 @@ func TestClients(t *testing.T) {
 
 func TestCacheBypassClientsRateLimit(t *testing.T) {
 	clock := clock.NewMock()
-	cacheBypassClients := cacheBypassClients{
+	cacheBypassClients := rateLimiter{
 		clock:         clock,
-		requests:      make(chan chan struct{}),
 		currentWindow: clock.Now(),
 		// Allows 3 bypass every 5 seconds
 		windowDuration: 5 * time.Second,

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -750,7 +750,11 @@ func (s *CoreAgentService) refresh() error {
 	timeSinceUpdate := time.Since(s.mu.lastUpdateTimestamp)
 	if timeSinceUpdate < time.Second {
 		log.Debugf("Requests too frequent, delaying by %v", time.Second-timeSinceUpdate)
-		time.Sleep(time.Second - timeSinceUpdate)
+		func() {
+			s.mu.Unlock()
+			defer s.mu.Lock()
+			time.Sleep(time.Second - timeSinceUpdate)
+		}()
 	}
 
 	activeClients := s.clients.activeClients()

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -984,6 +984,8 @@ func (s *CoreAgentService) ClientGetConfigs(_ context.Context, request *pbgo.Cli
 		return nil, err
 	}
 
+	// TODO: Do not hold the mutex while calling getTargetFiles -- it may go to
+	// disk or network.
 	targetFiles, err := getTargetFiles(s.mu.uptane, neededFiles)
 	if err != nil {
 		return nil, err
@@ -1057,6 +1059,8 @@ func (s *CoreAgentService) apiKeyUpdateCallback() func(string, model.Source, any
 			log.Warnf("Could not get org uuid: %s", err)
 			return
 		}
+
+		// TODO: Do not hold the mutex while calling FetchOrgData.
 		newOrgUUID, err := s.mu.api.FetchOrgData(context.Background())
 		if err != nil {
 			log.Warnf("Could not get org uuid: %s", err)

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -93,7 +93,7 @@ type Service struct {
 	rcType string
 }
 
-func (s *Service) getNewDirectorRoots(uptane uptaneClient, currentVersion uint64, newVersion uint64) ([][]byte, error) {
+func getNewDirectorRoots(uptane uptaneClient, currentVersion uint64, newVersion uint64) ([][]byte, error) {
 	var roots [][]byte
 	for i := currentVersion + 1; i <= newVersion; i++ {
 		root, err := uptane.DirectorRoot(i)
@@ -105,7 +105,7 @@ func (s *Service) getNewDirectorRoots(uptane uptaneClient, currentVersion uint64
 	return roots, nil
 }
 
-func (s *Service) getTargetFiles(uptaneClient uptaneClient, targetFilePaths []string) ([]*pbgo.File, error) {
+func getTargetFiles(uptaneClient uptaneClient, targetFilePaths []string) ([]*pbgo.File, error) {
 	files, err := uptaneClient.TargetFiles(targetFilePaths)
 	if err != nil {
 		return nil, err
@@ -949,7 +949,7 @@ func (s *CoreAgentService) ClientGetConfigs(_ context.Context, request *pbgo.Cli
 	if tufVersions.DirectorTargets == request.Client.State.TargetsVersion {
 		return &pbgo.ClientGetConfigsResponse{}, nil
 	}
-	roots, err := s.getNewDirectorRoots(s.uptane, request.Client.State.RootVersion, tufVersions.DirectorRoot)
+	roots, err := getNewDirectorRoots(s.uptane, request.Client.State.RootVersion, tufVersions.DirectorRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -968,7 +968,7 @@ func (s *CoreAgentService) ClientGetConfigs(_ context.Context, request *pbgo.Cli
 		return nil, err
 	}
 
-	targetFiles, err := s.getTargetFiles(s.uptane, neededFiles)
+	targetFiles, err := getTargetFiles(s.uptane, neededFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -1334,7 +1334,7 @@ func (c *HTTPClient) getUpdate(
 	}
 
 	// Gather the files and map-ify them for the state data structure
-	targetFiles, err := c.getTargetFiles(c.uptane, configs)
+	targetFiles, err := getTargetFiles(c.uptane, configs)
 	if err != nil {
 		return nil, err
 	}
@@ -1344,7 +1344,7 @@ func (c *HTTPClient) getUpdate(
 	}
 
 	// Gather some TUF metadata files we need to send down
-	roots, err := c.getNewDirectorRoots(c.uptane, currentRootVersion, tufVersions.DirectorRoot)
+	roots, err := getNewDirectorRoots(c.uptane, currentRootVersion, tufVersions.DirectorRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -118,75 +118,77 @@ func getTargetFiles(uptaneClient uptaneClient, targetFilePaths []string) ([]*pbg
 // backend.  and maintains the local state of the configuration on behalf of its
 // clients.
 type CoreAgentService struct {
-	mu sync.Mutex
-
 	// rcType is used to differentiate multiple RC services running in a single
 	// agent.  Today, it is simply logged as a prefix in all log messages to
 	// help when triaging via logs.
 	rcType string
 
-	firstUpdate bool
-
-	// We record the startup time to ensure we flush client configs if we can't contact the backend in time
-	startupTime time.Time
-
-	defaultRefreshInterval         time.Duration
-	refreshIntervalOverrideAllowed bool
+	clock         clock.Clock
+	hostname      string
+	tagsGetter    func() []string
+	traceAgentEnv string
+	agentVersion  string
+	site          string
+	configRoot    string
+	directorRoot  string
+	// We record the startup time to ensure we flush client configs if we can't
+	// contact the backend in time
+	startupTime           time.Time
+	disableConfigPollLoop bool
+	// Set the interval for which we will poll the org status
+	orgStatusRefreshInterval time.Duration
 
 	// The backoff policy used for retries when errors are encountered
 	backoffPolicy backoff.Policy
-	// The number of errors we're currently tracking within the context of our backoff policy
-	backoffErrorCount int
+	// Used to report metrics on cache bypass requests
+	telemetryReporter RcTelemetryReporter
+	// A background task used to perform connectivity tests using a WebSocket -
+	// data gathering for future development.
+	websocketTest startstop.StartStoppable
+
+	// Self-synchronized (has internal locking)
+	clients            *clients
+	cacheBypassClients cacheBypassClients
 
 	// Channels to stop the services main goroutines
 	stopOrgPoller    chan struct{}
 	stopConfigPoller chan struct{}
 	stopOnce         sync.Once
 
-	clock         clock.Clock
-	hostname      string
-	tagsGetter    func() []string
-	traceAgentEnv string
-	uptane        coreAgentUptaneClient
-	api           api.API
+	mu struct {
+		sync.Mutex
 
-	products           map[rdata.Product]struct{}
-	newProducts        map[rdata.Product]struct{}
-	clients            *clients
-	cacheBypassClients cacheBypassClients
+		uptane coreAgentUptaneClient
+		api    api.API
 
-	// Used to report metrics on cache bypass requests
-	telemetryReporter RcTelemetryReporter
+		firstUpdate bool
 
-	lastUpdateTimestamp time.Time
-	lastUpdateErr       error
+		defaultRefreshInterval         time.Duration
+		refreshIntervalOverrideAllowed bool
 
-	// Used to rate limit the 4XX error logs
-	fetchErrorCount    uint64
-	lastFetchErrorType error
-	//  Number of /configurations calls where we get 503 or 504 errors
-	fetchConfigs503And504ErrCount uint64
+		lastUpdateTimestamp time.Time
+		lastUpdateErr       error
 
-	//  Number of /status calls where we get 503 or 504 errors
-	fetchOrgStatus503And504ErrCount uint64
+		// Used to rate limit the 4XX error logs
+		fetchErrorCount    uint64
+		lastFetchErrorType error
 
-	// Previous /status response
-	previousOrgStatus *pbgo.OrgStatusResponse
+		// Number of /configurations calls where we get 503 or 504 errors.
+		fetchConfigs503And504ErrCount uint64
 
-	agentVersion string
+		// Number of /status calls where we get 503 or 504 errors.
+		fetchOrgStatus503And504ErrCount uint64
 
-	disableConfigPollLoop bool
+		// Previous /status response
+		previousOrgStatus *pbgo.OrgStatusResponse
 
-	// set the interval for which we will poll the org status
-	orgStatusRefreshInterval time.Duration
+		// The number of errors we're currently tracking within the context
+		// of our backoff policy
+		backoffErrorCount int
 
-	site         string
-	configRoot   string
-	directorRoot string
-
-	// A background task used to perform connectivity tests using a WebSocket -
-	// data gathering for future development.
-	websocketTest startstop.StartStoppable
+		products    map[rdata.Product]struct{}
+		newProducts map[rdata.Product]struct{}
+	}
 }
 
 // uptaneClient provides functions to get TUF/uptane repo data.
@@ -499,22 +501,24 @@ func NewService(cfg model.Reader, rcType, baseRawURL, hostname string, tagsGette
 
 	now := clock.Now().UTC()
 	cas := &CoreAgentService{
-		rcType:                         rcType,
-		firstUpdate:                    true,
-		startupTime:                    now,
-		defaultRefreshInterval:         options.refresh,
-		refreshIntervalOverrideAllowed: options.refreshIntervalOverrideAllowed,
-		backoffErrorCount:              0,
-		backoffPolicy:                  backoffPolicy,
-		products:                       make(map[rdata.Product]struct{}),
-		newProducts:                    make(map[rdata.Product]struct{}),
-		hostname:                       hostname,
-		tagsGetter:                     tagsGetter,
-		clock:                          clock,
-		traceAgentEnv:                  options.traceAgentEnv,
-		api:                            http,
-		uptane:                         uptaneClient,
-		clients:                        newClients(clock, options.clientTTL),
+		rcType:                   rcType,
+		startupTime:              now,
+		hostname:                 hostname,
+		tagsGetter:               tagsGetter,
+		clock:                    clock,
+		traceAgentEnv:            options.traceAgentEnv,
+		agentVersion:             agentVersion,
+		stopOrgPoller:            make(chan struct{}),
+		stopConfigPoller:         make(chan struct{}),
+		disableConfigPollLoop:    options.disableConfigPollLoop,
+		orgStatusRefreshInterval: options.orgStatusRefreshInterval,
+		site:                     options.site,
+		configRoot:               configRoot,
+		directorRoot:             directorRoot,
+		backoffPolicy:            backoffPolicy,
+		telemetryReporter:        telemetryReporter,
+		websocketTest:            websocketTest,
+		clients:                  newClients(clock, options.clientTTL),
 		cacheBypassClients: cacheBypassClients{
 			clock:    clock,
 			requests: make(chan chan struct{}),
@@ -526,17 +530,15 @@ func NewService(cfg model.Reader, rcType, baseRawURL, hostname string, tagsGette
 			capacity:       options.clientCacheBypassLimit,
 			allowance:      options.clientCacheBypassLimit,
 		},
-		telemetryReporter:        telemetryReporter,
-		agentVersion:             agentVersion,
-		stopOrgPoller:            make(chan struct{}),
-		stopConfigPoller:         make(chan struct{}),
-		disableConfigPollLoop:    options.disableConfigPollLoop,
-		orgStatusRefreshInterval: options.orgStatusRefreshInterval,
-		site:                     options.site,
-		configRoot:               configRoot,
-		directorRoot:             directorRoot,
-		websocketTest:            websocketTest,
 	}
+	cas.mu.firstUpdate = true
+	cas.mu.defaultRefreshInterval = options.refresh
+	cas.mu.refreshIntervalOverrideAllowed = options.refreshIntervalOverrideAllowed
+	cas.mu.backoffErrorCount = 0
+	cas.mu.products = make(map[rdata.Product]struct{})
+	cas.mu.newProducts = make(map[rdata.Product]struct{})
+	cas.mu.api = http
+	cas.mu.uptane = uptaneClient
 
 	cfg.OnUpdate(cas.apiKeyUpdateCallback())
 
@@ -583,13 +585,15 @@ func (s *CoreAgentService) Start() {
 // UpdatePARJWT updates the stored JWT for Private Action Runners
 // for authentication to the remote config backend.
 func (s *CoreAgentService) UpdatePARJWT(jwt string) {
-	s.api.UpdatePARJWT(jwt)
+	s.mu.Lock()
+	s.mu.api.UpdatePARJWT(jwt)
+	s.mu.Unlock()
 }
 
 func startWithAgentPollLoop(s *CoreAgentService) {
 	err := s.refresh()
 	if err != nil {
-		logRefreshError(s, err)
+		s.logRefreshError(err)
 	}
 
 	for {
@@ -612,7 +616,7 @@ func startWithAgentPollLoop(s *CoreAgentService) {
 		}
 
 		if err != nil {
-			logRefreshError(s, err)
+			s.logRefreshError(err)
 		}
 	}
 }
@@ -625,20 +629,25 @@ func startWithoutAgentPollLoop(s *CoreAgentService) {
 			err = s.refresh()
 		} else {
 			err = errors.New("cache bypass limit exceeded")
-			s.lastUpdateErr = err
+			s.mu.Lock()
+			s.mu.lastUpdateErr = err
+			s.mu.Unlock()
 			s.telemetryReporter.IncRateLimit()
 		}
 		close(response)
 		if err != nil {
-			logRefreshError(s, err)
+			s.logRefreshError(err)
 		}
 	}
 }
 
-func logRefreshError(s *CoreAgentService, err error) {
-	if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled && s.previousOrgStatus.Authorized {
+func (s *CoreAgentService) logRefreshError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev := s.mu.previousOrgStatus
+	if prev != nil && prev.Enabled && prev.Authorized {
 		exportedLastUpdateErr.Set(err.Error())
-		if s.fetchConfigs503And504ErrCount < maxFetchConfigsUntilLogLevelErrors {
+		if s.mu.fetchConfigs503And504ErrCount < maxFetchConfigsUntilLogLevelErrors {
 			log.Warnf("[%s] Could not refresh Remote Config: %v", s.rcType, err)
 		} else {
 			log.Errorf("[%s] Could not refresh Remote Config: %v", s.rcType, err)
@@ -654,14 +663,26 @@ func (s *CoreAgentService) Stop() error {
 	s.stopOnce.Do(func() {
 		s.websocketTest.Stop()
 		close(s.stopConfigPoller)
-	        // close boltDB via the transactional store
-		err = s.uptane.Close()
+
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		// close boltDB via the transactional store
+		err = s.mu.uptane.Close()
 	})
 	return err
 }
 
+func (s *CoreAgentService) getAPI() api.API {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.api
+}
+
 func (s *CoreAgentService) pollOrgStatus() {
-	response, err := s.api.FetchOrgStatus(context.Background())
+	response, err := s.getAPI().FetchOrgStatus(context.Background())
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if err != nil {
 		// Unauthorized and proxy error are caught by the main loop requesting the latest config
 		if errors.Is(err, api.ErrUnauthorized) || errors.Is(err, api.ErrProxy) {
@@ -669,22 +690,23 @@ func (s *CoreAgentService) pollOrgStatus() {
 		}
 
 		if errors.Is(err, api.ErrGatewayTimeout) || errors.Is(err, api.ErrServiceUnavailable) {
-			s.fetchOrgStatus503And504ErrCount++
+			s.mu.fetchOrgStatus503And504ErrCount++
 		}
 
-		if s.fetchOrgStatus503And504ErrCount < maxFetchOrgStatusUntilLogLevelErrors {
+		if s.mu.fetchOrgStatus503And504ErrCount < maxFetchOrgStatusUntilLogLevelErrors {
 			log.Warnf("[%s] Could not refresh Remote Config: %v", s.rcType, err)
 		} else {
 			log.Errorf("[%s] Could not refresh Remote Config: %v", s.rcType, err)
 		}
 		return
 	}
-	s.fetchOrgStatus503And504ErrCount = 0
+	s.mu.fetchOrgStatus503And504ErrCount = 0
 
 	// Print info log when the new status is different from the previous one, or if it's the first run
-	if s.previousOrgStatus == nil ||
-		s.previousOrgStatus.Enabled != response.Enabled ||
-		s.previousOrgStatus.Authorized != response.Authorized {
+	prev := s.mu.previousOrgStatus
+	if prev == nil ||
+		prev.Enabled != response.Enabled ||
+		prev.Authorized != response.Authorized {
 		if response.Enabled {
 			if response.Authorized {
 				log.Infof("[%s] Remote Configuration is enabled for this organization and agent.", s.rcType)
@@ -700,7 +722,7 @@ func (s *CoreAgentService) pollOrgStatus() {
 			}
 		}
 	}
-	s.previousOrgStatus = &pbgo.OrgStatusResponse{
+	s.mu.previousOrgStatus = &pbgo.OrgStatusResponse{
 		Enabled:    response.Enabled,
 		Authorized: response.Authorized,
 	}
@@ -709,9 +731,14 @@ func (s *CoreAgentService) pollOrgStatus() {
 }
 
 func (s *CoreAgentService) calculateRefreshInterval() time.Duration {
-	backoffTime := s.backoffPolicy.GetBackoffDuration(s.backoffErrorCount)
+	s.mu.Lock()
+	backoffErrorCount := s.mu.backoffErrorCount
+	defaultRefreshInterval := s.mu.defaultRefreshInterval
+	s.mu.Unlock()
 
-	return s.defaultRefreshInterval + backoffTime
+	backoffTime := s.backoffPolicy.GetBackoffDuration(backoffErrorCount)
+
+	return defaultRefreshInterval + backoffTime
 }
 
 func (s *CoreAgentService) refresh() error {
@@ -720,49 +747,53 @@ func (s *CoreAgentService) refresh() error {
 	// We can't let the backend process an update twice in the same second due to the fact that we
 	// use the epoch with seconds resolution as the version for the TUF Director Targets. If this happens,
 	// the update will appear to TUF as being identical to the previous update and it will be dropped.
-	timeSinceUpdate := time.Since(s.lastUpdateTimestamp)
+	timeSinceUpdate := time.Since(s.mu.lastUpdateTimestamp)
 	if timeSinceUpdate < time.Second {
 		log.Debugf("Requests too frequent, delaying by %v", time.Second-timeSinceUpdate)
 		time.Sleep(time.Second - timeSinceUpdate)
 	}
 
 	activeClients := s.clients.activeClients()
-	s.refreshProducts(activeClients)
-	previousState, err := s.uptane.TUFVersionState()
+	s.refreshProductsLocked(activeClients)
+	previousState, err := s.mu.uptane.TUFVersionState()
 	if err != nil {
 		log.Warnf("[%s] could not get previous TUF version state: %v", s.rcType, err)
 	}
-	if s.forceRefresh() || err != nil {
+	if s.mu.firstUpdate || err != nil {
 		previousState = uptane.TUFVersions{}
 	}
-	clientState, err := s.getClientState()
-	if err != nil {
+	var clientState []byte
+	if rawTargetsCustom, err := s.mu.uptane.TargetsCustom(); err != nil {
 		log.Warnf("[%s] could not get previous backend client state: %v", s.rcType, err)
+	} else if custom, err := parseTargetsCustom(rawTargetsCustom); err != nil {
+		log.Warnf("[%s] could not parse targets custom: %v", s.rcType, err)
+	} else {
+		clientState = custom.OpaqueBackendState
 	}
-	orgUUID, err := s.uptane.StoredOrgUUID()
+	orgUUID, err := s.mu.uptane.StoredOrgUUID()
 	if err != nil {
 		s.mu.Unlock()
 		return err
 	}
 
-	request := buildLatestConfigsRequest(s.hostname, s.agentVersion, s.tagsGetter(), s.traceAgentEnv, orgUUID, previousState, activeClients, s.products, s.newProducts, s.lastUpdateErr, clientState)
+	request := buildLatestConfigsRequest(s.hostname, s.agentVersion, s.tagsGetter(), s.traceAgentEnv, orgUUID, previousState, activeClients, s.mu.products, s.mu.newProducts, s.mu.lastUpdateErr, clientState)
 	s.mu.Unlock()
 	ctx := context.Background()
-	response, err := s.api.Fetch(ctx, request)
+	response, err := s.mu.api.Fetch(ctx, request)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.lastUpdateErr = nil
+	s.mu.lastUpdateErr = nil
 	if err != nil {
-		s.backoffErrorCount = s.backoffPolicy.IncError(s.backoffErrorCount)
-		s.lastUpdateErr = fmt.Errorf("api: %v", err)
-		if s.lastFetchErrorType != err {
-			s.lastFetchErrorType = err
-			s.fetchErrorCount = 0
+		s.mu.backoffErrorCount = s.backoffPolicy.IncError(s.mu.backoffErrorCount)
+		s.mu.lastUpdateErr = fmt.Errorf("api: %v", err)
+		if s.mu.lastFetchErrorType != err {
+			s.mu.lastFetchErrorType = err
+			s.mu.fetchErrorCount = 0
 		}
 
 		if errors.Is(err, api.ErrUnauthorized) || errors.Is(err, api.ErrProxy) {
-			if s.fetchErrorCount < initialFetchErrorLog {
-				s.fetchErrorCount++
+			if s.mu.fetchErrorCount < initialFetchErrorLog {
+				s.mu.fetchErrorCount++
 				return err
 			}
 			// If we saw the error enough time, we consider that RC not working is a normal behavior
@@ -773,72 +804,56 @@ func (s *CoreAgentService) refresh() error {
 		}
 
 		if errors.Is(err, api.ErrGatewayTimeout) || errors.Is(err, api.ErrServiceUnavailable) {
-			s.fetchConfigs503And504ErrCount++
+			s.mu.fetchConfigs503And504ErrCount++
 		}
 		return err
 	}
-	s.fetchErrorCount = 0
-	s.fetchConfigs503And504ErrCount = 0
-	err = s.uptane.Update(response)
+	s.mu.fetchErrorCount = 0
+	s.mu.fetchConfigs503And504ErrCount = 0
+	err = s.mu.uptane.Update(response)
 	if err != nil {
-		s.backoffErrorCount = s.backoffPolicy.IncError(s.backoffErrorCount)
-		s.lastUpdateErr = fmt.Errorf("tuf: %v", err)
+		s.mu.backoffErrorCount = s.backoffPolicy.IncError(s.mu.backoffErrorCount)
+		s.mu.lastUpdateErr = fmt.Errorf("tuf: %v", err)
 		return err
 	}
 	// If a user hasn't explicitly set the refresh interval, allow the backend to override it based
 	// on the contents of our update request
-	if s.refreshIntervalOverrideAllowed {
-		ri, err := s.getRefreshInterval()
-		if err == nil && ri > 0 && s.defaultRefreshInterval != ri {
-			s.defaultRefreshInterval = ri
+	if s.mu.refreshIntervalOverrideAllowed {
+		ri, err := s.getRefreshIntervalLocked()
+		if err == nil && ri > 0 && s.mu.defaultRefreshInterval != ri {
+			s.mu.defaultRefreshInterval = ri
 			s.cacheBypassClients.windowDuration = ri
 			log.Infof("[%s] Overriding agent's base refresh interval to %v due to backend recommendation", s.rcType, ri)
 		}
 	}
 
-	s.lastUpdateTimestamp = time.Now()
+	s.mu.lastUpdateTimestamp = time.Now()
 
-	s.firstUpdate = false
-	for product := range s.newProducts {
-		s.products[product] = struct{}{}
+	s.mu.firstUpdate = false
+	for product := range s.mu.newProducts {
+		s.mu.products[product] = struct{}{}
 	}
-	s.newProducts = make(map[rdata.Product]struct{})
+	s.mu.newProducts = make(map[rdata.Product]struct{})
 
-	s.backoffErrorCount = s.backoffPolicy.DecError(s.backoffErrorCount)
+	s.mu.backoffErrorCount = s.backoffPolicy.DecError(s.mu.backoffErrorCount)
 
 	exportedLastUpdateErr.Set("")
 
 	return nil
 }
 
-func (s *CoreAgentService) forceRefresh() bool {
-	return s.firstUpdate
-}
-
-func (s *CoreAgentService) refreshProducts(activeClients []*pbgo.Client) {
+func (s *CoreAgentService) refreshProductsLocked(activeClients []*pbgo.Client) {
 	for _, client := range activeClients {
 		for _, product := range client.Products {
-			if _, hasProduct := s.products[rdata.Product(product)]; !hasProduct {
-				s.newProducts[rdata.Product(product)] = struct{}{}
+			if _, hasProduct := s.mu.products[rdata.Product(product)]; !hasProduct {
+				s.mu.newProducts[rdata.Product(product)] = struct{}{}
 			}
 		}
 	}
 }
 
-func (s *CoreAgentService) getClientState() ([]byte, error) {
-	rawTargetsCustom, err := s.uptane.TargetsCustom()
-	if err != nil {
-		return nil, err
-	}
-	custom, err := parseTargetsCustom(rawTargetsCustom)
-	if err != nil {
-		return nil, err
-	}
-	return custom.OpaqueBackendState, nil
-}
-
-func (s *CoreAgentService) getRefreshInterval() (time.Duration, error) {
-	rawTargetsCustom, err := s.uptane.TargetsCustom()
+func (s *CoreAgentService) getRefreshIntervalLocked() (time.Duration, error) {
+	rawTargetsCustom, err := s.mu.uptane.TargetsCustom()
 	if err != nil {
 		return 0, err
 	}
@@ -856,8 +871,8 @@ func (s *CoreAgentService) getRefreshInterval() (time.Duration, error) {
 	return value, nil
 }
 
-func (s *CoreAgentService) flushCacheResponse() (*pbgo.ClientGetConfigsResponse, error) {
-	targets, err := s.uptane.UnsafeTargetsMeta()
+func (s *CoreAgentService) flushCacheResponseLocked() (*pbgo.ClientGetConfigsResponse, error) {
+	targets, err := s.mu.uptane.UnsafeTargetsMeta()
 	if err != nil {
 		return nil, err
 	}
@@ -917,21 +932,21 @@ func (s *CoreAgentService) ClientGetConfigs(_ context.Context, request *pbgo.Cli
 
 		s.mu.Lock()
 	}
-	if s.disableConfigPollLoop && s.lastUpdateErr != nil {
-		return nil, s.lastUpdateErr
+	if s.disableConfigPollLoop && s.mu.lastUpdateErr != nil {
+		return nil, s.mu.lastUpdateErr
 	}
 
 	s.clients.seen(request.Client)
-	tufVersions, err := s.uptane.TUFVersionState()
+	tufVersions, err := s.mu.uptane.TUFVersionState()
 	if err != nil {
 		return nil, err
 	}
 
 	// We only want to check for this if we have successfully initialized the TUF database
-	if !s.firstUpdate {
+	if !s.mu.firstUpdate {
 
 		// get the expiration time of timestamp.json
-		expires, err := s.uptane.TimestampExpires()
+		expires, err := s.mu.uptane.TimestampExpires()
 		if err != nil {
 			return nil, err
 		}
@@ -939,19 +954,19 @@ func (s *CoreAgentService) ClientGetConfigs(_ context.Context, request *pbgo.Cli
 		// all clients must flush their configuration state.
 		if expires.Before(time.Now()) {
 			log.Warnf("Timestamp expired at %s, flushing cache", expires.Format(time.RFC3339))
-			return s.flushCacheResponse()
+			return s.flushCacheResponseLocked()
 		}
 	}
 
 	if tufVersions.DirectorTargets == request.Client.State.TargetsVersion {
 		return &pbgo.ClientGetConfigsResponse{}, nil
 	}
-	roots, err := getNewDirectorRoots(s.uptane, request.Client.State.RootVersion, tufVersions.DirectorRoot)
+	roots, err := getNewDirectorRoots(s.mu.uptane, request.Client.State.RootVersion, tufVersions.DirectorRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	directorTargets, err := s.uptane.Targets()
+	directorTargets, err := s.mu.uptane.Targets()
 	if err != nil {
 		return nil, err
 	}
@@ -965,12 +980,12 @@ func (s *CoreAgentService) ClientGetConfigs(_ context.Context, request *pbgo.Cli
 		return nil, err
 	}
 
-	targetFiles, err := getTargetFiles(s.uptane, neededFiles)
+	targetFiles, err := getTargetFiles(s.mu.uptane, neededFiles)
 	if err != nil {
 		return nil, err
 	}
 
-	targetsRaw, err := s.uptane.TargetsMeta()
+	targetsRaw, err := s.mu.uptane.TargetsMeta()
 	if err != nil {
 		return nil, err
 	}
@@ -1030,15 +1045,15 @@ func (s *CoreAgentService) apiKeyUpdateCallback() func(string, model.Source, any
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		s.api.UpdateAPIKey(newKey)
+		s.mu.api.UpdateAPIKey(newKey)
 
 		// Verify that the Org UUID hasn't changed
-		storedOrgUUID, err := s.uptane.StoredOrgUUID()
+		storedOrgUUID, err := s.mu.uptane.StoredOrgUUID()
 		if err != nil {
 			log.Warnf("Could not get org uuid: %s", err)
 			return
 		}
-		newOrgUUID, err := s.api.FetchOrgData(context.Background())
+		newOrgUUID, err := s.mu.api.FetchOrgData(context.Background())
 		if err != nil {
 			log.Warnf("Could not get org uuid: %s", err)
 			return
@@ -1052,7 +1067,11 @@ func (s *CoreAgentService) apiKeyUpdateCallback() func(string, model.Source, any
 
 // ConfigGetState returns the state of the configuration and the director repos in the local store
 func (s *CoreAgentService) ConfigGetState() (*pbgo.GetStateConfigResponse, error) {
-	state, err := s.uptane.State()
+	s.mu.Lock()
+	uptane := s.mu.uptane
+	s.mu.Unlock()
+
+	state, err := uptane.State()
 	if err != nil {
 		return nil, err
 	}
@@ -1083,7 +1102,7 @@ func (s *CoreAgentService) ConfigResetState() (*pbgo.ResetStateConfigResponse, e
 	defer s.mu.Unlock()
 
 	// get metadata from current ts to recreate it with same params
-	metadata, err := s.uptane.GetTransactionalStoreMetadata()
+	metadata, err := s.mu.uptane.GetTransactionalStoreMetadata()
 	if err != nil {
 		return nil, err
 	}
@@ -1094,13 +1113,13 @@ func (s *CoreAgentService) ConfigResetState() (*pbgo.ResetStateConfigResponse, e
 	}
 	uptaneClient, err := uptane.NewCoreAgentClientWithRecreatedTransactionalStore(
 		metadata,
-		newRCBackendOrgUUIDProvider(s.api),
+		newRCBackendOrgUUIDProvider(s.mu.api),
 		opt...,
 	)
 	if err != nil {
 		return nil, err
 	}
-	s.uptane = uptaneClient
+	s.mu.uptane = uptaneClient
 
 	return &pbgo.ResetStateConfigResponse{}, err
 }
@@ -1203,10 +1222,14 @@ func validateRequest(request *pbgo.ClientGetConfigsRequest) error {
 
 // HTTPClient fetches Remote Configurations from an HTTP(s)-based backend
 type HTTPClient struct {
-	mu         sync.Mutex
-	rcType     string
-	lastUpdate time.Time
-	uptane     cdnUptaneClient
+	rcType string
+	uptane cdnUptaneClient
+
+	mu struct {
+		sync.Mutex
+
+		lastUpdate time.Time
+	}
 }
 
 // NewHTTPClient creates a new HTTPClient that can be used to fetch Remote Configurations from an HTTP(s)-based backend
@@ -1270,8 +1293,8 @@ func (c *HTTPClient) update(ctx context.Context) error {
 func (c *HTTPClient) shouldUpdate() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if time.Since(c.lastUpdate) > maxCDNUpdateFrequency {
-		c.lastUpdate = time.Now()
+	if time.Since(c.mu.lastUpdate) > maxCDNUpdateFrequency {
+		c.mu.lastUpdate = time.Now()
 		return true
 	}
 	return false

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -5,9 +5,9 @@
 
 // Package service represents the agent's core remoteconfig service
 //
-// The `Service` type provides a communication layer for downstream clients to request
-// configuration, as well as the ability to track clients for requesting complete update
-// payloads from the remote config backend.
+// The `CoreAgentService` type provides a communication layer for downstream
+// clients to request configuration, as well as the ability to track clients for
+// requesting complete update payloads from the remote config backend.
 package service
 
 import (
@@ -82,17 +82,6 @@ var (
 	exportedLastUpdateErr       = expvar.String{}
 )
 
-// Service defines the remote config management service responsible for fetching, storing
-// and dispatching the configurations
-type Service struct {
-	sync.Mutex
-
-	// rcType is used to differentiate multiple RC services running in a single agent.
-	// Today, it is simply logged as a prefix in all log messages to help when triaging
-	// via logs.
-	rcType string
-}
-
 func getNewDirectorRoots(uptane uptaneClient, currentVersion uint64, newVersion uint64) ([][]byte, error) {
 	var roots [][]byte
 	for i := currentVersion + 1; i <= newVersion; i++ {
@@ -123,9 +112,19 @@ func getTargetFiles(uptaneClient uptaneClient, targetFilePaths []string) ([]*pbg
 	return configFiles, nil
 }
 
-// CoreAgentService fetches  Remote Configurations from the RC backend
+// CoreAgentService implements rcservice.Component.
+//
+// It fetches and orchestrates the fetching of Remote Configurations from the RC
+// backend.  and maintains the local state of the configuration on behalf of its
+// clients.
 type CoreAgentService struct {
-	Service
+	sync.Mutex
+
+	// rcType is used to differentiate multiple RC services running in a single
+	// agent.  Today, it is simply logged as a prefix in all log messages to
+	// help when triaging via logs.
+	rcType string
+
 	firstUpdate bool
 
 	// We record the startup time to ensure we flush client configs if we can't contact the backend in time
@@ -499,9 +498,7 @@ func NewService(cfg model.Reader, rcType, baseRawURL, hostname string, tagsGette
 
 	now := clock.Now().UTC()
 	cas := &CoreAgentService{
-		Service: Service{
-			rcType: rcType,
-		},
+		rcType:                         rcType,
 		firstUpdate:                    true,
 		startupTime:                    now,
 		defaultRefreshInterval:         options.refresh,
@@ -1206,7 +1203,8 @@ func validateRequest(request *pbgo.ClientGetConfigsRequest) error {
 
 // HTTPClient fetches Remote Configurations from an HTTP(s)-based backend
 type HTTPClient struct {
-	Service
+	sync.Mutex
+	rcType     string
 	lastUpdate time.Time
 	uptane     cdnUptaneClient
 }
@@ -1228,9 +1226,7 @@ func NewHTTPClient(runPath, site, apiKey, agentVersion string) (*HTTPClient, err
 	}
 
 	return &HTTPClient{
-		Service: Service{
-			rcType: "CDN",
-		},
+		rcType: "CDN",
 		uptane: uptaneCDNClient,
 	}, nil
 }

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -974,7 +974,10 @@ func TestWithApiKeyUpdate(t *testing.T) {
 	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", getHostTags, mockTelemetryReporter, agentVersion, options...)
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
-	t.Cleanup(func() { service.Stop() })
+	t.Cleanup(func() {
+		assert.NoError(t, service.Stop())
+		assert.NoError(t, service.Stop()) // ensure idempotency
+	})
 	service.api = api
 	service.uptane = uptaneClient
 
@@ -1245,7 +1248,8 @@ func TestWithTraceAgentEnv(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "dog", service.traceAgentEnv)
 	assert.NotNil(t, service)
-	t.Cleanup(func() { service.Stop() })
+	assert.NoError(t, service.Stop())
+	assert.NoError(t, service.Stop()) // ensure idempotency
 }
 
 func TestWithDatabaseFileName(t *testing.T) {

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -1438,9 +1438,7 @@ func getHostTags() []string {
 
 func setupCDNClient(uptaneClient *mockCDNUptane) *HTTPClient {
 	return &HTTPClient{
-		Service: Service{
-			rcType: "CDN",
-		},
+		rcType: "CDN",
 		uptane: uptaneClient,
 	}
 }

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -314,17 +314,17 @@ func TestFetchOrgStatus503And504IncrementsErrCount(t *testing.T) {
 		Authorized: true,
 	}
 	// start with no previous errors
-	assert.Equal(t, service.mu.fetchOrgStatus503And504ErrCount, uint64(0))
+	assert.Equal(t, service.orgStatusPoller.mu.fetchOrgStatus503And504ErrCount, uint64(0))
 
 	api.On("FetchOrgStatus", mock.Anything).Return(response, httpapi.ErrGatewayTimeout)
-	service.pollOrgStatus()
-	assert.Equal(t, service.mu.fetchOrgStatus503And504ErrCount, uint64(1))
+	service.orgStatusPoller.poll(service.getAPI(), service.rcType)
+	assert.Equal(t, service.orgStatusPoller.mu.fetchOrgStatus503And504ErrCount, uint64(1))
 
-	assert.Nil(t, service.mu.previousOrgStatus)
+	assert.Nil(t, service.orgStatusPoller.getPreviousStatus())
 	api.On("FetchOrgStatus", mock.Anything).Return(response, httpapi.ErrGatewayTimeout)
 
-	service.pollOrgStatus()
-	assert.Equal(t, service.mu.fetchOrgStatus503And504ErrCount, uint64(2))
+	service.orgStatusPoller.poll(service.getAPI(), service.rcType)
+	assert.Equal(t, service.orgStatusPoller.mu.fetchOrgStatus503And504ErrCount, uint64(2))
 }
 
 func TestFetchOrgStatusSuccessResetsErrorCount(t *testing.T) {
@@ -333,19 +333,19 @@ func TestFetchOrgStatusSuccessResetsErrorCount(t *testing.T) {
 	uptaneClient := &mockCoreAgentUptane{}
 	service := newTestService(t, api, uptaneClient, clock)
 
-	service.mu.fetchOrgStatus503And504ErrCount = 1
+	service.orgStatusPoller.mu.fetchOrgStatus503And504ErrCount = 1
 	response := &pbgo.OrgStatusResponse{
 		Enabled:    true,
 		Authorized: true,
 	}
 	// start with 1 error
-	assert.Equal(t, service.mu.fetchOrgStatus503And504ErrCount, uint64(1))
+	assert.Equal(t, service.orgStatusPoller.mu.fetchOrgStatus503And504ErrCount, uint64(1))
 
-	assert.Nil(t, service.mu.previousOrgStatus)
+	assert.Nil(t, service.orgStatusPoller.getPreviousStatus())
 	api.On("FetchOrgStatus", mock.Anything).Return(response, nil)
 
-	service.pollOrgStatus()
-	assert.Equal(t, service.mu.fetchOrgStatus503And504ErrCount, uint64(0))
+	service.orgStatusPoller.poll(service.getAPI(), service.rcType)
+	assert.Equal(t, service.orgStatusPoller.mu.fetchOrgStatus503And504ErrCount, uint64(0))
 }
 
 func TestServiceBackoffFailure(t *testing.T) {
@@ -1210,24 +1210,24 @@ func TestOrgStatus(t *testing.T) {
 		Authorized: true,
 	}
 
-	assert.Nil(t, service.mu.previousOrgStatus)
+	assert.Nil(t, service.orgStatusPoller.getPreviousStatus())
 	api.On("FetchOrgStatus", mock.Anything).Return(response, nil)
 
-	service.pollOrgStatus()
-	prev := service.mu.previousOrgStatus
+	service.orgStatusPoller.poll(service.getAPI(), service.rcType)
+	prev := service.orgStatusPoller.getPreviousStatus()
 	assert.True(t, prev.Enabled)
 	assert.True(t, prev.Authorized)
 
 	api.On("FetchOrgStatus", mock.Anything).Return(nil, fmt.Errorf("Error"))
-	service.pollOrgStatus()
-	prev = service.mu.previousOrgStatus
+	service.orgStatusPoller.poll(service.getAPI(), service.rcType)
+	prev = service.orgStatusPoller.getPreviousStatus()
 	assert.True(t, prev.Enabled)
 	assert.True(t, prev.Authorized)
 
 	response.Authorized = false
 	api.On("FetchOrgStatus", mock.Anything).Return(response, nil)
-	service.pollOrgStatus()
-	prev = service.mu.previousOrgStatus
+	service.orgStatusPoller.poll(service.getAPI(), service.rcType)
+	prev = service.orgStatusPoller.getPreviousStatus()
 	assert.True(t, prev.Enabled)
 	assert.False(t, prev.Authorized)
 }
@@ -1575,7 +1575,7 @@ func TestWithOrgStatusPollingIntervalNoConfigPassed(t *testing.T) {
 	}
 	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", getHostTags, mockTelemetryReporter, agentVersion, options...)
 	assert.NoError(t, err)
-	assert.Equal(t, service.orgStatusRefreshInterval, defaultRefreshInterval)
+	assert.Equal(t, service.orgStatusPoller.refreshInterval, defaultRefreshInterval)
 	assert.NotNil(t, service)
 	service.Stop()
 }
@@ -1594,7 +1594,7 @@ func TestWithOrgStatusPollingIntervalConfigPassed(t *testing.T) {
 	}
 	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", getHostTags, mockTelemetryReporter, agentVersion, options...)
 	assert.NoError(t, err)
-	assert.Equal(t, service.orgStatusRefreshInterval, 54*time.Second)
+	assert.Equal(t, service.orgStatusPoller.refreshInterval, 54*time.Second)
 	assert.NotNil(t, service)
 	service.Stop()
 }


### PR DESCRIPTION
### What does this PR do?

This PR is a bundle of cleanups around the code in `pkg/config/remote/service`. It fixes some race conditions, and more generally attempts to tame and document the use of mutexes around this service.

### Motivation

I'm making changes to this package as part of https://datadoghq.atlassian.net/browse/DEBUG-4590 and was having a hard time getting a handle of the synchronization.

### Describe how you validated your changes

All the tests pass, and no behavior should be changed.

### Additional Notes

This pattern of using an anonymous struct with an embedded mutex to document what is protected by that mutex is a pattern I've seen widely used in the Go ecosystem and one I've found broadly beneficial.

*PLEASE REVIEW COMMIT BY COMMIT*