### PR TITLE
[PEDS] disable CWS in USM tests

### DIFF
--- a/pkg/eventmonitor/testutil/testutil.go
+++ b/pkg/eventmonitor/testutil/testutil.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	emconfig "github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
+	secmodule "github.com/DataDog/datadog-agent/pkg/security/module"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 )
 
@@ -32,6 +33,9 @@ func StartEventMonitor(tb testing.TB, callback PreStartCallback) {
 	emconfig := emconfig.NewConfig()
 	secconfig, err := secconfig.NewConfig()
 	require.NoError(tb, err)
+
+	// disable the CWS part (similar to running USM/CNM only)
+	secmodule.DisableRuntimeSecurity(secconfig)
 
 	// Needed for the socket creation to work
 	require.NoError(tb, os.MkdirAll("/opt/datadog-agent/run/", 0755))


### PR DESCRIPTION
### What does this PR do?

There is no need to have CWS running when running USM tests, this PR disables the CWS unneeded features, similarly to how the event monitor does it when running PEDS in test mode. 

### Motivation

### Describe how you validated your changes

### Additional Notes
