### PR TITLE
[CWS] Update the rules merging policy

### DIFF
--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -53,11 +53,11 @@ type PolicyRule struct {
 	Accepted bool
 	Error    error
 	// FilterType is used to keep track of the type of filter that caused the rule to be filtered out
-	FilterType         FilterType
-	Policy             PolicyInfo
-	ModifiedBy         []PolicyInfo
-	UsedBy             []PolicyInfo
-	EnableDisableCount int // tracks the number of times the rule was enabled/disabled
+	FilterType  FilterType
+	Policy      PolicyInfo
+	ModifiedBy  []PolicyInfo
+	UsedBy      []PolicyInfo
+	EnableCount int // tracks the number of times the rule was enabled/disabled.It is only updated when merging conflicting rules.
 
 }
 
@@ -153,9 +153,9 @@ func applyOverride(rd1, rd2 *PolicyRule) {
 func (r *PolicyRule) MergeWith(r2 *PolicyRule) {
 
 	if r2.Def.Disabled {
-		r.EnableDisableCount--
+		r.EnableCount--
 	} else {
-		r.EnableDisableCount++
+		r.EnableCount++
 	}
 
 	switch r2.Def.Combine {
@@ -174,7 +174,7 @@ func (r *PolicyRule) MergeWith(r2 *PolicyRule) {
 		r.Policy = r2.Policy
 	} else {
 		if r.Policy.Type == DefaultPolicyType && r2.Policy.Type == CustomPolicyType {
-			if !r2.Def.Disabled || (r2.Def.Disabled && r.EnableDisableCount < 0) {
+			if !r2.Def.Disabled || (r2.Def.Disabled && r.EnableCount < 0) {
 				r.Def.Disabled = r2.Def.Disabled
 				r.Policy = r2.Policy
 			}

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -53,10 +53,12 @@ type PolicyRule struct {
 	Accepted bool
 	Error    error
 	// FilterType is used to keep track of the type of filter that caused the rule to be filtered out
-	FilterType FilterType
-	Policy     PolicyInfo
-	ModifiedBy []PolicyInfo
-	UsedBy     []PolicyInfo
+	FilterType         FilterType
+	Policy             PolicyInfo
+	ModifiedBy         []PolicyInfo
+	UsedBy             []PolicyInfo
+	EnableDisableCount int // tracks the number of times the rule was enabled/disabled
+
 }
 
 // AreActionsSupported returns true if the actions defined on the rule are supported given a list of enabled event types
@@ -149,6 +151,13 @@ func applyOverride(rd1, rd2 *PolicyRule) {
 
 // MergeWith merges rule r2 into r
 func (r *PolicyRule) MergeWith(r2 *PolicyRule) {
+
+	if r2.Def.Disabled {
+		r.EnableDisableCount--
+	} else {
+		r.EnableDisableCount++
+	}
+
 	switch r2.Def.Combine {
 	case OverridePolicy:
 		if !r2.Def.Disabled {
@@ -165,8 +174,10 @@ func (r *PolicyRule) MergeWith(r2 *PolicyRule) {
 		r.Policy = r2.Policy
 	} else {
 		if r.Policy.Type == DefaultPolicyType && r2.Policy.Type == CustomPolicyType {
-			r.Def.Disabled = r2.Def.Disabled
-			r.Policy = r2.Policy
+			if !r2.Def.Disabled || (r2.Def.Disabled && r.EnableDisableCount < 0) {
+				r.Def.Disabled = r2.Def.Disabled
+				r.Policy = r2.Policy
+			}
 		}
 	}
 

--- a/pkg/security/secl/rules/policy_loader_test.go
+++ b/pkg/security/secl/rules/policy_loader_test.go
@@ -1011,6 +1011,249 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 			},
 		},
 		{
+			name: "P0.DR0 enabled, P1.DR0 enabled, P2.CR0 disabled => P0.DR0 enabled",
+			fields: fields{
+				Providers: []PolicyProvider{
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P0.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: DefaultPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
+											{ID: "rule_2", Expression: "exec.file.path == \"/etc/default/bar\""},
+										},
+									},
+								},
+							})
+						},
+					},
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P1.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: DefaultPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
+											{ID: "rule_2", Expression: "exec.file.path == \"/etc/default/bar\""},
+										},
+									},
+								},
+							})
+						},
+					},
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P2.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: CustomPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_2", Expression: "exec.file.path == \"/etc/default/bar\"", Disabled: true},
+										},
+									},
+								},
+							})
+						},
+					},
+				},
+			},
+			want: func(t assert.TestingT, got map[eval.RuleID]*Rule, _ ...interface{}) bool {
+				expected := map[eval.RuleID]*Rule{
+					"rule_1": {
+						PolicyRule: &PolicyRule{
+							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
+							Policy: PolicyInfo{
+								Name:   "P0.policy",
+								Source: PolicyProviderTypeRC,
+								Type:   DefaultPolicyType,
+							},
+							Accepted: true,
+						},
+					},
+					"rule_2": {
+						PolicyRule: &PolicyRule{
+							Def: &RuleDefinition{ID: "rule_2", Expression: "exec.file.path == \"/etc/default/bar\""},
+							Policy: PolicyInfo{
+								Name:   "P0.policy",
+								Source: PolicyProviderTypeRC,
+								Type:   DefaultPolicyType,
+							},
+							Accepted: true,
+						},
+					},
+				}
+				return checkOverrideResult(t, expected, got)
+			},
+		},
+		{
+			name: "P0.DR0 enabled, P1.DR0 enabled, P2.CR0 disabled, P3.CR0 disabled => R0 disabled",
+			fields: fields{
+				Providers: []PolicyProvider{
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P0.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: DefaultPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
+											{ID: "rule_2", Expression: "exec.file.path == \"/etc/default/bar\""},
+										},
+									},
+								},
+							})
+						},
+					},
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P1.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: DefaultPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
+										},
+									},
+								},
+							})
+						},
+					},
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P2.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: CustomPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\"", Disabled: true},
+										},
+									},
+								},
+							})
+						},
+					},
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P3.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: CustomPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\"", Disabled: true},
+										},
+									},
+								},
+							})
+						},
+					},
+				},
+			},
+			want: func(t assert.TestingT, got map[eval.RuleID]*Rule, _ ...interface{}) bool {
+				expected := map[eval.RuleID]*Rule{
+					"rule_2": {
+						PolicyRule: &PolicyRule{
+							Def: &RuleDefinition{ID: "rule_2", Expression: "exec.file.path == \"/etc/default/bar\""},
+							Policy: PolicyInfo{
+								Name:   "P0.policy",
+								Source: PolicyProviderTypeRC,
+								Type:   DefaultPolicyType,
+							},
+							Accepted: true,
+						},
+					},
+				}
+				return checkOverrideResult(t, expected, got)
+			},
+		},
+		{
+			name: "P0.DR0 disabled, P1.DR0 disabled, P2.CR0 enabled => P2.CRO enabled",
+			fields: fields{
+				Providers: []PolicyProvider{
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P0.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: DefaultPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\"", Disabled: true},
+										},
+									},
+								},
+							})
+						},
+					},
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P1.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: DefaultPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\"", Disabled: true},
+										},
+									},
+								},
+							})
+						},
+					},
+					dummyRCProvider{
+						dummyLoadPoliciesFunc: func() ([]*Policy, *multierror.Error) {
+							return testPoliciesToPolicies([]*testPolicyDef{
+								{
+									name:       "P2.policy",
+									source:     PolicyProviderTypeRC,
+									policyType: CustomPolicyType,
+									def: PolicyDef{
+										Rules: []*RuleDefinition{
+											{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
+										},
+									},
+								},
+							})
+						},
+					},
+				},
+			},
+			want: func(t assert.TestingT, got map[eval.RuleID]*Rule, _ ...interface{}) bool {
+				expected := map[eval.RuleID]*Rule{
+					"rule_1": {
+						PolicyRule: &PolicyRule{
+							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
+							Policy: PolicyInfo{
+								Name:   "P2.policy",
+								Source: PolicyProviderTypeRC,
+								Type:   CustomPolicyType,
+							},
+							Accepted: true,
+						},
+					},
+				}
+				return checkOverrideResult(t, expected, got)
+			},
+		},
+		{
 			name: "P0.DR disabled, P1.CR disabled => CR disabled",
 			fields: fields{
 				Providers: []PolicyProvider{
@@ -2598,20 +2841,18 @@ func testPoliciesToPolicies(testPolicies []*testPolicyDef) ([]*Policy, *multierr
 }
 
 func checkOverrideResult(t assert.TestingT, expected map[eval.RuleID]*Rule, got map[eval.RuleID]*Rule) bool {
-	if len(expected) == 0 {
-		return assert.Equal(t, len(expected), len(got))
-	}
+	assert.Equal(t, len(expected), len(got))
 
-	// From here, we know that we expect exacly one element
-	var ruleID eval.RuleID
-	for r := range expected {
-		ruleID = r
-		break
+	for ruleID, r := range expected {
+		res := assert.NotNil(t, got[ruleID]) &&
+			assert.Equal(t, r.PolicyRule.Def, got[ruleID].PolicyRule.Def) &&
+			assert.Equal(t, r.PolicyRule.Policy.Name, got[ruleID].Policy.Name) &&
+			assert.Equal(t, r.PolicyRule.Policy.Source, got[ruleID].Policy.Source) &&
+			assert.Equal(t, r.PolicyRule.Policy.Type, got[ruleID].Policy.Type) &&
+			assert.Equal(t, r.PolicyRule.Accepted, got[ruleID].PolicyRule.Accepted)
+		if !res {
+			return res
+		}
 	}
-	return (assert.Equal(t, 1, len(got)) &&
-		assert.Equal(t, expected[ruleID].PolicyRule.Def, got[ruleID].PolicyRule.Def) &&
-		assert.Equal(t, expected[ruleID].PolicyRule.Policy.Name, got[ruleID].Policy.Name) &&
-		assert.Equal(t, expected[ruleID].PolicyRule.Policy.Source, got[ruleID].Policy.Source) &&
-		assert.Equal(t, expected[ruleID].PolicyRule.Policy.Type, got[ruleID].Policy.Type) &&
-		assert.Equal(t, expected[ruleID].PolicyRule.Accepted, got[ruleID].PolicyRule.Accepted))
+	return true
 }


### PR DESCRIPTION
### What does this PR do?
This PR makes some changes in how we merge 2 conflicting rules. It introduces the field `EnableDisableCount` which is used to keep track how many times a given rule was enabled / disabled in different policies.
This does not affect how we enable a previously disabled rule:
- it takes just one custom policy to enable a rule for it to be enabled
What changes is how we disable a previously disable rule
- The disabling policy has to set disabled to true for the rule
- The rule has to be set to disabled at least the same amount of times it was enabled by other policies (`EnableDisableCount < 0`)

**Practical example**
- `rule A` is enabled in `best-practice.policy`
- `rule A` is enabled in `compliance.policy` 

Let's disable rule A for `best-practice.policy`, we create
- `custom-best-practice.policy` setting `rule A` to disabled

=> rule A is still enabled because the user wants it to be enabled for `compliance.policy` 

To disable rule A altogether, we additionally need to create:
- `custom-compliance.policy` setting `rule A` to disabled

=> rule A is disabled