### PR TITLE
Add release note: rebuilt `x86_64` deps honor documented min macOS 11.0 ABI

### DIFF
--- a/releasenotes/notes/rebuilt-deps-honor-min-macos-11.0-abi-as-documented-9c84d9f4e17fc914.yaml
+++ b/releasenotes/notes/rebuilt-deps-honor-min-macos-11.0-abi-as-documented-9c84d9f4e17fc914.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    All internally rebuilt `x86_64` dependencies now uniformly target the documented macOS 11.0 minimal ABI.
+    Previously, some still targeted macOS 10.12 or 10.13, even though support for 10.x was dropped in Agent 7.62.0 and
+    numerous `x86_64` dependencies were already targeting newer ABI versions.


### PR DESCRIPTION
### What does this PR do?
Clarify the advertised mininum ABI version is now observed by the `x86_64` build of the Agent for macOS.

### Motivation
> Even though this makes the behavior conform to the docs, we should consider mentioning that in the release notes as it changes undocumented behavior.

(https://github.com/DataDog/integrations-core/pull/21652#pullrequestreview-3352162690)