### PR TITLE
fix(CI): Add missing dependency between DDOT & new-e2e-installer

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -665,6 +665,7 @@ new-e2e-installer:
     - deploy_installer_oci
     - deploy_agent_oci
     - qa_installer_script_linux
+    - deploy_ddot_oci
   variables:
     TARGETS: ./tests/installer/unix
     TEAM: fleet


### PR DESCRIPTION
### What does this PR do?
Adds a missing dependency between `new-e2e-installer` & `deploy_ddot_oci`; causing the former to fail if any of the dependencies of the latter fail.

### Motivation

### Describe how you validated your changes

### Additional Notes
