### PR TITLE
Make `bazel` job blocking again on Windows

### DIFF
--- a/.gitlab/bazel/build-deps.yaml
+++ b/.gitlab/bazel/build-deps.yaml
@@ -46,6 +46,6 @@ bazel:build-deps:windows-amd64:
   variables:
     ARCH: x64
     SCRIPT: |-
-      echo "🟡 TODO(regis): compilation errors remain - limiting to a working subset for the time being"
+      [Console]::WriteLine("🟡 TODO(regis): compilation errors remain - limiting to a working subset for the time being")
       bazel build '@zlib//...' '@libffi//:ffi'
       # bazel build @bzip2//...

--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -26,8 +26,6 @@
 .bazel:ext:windows:
   extends: .windows_docker_default
   timeout: 60m # pulling images alone can take more than 30m
-  allow_failure: true
-  retry: 0
   variables:
     GIT_DEPTH: 2
   script:
@@ -53,4 +51,4 @@
       --volume="${RUNNER_TEMP_PROJECT_DIR}:$RUNNER_TEMP_PROJECT_DIR"
       --workdir="$CI_PROJECT_DIR"
       "$WINBUILDIMAGE"
-      powershell -NonInteractive -NoLogo -NoProfile -OutputFormat Text -EncodedCommand $EncodedCommand
+      powershell -NonInteractive -NoLogo -NoProfile -InputFormat Text -OutputFormat Text -EncodedCommand $EncodedCommand


### PR DESCRIPTION
### What does this PR do?
As #incident-42947 is now marked as stable, this change aims at bringing back (see #41023) a `bazel` build job to a gating criteria so that regressions when building dependencies on Windows can't go unnoticed.

The change also removes an unwanted `#< CLIXML` header in the job output, see https://github.com/PowerShell/PowerShell/issues/16678.