### PR TITLE
CEL Program Runtime Error Handling

### DIFF
--- a/comp/core/workloadfilter/impl/filter_bundle.go
+++ b/comp/core/workloadfilter/impl/filter_bundle.go
@@ -26,10 +26,7 @@ func (fb *filterBundle) GetResult(obj workloadfilter.Filterable) workloadfilter.
 	for _, filterSet := range fb.filterSets {
 		var setResult = workloadfilter.Unknown
 		for _, prg := range filterSet {
-			res, prgErrs := prg.Evaluate(obj)
-			if prgErrs != nil {
-				fb.log.Debug(prgErrs)
-			}
+			res := prg.Evaluate(obj)
 			if res == workloadfilter.Included {
 				fb.log.Debugf("Resource %s is included by filter %d", obj.Type(), prg)
 				return res

--- a/comp/core/workloadfilter/program/annotations_program.go
+++ b/comp/core/workloadfilter/program/annotations_program.go
@@ -20,12 +20,12 @@ type AnnotationsProgram struct {
 var _ FilterProgram = &AnnotationsProgram{}
 
 // Evaluate evaluates the filter program for a Result (Included, Excluded, or Unknown)
-func (p AnnotationsProgram) Evaluate(entity filterdef.Filterable) (filterdef.Result, []error) {
+func (p AnnotationsProgram) Evaluate(entity filterdef.Filterable) filterdef.Result {
 	isExcluded := containers.IsExcludedByAnnotationInner(entity.GetAnnotations(), entity.GetName(), p.ExcludePrefix)
 	if isExcluded {
-		return filterdef.Excluded, nil
+		return filterdef.Excluded
 	}
-	return filterdef.Unknown, nil
+	return filterdef.Unknown
 }
 
 // GetInitializationErrors returns any errors that occurred during the creation/initialization of the program

--- a/comp/core/workloadfilter/program/annotations_program_test.go
+++ b/comp/core/workloadfilter/program/annotations_program_test.go
@@ -42,7 +42,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 		annotations    map[string]string
 		excludePrefix  string
 		expectedResult filterdef.Result
-		expectedErrors int
 	}{
 		{
 			name:           "No annotations - should return Unknown",
@@ -50,7 +49,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			annotations:    map[string]string{},
 			excludePrefix:  "",
 			expectedResult: filterdef.Unknown,
-			expectedErrors: 0,
 		},
 		{
 			name:       "Global exclude annotation set to true - should be Excluded",
@@ -60,7 +58,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			},
 			excludePrefix:  "",
 			expectedResult: filterdef.Excluded,
-			expectedErrors: 0,
 		},
 		{
 			name:       "Global exclude annotation set to false - should return Unknown",
@@ -70,7 +67,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			},
 			excludePrefix:  "",
 			expectedResult: filterdef.Unknown,
-			expectedErrors: 0,
 		},
 		{
 			name:       "Global exclude annotation set to 1 - should be Excluded",
@@ -80,7 +76,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			},
 			excludePrefix:  "",
 			expectedResult: filterdef.Excluded,
-			expectedErrors: 0,
 		},
 		{
 			name:       "Container-specific exclude annotation set to true - should be Excluded",
@@ -90,7 +85,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			},
 			excludePrefix:  "",
 			expectedResult: filterdef.Excluded,
-			expectedErrors: 0,
 		},
 		{
 			name:       "Container-specific exclude annotation set to false - should return Unknown",
@@ -100,7 +94,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			},
 			excludePrefix:  "",
 			expectedResult: filterdef.Unknown,
-			expectedErrors: 0,
 		},
 		{
 			name:       "Logs exclude prefix - global logs exclude",
@@ -110,7 +103,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			},
 			excludePrefix:  "logs_",
 			expectedResult: filterdef.Excluded,
-			expectedErrors: 0,
 		},
 		{
 			name:       "Wrong prefix should not trigger exclusion",
@@ -120,7 +112,6 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			},
 			excludePrefix:  "metrics_", // looking for metrics_ but have logs_
 			expectedResult: filterdef.Unknown,
-			expectedErrors: 0,
 		},
 	}
 
@@ -139,11 +130,10 @@ func TestAnnotationsProgram_Evaluate(t *testing.T) {
 			}
 
 			// Evaluate the program
-			result, errors := program.Evaluate(entity)
+			result := program.Evaluate(entity)
 
 			// Assert results
 			assert.Equal(t, tt.expectedResult, result, "Expected result does not match")
-			assert.Len(t, errors, tt.expectedErrors, "Expected number of errors does not match")
 		})
 	}
 }

--- a/comp/core/workloadfilter/program/cel_program.go
+++ b/comp/core/workloadfilter/program/cel_program.go
@@ -10,8 +10,8 @@ package program
 import (
 	"os"
 
-	filterdef "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/google/cel-go/cel"
 )
