### PR TITLE
fix: Podman logging without docker socket

### DIFF
--- a/pkg/logs/internal/util/containersorpods/containers_or_pods_test.go
+++ b/pkg/logs/internal/util/containersorpods/containers_or_pods_test.go
@@ -75,7 +75,7 @@ func TestChoose(t *testing.T) {
 		test([]env.Feature{env.Podman}, false, dockerReadyBit, LogContainers))
 
 	t.Run("docker not ready, only Podman enabled",
-		test([]env.Feature{env.Podman}, false, 0, LogUnknown))
+		test([]env.Feature{env.Podman}, false, 0, LogContainers))
 
 	// - if the kubernetes feature is available and no container features are
 	//   available, wait for the kubelet service to start, and return LogPods
@@ -85,6 +85,9 @@ func TestChoose(t *testing.T) {
 
 	t.Run("k8s not ready, only k8s enabled",
 		test([]env.Feature{env.Kubernetes}, false, 0, LogUnknown))
+
+	t.Run("k8s not ready, only Podman enabled",
+		test([]env.Feature{env.Podman, env.Kubernetes}, false, 0, LogUnknown))
 
 	// - if none of the features are available, LogNothing
 

--- a/releasenotes/notes/fix-podman-log-collection-3369fc8fba539f77.yaml
+++ b/releasenotes/notes/fix-podman-log-collection-3369fc8fba539f77.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix Podman log collection without Docker socket being mapped in the container.


### PR DESCRIPTION
### What does this PR do?
Fix log collection on Podman runtime.
Podman containers needs to be run with `--log-driver=k8s-file` for the Agent to collect logs

### Motivation
In order to collect logs with Podman runtime Docker socket should not be necessary.

### Describe how you validated your changes

1. Spin up EC2 instance with RHEL 9
2. Follow the steps to deploy rootless agent: https://docs.google.com/document/d/1bJWG2gJlF6y2rI3VnFcl3WkOdNwO3SiQ-iRmmAGa9-M
3. deploy test workload as: `podman run -d --log-driver=k8s-file docker.io/chentex/random-logger`

check the logs

### Additional Notes
![Screenshot 2025-10-22 at 17 01 17](https://github.com/user-attachments/assets/609403a6-aa31-4663-b31c-29cd077ad977)
