### PR TITLE
Add `encoding` to Agent status output for file tailers

### DIFF
--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -170,6 +170,7 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 		dictionary["Port"] = c.Port
 	case config.FileType:
 		dictionary["Path"] = c.Path
+		dictionary["Encoding"] = c.Encoding
 		dictionary["TailingMode"] = c.TailingMode
 		dictionary["Identifier"] = c.Identifier
 	case config.DockerType:

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -49,6 +49,19 @@ func TestSourceAreGroupedByIntegrations(t *testing.T) {
 	}
 }
 
+func TestFileConfiguration(t *testing.T) {
+	defer Clear()
+	mockConfig := configmock.New(t)
+	InitStatus(mockConfig, testutils.CreateSources([]*sources.LogSource{
+		sources.NewLogSource("foo", &config.LogsConfig{Type: "file", Path: "/foo/bar", Encoding: "utf-16-le"}),
+	}))
+
+	status := Get(false)
+	source := status.Integrations[0].Sources[0]
+	assert.Equal(t, source.Configuration["Path"], "/foo/bar")
+	assert.Equal(t, source.Configuration["Encoding"], "utf-16-le")
+}
+
 func TestStatusDeduplicateWarnings(t *testing.T) {
 	defer Clear()
 	initStatus(t)

--- a/releasenotes/notes/add-encoding-to-status-13bcf3de3fe163eb.yaml
+++ b/releasenotes/notes/add-encoding-to-status-13bcf3de3fe163eb.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Agent status output now contains the encoding configuration for file
+    tailers if any is configured.


### PR DESCRIPTION
### What does this PR do?

Adds the `encoding` configuration to Agent status output for file tailer configuration, if it is set.

Before:

```
  ============
  Integrations
  ============

  logs
  ----
    - Type: file
      Path: /Users/jesse.szwedko/tmp/sds/*.log
      Service: service-sds-test
      Source: source-sds-test
      Status: OK
      Inputs:
        /Users/jesse.szwedko/tmp/sds/4.log
        /Users/jesse.szwedko/tmp/sds/3.log
        /Users/jesse.szwedko/tmp/sds/2.log
        /Users/jesse.szwedko/tmp/sds/1.log
        /Users/jesse.szwedko/tmp/sds/6.log
        /Users/jesse.szwedko/tmp/sds/5.log
      Bytes Read: 0
      Lines Combined: 0
      MultiLine matches: 0
      Pipeline Latency:
        Average Latency: 0s
        24h Average Latency: 0s
        Peak Latency: 0s
        24h Peak Latency: 0s
      Processing Rules: No rules applied
```

After:
```
  ============
  Integrations
  ============

  logs
  ----
    - Type: file
      Encoding: utf-16-le
      Path: /Users/jesse.szwedko/tmp/sds/*.log
      Service: service-sds-test
      Source: source-sds-test
      Status: OK
      Inputs:
        /Users/jesse.szwedko/tmp/sds/6.log
        /Users/jesse.szwedko/tmp/sds/5.log
        /Users/jesse.szwedko/tmp/sds/4.log
        /Users/jesse.szwedko/tmp/sds/3.log
        /Users/jesse.szwedko/tmp/sds/2.log
        /Users/jesse.szwedko/tmp/sds/1.log
      Bytes Read: 0
      Lines Combined: 0
      MultiLine matches: 0
      Pipeline Latency:
        Average Latency: 0s
        24h Average Latency: 0s
        Peak Latency: 0s
        24h Peak Latency: 0s
      Processing Rules: No rules applied
```

If `encoding` is not set in the configuration it will not be present in the status output.

### Motivation

When debugging a customer issue it initially seemed like the encoding configuration might not be propagating all the way through.

### Describe how you validated your changes

I ran the Agent locally with the following file tailer config in `bin/agent/dist/conf.d/logs.yaml`:

```yaml
logs:
  - type: file
    path: /Users/jesse.szwedko/tmp/sds/*.log
    service: service-sds-test
    source: source-sds-test
    log_processing_rules:
      - type: multi_line
        name: log_start_with_date
        pattern: \d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])
      - type: exclude_at_match
        name: exclude_nginx_healthchecks
        pattern: '"request": "GET \/alive\.php .*", "status": "200"'
```

And then ran `./bin/agent/agent status -c ./bin/agent/dist`.

### Additional Notes