@@ -27,14 +27,14 @@ type CELProgram struct {
 var _ FilterProgram = &CELProgram{}
 
 // Evaluate evaluates the filter program for a Result (Included, Excluded, or Unknown)
-func (p CELProgram) Evaluate(entity filterdef.Filterable) (filterdef.Result, []error) {
+func (p CELProgram) Evaluate(entity workloadfilter.Filterable) workloadfilter.Result {
 	if p.Exclude != nil {
 		out, _, err := p.Exclude.Eval(map[string]any{string(entity.Type()): entity.Serialize()})
 		if err == nil {
 			res, ok := out.Value().(bool)
 			if ok {
 				if res {
-					return filterdef.Excluded, nil
+					return workloadfilter.Excluded
 				}
 			} else {
 				log.Criticalf(`filter '%s' from 'cel_workload_exclude' failed to convert value to bool: %v`, p.Name, out.Value())
@@ -48,7 +48,7 @@ func (p CELProgram) Evaluate(entity filterdef.Filterable) (filterdef.Result, []e
 		}
 	}
 
-	return filterdef.Unknown, nil
+	return workloadfilter.Unknown
 }
 
 // GetInitializationErrors returns any errors that occurred during the creation/initialization of the program

--- a/comp/core/workloadfilter/program/legacy_program.go
+++ b/comp/core/workloadfilter/program/legacy_program.go
@@ -18,13 +18,15 @@ type LegacyFilterProgram struct {
 	InitializationErrors []error
 }
 
+var _ FilterProgram = &LegacyFilterProgram{}
+
 // Evaluate evaluates the filter program for a Result (Included, Excluded, or Unknown)
-func (n LegacyFilterProgram) Evaluate(entity workloadfilter.Filterable) (workloadfilter.Result, []error) {
+func (n LegacyFilterProgram) Evaluate(entity workloadfilter.Filterable) workloadfilter.Result {
 	if n.Filter == nil {
-		return workloadfilter.Unknown, nil
+		return workloadfilter.Unknown
 	}
 	annotations, name, image, namespace := getLegacyFilterValues(entity)
-	return n.Filter.GetResult(annotations, name, image, namespace), nil
+	return n.Filter.GetResult(annotations, name, image, namespace)
 }
 
 // GetInitializationErrors returns any errors that occurred during the creation/initialization of the program

--- a/comp/core/workloadfilter/program/program.go
+++ b/comp/core/workloadfilter/program/program.go
@@ -6,15 +6,13 @@
 // Package program contains the implementation of filtering programs.
 package program
 
-import (
-	filterdef "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
-)
+import workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 
 // FilterProgram is an interface that defines a method for evaluating a filter program.
 type FilterProgram interface {
 
 	// Evaluate evaluates the filter program for a Result (Included, Excluded, or Unknown)
-	Evaluate(entity filterdef.Filterable) (filterdef.Result, []error)
+	Evaluate(entity workloadfilter.Filterable) workloadfilter.Result
 
 	// GetInitializationErrors returns any errors that occurred
 	// during the initialization of the filtering program

--- a/comp/core/workloadfilter/program/regex_program.go
+++ b/comp/core/workloadfilter/program/regex_program.go
@@ -23,18 +23,18 @@ type RegexProgram struct {
 var _ FilterProgram = &RegexProgram{}
 
 // Evaluate evaluates the filter program for a Result (Included, Excluded, or Unknown)
-func (p *RegexProgram) Evaluate(entity workloadfilter.Filterable) (workloadfilter.Result, []error) {
+func (p *RegexProgram) Evaluate(entity workloadfilter.Filterable) workloadfilter.Result {
 	if p.ExcludeRegex == nil {
-		return workloadfilter.Unknown, nil
+		return workloadfilter.Unknown
 	}
 
 	field := p.ExtractField(entity)
 	for _, r := range p.ExcludeRegex {
 		if r.MatchString(field) {
-			return workloadfilter.Excluded, nil
+			return workloadfilter.Excluded
 		}
 	}
-	return workloadfilter.Unknown, nil
+	return workloadfilter.Unknown
 }
 
 // GetInitializationErrors returns any errors that occurred during the creation/initialization of the program


### PR DESCRIPTION
### What does this PR do?

Gracefully crashes the Agent during a runtime error for a `cel.Program`. These can both derive from an evaluation error or type conversion to bool.

https://github.com/DataDog/datadog-agent/blob/7b08f7205d429c442c809602ade6e5df42ea4f77/comp/core/workloadfilter/program/cel_program.go#L32

https://github.com/DataDog/datadog-agent/blob/7b08f7205d429c442c809602ade6e5df42ea4f77/comp/core/workloadfilter/program/cel_program.go#L34

Eval errors rise when users define faulty programs like `1/0` or infinite loops. Type conversions result when a user defines a rule that doesn't result in a boolean output like `container.name` or `"some-value"` as the entire rule. 

### Motivation

Standardize `cel_workload_exclude` behavior from user misconfiguration to gracefully crash the Agent process. This PR covers runtime errors during the evaluation of the `cel.Program` whereas previous PRs covered the parse/compile time validation of the `cel.Program`.

### Describe how you validated your changes

N/A

### Additional Notes

These errors/crashes will only occur when the filter is used. Would expect every filter to be used at least once within 10 seconds of the Agent or ClusterAgent process starting since filtering is used in core components like Autodiscovery.

Alternatively, we can exclude telemetry that makes a failed request to the filter. We can also log errors to the Agent process every time a client uses the incorrectly defined filter.