### PR TITLE
[CWS] handle 6.17 kernel `vfs_coredump` rename

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -264,14 +264,22 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
     return 0;
 }
 
-HOOK_ENTRY("do_coredump")
-int hook_do_coredump(ctx_t *ctx) {
+int __attribute__((always_inline)) coredump_common() {
     u64 key = bpf_get_current_pid_tgid();
     u8 in_coredump = 1;
 
     bpf_map_update_elem(&tasks_in_coredump, &key, &in_coredump, BPF_ANY);
-
     return 0;
+}
+
+HOOK_ENTRY("vfs_coredump")
+int hook_vfs_coredump(ctx_t *ctx) {
+    return coredump_common();
+}
+
+HOOK_ENTRY("do_coredump")
+int hook_do_coredump(ctx_t *ctx) {
+    return coredump_common();
 }
 
 int __attribute__((always_inline)) handle_do_exit(ctx_t *ctx) {
@@ -833,6 +841,6 @@ int hook_security_inode_follow_link(ctx_t *ctx) {
     if (!syscall) {
         return 0;
     }
-    syscall->exec.is_through_symlink = 1;    
+    syscall->exec.is_through_symlink = 1;
     return 0;
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -159,7 +159,10 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 				hookFunc("hook_vfs_open"),
 				hookFunc("hook_commit_creds"),
 				hookFunc("hook_switch_task_namespaces"),
-				hookFunc("hook_do_coredump"),
+				&manager.OneOf{Selectors: []manager.ProbesSelector{
+					hookFunc("hook_do_coredump"),
+					hookFunc("hook_vfs_coredump"),
+				}},
 				hookFunc("hook_audit_set_loginuid"),
 				hookFunc("rethook_audit_set_loginuid"),
 				hookFunc("hook_security_inode_follow_link"),

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -145,6 +145,12 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_coredump",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_prepare_binprm",
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

In kernel 6.17 `do_coredump` has been renamed `vfs_coredump` ([commit](https://github.com/torvalds/linux/commit/a6ed5691b2428cc578908ee050d5d4908a6e065e)), let's handle this correctly.

(the KMT test for ubuntu 25.10, using kernel 6.17, is not available now, but since this issue is preventing the probe from even starting, it's a pre-requisite)

### Motivation

### Describe how you validated your changes

### Additional Notes
