### PR TITLE
Reduce apm internal metrics overhead (CSI-1279)

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -663,6 +663,9 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.enable_v1_trace_endpoint"; core.IsSet(k) {
 		c.EnableV1TraceEndpoint = core.GetBool("apm_config.enable_v1_trace_endpoint")
 	}
+	if k := "apm_config.send_all_internal_stats"; core.IsSet(k) {
+		c.SendAllInternalStats = core.GetBool("apm_config.send_all_internal_stats")
+	}
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	return nil
 }

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -663,9 +663,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.enable_v1_trace_endpoint"; core.IsSet(k) {
 		c.EnableV1TraceEndpoint = core.GetBool("apm_config.enable_v1_trace_endpoint")
 	}
-	if k := "apm_config.send_all_internal_stats"; core.IsSet(k) {
-		c.SendAllInternalStats = core.GetBool("apm_config.send_all_internal_stats")
-	}
+	c.SendAllInternalStats = core.GetBool("apm_config.send_all_internal_stats") // default is false
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	return nil
 }

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -187,6 +187,7 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.debug.port", 5012, "DD_APM_DEBUG_PORT")
 	config.BindEnvAndSetDefault("apm_config.debug_v1_payloads", false, "DD_APM_DEBUG_V1_PAYLOADS")
 	config.BindEnvAndSetDefault("apm_config.enable_v1_trace_endpoint", false, "DD_APM_ENABLE_V1_TRACE_ENDPOINT")
