### PR TITLE
Increasing the timeout of sgc windows tests to 60s

### DIFF
--- a/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_aws_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_aws_win_test.go
@@ -39,5 +39,5 @@ secret_backend_config:
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		secretOutput := v.Env().Agent.Client.Secret()
 		require.Contains(t, secretOutput, "embedded_secret_key")
-	}, 30*time.Second, 2*time.Second, "could not check if secretOutput contains 'embedded_key' within the allotted time")
+	}, 60*time.Second, 2*time.Second, "could not check if secretOutput contains 'embedded_key' within the allotted time")
 }

--- a/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_win_test.go
@@ -58,5 +58,5 @@ secret_backend_config:
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		secretOutput := v.Env().Agent.Client.Secret()
 		require.Contains(t, secretOutput, "fake_yaml_key")
-	}, 30*time.Second, 2*time.Second, "could not check if secretOutput contains 'fake_yaml_key' within the allotted time")
+	}, 60*time.Second, 2*time.Second, "could not check if secretOutput contains 'fake_yaml_key' within the allotted time")
 }


### PR DESCRIPTION
### What does this PR do?

The sgc e2e tests on windows are flaky, so this pr tries to reduce the flakiness of them by increasing the timeout.

### Motivation

### Describe how you validated your changes

### Additional Notes
