### PR TITLE
Support map[string]string leaf values, more tests

### DIFF
--- a/pkg/config/nodetreemodel/helpers.go
+++ b/pkg/config/nodetreemodel/helpers.go
@@ -6,6 +6,8 @@
 package nodetreemodel
 
 import (
+	"fmt"
+	"reflect"
 	"strings"
 	"unicode"
 
@@ -66,4 +68,29 @@ func parseSizeInBytes(sizeStr string) uint {
 	size := max(cast.ToInt(sizeStr), 0)
 
 	return safeMul(uint(size), multiplier)
+}
+
+// ToMapStringInterface converts any type of map into a map[string]interface{}
+func ToMapStringInterface(data any, path string) (map[string]interface{}, error) {
+	if res, ok := data.(map[string]interface{}); ok {
+		return res, nil
+	}
+
+	v := reflect.ValueOf(data)
+	switch v.Kind() {
+	case reflect.Map:
+		convert := map[string]interface{}{}
+		iter := v.MapRange()
+		for iter.Next() {
+			key := iter.Key()
+			switch k := key.Interface().(type) {
+			case string:
+				convert[k] = iter.Value().Interface()
+			default:
+				convert[fmt.Sprintf("%v", key.Interface())] = iter.Value().Interface()
+			}
+		}
+		return convert, nil
+	}
+	return nil, fmt.Errorf("expected map at '%s' got: %v", path, v)
 }

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -105,31 +104,6 @@ func (c *ntmConfig) readConfigurationContent(target InnerNode, source model.Sour
 	return nil
 }
 
-// toMapStringInterface convert any type of map into a map[string]interface{}
-func toMapStringInterface(data any, path string) (map[string]interface{}, error) {
-	if res, ok := data.(map[string]interface{}); ok {
-		return res, nil
-	}
-
-	v := reflect.ValueOf(data)
-	switch v.Kind() {
-	case reflect.Map:
-		convert := map[string]interface{}{}
-		iter := v.MapRange()
-		for iter.Next() {
-			key := iter.Key()
-			switch k := key.Interface().(type) {
-			case string:
-				convert[k] = iter.Value().Interface()
-			default:
-				convert[fmt.Sprintf("%v", key.Interface())] = iter.Value().Interface()
-			}
-		}
-		return convert, nil
-	}
-	return nil, fmt.Errorf("invalid type from configuration for key '%s': %v", path, v)
-}
-
 // loadYamlInto traverses input data parsed from YAML, checking if each node is defined by the schema.
 // If found, the value from the YAML blob is imported into the 'dest' tree. Otherwise, a warning will be created.
 func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interface{}, atPath string, schema InnerNode, allowDynamicSchema bool) []error {
@@ -171,7 +145,7 @@ func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interfa
 		// by now we know schemaNode is an InnerNode
 		schemaInner, _ := schemaChild.(InnerNode)
 
-		childValue, err := toMapStringInterface(value, currPath)
+		childValue, err := ToMapStringInterface(value, currPath)
 		if err != nil {
 			warnings = append(warnings, err)
 			// Insert child node here as a leaf. It has the wrong type, but this maintains better

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -240,7 +240,7 @@ c: 1234
 	c := cfg.(*ntmConfig)
 
 	require.Len(t, c.warnings, 1)
-	assert.Equal(t, errors.New("invalid type from configuration for key 'c': 1234"), c.warnings[0])
+	assert.Equal(t, errors.New("expected map at 'c' got: 1234"), c.warnings[0])
 
 	// The file node with "1234" still exists, but it was not merged because it didn't match
 	// the schema layer.
@@ -267,36 +267,36 @@ tree(#ptr<000006>) source=file
 }
 
 func TestToMapStringInterface(t *testing.T) {
-	_, err := toMapStringInterface(nil, "key")
+	_, err := ToMapStringInterface(nil, "key")
 	assert.Error(t, err)
-	_, err = toMapStringInterface(1, "key")
+	_, err = ToMapStringInterface(1, "key")
 	assert.Error(t, err)
-	_, err = toMapStringInterface("test", "key")
+	_, err = ToMapStringInterface("test", "key")
 	assert.Error(t, err)
 
-	data, err := toMapStringInterface(map[int]string{1: "test"}, "key")
+	data, err := ToMapStringInterface(map[int]string{1: "test"}, "key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"1": "test"}, data)
-	data, err = toMapStringInterface(map[interface{}]string{1: "test"}, "key")
+	data, err = ToMapStringInterface(map[interface{}]string{1: "test"}, "key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"1": "test"}, data)
-	data, err = toMapStringInterface(map[interface{}]string{1: "test", "test2": "test2"}, "key")
+	data, err = ToMapStringInterface(map[interface{}]string{1: "test", "test2": "test2"}, "key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"1": "test", "test2": "test2"}, data)
 
-	data, err = toMapStringInterface(map[string]string{"test": "test"}, "key")
+	data, err = ToMapStringInterface(map[string]string{"test": "test"}, "key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"test": "test"}, data)
 
-	data, err = toMapStringInterface(map[string]interface{}{"test": "test"}, "key")
+	data, err = ToMapStringInterface(map[string]interface{}{"test": "test"}, "key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"test": "test"}, data)
 
-	data, err = toMapStringInterface(map[interface{}]interface{}{"test": "test"}, "key")
+	data, err = ToMapStringInterface(map[interface{}]interface{}{"test": "test"}, "key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"test": "test"}, data)
 
-	data, err = toMapStringInterface(map[interface{}]string{"test": "test"}, "key")
+	data, err = ToMapStringInterface(map[interface{}]string{"test": "test"}, "key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]interface{}{"test": "test"}, data)
 }

--- a/pkg/config/structure/compatibility_test.go
+++ b/pkg/config/structure/compatibility_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
@@ -249,4 +250,28 @@ func TestCompareNegativeNumber(t *testing.T) {
 
 	assert.Equal(t, uint64(0xfffffffffffffcf7), mf1.Large)
 	assert.Equal(t, uint64(0xfffffffffffffcf7), mf2.Large)
+}
+
+func TestUnmarshalKeyMapToBools(t *testing.T) {
+	viperConf, ntmConf := constructBothConfigs("", false, func(cfg model.Setup) {
+		cfg.BindEnvAndSetDefault("test", map[string]bool{})
+	})
+
+	type testBool struct {
+		A bool
+		B bool
+	}
+
+	objBool1 := testBool{}
+	objBool2 := testBool{}
+
+	viperConf.Set("test", map[string]bool{"a": false, "b": true}, model.SourceAgentRuntime)
+	err := unmarshalKeyReflection(viperConf, "test", &objBool1)
+	require.NoError(t, err)
+	assert.Equal(t, objBool1, testBool{A: false, B: true})
+
+	ntmConf.Set("test", map[string]bool{"a": false, "b": true}, model.SourceAgentRuntime)
+	err = unmarshalKeyReflection(ntmConf, "test", &objBool2)
+	require.NoError(t, err)
+	assert.Equal(t, objBool2, testBool{A: false, B: true})
 }

--- a/pkg/config/structure/compatibility_test.go
+++ b/pkg/config/structure/compatibility_test.go
@@ -126,7 +126,7 @@ network_devices:
 	// NOTE: Error message differs, but that is an acceptable difference
 	err = unmarshalKeyReflection(ntmConf, "network_devices.autodiscovery", &cfg)
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "can't GetChild(workers) of a leaf node")
+	assert.ErrorContains(t, err, "expected map at '' got: [map[workers:10]]")
 }
 
 type MetadataProviders struct {

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -362,14 +362,15 @@ func copyMap(target reflect.Value, input nodetreemodel.Node, currPath []string, 
 				}
 				input = converted
 			}
-		}
-		obj, err := nodetreemodel.ToMapStringInterface(leafValue, strings.Join(currPath, "."))
-		if err != nil {
-			return err
-		}
-		input, err = nodetreemodel.NewNodeTree(obj, model.SourceUnknown)
-		if err != nil {
-			return err
+		} else {
+			obj, err := nodetreemodel.ToMapStringInterface(leafValue, strings.Join(currPath, "."))
+			if err != nil {
+				return err
+			}
+			input, err = nodetreemodel.NewNodeTree(obj, model.SourceUnknown)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -351,12 +351,13 @@ func copyMap(target reflect.Value, input nodetreemodel.Node, currPath []string, 
 				input = converted
 			}
 		}
-		if m, ok := leafValue.(map[string]interface{}); ok {
-			var err error
-			input, err = nodetreemodel.NewNodeTree(m, model.SourceUnknown)
-			if err != nil {
-				return err
-			}
+		obj, err := nodetreemodel.ToMapStringInterface(leafValue, strings.Join(currPath, "."))
+		if err != nil {
+			return err
+		}
+		input, err = nodetreemodel.NewNodeTree(obj, model.SourceUnknown)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -270,6 +270,18 @@ func fieldNameToKey(field reflect.StructField) (string, specifierSet) {
 }
 
 func copyStruct(target reflect.Value, input nodetreemodel.Node, currPath []string, fs *featureSet) error {
+	if leafNode, ok := input.(nodetreemodel.LeafNode); ok {
+		m, err := nodetreemodel.ToMapStringInterface(leafNode.Get(), strings.Join(currPath, "."))
+		if err != nil {
+			return err
+		}
+		converted, err := nodetreemodel.NewNodeTree(m, model.SourceUnknown)
+		if err != nil {
+			return err
+		}
+		input = converted
+	}
+
 	targetType := target.Type()
 	usedFields := make(map[string]struct{})
 	for i := 0; i < targetType.NumField(); i++ {


### PR DESCRIPTION
### What does this PR do?

Support map[string]string leaf values when copying map values.

### Motivation

The config uses the schema to ensure that leaf nodes are able to have map values for an individual setting. But this wasn't correctly converting map[string]string because it was only looking for map[string]interface. Use the helper function ToMapStringInterface instead when copying maps in order to handle arbitrary map types.

### Describe how you validated your changes

Unit tests cover direct assignments, parsing from yaml, stringifying to debug text.

### Additional Notes
