### PR TITLE
Allow inspection of sections that contains more than SHF_ALLOC and SHF_EXECINSTR flags

### DIFF
--- a/pkg/network/go/bininspect/utils.go
+++ b/pkg/network/go/bininspect/utils.go
@@ -112,6 +112,10 @@ func FindReturnLocations(elfFile *safeelf.File, sym safeelf.Symbol, functionOffs
 	}
 }
 
+const (
+	executableSectionFlags = safeelf.SHF_ALLOC | safeelf.SHF_EXECINSTR
+)
+
 // SymbolToOffset returns the offset of the given symbol name in the given elf file.
 func SymbolToOffset(f *safeelf.File, symbol safeelf.Symbol) (uint32, error) {
 	if f == nil {
@@ -121,7 +125,7 @@ func SymbolToOffset(f *safeelf.File, symbol safeelf.Symbol) (uint32, error) {
 	var sectionsToSearchForSymbol []*safeelf.Section
 
 	for i := range f.Sections {
-		if f.Sections[i].Flags == safeelf.SHF_ALLOC+safeelf.SHF_EXECINSTR {
+		if f.Sections[i].Flags&executableSectionFlags == executableSectionFlags {
 			sectionsToSearchForSymbol = append(sectionsToSearchForSymbol, f.Sections[i])
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Fixes the `SymbolToOffset` function in `pkg/network/go/bininspect/utils.go` to properly identify executable sections in ELF binaries by using bitwise AND operations instead of exact equality when checking section flags.

### Motivation

The previous implementation used exact equality (`Flags == SHF_ALLOC+SHF_EXECINSTR`) to check section flags, which would fail to identify executable sections that had any additional flags set. Some binaries (like certain Envoy builds) have executable sections with extra flags (e.g., `SHF_ALLOC | SHF_EXECINSTR | SHF_LINK_ORDER`) that were being incorrectly filtered out, causing symbol resolution to fail.

This change uses bitwise AND (`Flags&executableSectionFlags == executableSectionFlags`) to check if the section has **at least** the required executable flags, allowing sections with additional flags to be correctly identified.

### Describe how you validated your changes

- Verified symbol resolution now works correctly with binaries that have complex section flags

### Additional Notes

This is related to SUSM-142 work for improving binary inspection capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)