### PR TITLE
dyninst/symdb: don't yield duplicate packages

### DIFF
--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -743,6 +743,13 @@ func (b *packagesIterator) close() {
 // Packages with no types or functions not yielded.
 func (b *packagesIterator) iterator() iter.Seq2[Package, error] {
 	var err error
+	// Keep track of packages we've seen so that we ignore compile units
+	// belonging to packages we've already yielded. This happens for packages
+	// that have assembly sources: each assembly file gets its own compile unit,
+	// and they all have the same name (the name of the Go package). In these
+	// cases, the iterator only yields the first compile unit for each package
+	// name; empirically the first unit corresponds to the non-assembly sources.
+	seenPackages := make(map[string]struct{})
 	return func(yield func(pkg Package, err error) bool) {
 		defer b.close()
 		entryReader := b.dwarfData.Reader()
@@ -768,6 +775,9 @@ func (b *packagesIterator) iterator() iter.Seq2[Package, error] {
 			if pkg == nil {
 				continue
 			}
+			if _, ok := seenPackages[pkg.Name]; ok {
+				continue
+			}
 
 			// Move all accumulated abstract functions to the output package.
 			// Note that we may have discovered abstract functions belonging to
@@ -783,6 +793,7 @@ func (b *packagesIterator) iterator() iter.Seq2[Package, error] {
 				if !yield(*pkg, nil /* error */) {
 					break
 				}
+				seenPackages[pkg.Name] = struct{}{}
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
Have the packages iterator keep track of which packages it already yielded and ignore compile units belonging to already-yielded packages. Go seems to produce multiple compile units for packages that include assembly source files -- one unit for the .go files, and a unit for each .s file. Before this patch, the iterator was returning such duplicates, and we were uploading and ingesting them. This was mostly fine (albeit confusing) as far as the backend was concerned, but now I'm changing the backend to overwrite the symbols from a package that already exists, rather than storing them side by side.

This patch makes it so that we only yield the symbols from the first compile unit for each package name, which empirically corresponds to the .go files.

