### PR TITLE
Remove last use of config.UnmarshalKey in favor of the structure implementation

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -602,7 +602,7 @@ func parseConfig(cfg config.Component) (*Config, error) {
 	atCfgMap := cfg.GetStringMap("agent_telemetry")
 	if len(atCfgMap) > 0 {
 		// Reconvert to string and back to object.
-		// Config.UnmarshalKey() is better but it did not work in some cases
+		// structure.UnmarshalKey() is better but it did not work in some cases
 		atCfgBytes, err := yaml.Marshal(atCfgMap)
 		if err != nil {
 			return nil, err

--- a/comp/core/workloadfilter/catalog/filter_config.go
+++ b/comp/core/workloadfilter/catalog/filter_config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/impl/parse"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 )
 
 // FilterConfig holds all configuration values needed for filter initialization
@@ -127,7 +128,7 @@ func loadCELConfig(cfg config.Component) ([]workloadfilter.RuleBundle, error) {
 	var celConfig []workloadfilter.RuleBundle
 
 	// First try the standard UnmarshalKey method (input defined in datadog.yaml)
-	err := cfg.UnmarshalKey("cel_workload_exclude", &celConfig)
+	err := structure.UnmarshalKey(cfg, "cel_workload_exclude", &celConfig)
 	if err == nil {
 		return celConfig, nil
 	}

--- a/comp/core/workloadfilter/catalog/filter_config_test.go
+++ b/comp/core/workloadfilter/catalog/filter_config_test.go
@@ -23,11 +23,11 @@ func TestNewFilterConfig_CELFallback(t *testing.T) {
 		mockConfig := configmock.New(t)
 
 		// Set up valid CEL config that should unmarshal successfully
-		celConfig := []workloadfilter.RuleBundle{
+		celConfig := []map[string]interface{}{
 			{
-				Products: []workloadfilter.Product{workloadfilter.ProductMetrics},
-				Rules: map[workloadfilter.ResourceType][]string{
-					workloadfilter.ContainerType: {"container.name == 'test'"},
+				"products": []string{"metrics"},
+				"rules": map[string][]string{
+					"container": {"container.name == 'test'"},
 				},
 			},
 		}

--- a/comp/core/workloadfilter/impl/parse/parse_test.go
+++ b/comp/core/workloadfilter/impl/parse/parse_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	configcomp "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 )
@@ -129,7 +130,7 @@ cel_workload_exclude:
 `
 	configComponent := configcomp.NewMockFromYAML(t, yamlConfig)
 	var filterConfig []workloadfilter.RuleBundle
-	err := configComponent.UnmarshalKey("cel_workload_exclude", &filterConfig)
+	err := structure.UnmarshalKey(configComponent, "cel_workload_exclude", &filterConfig)
 
 	require.NoError(t, err)
 	assert.Len(t, filterConfig, 2)

--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl/connfilter"
 	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl/pathteststore"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 )
 
@@ -43,7 +44,7 @@ type collectorConfigs struct {
 
 func newConfig(agentConfig config.Component, logger log.Component) *collectorConfigs {
 	var filterConfigs []connfilter.Config
-	err := agentConfig.UnmarshalKey("network_path.collector.filters", &filterConfigs)
+	err := structure.UnmarshalKey(agentConfig, "network_path.collector.filters", &filterConfigs)
 	if err != nil {
 		logger.Errorf("Error unmarshalling network_path.collector.filters")
 		filterConfigs = nil

--- a/pkg/collector/corechecks/containers/containerd/events_test.go
+++ b/pkg/collector/corechecks/containers/containerd/events_test.go
@@ -290,7 +290,8 @@ func TestComputeEvents(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	configYaml := `
 cel_workload_exclude:
-  - products: metrics
+  - products:
+      - metrics
     rules:
       containers:
         - container.image.reference.matches('not-monitored')

--- a/pkg/config/create/go.mod
+++ b/pkg/config/create/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.1
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1
+	github.com/DataDog/datadog-agent/pkg/config/structure v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.64.1
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.70.0
 )

--- a/pkg/config/create/read_config_file_fuzz_test.go
+++ b/pkg/config/create/read_config_file_fuzz_test.go
@@ -3,11 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package nodetreemodel
+package create
 
 import (
 	"strings"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 )
 
 func FuzzReadConfig(f *testing.F) {
@@ -79,8 +82,7 @@ dogstatsd_entity_id_precedence: ""
 other: value`) // Null value (YAML parses as nil)
 
 	f.Fuzz(func(_ *testing.T, yamlContent string) {
-
-		cfg := NewNodeTreeConfig("test", "TEST", nil).(*ntmConfig)
+		cfg := nodetreemodel.NewNodeTreeConfig("test", "TEST", nil) // nolint: forbidigo // legit use case
 		cfg.SetDefault("a", "default_a")
 		cfg.SetDefault("c.d", 42)
 		cfg.SetDefault("network_devices.snmp_traps.enabled", false)
@@ -126,11 +128,6 @@ other: value`) // Null value (YAML parses as nil)
 		cfg.GetSubfields("network_devices")
 		cfg.GetSubfields("c")
 
-		// Node access - test direct tree manipulation
-		cfg.GetNode("a")
-		cfg.GetNode("c")
-		cfg.GetNode("network_devices.snmp_traps")
-
 		// Configuration metadata - test config state inspection
 		cfg.ConfigFileUsed()
 		cfg.ExtraConfigFilesUsed()
@@ -149,8 +146,8 @@ other: value`) // Null value (YAML parses as nil)
 			// Only test additional operations if ReadConfig succeeded
 			// Test unmarshal functionality on valid configs
 			var result map[string]interface{}
-			cfg.UnmarshalKey("", &result)
-			cfg.UnmarshalKey("c", &result)
+			structure.UnmarshalKey(cfg, "", &result)
+			structure.UnmarshalKey(cfg, "c", &result)
 
 			// Test settings retrieval with sequence ID
 			_, _ = cfg.AllSettingsWithSequenceID()

--- a/pkg/util/docker/event_pull_test.go
+++ b/pkg/util/docker/event_pull_test.go
@@ -28,7 +28,8 @@ func TestProcessContainerEvent(t *testing.T) {
 
 	configYaml := `
 cel_workload_exclude:
-  - products: global
+  - products:
+      - global
     rules:
       containers:
        - container.name == 'excluded_cel_name'


### PR DESCRIPTION
### What does this PR do?
Remove last use of `config.UnmarshalKey` in favor of the `structure` implementation

### Describe how you validated your changes

Running the CI is enough