### PR TITLE
Fix the command runner readiness

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -43,9 +43,9 @@ func NewHostAgentClient(context common.Context, hostOutput remote.HostOutput, wa
 
 	if params.ShouldWaitForReady {
 		if err := waitForReadyTimeout(commandRunner, agentReadyTimeout); err != nil {
-			commandRunner.isReady = true
 			return nil, err
 		}
+		commandRunner.isReady = true
 	}
 
 	return commandRunner, nil


### PR DESCRIPTION
### What does this PR do?

Make sure we set the commandRunner as ready when waitReady succeeded

### Motivation

### Describe how you validated your changes

### Additional Notes