+	config.BindEnvAndSetDefault("apm_config.send_all_internal_stats", false, "DD_APM_SEND_ALL_INTERNAL_STATS")
 	config.BindEnv("apm_config.features", "DD_APM_FEATURES") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.ParseEnvAsStringSlice("apm_config.features", func(s string) []string {
 		// Either commas or spaces can be used as separators.

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -201,7 +201,7 @@ func (lp *LifecycleProcessor) processTrace(spans []*pb.Span) {
 	}
 
 	lp.ProcessTrace(&api.Payload{
-		Source:        info.NewReceiverStats().GetTagStats(info.Tags{}),
+		Source:        info.NewReceiverStats(true).GetTagStats(info.Tags{}),
 		TracerPayload: tracerPayload,
 	})
 }

--- a/pkg/serverless/trace/cold_start_span_creator.go
+++ b/pkg/serverless/trace/cold_start_span_creator.go
@@ -168,7 +168,7 @@ func (c *ColdStartSpanCreator) processSpan(coldStartSpan *pb.Span) {
 	}
 
 	c.TraceAgent.Process(&api.Payload{
-		Source:        info.NewReceiverStats().GetTagStats(info.Tags{}),
+		Source:        info.NewReceiverStats(true).GetTagStats(info.Tags{}),
 		TracerPayload: tracerPayload,
 	})
 }

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -150,7 +150,7 @@ func NewHTTPReceiver(
 	containerIDProvider := NewIDProvider(conf.ContainerProcRoot, conf.ContainerIDFromOriginInfo)
 	telemetryForwarder := NewTelemetryForwarder(conf, containerIDProvider, statsd)
 	return &HTTPReceiver{
-		Stats: info.NewReceiverStats(),
+		Stats: info.NewReceiverStats(conf.SendAllInternalStats),
 
 		out:                 out,
 		outV1:               outV1,
@@ -912,7 +912,7 @@ func (r *HTTPReceiver) loop() {
 	defer close(r.exit)
 
 	var lastLog time.Time
-	accStats := info.NewReceiverStats()
+	accStats := info.NewReceiverStats(r.conf.SendAllInternalStats)
 
 	t := time.NewTicker(5 * time.Second)
 	defer t.Stop()

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -555,6 +555,9 @@ type AgentConfig struct {
 
 	// EnableV1TraceEndpoint enables the V1 trace endpoint, it is hidden by default
 	EnableV1TraceEndpoint bool
+
+	// SendAllInternalStats enables all internal stats to be published, otherwise some less-frequently-used stats will be omitted when zero to save costs
+	SendAllInternalStats bool
 }
 
 // RemoteClient client is used to APM Sampling Updates from a remote source.

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -396,7 +396,7 @@ func TestInfoReceiverStats(t *testing.T) {
 	conf := testInit(t, nil)
 	assert.NotNil(conf)
 
-	stats := NewReceiverStats()
+	stats := NewReceiverStats(true)
 	t1 := &TagStats{
 		Tags{Lang: "python"},
 		Stats{},

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -150,8 +150,7 @@ func (ts *TagStats) publishAndReset(statsd statsd.ClientInterface, sendAllStats 
 		ts.SpansDropped.Swap(0), tags, 1)
 	publishNonZeroStats(statsd, tags, ts.SpansFiltered.Swap(0), "datadog.trace_agent.receiver.spans_filtered", sendAllStats)
 	publishNonZeroStats(statsd, tags, ts.EventsExtracted.Swap(0), "datadog.trace_agent.receiver.events_extracted", sendAllStats)
-	_ = statsd.Count("datadog.trace_agent.receiver.events_sampled",
-		ts.EventsSampled.Swap(0), tags, 1)
+	publishNonZeroStats(statsd, tags, ts.EventsSampled.Swap(0), "datadog.trace_agent.receiver.events_sampled", sendAllStats)
 	_ = statsd.Count("datadog.trace_agent.receiver.payload_accepted",
 		ts.PayloadAccepted.Swap(0), tags, 1)
 	_ = statsd.Count("datadog.trace_agent.receiver.payload_refused",

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -299,8 +299,8 @@ func TestReceiverStatsZeroValueStatsNotPublished(t *testing.T) {
 	t.Run("PublishAndReset", func(t *testing.T) {
 		rs := testStats()
 		rs.PublishAndReset(statsclient)
-		// We would expect 9 here, but we made TracesFiltered non-zero so it will be reported, thus 10
-		assert.EqualValues(t, 10, len(statsclient.CountCalls))
+		// Non-zero stats for some fields aren't published so only 9 here
+		assert.EqualValues(t, 9, len(statsclient.CountCalls))
 		assertStatsAreReset(t, rs)
 	})
 }

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -246,7 +246,7 @@ func TestReceiverStats(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
-		stats := NewReceiverStats()
+		stats := NewReceiverStats(false)
 		newstats := testStats()
 		stats.Acc(newstats)
 		assert.EqualValues(t, stats, newstats)
@@ -266,6 +266,41 @@ func TestReceiverStats(t *testing.T) {
 		assert.Equal(t, "[WARN] [lang:go lang_version:1.12 lang_vendor:gov interpreter:gcc tracer_version:1.33 endpoint_version:v0.4 service:service] -> traces_dropped(decoding_error:1, empty_trace:3, foreign_span:6, msgp_short_bytes:9, payload_too_large:2, span_id_zero:5, timeout:7, trace_id_zero:4, unexpected_eof:8), spans_malformed(base_service_invalid:10, base_service_truncate:9, duplicate_span_id:1, invalid_duration:15, invalid_http_status_code:16, invalid_start_date:14, peer_service_invalid:8, peer_service_truncate:7, resource_empty:12, service_empty:2, service_invalid:4, service_truncate:3, span_name_empty:5, span_name_invalid:11, span_name_truncate:6, type_truncate:13). Enable debug logging for more details.",
 			logs[1])
 
+		assertStatsAreReset(t, rs)
+	})
+}
+
+func TestReceiverStatsZeroValueStatsNotPublished(t *testing.T) {
+	statsclient := &teststatsd.Client{}
+	tags := Tags{
+		Lang:            "go",
+		LangVersion:     "1.12",
+		LangVendor:      "gov",
+		Interpreter:     "gcc",
+		TracerVersion:   "1.33",
+		EndpointVersion: "v0.4",
+		Service:         "service",
+	}
+	testStats := func() *ReceiverStats {
+		stats := NewStats()
+		stats.TracesReceived.Store(1)
+		stats.TracesFiltered.Store(8)
+		return &ReceiverStats{
+			Stats: map[Tags]*TagStats{
+				tags: {
+					Tags:  tags,
+					Stats: stats,
+				},
+			},
+			SendAllStats: false,
+		}
+	}
+
+	t.Run("PublishAndReset", func(t *testing.T) {
+		rs := testStats()
+		rs.PublishAndReset(statsclient)
+		// We would expect 9 here, but we made TracesFiltered non-zero so it will be reported, thus 10
+		assert.EqualValues(t, 10, len(statsclient.CountCalls))
 		assertStatsAreReset(t, rs)
 	})
 }

--- a/releasenotes/notes/apm-send-all-stats-0cecf5b3a62b192f.yaml
+++ b/releasenotes/notes/apm-send-all-stats-0cecf5b3a62b192f.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    APM: Some less-frequently-used stats about the behavior of the Trace Agent will now be omitted when zero to reduce overhead.
+   APM: The Trace Agent now omits infrequently used statistics when their values are zero, reducing overhead.
     This can be overridden by setting the new configuration option `apm_config.send_all_internal_stats` to true.

--- a/releasenotes/notes/apm-send-all-stats-0cecf5b3a62b192f.yaml
+++ b/releasenotes/notes/apm-send-all-stats-0cecf5b3a62b192f.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Some less-frequently-used stats about the behavior of the Trace Agent will now be omitted when zero to reduce overhead.
+    This can be overridden by setting the new configuration option `apm_config.send_all_internal_stats` to true.

--- a/test/new-e2e/tests/apm/tests.go
+++ b/test/new-e2e/tests/apm/tests.go
@@ -341,17 +341,18 @@ func testTraceAgentMetricTags(t *testing.T, c *assert.CollectT, service string, 
 		"datadog.trace_agent.receiver.traces_received":  {},
 		"datadog.trace_agent.receiver.spans_received":   {},
 		"datadog.trace_agent.receiver.traces_bytes":     {},
-		"datadog.trace_agent.receiver.traces_filtered":  {},
 		"datadog.trace_agent.receiver.spans_dropped":    {},
-		"datadog.trace_agent.receiver.spans_filtered":   {},
 		"datadog.trace_agent.receiver.traces_priority":  {},
 		// These metrics are only emitted when non-zero to reduce cardinality
-		//"datadog.trace_agent.normalizer.traces_dropped":         {},
-		//"datadog.trace_agent.normalizer.spans_malformed":        {},
-		"datadog.trace_agent.receiver.client_dropped_p0_spans":  {},
-		"datadog.trace_agent.receiver.client_dropped_p0_traces": {},
-		"datadog.trace_agent.receiver.events_sampled":           {},
-		"datadog.trace_agent.receiver.events_extracted":         {},
+		// "datadog.trace_agent.normalizer.traces_dropped":         {},
+		// "datadog.trace_agent.normalizer.spans_malformed":        {},
+		// "datadog.trace_agent.receiver.client_dropped_p0_spans":  {},
+		// "datadog.trace_agent.receiver.client_dropped_p0_traces": {},
+		// "datadog.trace_agent.receiver.events_sampled":   {},
+		// "datadog.trace_agent.receiver.events_extracted":         {},
+		// "datadog.trace_agent.receiver.traces_filtered":  {},
+		// "datadog.trace_agent.receiver.spans_filtered":  {},
+
 	}
 	serviceTag := "service:" + service
 	for m := range expected {


### PR DESCRIPTION
### What does this PR do?
Skip zero value metrics that are rarely used, these metrics provide _some_ debugging value, but don't provide any signal when `0`, thus we can stop sending these and reduce the overhead here a small amount. DM me for exact cost calculations

### Motivation
Reduce overhead
### Describe how you validated your changes
Ran locally and observed these metrics do not appear, but the other ones still do. Also unit tests

### Additional Notes
