### PR TITLE
[CWS] fix creds UID offset on AL2 4.14.255

### DIFF
--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -310,6 +310,8 @@ func getCredsUIDOffset(kv *kernel.Version) uint64 {
 	switch {
 	case kv.IsCOSKernel():
 		return 20
+	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_14, kernel.Kernel4_15) && kv.Code.Patch() > 250:
+		return 8
 	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5) && kv.Code.Patch() > 250:
 		return 8
 	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11) && kv.Code.Patch() > 200:


### PR DESCRIPTION
### What does this PR do?

We recently got some new failures on the octogon constant test, newer AL2 4.14 kernels have the creds UID offset set to 8. This PR fixes this small failure.

### Motivation

### Describe how you validated your changes

### Additional Notes
