### PR TITLE
[CXP-2767] mark core agent process check with npm as flaky

### DIFF
--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeClient "k8s.io/client-go/kubernetes"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -219,6 +220,8 @@ func (s *K8sCoreAgentSuite) TestProcessCheckInCoreAgent() {
 }
 
 func (s *K8sCoreAgentSuite) TestProcessCheckInCoreAgentWithNPM() {
+	// https://datadoghq.atlassian.net/browse/CXP-2767
+	flake.Mark(s.T())
 	t := s.T()
 
 	helmValues, err := createHelmValues(helmConfig{


### PR DESCRIPTION
### What does this PR do?
- marks test flaky in main as flaky

### Motivation
- flaking test https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.name%3A%22TestK8sCoreAgentTestSuite%2FTestProcessCheckInCoreAgentWithNPM%22%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fprocess%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1760450360770&end=1761055160770&paused=false

### Describe how you validated your changes
- CI

### Additional Notes
