### PR TITLE
usm: tests: Fix race in TestVerifySketches

### DIFF
--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -2301,7 +2301,9 @@ func testHTTPLikeSketches(t *testing.T, tr *tracer.Tracer, client *nethttp.Clien
 	var getRequestStats, postRequestsStats *http.RequestStats
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		conns, cleanup := getConnections(ct, tr)
-		defer cleanup()
+		// Calling cleanup will restore the requestStats to a pool, and can modify/empty it.
+		// hence, we call the cleanup only during the end of the test
+		t.Cleanup(cleanup)
 
 		requests := conns.USMData.HTTP
 		if isHTTP2 {
@@ -2441,7 +2443,9 @@ func testKafkaSketches(t *testing.T, tr *tracer.Tracer) {
 	var fetchRequestStats, produceTopic1RequestsStats, produceTopic2RequestsStats *kafka.RequestStats
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		conns, cleanup := getConnections(ct, tr)
-		defer cleanup()
+		// Calling cleanup will restore the requestStats to a pool, and can modify/empty it.
+		// hence, we call the cleanup only during the end of the test
+		t.Cleanup(cleanup)
 
 		requests := conns.USMData.Kafka
 		if fetchRequestStats == nil || produceTopic1RequestsStats == nil || produceTopic2RequestsStats == nil {
@@ -2525,7 +2529,9 @@ func testPostgresSketches(t *testing.T, tr *tracer.Tracer) {
 	var insertRequestStats, selectRequestsStats *pgutils.RequestStat
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		conns, cleanup := getConnections(ct, tr)
-		defer cleanup()
+		// Calling cleanup will restore the requestStats to a pool, and can modify/empty it.
+		// hence, we call the cleanup only during the end of the test
+		t.Cleanup(cleanup)
 
 		requests := conns.USMData.Postgres
 		if insertRequestStats == nil || selectRequestsStats == nil {
@@ -2590,7 +2596,9 @@ func testRedisSketches(t *testing.T, tr *tracer.Tracer) {
 	var getRequestStats, setRequestStats *redis.RequestStats
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		conns, cleanup := getConnections(ct, tr)
-		defer cleanup()
+		// Calling cleanup will restore the requestStats to a pool, and can modify/empty it.
+		// hence, we call the cleanup only during the end of the test
+		t.Cleanup(cleanup)
 
 		requests := conns.USMData.Redis
 		if len(requests) == 0 {


### PR DESCRIPTION
## Summary
- Fixed race condition in TestVerifySketches and related sketch test functions
- Moved cleanup calls from defer to t.Cleanup to prevent premature restoration of requestStats to pool

## Details
The issue was that `defer cleanup()` was being called on every iteration of `require.EventuallyWithT`, which would restore the requestStats objects back to their pools. This could cause the stats to be modified or emptied while still being accessed, leading to race conditions.

The fix changes the cleanup pattern from `defer cleanup()` to `t.Cleanup(cleanup)`, ensuring cleanup only happens once at the end of the test rather than on each iteration.

## Test Plan
- Existing USM tests should pass without race conditions
- The following test functions have been fixed:
  - `testHTTPLikeSketches`
  - `testKafkaSketches`
  - `testPostgresSketches`
  - `testRedisSketches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)