### PR TITLE
[backport 7.71.x] [netpath] Fix ICMP address family bug

### DIFF
--- a/pkg/networkpath/traceroute/runner/runner_test.go
+++ b/pkg/networkpath/traceroute/runner/runner_test.go
@@ -6,6 +6,7 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"testing"
@@ -428,4 +429,11 @@ func TestTCPFallback(t *testing.T) {
 		require.Equal(t, dummyErr, err)
 		require.Nil(t, results)
 	})
+}
+
+func TestLookupIPIsUnmapped(t *testing.T) {
+	dest, err := lookupIP(context.Background(), "8.8.8.8")
+	require.NoError(t, err)
+
+	require.Len(t, dest, 4)
 }

--- a/releasenotes/notes/icmp-mapped-ipv6-0f5eb8546238967b.yaml
+++ b/releasenotes/notes/icmp-mapped-ipv6-0f5eb8546238967b.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug causing ICMP traceroutes to not work properly on 7.71.x.
+ 


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug in 7.71 where ICMP traceroutes are broken. The root cause was that Go's implementation of LookupIP turns IPv4 addresses into IPv4-mapped IPv6 addresses. This at least breaks Windows, and probably Linux as well.

### Motivation
Customer reported this error:
```
unable to run traceroute for host: <IP scrubbed>: icmp traceroute failed: ICMP Traceroute failed to make NewSourceSink: NewSourceSink failed to init rawConn: NewRawConn: IPv6 is not supported
```

### Describe how you validated your changes
I added a test, `TestLookupIPIsUnmapped` which used to fail before unmapping this.

### Additional Notes
This code was deleted/partially moved in 7.72, so there is no PR to the main branch, just this backport.