### PR TITLE
Collect installer logs after failed tests

### DIFF
--- a/test/new-e2e/tests/installer/windows/consts/consts.go
+++ b/test/new-e2e/tests/installer/windows/consts/consts.go
@@ -32,8 +32,8 @@ const (
 	// NamedPipe is the name of the named pipe used by the Datadog Installer
 	NamedPipe string = `\\.\pipe\dd_installer`
 
-	// baseConfigPath is the base path for the Installer configuration
-	baseConfigPath = "C:/ProgramData/Datadog/Installer"
+	// BaseConfigPath is the base path for the Installer configuration
+	BaseConfigPath = "C:/ProgramData/Datadog/Installer"
 
 	// PipelineOCIRegistry is the OCI registry that pipelines submit packages to
 	// Use special domain instead of cloudfront to avoid NAT gateway costs
@@ -57,18 +57,18 @@ var (
 	// InstallerConfigPaths are the paths that the Datadog Installer uses to store its working files.
 	// They are normally created by the install script / bootstrap.
 	InstallerConfigPaths = []string{
-		path.Join(baseConfigPath, "packages"),
-		path.Join(baseConfigPath, "configs"),
-		path.Join(baseConfigPath, "tmp"),
+		path.Join(BaseConfigPath, "packages"),
+		path.Join(BaseConfigPath, "configs"),
+		path.Join(BaseConfigPath, "tmp"),
 	}
 )
 
 // GetExperimentDirFor is the path to the experiment symbolic link on disk
 func GetExperimentDirFor(packageName string) string {
-	return fmt.Sprintf("%s\\packages\\%s\\experiment", baseConfigPath, packageName)
+	return fmt.Sprintf("%s\\packages\\%s\\experiment", BaseConfigPath, packageName)
 }
 
 // GetStableDirFor is the path to the stable symbolic link on disk
 func GetStableDirFor(packageName string) string {
-	return fmt.Sprintf("%s\\packages\\%s\\stable", baseConfigPath, packageName)
+	return fmt.Sprintf("%s\\packages\\%s\\stable", BaseConfigPath, packageName)
 }


### PR DESCRIPTION
### What does this PR do?
Downloads the windows agent installer logs from the remote host when the e2e tests fail.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1340

### Describe how you validated your changes
Changed the `TestUpgradeAgentPackage` test to fail (assert 0 = 1) and ran:
```
$env:E2E_PIPELINE_ID="79526517"; $env:CURRENT_AGENT_VERSION="7.73.0-devel"; $env:CURRENT_AGENT_VERISON_PACKAGE="7.73.0-devel.git.291.7f7c10c.pipeline.79526517-1"; go test -v -timeout 30m ./tests/installer/windows/suites/agent-package -run 'TestAgentUpgradesOnDC$/TestUpgradeAgentPackage$' -count 1
```

### Additional Notes
