### PR TITLE
[CWS] fix small strconv.Atoi type confusion issues

### DIFF
--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -301,7 +301,7 @@ func checkPidExists(sysFScGroupPath string, expectedPid uint32) (bool, error) {
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
-		if pid, err := strconv.Atoi(strings.TrimSpace(scanner.Text())); err == nil && uint32(pid) == expectedPid {
+		if pid, err := strconv.ParseUint(strings.TrimSpace(scanner.Text()), 10, 32); err == nil && uint32(pid) == expectedPid {
 			return true, nil
 		}
 	}
@@ -328,7 +328,7 @@ func (cfs *CGroupFS) GetCgroupPids(cgroupName string) ([]uint32, error) {
 		scanner := bufio.NewScanner(bytes.NewReader(data))
 		res := []uint32{}
 		for scanner.Scan() {
-			if pid, err := strconv.Atoi(strings.TrimSpace(scanner.Text())); err == nil {
+			if pid, err := strconv.ParseUint(strings.TrimSpace(scanner.Text()), 10, 32); err == nil {
 				res = append(res, uint32(pid))
 			}
 		}
@@ -393,7 +393,7 @@ func (cfs *CGroupFS) detectCurrentCgroupPath(currentPid, currentNSPid uint32) {
 				if err == nil {
 					scanner := bufio.NewScanner(bytes.NewReader(data))
 					for scanner.Scan() {
-						if pid, err := strconv.Atoi(strings.TrimSpace(scanner.Text())); err == nil && uint32(pid) == currentNSPid {
+						if pid, err := strconv.ParseUint(strings.TrimSpace(scanner.Text()), 10, 32); err == nil && uint32(pid) == currentNSPid {
 							cgroupPath = filepath.Dir(path)
 							return fs.SkipAll
 						}

--- a/pkg/security/utils/mount_linux.go
+++ b/pkg/security/utils/mount_linux.go
@@ -136,7 +136,7 @@ func GetHostMountPathID(mountPath string) (uint32, error) {
 		}
 
 		if fields[4] == mountPath {
-			id, err := strconv.Atoi(fields[0])
+			id, err := strconv.ParseUint(fields[0], 10, 32)
 			if err != nil {
 				return 0, err
 			}

--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -444,7 +444,7 @@ func GetNsPids(pid uint32, task string) ([]uint32, error) {
 			// Convert string values to integers
 			nspids := make([]uint32, 0, len(fields))
 			for _, field := range fields {
-				val, err := strconv.ParseUint(field, 10, 64)
+				val, err := strconv.ParseUint(field, 10, 32)
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse NSpid value: %w", err)
 				}
@@ -527,7 +527,7 @@ func GetTracerPid(pid uint32) (uint32, error) {
 			line = strings.TrimPrefix(line, "TracerPid:")
 			line = strings.TrimSpace(line)
 
-			tracerPid, err := strconv.ParseUint(line, 10, 64)
+			tracerPid, err := strconv.ParseUint(line, 10, 32)
 			if err != nil {
 				return 0, fmt.Errorf("failed to parse TracerPid value: %w", err)
 			}


### PR DESCRIPTION
### What does this PR do?

(_copilot generated summary:_)

This pull request updates several functions across the codebase to consistently use 32-bit unsigned integer parsing (`ParseUint` with base 10, bit size 32) when converting string representations of process IDs (PIDs) and related identifiers. This change improves type safety and ensures that PIDs and related values are correctly handled as `uint32`, matching their intended usage throughout the code.

**PID and identifier parsing improvements:**

* Replaced usage of `strconv.Atoi` and `strconv.ParseUint` with larger bit sizes by `strconv.ParseUint` with a 32-bit size in functions that parse PIDs from cgroup files, ensuring correct conversion to `uint32` in `cgroup.go`. [[1]](diffhunk://#diff-abe8544eb9bc5cb47c2d0fc3123ca8435e51f3ea0c35920c4dda1c0278be22dfL304-R304) [[2]](diffhunk://#diff-abe8544eb9bc5cb47c2d0fc3123ca8435e51f3ea0c35920c4dda1c0278be22dfL331-R331) [[3]](diffhunk://#diff-abe8544eb9bc5cb47c2d0fc3123ca8435e51f3ea0c35920c4dda1c0278be22dfL396-R396)
* Updated parsing of mount path IDs in `mount_linux.go` to use `strconv.ParseUint` with a 32-bit size for consistency and correctness with `uint32` return type.
* Changed parsing of namespace PIDs and tracer PIDs in `proc_linux.go` to use `strconv.ParseUint` with a 32-bit size, ensuring proper handling of these values as `uint32`. [[1]](diffhunk://#diff-306a6681d8cd0546e69f3e30ecc4ba192a9cfc547cbd3d9ef3dac8c69460eb67L447-R447) [[2]](diffhunk://#diff-306a6681d8cd0546e69f3e30ecc4ba192a9cfc547cbd3d9ef3dac8c69460eb67L530-R530)

### Motivation

### Describe how you validated your changes

### Additional Notes
