### PR TITLE
fix(installer): Remove old installer unit service files in the Agent postinst

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -109,6 +109,12 @@ var (
 		SysvinitMainService: "datadog-agent",
 		SysvinitServices:    []string{"datadog-agent", "datadog-agent-trace", "datadog-agent-process", "datadog-agent-security"},
 	}
+
+	// oldInstallerUnitsPaths are the deb/rpm/oci installer package unit paths
+	oldInstallerUnitPaths = file.Paths{
+		"datadog-installer-exp.service",
+		"datadog-installer.service",
+	}
 )
 
 // installFilesystem sets up the filesystem for the agent installation
@@ -154,6 +160,11 @@ func installFilesystem(ctx HookContext) (err error) {
 	// 5. Handle install info
 	if err = installinfo.WriteInstallInfo(ctx, string(ctx.PackageType)); err != nil {
 		return fmt.Errorf("failed to write install info: %v", err)
+	}
+
+	// 6. Remove old installer units if they exist
+	if err = oldInstallerUnitPaths.EnsureAbsent(ctx, "/etc/systemd/system"); err != nil {
+		return fmt.Errorf("failed to remove old installer units: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
Removes old installer deb/rpm/oci service units that prevent the newer installer (in the agent) unit from starting

### Motivation
Unblocking remote agent management for newer versions

### Describe how you validated your changes

### Additional Notes
