### PR TITLE
Build popt with bazel

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -18,6 +18,7 @@ filegroup(
             "@libsepol//:sepol",
             "@nghttp2",
             "@pcre2",
+            "@popt",
         ],
         "//conditions:default": [],
     }),

--- a/deps/popt.BUILD.bazel
+++ b/deps/popt.BUILD.bazel
@@ -1,0 +1,116 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "LICENSE",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "libpopt",
+    srcs = [
+        "src/popt.c",
+        "src/poptconfig.c",
+        "src/popthelp.c",
+        "src/poptint.c",
+        "src/poptint.h",
+        "src/poptparse.c",
+        "src/system.h",
+    ],
+    textual_hdrs = [
+        "src/lookup3.c",
+    ],
+    hdrs = [
+        "src/popt.h",
+    ],
+    copts = [
+        "-std=gnu99",
+        "-O2",
+    ],
+    local_defines = [
+        "_GNU_SOURCE",
+        "HAVE_STPCPY",
+        "HAVE_STRERROR",
+        "HAVE_GETUID",
+        "HAVE_GETEUID",
+        "HAVE_MTRACE",
+        "HAVE_SECURE_GETENV",
+        "HAVE_SETUID",
+        "HAVE_VASPRINTF",
+        "HAVE_SRANDOM",
+        "HAVE_GLOB_PATTERN_P",
+        "HAVE_MBSRTOWCS",
+        "HAVE_FNMATCH_H",
+        "HAVE_GLOB_H",
+        "HAVE_LANGINFO_H",
+        "HAVE_MCHECK_H",
+        "HAVE_STDALIGN_H",
+        'PACKAGE=\\"popt\\"',
+        'POPT_SYSCONFDIR=\\"/etc/\\"',
+    ],
+)
+
+cc_shared_library(
+    name = "popt",
+    deps = [
+        ":libpopt",
+    ],
+    additional_linker_inputs = [
+        "src/libpopt.vers",
+    ],
+    user_link_flags = [
+        "-Wl,--no-undefined",
+        "-Wl,--version-script=$(location src/libpopt.vers)",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+so_symlink(
+    name = "lib_files",
+    src = ":popt",
+    libname = "libpopt",
+    version = "0.0.2",
+)
+
+expand_template(
+    name = "gen_pkgconfig",
+    out = "popt.pc",
+    substitutions = {
+        # Prepare the .pc file for our own substitution later
+        "@prefix@": "##PREFIX##",
+        "@exec_prefix@": "${prefix}",
+        "@libdir@": "${prefix}/lib",
+        "@includedir@": "${prefix}/include",
+        "@VERSION@": "1.19",
+        "@LTLIBICONV@": "",
+    },
+    template = "popt.pc.in",
+)
+
+pkg_files(
+    name = "hdr_files",
+    srcs = glob(["src/popt.h"]),
+    prefix = "include",
+)
+
+pkg_files(
+    name = "pc_file",
+    srcs = [":gen_pkgconfig"],
+    prefix = "lib/pkgconfig",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":hdr_files",
+        ":lib_files",
+        ":pc_file",
+    ],
+)

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -101,3 +101,11 @@ http_archive(
     strip_prefix = "nghttp2-1.58.0",
     url = "https://github.com/nghttp2/nghttp2/releases/download/v1.58.0/nghttp2-1.58.0.tar.gz",
 )
+
+http_archive(
+    name = "popt",
+    build_file = "//deps:popt.BUILD.bazel",
+    sha256 = "c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9",
+    strip_prefix = "popt-1.19",
+    url = "http://ftp.rpm.org/popt/releases/popt-1.x/popt-1.19.tar.gz",
+)

--- a/omnibus/config/software/popt.rb
+++ b/omnibus/config/software/popt.rb
@@ -31,18 +31,8 @@ end
 relative_path "popt-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  env["CFLAGS"] << " -fPIC"
-
-  update_config_guess
-
-  configure_options = [
-    "--disable-static",
-    "--disable-nls",
-  ]
-  configure(*configure_options, env: env)
-
-  make "-j #{workers}", env: env
-  make "install", env: env
+  command_on_repo_root "bazelisk run -- @popt//:install --destdir='#{install_dir}/embedded'"
+  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+    " #{install_dir}/embedded/lib/pkgconfig/popt.pc" \
+    " #{install_dir}/embedded/lib/libpopt.so"
 end


### PR DESCRIPTION
### What does this PR do?

Build popt with bazel from omnibus

### Motivation

Migrating our native dependencies to bazel

### Describe how you validated your changes

Local build (and CI when AWS recovers)

### Additional Notes

This local_define: `'POPT_SYSCONFDIR=\\"/etc/\\"',` is open to debate. 
In theory it is derived from the install location, but needs to be known at build time, which we can't do when building with bazel.
The value is used to load potential `popt` configuration files.
The current location is `/opt/datadog-agent/etc/` which doesn't exist, so any configuration loading will fail, while it could succeed with the new value, but I'm not sure if we want it to potentially succeed.

We could also ensure it never succeed by passing an ostensibly invalid path.