### PR TITLE
[CONTP-1017] Fix CI failure in KubernetesAdmissionEvents  

### DIFF
--- a/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
+++ b/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
@@ -51,12 +51,6 @@ func compareText(expected, actual event.Event) bool {
 
 // TestKubernetesAdmissionEvents tests the KubernetesAdmissionEvents webhook.
 func TestKubernetesAdmissionEvents(t *testing.T) {
-	// Mock demultiplexer and sender
-	demultiplexerMock := createDemultiplexer(t)
-	mockSender := mocksender.NewMockSenderWithSenderManager(eventType, demultiplexerMock)
-	err := demultiplexerMock.SetSender(mockSender, eventType)
-	assert.NoError(t, err)
-
 	// Mock Datadog Config
 	datadogConfigMock := config.NewMock(t)
 	datadogConfigMock.SetWithoutSource("admission_controller.kubernetes_admission_events.enabled", true)
@@ -252,6 +246,12 @@ func TestKubernetesAdmissionEvents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Mock demultiplexer and sender - create fresh instances for each test case
+			demultiplexerMock := createDemultiplexer(t)
+			mockSender := mocksender.NewMockSenderWithSenderManager(eventType, demultiplexerMock)
+			err := demultiplexerMock.SetSender(mockSender, eventType)
+			assert.NoError(t, err)
+
 			// Create the webhook
 			kubernetesAuditWebhook := NewWebhook(datadogConfigMock, demultiplexerMock, tt.supportsMatchConditions)
 			assert.True(t, kubernetesAuditWebhook.IsEnabled())


### PR DESCRIPTION
### What does this PR do?

Fixes test state pollution in `TestKubernetesAdmissionEvents` by creating fresh mock instances for each test subcase instead of sharing a single mock across all subtests.

### Motivation

The test was failing because mock sender and demultiplexer were created once and reused across multiple test cases (CREATE, UPDATE, DELETE). This caused call histories to accumulate, leading to assertion failures where the mock remembered previous operations. Each subtest now gets isolated mock instances to prevent cross-contamination.

### Describe how you validated your changes

The fix ensures that:
- Each test subcase receives a clean mock state with no prior call history
- Assertions only validate calls from the current test case
- The `Pod_deletion` and other subtests now pass by comparing actual events against expected events in isolation
- Proper test isolation prevents flaky behavior from test execution order

### Additional Notes

This issue was made apparent by recent changes to event recording in PR #41683. The fix follows Go testing best practices by isolating mutable shared state within test scopes.