### PR TITLE
[corechecks/kubelet/cadvisor] Fix panic

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
@@ -170,7 +170,11 @@ func (p *Provider) processContainerMetric(metricType, metricName string, metricF
 			cID, _ := kubelet.KubeContainerIDToTaggerEntityID(containerID)
 			tags, _ = p.tagger.Tag(cID, types.HighCardinality)
 
-			tags = common.AppendKubeStaticCPUsTag(p.store, pod.QOSClass, cID, tags)
+			// The pod can be nil here if it's deleted from wmeta after getting
+			// the samples
+			if pod != nil {
+				tags = common.AppendKubeStaticCPUsTag(p.store, pod.QOSClass, cID, tags)
+			}
 		}
 
 		if len(tags) == 0 {

--- a/releasenotes/notes/kubelet-check-panic-c16ccadb6a271dc8.yaml
+++ b/releasenotes/notes/kubelet-check-panic-c16ccadb6a271dc8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a panic that could happen in the kubelet check when a pod was deleted while collecting metrics.


### PR DESCRIPTION
### What does this PR do?

Fixes a panic in the Kubelet check.

It triggers if the pod is deleted in the middle of the execution of the check. I think the pod needs to exist here: https://github.com/DataDog/datadog-agent/blob/517a31e60bf41d4d775551fa79eb7aa214d42371/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go#L152 and be deleted before here: https://github.com/DataDog/datadog-agent/blob/517a31e60bf41d4d775551fa79eb7aa214d42371/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go#L158

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x34d3710]

goroutine 658 [running]:
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/cadvisor.(*Provider).processContainerMetric(0x40017170e0, {0x50348d3, 0x4}, {0x509eb5d, 0x1a}, 0x40030c75c0, {0x0, 0x0, 0x0}, {0x5661158, ...})
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go:175 +0x750
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/cadvisor.(*Provider).containerCPUUsageSecondsTotal(0x40017170e0, 0x40030c75c0, {0x5661158, 0x4004816190})
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go:420 +0x124
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/prometheus.(*Provider).Provide(0x4001717140, {0x5646138, 0x40007844e0}, {0x5661158, 0x4004816190})
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/prometheus/provider.go:214 +0x6d4
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet.(*KubeletCheck).Run(0x4002943dc0)
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/kubelet.go:167 +0x3d4
github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware.(*CheckWrapper).Run(0x40011d8e60)
        /home/datadog/go/src/github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go:62 +0x350
github.com/DataDog/datadog-agent/pkg/collector/worker.(*Worker).Run(0x4001dd2000)
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/worker/worker.go:165 +0x41c
github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker.func1()
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:145 +0xc4
created by github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker in goroutine 385
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:142 +0x328

```

### Describe how you validated your changes

It's difficult to write a unit test for this because as explained above, the pod needs to be deleted in the middle of the test to trigger this.