### PR TITLE
[network path] update ip filter behaviour

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/connfilter/connfilter.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/connfilter/connfilter.go
@@ -25,8 +25,8 @@ type ConnFilter struct {
 }
 
 // NewConnFilter constructor
-func NewConnFilter(config []Config, site string) (*ConnFilter, []error) {
-	defaultConfig := getDefaultConnFilters(site)
+func NewConnFilter(config []Config, site string, monitorIPWithoutDomain bool) (*ConnFilter, []error) {
+	defaultConfig := getDefaultConnFilters(site, monitorIPWithoutDomain)
 	newConfigs := append(defaultConfig, config...)
 
 	var filters []Filter
@@ -88,6 +88,9 @@ func NewConnFilter(config []Config, site string) (*ConnFilter, []error) {
 // IsIncluded return true if the matching domain and ip of a connection should be included
 func (f *ConnFilter) IsIncluded(domain string, ip string) bool {
 	isIncluded := true
+	if domain == "" {
+		isIncluded = false
+	}
 	for _, filter := range f.filters {
 		matched := false
 		if filter.matchDomain != nil {

--- a/comp/networkpath/npcollector/npcollectorimpl/connfilter/connfilter_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/connfilter/connfilter_test.go
@@ -344,7 +344,7 @@ filters:
 			} else {
 				require.NoError(t, err)
 			}
-			assert.Len(t, connFilter.filters, tt.expectedCustomFilterCount+len(getDefaultConnFilters(tt.ddSite)))
+			assert.Len(t, connFilter.filters, tt.expectedCustomFilterCount+len(getDefaultConnFilters(tt.ddSite, false)))
 			for _, expMatch := range tt.expectedMatches {
 				require.NotNil(t, connFilter)
 				assert.Equal(t, connFilter.IsIncluded(expMatch.domain, expMatch.ip), expMatch.shouldMatch, expMatch)

--- a/comp/networkpath/npcollector/npcollectorimpl/connfilter/connfilter_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/connfilter/connfilter_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
+//go:build test
+
 package connfilter
 
 import (
@@ -22,6 +24,7 @@ func TestNewConnFilter(t *testing.T) {
 		name                      string
 		config                    string
 		ddSite                    string
+		monitorIPWithoutDomain    bool
 		expectedMatches           []expectedMatch
 		expectedErr               string
 		expectedCustomFilterCount int
@@ -107,9 +110,9 @@ filters:
     type: exclude
 `,
 			expectedMatches: []expectedMatch{
-				{ip: "10.10.10.10", shouldMatch: false},
-				{ip: "10.10.10.9", shouldMatch: true},
-				{ip: "10.10.10.11", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.10", shouldMatch: false},
+				{domain: "abc", ip: "10.10.10.9", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.11", shouldMatch: true},
 			},
 			expectedCustomFilterCount: 1,
 		},
@@ -121,8 +124,8 @@ filters:
     type: exclude
 `,
 			expectedMatches: []expectedMatch{
-				{ip: "2001:4860:4860::8888", shouldMatch: false},
-				{ip: "2001:4860:4860::8844", shouldMatch: true},
+				{domain: "abc", ip: "2001:4860:4860::8888", shouldMatch: false},
+				{domain: "abc", ip: "2001:4860:4860::8844", shouldMatch: true},
 			},
 			expectedCustomFilterCount: 1,
 		},
@@ -136,9 +139,9 @@ filters:
     type: include
 `,
 			expectedMatches: []expectedMatch{
-				{ip: "10.10.10.10", shouldMatch: true},
-				{ip: "10.10.10.9", shouldMatch: true},
-				{ip: "10.10.10.11", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.10", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.9", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.11", shouldMatch: true},
 			},
 			expectedCustomFilterCount: 2,
 		},
@@ -154,16 +157,16 @@ filters:
     type: include
 `,
 			expectedMatches: []expectedMatch{
-				{ip: "10.10.10.0", shouldMatch: true},
-				{ip: "10.10.10.1", shouldMatch: true},
-				{ip: "10.10.10.2", shouldMatch: true},
-				{ip: "10.10.10.3", shouldMatch: true},
-				{ip: "10.10.10.4", shouldMatch: false},
-				{ip: "10.10.10.5", shouldMatch: false},
-				{ip: "10.10.10.100", shouldMatch: true},
-				{ip: "10.10.10.101", shouldMatch: false},
-				{ip: "10.10.10.255", shouldMatch: false},
-				{ip: "10.10.10.256", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.0", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.1", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.2", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.3", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.4", shouldMatch: false},
+				{domain: "abc", ip: "10.10.10.5", shouldMatch: false},
+				{domain: "abc", ip: "10.10.10.100", shouldMatch: true},
+				{domain: "abc", ip: "10.10.10.101", shouldMatch: false},
+				{domain: "abc", ip: "10.10.10.255", shouldMatch: false},
+				{domain: "abc", ip: "10.10.10.256", shouldMatch: true},
 			},
 			expectedCustomFilterCount: 3,
 		},
@@ -335,10 +338,38 @@ filters:
 			expectedErr:               "invalid filter type: invalid",
 			expectedCustomFilterCount: 1,
 		},
+		{
+			name: "monitor IP without domain enabled",
+			config: `
+filters:
+`,
+			ddSite:                 "datad0g.com",
+			monitorIPWithoutDomain: true,
+			expectedMatches: []expectedMatch{
+				{domain: "", ip: "1.1.1.1", shouldMatch: true},
+				{domain: "cloudflare", ip: "1.1.1.1", shouldMatch: true},
+			},
+			expectedErr:               "",
+			expectedCustomFilterCount: 1,
+		},
+		{
+			name: "monitor IP without domain disabled",
+			config: `
+filters:
+`,
+			ddSite:                 "datad0g.com",
+			monitorIPWithoutDomain: false,
+			expectedMatches: []expectedMatch{
+				{domain: "", ip: "1.1.1.1", shouldMatch: false},
+				{domain: "cloudflare", ip: "1.1.1.1", shouldMatch: true},
+			},
+			expectedErr:               "",
+			expectedCustomFilterCount: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			connFilter, err := getConnFilter(t, tt.config, tt.ddSite)
+			connFilter, err := getConnFilter(t, tt.config, tt.ddSite, tt.monitorIPWithoutDomain)
 			if tt.expectedErr != "" {
 				assert.ErrorContains(t, err, tt.expectedErr)
 			} else {

--- a/comp/networkpath/npcollector/npcollectorimpl/connfilter/connfilter_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/connfilter/connfilter_test.go
@@ -366,6 +366,31 @@ filters:
 			expectedErr:               "",
 			expectedCustomFilterCount: 0,
 		},
+		{
+			name: "monitor IP without domain disabled with filters",
+			config: `
+filters:
+  - match_ip: 10.10.10.0/30
+    type: include
+  - match_ip: 10.10.10.100
+    type: include
+`,
+			ddSite:                 "datad0g.com",
+			monitorIPWithoutDomain: false,
+			expectedMatches: []expectedMatch{
+				{domain: "cloudflare", ip: "1.1.1.1", shouldMatch: true},
+				{ip: "1.1.1.1", shouldMatch: false},
+				{ip: "10.10.20.0", shouldMatch: false},
+				{ip: "10.10.10.0", shouldMatch: true},
+				{ip: "10.10.10.1", shouldMatch: true},
+				{ip: "10.10.10.2", shouldMatch: true},
+				{ip: "10.10.10.3", shouldMatch: true},
+				{ip: "10.10.10.4", shouldMatch: false},
+				{ip: "10.10.10.100", shouldMatch: true},
+			},
+			expectedErr:               "",
+			expectedCustomFilterCount: 2,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/comp/networkpath/npcollector/npcollectorimpl/connfilter/defaultconnfilters.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/connfilter/defaultconnfilters.go
@@ -5,7 +5,7 @@
 
 package connfilter
 
-func getDefaultConnFilters(site string) []Config {
+func getDefaultConnFilters(site string, monitorIPWithoutDomain bool) []Config {
 	defaultConfig := []Config{
 		{
 			Type:        FilterTypeExclude,
@@ -24,6 +24,12 @@ func getDefaultConnFilters(site string) []Config {
 		defaultConfig = append(defaultConfig, Config{
 			Type:        FilterTypeExclude,
 			MatchDomain: "*." + site,
+		})
+	}
+	if monitorIPWithoutDomain {
+		defaultConfig = append(defaultConfig, Config{
+			Type:    FilterTypeInclude,
+			MatchIP: "0.0.0.0/0",
 		})
 	}
 	return defaultConfig

--- a/comp/networkpath/npcollector/npcollectorimpl/connfilter/testutils_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/connfilter/testutils_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
+//go:build test
+
 package connfilter
 
 import (
@@ -13,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/structure"
 )
 
-func getConnFilter(t *testing.T, configString string, ddSite string) (*ConnFilter, error) {
+func getConnFilter(t *testing.T, configString string, ddSite string, monitorIPWithoutDomain bool) (*ConnFilter, error) {
 	var configs []Config
 
 	cfg := configComponent.NewMockFromYAML(t, configString)
@@ -21,7 +23,7 @@ func getConnFilter(t *testing.T, configString string, ddSite string) (*ConnFilte
 	if err != nil {
 		return nil, err
 	}
-	connFilter, errs := NewConnFilter(configs, ddSite, false)
+	connFilter, errs := NewConnFilter(configs, ddSite, monitorIPWithoutDomain)
 	if len(errs) > 0 {
 		err = errors.Join(errs...)
 	}

--- a/comp/networkpath/npcollector/npcollectorimpl/connfilter/testutils_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/connfilter/testutils_test.go
@@ -21,7 +21,7 @@ func getConnFilter(t *testing.T, configString string, ddSite string) (*ConnFilte
 	if err != nil {
 		return nil, err
 	}
-	connFilter, errs := NewConnFilter(configs, ddSite)
+	connFilter, errs := NewConnFilter(configs, ddSite, false)
 	if len(errs) > 0 {
 		err = errors.Join(errs...)
 	}

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -95,7 +95,7 @@ func newNoopNpCollectorImpl() *npCollectorImpl {
 
 func newNpCollectorImpl(epForwarder eventplatform.Forwarder, collectorConfigs *collectorConfigs, logger log.Component, telemetrycomp telemetryComp.Component, rdnsquerier rdnsquerier.Component, statsd ddgostatsd.ClientInterface) *npCollectorImpl {
 	logger.Infof("New NpCollector %+v", collectorConfigs)
-	filter, errs := connfilter.NewConnFilter(collectorConfigs.filterConfig, collectorConfigs.ddSite)
+	filter, errs := connfilter.NewConnFilter(collectorConfigs.filterConfig, collectorConfigs.ddSite, collectorConfigs.monitorIPWithoutDomain)
 
 	if len(errs) > 0 {
 		logger.Errorf("connection filter errors: %s", errors.Join(errs...))
@@ -241,11 +241,11 @@ func (s *npCollectorImpl) shouldScheduleNetworkPathForConn(conn *model.Connectio
 		return false
 	}
 
-	skipIPWithoutDomain := !s.collectorConfigs.monitorIPWithoutDomain
-	if domain == "" && skipIPWithoutDomain {
-		s.statsdClient.Incr(netpathConnsSkippedMetricName, []string{"reason:skip_ip_without_domain"}, 1) //nolint:errcheck
-		return false
-	}
+	//skipIPWithoutDomain := !s.collectorConfigs.monitorIPWithoutDomain
+	//if domain == "" && skipIPWithoutDomain {
+	//	s.statsdClient.Incr(netpathConnsSkippedMetricName, []string{"reason:skip_ip_without_domain"}, 1) //nolint:errcheck
+	//	return false
+	//}
 
 	if !s.filter.IsIncluded(domain, conn.Raddr.GetIp()) {
 		s.statsdClient.Incr(netpathConnsSkippedMetricName, []string{"reason:skip_not_matched_by_filters"}, 1) //nolint:errcheck

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -241,12 +241,6 @@ func (s *npCollectorImpl) shouldScheduleNetworkPathForConn(conn *model.Connectio
 		return false
 	}
 
-	//skipIPWithoutDomain := !s.collectorConfigs.monitorIPWithoutDomain
-	//if domain == "" && skipIPWithoutDomain {
-	//	s.statsdClient.Incr(netpathConnsSkippedMetricName, []string{"reason:skip_ip_without_domain"}, 1) //nolint:errcheck
-	//	return false
-	//}
-
 	if !s.checkPassesConnCIDRFilters(conn, vpcSubnets) {
 		s.statsdClient.Incr(netpathConnsSkippedMetricName, []string{"reason:skip_not_matched_by_conn_filters"}, 1) //nolint:errcheck
 		return false

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -247,12 +247,17 @@ func (s *npCollectorImpl) shouldScheduleNetworkPathForConn(conn *model.Connectio
 	//	return false
 	//}
 
+	if !s.checkPassesConnCIDRFilters(conn, vpcSubnets) {
+		s.statsdClient.Incr(netpathConnsSkippedMetricName, []string{"reason:skip_not_matched_by_conn_filters"}, 1) //nolint:errcheck
+		return false
+	}
+
 	if !s.filter.IsIncluded(domain, conn.Raddr.GetIp()) {
 		s.statsdClient.Incr(netpathConnsSkippedMetricName, []string{"reason:skip_not_matched_by_filters"}, 1) //nolint:errcheck
 		return false
 	}
 
-	return s.checkPassesConnCIDRFilters(conn, vpcSubnets)
+	return true
 }
 
 func (s *npCollectorImpl) getVPCSubnets() ([]*net.IPNet, error) {

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -1760,6 +1760,22 @@ network_path:
 			shouldSchedule: false,
 		},
 		{
+			name: "FILTERS: include IP",
+			filters: `
+network_path:
+  collector:
+    filters:
+      - match_ip: '10.10.10.10'
+        type: include
+`,
+			conn: &model.Connection{
+				Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000)},
+				Raddr:     &model.Addr{Ip: "10.10.10.10", Port: int32(80)},
+				Direction: model.ConnectionDirection_outgoing,
+			},
+			shouldSchedule: true,
+		},
+		{
 			name:                   "FILTERS: test monitor all IPs without domain",
 			domain:                 "",
 			monitorIPWithoutDomain: true,

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -22,6 +22,9 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl/connfilter"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1477,15 +1480,17 @@ var cidrExcludedStat = teststatsd.MetricsArgs{Name: netpathConnsSkippedMetricNam
 
 func Test_npCollectorImpl_shouldScheduleNetworkPathForConn(t *testing.T) {
 	tests := []struct {
-		name               string
-		conn               *model.Connection
-		vpcSubnets         []*net.IPNet
-		domain             string
-		shouldSchedule     bool
-		subnetSkipped      bool
-		sourceExcludes     map[string][]string
-		destExcludes       map[string][]string
-		connectionExcluded bool
+		name                   string
+		conn                   *model.Connection
+		vpcSubnets             []*net.IPNet
+		domain                 string
+		shouldSchedule         bool
+		subnetSkipped          bool
+		sourceExcludes         map[string][]string
+		destExcludes           map[string][]string
+		filters                string
+		monitorIPWithoutDomain bool
+		connectionExcluded     bool
 	}{
 		{
 			name:   "should schedule",
@@ -1737,15 +1742,49 @@ func Test_npCollectorImpl_shouldScheduleNetworkPathForConn(t *testing.T) {
 			shouldSchedule:     true,
 			connectionExcluded: false,
 		},
+		{
+			name:   "FILTERS: excluded domain to test that filters works",
+			domain: "google.com",
+			filters: `
+network_path:
+  collector:
+    filters:
+      - match_domain: 'google.com'
+        type: exclude
+`,
+			conn: &model.Connection{
+				Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000)},
+				Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
+				Direction: model.ConnectionDirection_outgoing,
+			},
+			shouldSchedule: false,
+		},
+		{
+			name:                   "FILTERS: test monitor all IPs without domain",
+			domain:                 "",
+			monitorIPWithoutDomain: true,
+			conn: &model.Connection{
+				Laddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(30000)},
+				Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
+				Direction: model.ConnectionDirection_outgoing,
+			},
+			shouldSchedule: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var configs []connfilter.Config
+			cfg := configComponent.NewMockFromYAML(t, tt.filters)
+			err := structure.UnmarshalKey(cfg, "network_path.collector.filters", &configs)
+			require.NoError(t, err)
 			agentConfigs := map[string]any{
 				"network_path.connections_monitoring.enabled":         true,
 				"network_path.collector.disable_intra_vpc_collection": true,
 				"network_path.collector.source_excludes":              tt.sourceExcludes,
 				"network_path.collector.dest_excludes":                tt.destExcludes,
+				"network_path.collector.filters":                      configs,
+				"network_path.collector.monitor_ip_without_domain":    tt.monitorIPWithoutDomain,
 			}
 			stats := &teststatsd.Client{}
 			_, npCollector := newTestNpCollector(t, agentConfigs, stats)


### PR DESCRIPTION
### What does this PR do?

[network path] update ip filter behaviour

- It's now possible to only include some IPs easily using filters
- User can still include all IPs without domain using `network_path.collector.monitor_ip_without_domain: true`

### Motivation


Problem: with previous behaviour, it wasn't possible for user to only include some IPs easily using filter


### Describe how you validated your changes

### Additional Notes
