### PR TITLE
dyninst/symdb: tag package symbols with agent version

### DIFF
--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/uploader"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 // symdbManager deals with uploading symbols to the SymDB backend.
@@ -357,7 +358,7 @@ func (m *symdbManager) performUpload(ctx context.Context, procID processKey, run
 			return context.Cause(ctx)
 		}
 
-		scope := uploader.ConvertPackageToScope(pkg)
+		scope := uploader.ConvertPackageToScope(pkg, version.AgentVersion)
 		uploadBuffer = append(uploadBuffer, scope)
 		bufferFuncs += pkg.Stats().NumFunctions
 		if err := maybeFlush(false /* force */); err != nil {

--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -254,7 +254,7 @@ func run() (retErr error) {
 		}
 
 		if up != nil {
-			scope := uploader.ConvertPackageToScope(pkg)
+			scope := uploader.ConvertPackageToScope(pkg, "cli" /* agentVersion */)
 			uploadBuffer = append(uploadBuffer, scope)
 			bufferFuncs += pkg.Stats().NumFunctions
 			if err := maybeFlush(false /* force */); err != nil {

--- a/pkg/dyninst/symdb/uploader/uploader_test.go
+++ b/pkg/dyninst/symdb/uploader/uploader_test.go
@@ -170,6 +170,9 @@ func TestSymDBUploader(t *testing.T) {
 				Name:      "main",
 				StartLine: 0,
 				EndLine:   0,
+				LanguageSpecifics: &LanguageSpecifics{
+					AgentVersion: "7.72.0-test",
+				},
 				Scopes: []Scope{
 					{
 						ScopeType:  ScopeTypeMethod,


### PR DESCRIPTION
Tag each package scope that we upload with the version of the agent that produced the symbol information. I'm using a new key in language-specifics for package scopes.
This information seems generally useful for debugging, but also I intend to use it on the backend to decide if new symbols being uploaded should overwrite existing ones or, if they're uploaded by the same agent version as before, should be ignore.

The agent version is technically available to the backend even without the agent explicitly including this info in the upload -- we have the agent version as a tag on the log message carrying the symbols attachment, so the backend could read it from there and add it to the symbols, or persist it somewhere else. Still, including it explicitly in the upload seems cleaner.