### PR TITLE
fix(installer): Force disable units + fix telemetry

### DIFF
--- a/pkg/fleet/installer/packages/service/systemd/systemd.go
+++ b/pkg/fleet/installer/packages/service/systemd/systemd.go
@@ -105,7 +105,7 @@ func DisableUnit(ctx context.Context, unit string) error {
 		return nil
 	}
 
-	err := telemetry.CommandContext(ctx, "systemctl", "disable", unit).Run()
+	err := telemetry.CommandContext(ctx, "systemctl", "disable", "--force", unit).Run()
 	exitErr := &exec.ExitError{}
 	if !errors.As(err, &exitErr) {
 		return err


### PR DESCRIPTION
### What does this PR do?
* Some customers fail to upgrade because they can't disable the stable unit, so we force it
* Fixes some telemetry's `CommandContext` as we don't always have `stderr` on failure

### Motivation

### Describe how you validated your changes

### Additional Notes
