### PR TITLE
Use configmock for crio tests

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/crio/crio_test.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/crio_test.go
@@ -20,10 +20,12 @@ import (
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func TestPull(t *testing.T) {
+	configmock.New(t)
 
 	const envVarName = "DD_CONTAINER_IMAGE_ENABLED"
 	originalValue := os.Getenv(envVarName)


### PR DESCRIPTION
### What does this PR do?

Use the configmock for a test in `internal/crio` which indirectly uses the globally accessible config object.

### Motivation

This fixes the test `comp/core/workloadmeta/collectors/internal/crio/crio_test` when `DD_CONF_NODETREEMODEL` is set to `enable`.

### Describe how you validated your changes

Ran the test.

### Additional Notes
