### PR TITLE
Change `pkg/util/log` public interface to use LogLevel instead of string

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -422,7 +422,7 @@ func setupLogger() {
 	logLevel := "error"
 	if userLogLevel := os.Getenv(logLevelEnvVar); len(userLogLevel) > 0 {
 		if seelogLogLevel, err := log.ValidateLogLevel(userLogLevel); err == nil {
-			logLevel = seelogLogLevel
+			logLevel = seelogLogLevel.String()
 		} else {
 			log.Errorf("Invalid log level '%s', using default log level '%s'", userLogLevel, logLevel)
 		}

--- a/comp/core/log/mock/mock.go
+++ b/comp/core/log/mock/mock.go
@@ -43,12 +43,12 @@ func New(t testing.TB) log.Component {
 
 	t.Cleanup(func() {
 		// stop using the logger to avoid a race condition
-		pkglog.ChangeLogLevel(pkglog.Default(), "debug")
+		pkglog.ChangeLogLevel(pkglog.Default(), pkglog.DebugLvl)
 		iface.Flush()
 	})
 
 	// install the logger into pkg/util/log
-	pkglog.ChangeLogLevel(iface, "debug")
+	pkglog.ChangeLogLevel(iface, pkglog.DebugLvl)
 
 	return pkglog.NewWrapper(2)
 }

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -62,7 +62,7 @@ func Test_Enabled(t *testing.T) {
 			w := bufio.NewWriter(&b)
 			l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.WarnLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			log.SetupLogger(l, "warn")
+			log.SetupLogger(l, log.WarnLvl)
 
 			haAgent := newTestHaAgentComponent(t, tt.configs, l).Comp.(*haAgentImpl)
 

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -339,7 +339,7 @@ func TestFlowAggregator_flush_submitCollectorMetrics_error(t *testing.T) {
 
 	l, err := ddlog.LoggerFromWriterWithMinLevelAndFormat(w, ddlog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	require.NoError(t, err)
-	ddlog.SetupLogger(l, "debug")
+	ddlog.SetupLogger(l, ddlog.DebugLvl)
 
 	sender := mocksender.NewMockSender("")
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -50,7 +50,7 @@ func Test_NpCollector_StartAndStop(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	utillog.SetupLogger(l, "debug")
+	utillog.SetupLogger(l, utillog.DebugLvl)
 
 	assert.False(t, npCollector.running)
 
@@ -997,7 +997,7 @@ func Test_npCollectorImpl_ScheduleConns(t *testing.T) {
 			w := bufio.NewWriter(&b)
 			l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			utillog.SetupLogger(l, "debug")
+			utillog.SetupLogger(l, utillog.DebugLvl)
 
 			npCollector.ScheduleConns(tt.conns)
 
@@ -1048,7 +1048,7 @@ func Test_npCollectorImpl_stopWorker(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	utillog.SetupLogger(l, "debug")
+	utillog.SetupLogger(l, utillog.DebugLvl)
 
 	stopped := make(chan bool, 1)
 	go func() {
@@ -1204,7 +1204,7 @@ func Benchmark_npCollectorImpl_ScheduleConns(b *testing.B) {
 	w := bufio.NewWriter(file)
 	l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg\n")
 	assert.Nil(b, err)
-	utillog.SetupLogger(l, "debug")
+	utillog.SetupLogger(l, utillog.DebugLvl)
 	defer w.Flush()
 
 	app, npCollector := newTestNpCollector(b, agentConfigs, &teststatsd.Client{})

--- a/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/pathteststore/pathteststore_test.go
@@ -92,7 +92,7 @@ func Test_pathtestStore_add(t *testing.T) {
 			w := bufio.NewWriter(&b)
 			l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			utillog.SetupLogger(l, "debug")
+			utillog.SetupLogger(l, utillog.DebugLvl)
 
 			config := Config{
 				ContextsLimit: tc.initialSize,

--- a/comp/remote-config/rcclient/rcclientimpl/rcclient_test.go
+++ b/comp/remote-config/rcclient/rcclientimpl/rcclient_test.go
@@ -133,7 +133,7 @@ func TestRCClientCreate(t *testing.T) {
 }
 
 func TestAgentConfigCallback(t *testing.T) {
-	pkglog.SetupLogger(pkglog.Default(), "info")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.InfoLvl)
 	cfg := configmock.New(t)
 
 	var ipcComp ipc.Component
@@ -236,7 +236,7 @@ func TestAgentConfigCallback(t *testing.T) {
 }
 
 func TestAgentMRFConfigCallback(t *testing.T) {
-	pkglog.SetupLogger(pkglog.Default(), "info")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.InfoLvl)
 	cfg := configmock.New(t)
 
 	var ipcComp ipc.Component

--- a/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
+++ b/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
@@ -45,7 +45,7 @@ func Test_SyntheticsTestScheduler_StartAndStop(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	utillog.SetupLogger(l, "debug")
+	utillog.SetupLogger(l, utillog.DebugLvl)
 	configs := &schedulerConfigs{
 		workers:                    2,
 		flushInterval:              100 * time.Millisecond,
@@ -92,7 +92,7 @@ func Test_SyntheticsTestScheduler_OnConfigUpdate(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	utillog.SetupLogger(l, "debug")
+	utillog.SetupLogger(l, utillog.DebugLvl)
 	configs := &schedulerConfigs{
 		workers:                    2,
 		flushInterval:              100 * time.Millisecond,
@@ -423,7 +423,7 @@ func Test_SyntheticsTestScheduler_Processing(t *testing.T) {
 			w := bufio.NewWriter(&b)
 			l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			utillog.SetupLogger(l, "debug")
+			utillog.SetupLogger(l, utillog.DebugLvl)
 
 			fixedBase := time.UnixMilli(1756901488589)
 			step := 0
@@ -503,7 +503,7 @@ func Test_SyntheticsTestScheduler_RunWorker_ProcessesTestCtxAndSendsResult(t *te
 	w := bufio.NewWriter(&b)
 	l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	utillog.SetupLogger(l, "debug")
+	utillog.SetupLogger(l, utillog.DebugLvl)
 	ctx, cancel := context.WithCancel(context.TODO())
 
 	scheduler := &syntheticsTestScheduler{
@@ -579,7 +579,7 @@ func TestFlushEnqueuesDueTests(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := utillog.LoggerFromWriterWithMinLevelAndFormat(w, utillog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	utillog.SetupLogger(l, "debug")
+	utillog.SetupLogger(l, utillog.DebugLvl)
 
 	scheduler := &syntheticsTestScheduler{
 		timeNowFn:                    func() time.Time { return now },

--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -147,7 +147,7 @@ func TestSplitTagRegex(t *testing.T) {
 
 		logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 		assert.Nil(t, err)
-		log.SetupLogger(logger, "debug")
+		log.SetupLogger(logger, log.DebugLvl)
 		assert.Nil(t, splitTagRegex(bad.tag))
 		w.Flush()
 		assert.Contains(t, b.String(), "[ERROR] Invalid regex pattern in tag filter: \"key\":\"[value\"")

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -30,10 +30,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestEBPFPerfBufferLength(t *testing.T) {
-	ebpftest.FailLogLevel(t, "trace")
+	ebpftest.FailLogLevel(t, log.TraceLvl)
 
 	ebpftest.RequireKernelVersion(t, minimumKernelVersion)
 	ebpftest.TestBuildMode(t, ebpftest.CORE, "", func(t *testing.T) {

--- a/pkg/collector/corechecks/net/networkv2/network_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_test.go
@@ -1982,7 +1982,7 @@ procfs_path: "/mocked/procfs"
 
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 	mockSender := mocksender.NewMockSender(networkCheck.ID())
 	err = networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
@@ -2017,7 +2017,7 @@ procfs_path: "/mocked/procfs"
 
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 	mockSender := mocksender.NewMockSender(networkCheck.ID())
 	err = networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
@@ -2051,7 +2051,7 @@ procfs_path: "/mocked/procfs"
 
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 	mockSender := mocksender.NewMockSender(networkCheck.ID())
 	err = networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
@@ -875,7 +875,7 @@ func Test_fetchColumnOids_alreadyProcessed(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	require.NoError(t, err)
-	log.SetupLogger(l, "debug")
+	log.SetupLogger(l, log.DebugLvl)
 
 	sess := session.CreateMockSession()
 

--- a/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
@@ -220,7 +220,7 @@ func TrapLogs(t testing.TB, level log.LogLevel) LogValidator {
 		t.Errorf("Failed to create a logger: %v", err)
 		return LogValidator{}
 	}
-	log.SetupLogger(l, level.String())
+	log.SetupLogger(l, level)
 	return LogValidator{b: &b, w: w, l: l}
 }
 

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -34,7 +34,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 	w := bufio.NewWriter(&b)
 	l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.TraceLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(l, "debug")
+	log.SetupLogger(l, log.DebugLvl)
 
 	var storeWithoutIfName = &valuestore.ResultValueStore{
 		ScalarValues: valuestore.ScalarResultValuesType{

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -318,7 +318,7 @@ func TestSendMetric(t *testing.T) {
 
 			l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			log.SetupLogger(l, "debug")
+			log.SetupLogger(l, log.DebugLvl)
 
 			mockSender := mocksender.NewMockSender("foo")
 			metricSender := MetricSender{sender: mockSender}
@@ -571,7 +571,7 @@ func Test_metricSender_reportMetrics(t *testing.T) {
 
 			l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			log.SetupLogger(l, "debug")
+			log.SetupLogger(l, log.DebugLvl)
 
 			mockSender := mocksender.NewMockSender("foo")
 			mockSender.SetupAcceptAll()
@@ -761,7 +761,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 
 			l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			log.SetupLogger(l, "debug")
+			log.SetupLogger(l, log.DebugLvl)
 
 			mockSender := mocksender.NewMockSender("foo")
 			metricSender := MetricSender{sender: mockSender}

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
@@ -785,7 +785,7 @@ metric_tags:
 
 			l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			log.SetupLogger(l, "debug")
+			log.SetupLogger(l, log.DebugLvl)
 
 			m := profiledefinition.MetricsConfig{}
 			yaml.Unmarshal(tt.rawMetricConfig, &m)
@@ -1104,7 +1104,7 @@ func Test_getContantMetricValues(t *testing.T) {
 
 			l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 			assert.Nil(t, err)
-			log.SetupLogger(l, "debug")
+			log.SetupLogger(l, log.DebugLvl)
 
 			values := getConstantMetricValues(tt.metricTags, tt.values)
 

--- a/pkg/collector/corechecks/snmp/internal/session/session_test.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session_test.go
@@ -290,7 +290,7 @@ func Test_snmpSession_traceLog_disabled(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.InfoLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(l, "info")
+	log.SetupLogger(l, log.InfoLvl)
 
 	s, err := NewGosnmpSession(&config)
 	gosnmpSess := s.(*GosnmpSession)
@@ -307,7 +307,7 @@ func Test_snmpSession_traceLog_enabled(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.TraceLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(l, "trace")
+	log.SetupLogger(l, log.TraceLvl)
 
 	s, err := NewGosnmpSession(&config)
 	gosnmpSess := s.(*GosnmpSession)

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -250,7 +250,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndUsageSystemCallReturns
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
 	err = diskCheck.Run()
@@ -300,7 +300,7 @@ file_system_global_blacklist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
 
@@ -321,7 +321,7 @@ device_global_blacklist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
 
@@ -342,7 +342,7 @@ mount_point_global_blacklist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
 
@@ -363,7 +363,7 @@ file_system_whitelist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -384,7 +384,7 @@ file_system_blacklist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -405,7 +405,7 @@ device_whitelist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -426,7 +426,7 @@ device_blacklist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -447,7 +447,7 @@ mount_point_whitelist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -468,7 +468,7 @@ mount_point_blacklist:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -489,7 +489,7 @@ excluded_mountpoint_re:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -510,7 +510,7 @@ excluded_filesystems:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -531,7 +531,7 @@ excluded_disks:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -552,7 +552,7 @@ excluded_disk_re:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -1090,7 +1090,7 @@ func TestGivenADiskCheckWithMinDiskSizeConfiguredTo1MiBConfig_WhenCheckRunsAndUs
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.InfoLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "info")
+	log.SetupLogger(logger, log.InfoLvl)
 
 	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 	err = diskCheck.Run()

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
@@ -360,7 +360,7 @@ create_mounts:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	err = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 
@@ -388,7 +388,7 @@ create_mounts:
 	w := bufio.NewWriter(&b)
 	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %Msg")
 	assert.Nil(t, err)
-	log.SetupLogger(logger, "debug")
+	log.SetupLogger(logger, log.DebugLvl)
 
 	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
 	err = diskCheck.Run()

--- a/pkg/dyninst/dyninsttest/util.go
+++ b/pkg/dyninst/dyninsttest/util.go
@@ -65,9 +65,10 @@ func (s Semaphore) Acquire() (release func()) {
 // SetupLogging is used to have a consistent logging setup for all tests.
 // It is best to call this in TestMain.
 func SetupLogging() {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "debug"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.DebugLvl
 	}
 	const defaultFormat = "%l %Date(15:04:05.000000000) @%File:%Line| %Msg%n"
 	var format string

--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -83,9 +83,10 @@ To upload the SymDB data rather than printing it, use:
 		os.Exit(1)
 	}
 
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "info"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.InfoLvl
 	}
 	log.SetupLogger(log.Default(), logLevel)
 	defer log.Flush()

--- a/pkg/ebpf/ebpftest/fail_log.go
+++ b/pkg/ebpf/ebpftest/fail_log.go
@@ -17,12 +17,12 @@ import (
 )
 
 // FailLogLevel sets the logger level for this test only and only outputs if the test fails
-func FailLogLevel(t testing.TB, level string) {
+func FailLogLevel(t testing.TB, level log.LogLevel) {
 	t.Helper()
 	inner := &failureTestLogger{TB: t}
 	t.Cleanup(func() {
 		t.Helper()
-		log.SetupLogger(log.Default(), "off")
+		log.SetupLogger(log.Default(), log.Off)
 		inner.outputIfFailed()
 	})
 	logger, err := seelog.LoggerFromCustomReceiver(inner)

--- a/pkg/ebpf/ebpftest/log.go
+++ b/pkg/ebpf/ebpftest/log.go
@@ -16,9 +16,9 @@ import (
 )
 
 // LogLevel sets the logger level for this test only
-func LogLevel(t testing.TB, level string) {
+func LogLevel(t testing.TB, level log.LogLevel) {
 	t.Cleanup(func() {
-		log.SetupLogger(log.Default(), "off")
+		log.SetupLogger(log.Default(), log.Off)
 	})
 	logger, err := seelog.LoggerFromCustomReceiver(testLogger{t})
 	if err != nil {

--- a/pkg/ebpf/map_cleaner_test.go
+++ b/pkg/ebpf/map_cleaner_test.go
@@ -23,9 +23,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "warn"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.WarnLvl
 	}
 	log.SetupLogger(log.Default(), logLevel)
 	os.Exit(m.Run())

--- a/pkg/ebpf/verifier/stats_test.go
+++ b/pkg/ebpf/verifier/stats_test.go
@@ -32,9 +32,10 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "warn"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.WarnLvl
 	}
 	log.SetupLogger(log.Default(), logLevel)
 	os.Exit(m.Run())

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -198,7 +198,7 @@ func TestDestinationErrorLogFormat(t *testing.T) {
 	// Set up logger to capture log output
 	testLogger, err := log.LoggerFromWriterWithMinLevelAndFormat(writer, log.WarnLvl, "%Msg")
 	assert.NoError(t, err)
-	log.SetupLogger(testLogger, "warn")
+	log.SetupLogger(testLogger, log.WarnLvl)
 
 	// Send payload to trigger error log
 	err = server.Destination.unconditionalSend(&message.Payload{

--- a/pkg/logs/tailers/windowsevent/tailer_test.go
+++ b/pkg/logs/tailers/windowsevent/tailer_test.go
@@ -60,7 +60,7 @@ func TestReadEventsSuite(t *testing.T) {
 func (s *ReadEventsSuite) SetupSuite() {
 	// Enable logger
 	if false {
-		pkglog.SetupLogger(pkglog.Default(), "debug")
+		pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 	}
 
 	s.ti = eventlog_test.GetAPITesterByName(s.testAPI, s.T())

--- a/pkg/network/netlink/conntrack_integration_test.go
+++ b/pkg/network/netlink/conntrack_integration_test.go
@@ -26,9 +26,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "warn"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.WarnLvl
 	}
 	log.SetupLogger(log.Default(), logLevel)
 	os.Exit(m.Run())

--- a/pkg/network/port_test.go
+++ b/pkg/network/port_test.go
@@ -27,9 +27,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "warn"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.WarnLvl
 	}
 	log.SetupLogger(log.Default(), logLevel)
 

--- a/pkg/network/protocols/http/etw_interface_test.go
+++ b/pkg/network/protocols/http/etw_interface_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -251,7 +252,7 @@ func executeRequestForTest(t *testing.T, etw *EtwInterface, test testDef) ([]Win
 }
 
 func TestEtwTransactions(t *testing.T) {
-	ebpftest.LogLevel(t, "info")
+	ebpftest.LogLevel(t, log.InfoLvl)
 	cfg := config.New()
 	cfg.EnableHTTPMonitoring = true
 	cfg.EnableNativeTLSMonitoring = true

--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -30,10 +30,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	netnsutil "github.com/DataDog/datadog-agent/pkg/util/kernel/netns"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestConntrackers(t *testing.T) {
-	ebpftest.LogLevel(t, "trace")
+	ebpftest.LogLevel(t, log.TraceLvl)
 	t.Run("netlink", func(t *testing.T) {
 		runConntrackerTest(t, "netlink", setupNetlinkConntracker)
 	})

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/offsetguess"
 	tracertestutil "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
@@ -130,7 +131,7 @@ func TestOffsetGuess(t *testing.T) {
 	if prebuilt.IsDeprecated() {
 		t.Skip("skipping because prebuilt is deprecated on this platform")
 	}
-	ebpftest.LogLevel(t, "trace")
+	ebpftest.LogLevel(t, log.TraceLvl)
 	ebpftest.TestBuildMode(t, ebpftest.RuntimeCompiled, "", testOffsetGuess)
 }
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel/netns"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
@@ -449,7 +450,7 @@ func (s *TracerSuite) TestConnectionExpirationRegression() {
 
 func (s *TracerSuite) TestConntrackExpiration() {
 	t := s.T()
-	ebpftest.LogLevel(t, "trace")
+	ebpftest.LogLevel(t, log.TraceLvl)
 
 	cfg := testConfig()
 	skipOnEbpflessNotSupported(t, cfg)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -51,9 +51,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "warn"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.WarnLvl
 	}
 	log.SetupLogger(log.Default(), logLevel)
 	platformInit()

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -50,9 +50,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "warn"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.WarnLvl
 	}
 	log.SetupLogger(log.Default(), logLevel)
 	os.Exit(m.Run())

--- a/pkg/network/usm/tests/tracer_classification_test.go
+++ b/pkg/network/usm/tests/tracer_classification_test.go
@@ -39,9 +39,10 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	logLevel := os.Getenv("DD_LOG_LEVEL")
-	if logLevel == "" {
-		logLevel = "warn"
+	lvl := os.Getenv("DD_LOG_LEVEL")
+	logLevel, err := log.ValidateLogLevel(lvl)
+	if err != nil {
+		logLevel = log.WarnLvl
 	}
 	log.SetupLogger(log.Default(), logLevel)
 	platformInit()

--- a/pkg/networkconfigmanagement/profile/profile_processing_test.go
+++ b/pkg/networkconfigmanagement/profile/profile_processing_test.go
@@ -14,9 +14,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
-	"github.com/stretchr/testify/assert"
 )
 
 var testProfile = &NCMProfile{
@@ -156,7 +157,7 @@ func Test_extractMetadata(t *testing.T) {
 			w := bufio.NewWriter(&b)
 			l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.DebugLvl, "[%LEVEL] %FuncShort: %Msg\n")
 			assert.NoError(t, err)
-			log.SetupLogger(l, "debug")
+			log.SetupLogger(l, log.DebugLvl)
 
 			actual, _ := tt.profile.extractMetadata(tt.commandType, tt.configBytes)
 			w.Flush()

--- a/pkg/privileged-logs/module/handler_test.go
+++ b/pkg/privileged-logs/module/handler_test.go
@@ -26,7 +26,7 @@ func TestLogFileAccess(t *testing.T) {
 
 	l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.InfoLvl, "%Msg\n")
 	require.NoError(t, err)
-	log.SetupLogger(l, "info")
+	log.SetupLogger(l, log.InfoLvl)
 
 	module := NewPrivilegedLogsModule().(*privilegedLogsModule)
 

--- a/pkg/security/probe/probe_auditing_windows_test.go
+++ b/pkg/security/probe/probe_auditing_windows_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,7 +49,7 @@ func processUntilAudit(t *testing.T, et *etwTester) {
 
 func TestETWAuditNotifications(t *testing.T) {
 	t.Skip("Skipping test that requires admin privileges")
-	ebpftest.LogLevel(t, "info")
+	ebpftest.LogLevel(t, log.InfoLvl)
 	ex, err := os.Executable()
 	require.NoError(t, err, "could not get executable path")
 	testfilename := ex + ".testfile"

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"golang.org/x/sys/windows"
 )
@@ -533,7 +534,7 @@ func testFileOpen(t *testing.T, et *etwTester, testfilename string) {
 }
 func TestETWFileNotifications(t *testing.T) {
 	if false {
-		ebpftest.LogLevel(t, "info")
+		ebpftest.LogLevel(t, log.InfoLvl)
 	}
 	ex, err := os.Executable()
 	require.NoError(t, err, "could not get executable path")

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -1046,9 +1046,9 @@ func (tm *testModule) CloseWithOptions(zombieCheck bool) {
 var logInitilialized bool
 
 func initLogger() error {
-	logLevel, found := log.LogLevelFromString(logLevelStr)
-	if !found {
-		return fmt.Errorf("invalid log level '%s'", logLevel)
+	logLevel, err := log.ValidateLogLevel(logLevelStr)
+	if err != nil {
+		return err
 	}
 
 	if !logInitilialized {
@@ -1072,9 +1072,9 @@ func swapLogLevel(logLevel log.LogLevel) (log.LogLevel, error) {
 			return 0, err
 		}
 	}
-	log.SetupLogger(logger, logLevel.String())
+	log.SetupLogger(logger, logLevel)
 
-	prevLevel, _ := log.LogLevelFromString(logLevelStr)
+	prevLevel, _ := log.ValidateLogLevel(logLevelStr)
 	logLevelStr = logLevel.String()
 	return prevLevel, nil
 }

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -446,7 +446,7 @@ func BenchmarkStartEndInvocation(b *testing.B) {
 	// JSON payload). We're not interested in any output here, so we send it all to `io.Discard`.
 	l, err := log.LoggerFromWriterWithMinLevel(io.Discard, log.ErrorLvl)
 	assert.Nil(b, err)
-	log.SetupLogger(l, "error")
+	log.SetupLogger(l, log.ErrorLvl)
 
 	// relative to location of this test file
 	payloadFiles, err := os.ReadDir("../trace/testdata/event_samples")

--- a/pkg/snmp/gosnmplib/gosnmp_log_test.go
+++ b/pkg/snmp/gosnmplib/gosnmp_log_test.go
@@ -93,7 +93,7 @@ func TestTraceLevelLogWriter_Write(t *testing.T) {
 			w := bufio.NewWriter(&b)
 			l, err := log.LoggerFromWriterWithMinLevelAndFormat(w, log.TraceLvl, "[%LEVEL] %FuncShort: %Msg")
 			require.NoError(t, err)
-			log.SetupLogger(l, "trace")
+			log.SetupLogger(l, log.TraceLvl)
 
 			sw := &TraceLevelLogWriter{}
 			lineLen, err := sw.Write(tt.logLine)

--- a/pkg/trace/remoteconfighandler/remote_config_handler_test.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler_test.go
@@ -33,7 +33,7 @@ func TestStart(t *testing.T) {
 	prioritySampler := NewMockprioritySampler(ctrl)
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 
 	h := New(&agentConfig, prioritySampler, rareSampler, errorsSampler)
 
@@ -55,7 +55,7 @@ func TestPrioritySampler(t *testing.T) {
 	prioritySampler := NewMockprioritySampler(ctrl)
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 
 	agentConfig := config.AgentConfig{RemoteConfigClient: remoteClient, TargetTPS: 41, ErrorTPS: 41, RareSamplerEnabled: true, DebugServerPort: 1}
 	h := New(&agentConfig, prioritySampler, rareSampler, errorsSampler)
@@ -84,7 +84,7 @@ func TestErrorsSampler(t *testing.T) {
 	prioritySampler := NewMockprioritySampler(ctrl)
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 
 	agentConfig := config.AgentConfig{RemoteConfigClient: remoteClient, TargetTPS: 41, ErrorTPS: 41, RareSamplerEnabled: true, DebugServerPort: 1}
 	h := New(&agentConfig, prioritySampler, rareSampler, errorsSampler)
@@ -113,7 +113,7 @@ func TestRareSampler(t *testing.T) {
 	prioritySampler := NewMockprioritySampler(ctrl)
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 
 	agentConfig := config.AgentConfig{RemoteConfigClient: remoteClient, TargetTPS: 41, ErrorTPS: 41, RareSamplerEnabled: true, DebugServerPort: 1}
 	h := New(&agentConfig, prioritySampler, rareSampler, errorsSampler)
@@ -142,7 +142,7 @@ func TestEnvPrecedence(t *testing.T) {
 	prioritySampler := NewMockprioritySampler(ctrl)
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 
 	agentConfig := config.AgentConfig{RemoteConfigClient: remoteClient, TargetTPS: 41, ErrorTPS: 41, RareSamplerEnabled: true, DefaultEnv: "agent-env", DebugServerPort: 1}
 	h := New(&agentConfig, prioritySampler, rareSampler, errorsSampler)
@@ -182,7 +182,7 @@ func TestLogLevel(t *testing.T) {
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
 
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "Bearer fakeToken", r.Header.Get("Authorization"))
 		w.WriteHeader(200)
@@ -228,7 +228,7 @@ func TestStartWithMRF(t *testing.T) {
 	prioritySampler := NewMockprioritySampler(ctrl)
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 
 	h := New(&agentConfig, prioritySampler, rareSampler, errorsSampler)
 
@@ -248,7 +248,7 @@ func TestMRFUpdateCallback(t *testing.T) {
 	prioritySampler := NewMockprioritySampler(ctrl)
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 
 	agentConfig := config.AgentConfig{
 		RemoteConfigClient:    remoteClient,
@@ -305,7 +305,7 @@ func TestMRFUpdateCallbackWithMultipleConfigs(t *testing.T) {
 	prioritySampler := NewMockprioritySampler(ctrl)
 	errorsSampler := NewMockerrorsSampler(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
-	pkglog.SetupLogger(pkglog.Default(), "debug")
+	pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 
 	agentConfig := config.AgentConfig{
 		RemoteConfigClient:    remoteClient,

--- a/pkg/util/grpc/agent_client_test.go
+++ b/pkg/util/grpc/agent_client_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.SetupLogger(log.Default(), "trace")
+	log.SetupLogger(log.Default(), log.TraceLvl)
 	os.Exit(m.Run())
 }
 

--- a/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
@@ -635,7 +635,7 @@ func configureLoggerForTest(t *testing.T) func() {
 	if err != nil {
 		t.Fatalf("unable to configure logger, err: %v", err)
 	}
-	log.SetupLogger(logger, "trace")
+	log.SetupLogger(logger, log.TraceLvl)
 	return log.Flush
 }
 

--- a/pkg/util/log/klog_redirect_test.go
+++ b/pkg/util/log/klog_redirect_test.go
@@ -25,7 +25,7 @@ func TestKlogRedirectLoggerWrite(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %Msg\n")
-	SetupLogger(l, DebugStr)
+	SetupLogger(l, DebugLvl)
 
 	klogRedirectLogger := NewKlogRedirectLogger(3)
 

--- a/pkg/util/log/levels.go
+++ b/pkg/util/log/levels.go
@@ -38,10 +38,8 @@ func (level LogLevel) String() string {
 	return seelog.LogLevel(level).String()
 }
 
-// LogLevelFromString returns a LogLevel from a string
-//
-//nolint:revive // keeping the original function name from seelog
-func LogLevelFromString(levelStr string) (LogLevel, bool) {
+// logLevelFromString returns a LogLevel from a string
+func logLevelFromString(levelStr string) (LogLevel, bool) {
 	level, ok := seelog.LogLevelFromString(levelStr)
 	return LogLevel(level), ok
 }

--- a/pkg/util/log/log_bench_test.go
+++ b/pkg/util/log/log_bench_test.go
@@ -38,7 +38,7 @@ func BenchmarkLogScrubbing(b *testing.B) {
 	w := bufio.NewWriter(&buff)
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "info")
+	SetupLogger(l, InfoLvl)
 
 	for n := 0; n < b.N; n++ {
 		Infof("this is a credential encoding uri: %s", "http://user:password@host:port")
@@ -50,7 +50,7 @@ func BenchmarkLogScrubbingLevels(b *testing.B) {
 	w := bufio.NewWriter(&buff)
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "info")
+	SetupLogger(l, InfoLvl)
 
 	for n := 0; n < b.N; n++ {
 		Debugf("this is a credential encoding uri: %s", "http://user:password@host:port")
@@ -62,7 +62,7 @@ func BenchmarkLogWithContext(b *testing.B) {
 	w := bufio.NewWriter(&buff)
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "info")
+	SetupLogger(l, InfoLvl)
 
 	for n := 0; n < b.N; n++ {
 		Infoc("this is a credential encoding uri: %s", "http://user:password@host:port", "extra", "context")

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -779,7 +779,7 @@ func TestValidateLogLevel(t *testing.T) {
 
 func TestValidateLogLevelUnknownLevel(t *testing.T) {
 	logLevel, err := ValidateLogLevel("unknownLogLevel")
-	assert.Equal(t, "", logLevel)
+	assert.Equal(t, Off, logLevel)
 	assert.Error(t, err)
 	assert.Equal(t, "unknown log level: "+strings.ToLower("unknownLogLevel"), err.Error())
 }

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
 
-func changeLogLevel(level string) error {
+func changeLogLevel(level LogLevel) error {
 	return logger.changeLogLevel(level)
 }
 
@@ -52,7 +52,7 @@ func TestBasicLogging(t *testing.T) {
 	l, err := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %ExtraTextContext%Msg\n")
 	assert.NoError(t, err)
 
-	SetupLogger(l, "debug")
+	SetupLogger(l, DebugLvl)
 	assert.NotNil(t, logger.Load())
 
 	Tracef("%s", "foo")
@@ -118,7 +118,7 @@ func TestLogBuffer(t *testing.T) {
 	Errorf("%s", "foo")
 	Criticalf("%s", "foo")
 
-	SetupLogger(l, "debug")
+	SetupLogger(l, DebugLvl)
 	assert.NotNil(t, logger.Load())
 
 	w.Flush()
@@ -144,7 +144,7 @@ func TestLogBufferWithContext(t *testing.T) {
 	Errorc("baz", "number", 1, "str", "hello")
 	Criticalc("baz", "number", 1, "str", "hello")
 
-	SetupLogger(l, "debug")
+	SetupLogger(l, DebugLvl)
 	assert.NotNil(t, logger.Load())
 	w.Flush()
 
@@ -173,7 +173,7 @@ func TestCredentialScrubbingLogging(t *testing.T) {
 	l, err := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.NoError(t, err)
 
-	SetupLogger(l, "info")
+	SetupLogger(l, InfoLvl)
 	assert.NotNil(t, logger.Load())
 
 	Info("don't tell anyone: ", "SECRET")
@@ -216,11 +216,11 @@ func TestWarnNotNil(t *testing.T) {
 	assert.NotNil(t, Warn("test"))
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, CriticalLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "critical")
+	SetupLogger(l, CriticalLvl)
 
 	assert.NotNil(t, Warn("test"))
 
-	changeLogLevel("info")
+	changeLogLevel(InfoLvl)
 
 	assert.NotNil(t, Warn("test"))
 }
@@ -232,11 +232,11 @@ func TestWarnfNotNil(t *testing.T) {
 	assert.NotNil(t, Warn("test"))
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, CriticalLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "critical")
+	SetupLogger(l, CriticalLvl)
 
 	assert.NotNil(t, Warn("test"))
 
-	changeLogLevel("info")
+	changeLogLevel(InfoLvl)
 
 	assert.NotNil(t, Warn("test"))
 }
@@ -249,11 +249,11 @@ func TestWarncNotNil(t *testing.T) {
 
 	seelog.RegisterCustomFormatter("ExtraTextContext", createExtraTextContext)
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, CriticalLvl, "[%LEVEL] %FuncShort: %ExtraTextContext%Msg")
-	SetupLogger(l, "critical")
+	SetupLogger(l, CriticalLvl)
 
 	assert.NotNil(t, Warnc("test", "key", "val"))
 
-	changeLogLevel("info")
+	changeLogLevel(InfoLvl)
 
 	assert.NotNil(t, Warnc("test", "key", "val"))
 }
@@ -265,11 +265,11 @@ func TestErrorNotNil(t *testing.T) {
 	assert.NotNil(t, Error("test"))
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, CriticalLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "critical")
+	SetupLogger(l, CriticalLvl)
 
 	assert.NotNil(t, Error("test"))
 
-	changeLogLevel("info")
+	changeLogLevel(InfoLvl)
 
 	assert.NotNil(t, Error("test"))
 }
@@ -281,11 +281,11 @@ func TestErrorfNotNil(t *testing.T) {
 	assert.NotNil(t, Errorf("test"))
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, CriticalLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "critical")
+	SetupLogger(l, CriticalLvl)
 
 	assert.NotNil(t, Errorf("test"))
 
-	changeLogLevel("info")
+	changeLogLevel(InfoLvl)
 
 	assert.NotNil(t, Errorf("test"))
 }
@@ -298,11 +298,11 @@ func TestErrorcNotNil(t *testing.T) {
 
 	seelog.RegisterCustomFormatter("ExtraTextContext", createExtraTextContext)
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, CriticalLvl, "[%LEVEL] %FuncShort: %ExtraTextContext%Msg")
-	SetupLogger(l, "critical")
+	SetupLogger(l, CriticalLvl)
 
 	assert.NotNil(t, Errorc("test", "key", "val"))
 
-	changeLogLevel("info")
+	changeLogLevel(InfoLvl)
 
 	assert.NotNil(t, Errorc("test", "key", "val"))
 }
@@ -314,7 +314,7 @@ func TestCriticalNotNil(t *testing.T) {
 	assert.NotNil(t, Critical("test"))
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, InfoLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "info")
+	SetupLogger(l, InfoLvl)
 
 	assert.NotNil(t, Critical("test"))
 }
@@ -326,7 +326,7 @@ func TestCriticalfNotNil(t *testing.T) {
 	assert.NotNil(t, Criticalf("test"))
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, InfoLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "info")
+	SetupLogger(l, InfoLvl)
 
 	assert.NotNil(t, Criticalf("test"))
 }
@@ -339,7 +339,7 @@ func TestCriticalcNotNil(t *testing.T) {
 
 	seelog.RegisterCustomFormatter("ExtraTextContext", createExtraTextContext)
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, InfoLvl, "[%LEVEL] %FuncShort: %ExtraTextContext%Msg")
-	SetupLogger(l, "info")
+	SetupLogger(l, InfoLvl)
 
 	assert.NotNil(t, Criticalc("test", "key", "val"))
 }
@@ -349,7 +349,7 @@ func TestDebugFuncNoExecute(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, InfoLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "info")
+	SetupLogger(l, InfoLvl)
 
 	i := 0
 	DebugFunc(func() string { i = 1; return "hello" })
@@ -365,7 +365,7 @@ func TestDebugFuncExecute(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupLogger(l, "debug")
+	SetupLogger(l, DebugLvl)
 
 	i := 0
 	DebugFunc(func() string {
@@ -382,29 +382,28 @@ func TestDebugFuncExecute(t *testing.T) {
 func TestFuncVersions(t *testing.T) {
 	cases := []struct {
 		seelogLevel        LogLevel
-		strLogLevel        string
 		logFunc            func(func() string)
 		expectedToBeCalled bool
 	}{
-		{ErrorLvl, "error", DebugFunc, false},
-		{WarnLvl, "warn", DebugFunc, false},
-		{InfoLvl, "info", DebugFunc, false},
-		{DebugLvl, "debug", DebugFunc, true},
-		{TraceLvl, "trace", DebugFunc, true},
+		{ErrorLvl, DebugFunc, false},
+		{WarnLvl, DebugFunc, false},
+		{InfoLvl, DebugFunc, false},
+		{DebugLvl, DebugFunc, true},
+		{TraceLvl, DebugFunc, true},
 
-		{TraceLvl, "trace", TraceFunc, true},
-		{InfoLvl, "info", TraceFunc, false},
+		{TraceLvl, TraceFunc, true},
+		{InfoLvl, TraceFunc, false},
 
-		{InfoLvl, "info", InfoFunc, true},
-		{WarnLvl, "warn", InfoFunc, false},
+		{InfoLvl, InfoFunc, true},
+		{WarnLvl, InfoFunc, false},
 
-		{WarnLvl, "warn", WarnFunc, true},
-		{ErrorLvl, "error", WarnFunc, false},
+		{WarnLvl, WarnFunc, true},
+		{ErrorLvl, WarnFunc, false},
 
-		{ErrorLvl, "error", ErrorFunc, true},
-		{CriticalLvl, "critical", ErrorFunc, false},
+		{ErrorLvl, ErrorFunc, true},
+		{CriticalLvl, ErrorFunc, false},
 
-		{CriticalLvl, "critical", CriticalFunc, true},
+		{CriticalLvl, CriticalFunc, true},
 	}
 
 	for _, tc := range cases {
@@ -412,7 +411,7 @@ func TestFuncVersions(t *testing.T) {
 		w := bufio.NewWriter(&b)
 
 		l, _ := LoggerFromWriterWithMinLevelAndFormat(w, tc.seelogLevel, "[%LEVEL] %FuncShort: %Msg")
-		SetupLogger(l, tc.strLogLevel)
+		SetupLogger(l, tc.seelogLevel)
 
 		i := 0
 		tc.logFunc(func() string { i = 1; return "hello" })
@@ -435,26 +434,25 @@ func TestStackDepthfLogging(t *testing.T) {
 
 	cases := []struct {
 		seelogLevel        LogLevel
-		strLogLevel        string
 		expectedToBeCalled int
 	}{
-		{CriticalLvl, "critical", 1},
-		{ErrorLvl, "error", 2},
-		{WarnLvl, "warn", 3},
-		{InfoLvl, "info", 4},
-		{DebugLvl, "debug", 5},
-		{TraceLvl, "trace", 6},
+		{CriticalLvl, 1},
+		{ErrorLvl, 2},
+		{WarnLvl, 3},
+		{InfoLvl, 4},
+		{DebugLvl, 5},
+		{TraceLvl, 6},
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.strLogLevel, func(t *testing.T) {
+		t.Run(tc.seelogLevel.String(), func(t *testing.T) {
 			var b bytes.Buffer
 			w := bufio.NewWriter(&b)
 
 			l, err := LoggerFromWriterWithMinLevelAndFormat(w, tc.seelogLevel, "[%LEVEL] %Func: %Msg\n")
 			assert.NoError(t, err)
 
-			SetupLogger(l, tc.strLogLevel)
+			SetupLogger(l, tc.seelogLevel)
 
 			TracefStackDepth(stackDepth, "%s", "foo")
 			DebugfStackDepth(stackDepth, "%s", "foo")
@@ -502,7 +500,7 @@ func TestLoggerScrubbingCount(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	l, err := LoggerFromWriterWithMinLevelAndFormat(w, TraceLvl, "[%LEVEL] %FuncShort: %Msg")
 	require.NoError(t, err)
-	SetupLogger(l, "trace")
+	SetupLogger(l, TraceLvl)
 
 	testCases := []struct {
 		name  string
@@ -602,7 +600,7 @@ func TestLogNilInnerLogger(t *testing.T) {
 	// reset buffer state
 	logsBuffer = []func(){}
 
-	SetupLogger(Default(), DebugStr)
+	SetupLogger(Default(), DebugLvl)
 	logger.Load().inner = nil
 
 	Debug("message")
@@ -611,39 +609,29 @@ func TestLogNilInnerLogger(t *testing.T) {
 	assert.Equal(t, 1, len(logsBuffer))
 }
 
-func TestSetupLoggerWithUnknownLogLevel(t *testing.T) {
-	SetupLogger(Default(), "unknownLogLevel")
-
-	// providing an unknown log level sets the log level to InfoLvl
-	loggerLogLevel, _ := GetLogLevel()
-
-	assert.Equal(t, InfoLvl, loggerLogLevel)
-}
-
 func TestChangeLogLevel(t *testing.T) {
 	testCases := []struct {
-		logLevel    LogLevel
-		logLevelStr string
+		logLevel LogLevel
 	}{
-		{TraceLvl, TraceStr},
-		{DebugLvl, DebugStr},
-		{InfoLvl, InfoStr},
-		{WarnLvl, WarnStr},
-		{ErrorLvl, ErrorStr},
-		{CriticalLvl, CriticalStr},
-		{Off, OffStr},
+		{TraceLvl},
+		{DebugLvl},
+		{InfoLvl},
+		{WarnLvl},
+		{ErrorLvl},
+		{CriticalLvl},
+		{Off},
 	}
 
 	for _, tc := range testCases {
-		t.Run("change log level to "+tc.logLevelStr, func(t *testing.T) {
+		t.Run("change log level to "+tc.logLevel.String(), func(t *testing.T) {
 			var b bytes.Buffer
 			w := bufio.NewWriter(&b)
 
 			l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "")
 
-			SetupLogger(Default(), DebugStr)
+			SetupLogger(Default(), DebugLvl)
 
-			err := ChangeLogLevel(l, tc.logLevelStr)
+			err := ChangeLogLevel(l, tc.logLevel)
 			assert.NoError(t, err)
 
 			// log level should have been updated
@@ -656,43 +644,25 @@ func TestChangeLogLevel(t *testing.T) {
 	}
 }
 
-func TestChangeLogLevelUnknownLevel(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-
-	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "")
-
-	SetupLogger(Default(), InfoStr)
-
-	err := ChangeLogLevel(l, "unknownLogLevel")
-	assert.Error(t, err)
-	assert.Equal(t, "bad log level", err.Error())
-
-	// log level and inner logger should not have changed
-	level, _ := GetLogLevel()
-	assert.Equal(t, InfoLvl, level)
-	assert.NotEqual(t, l, logger.Load().inner)
-}
-
 func TestChangeLogLevelNilLogger(t *testing.T) {
 	logger.Store(nil)
 
-	err := logger.changeLogLevel(InfoStr)
+	err := logger.changeLogLevel(InfoLvl)
 	assert.Error(t, err)
 	assert.Equal(t, "cannot change loglevel: logger not initialized", err.Error())
 }
 
 func TestChangeLogLevelNilInnerLogger(t *testing.T) {
-	SetupLogger(Default(), DebugStr)
+	SetupLogger(Default(), DebugLvl)
 	logger.Load().inner = nil
 
-	err := logger.changeLogLevel(InfoStr)
+	err := logger.changeLogLevel(InfoLvl)
 	assert.Error(t, err)
 	assert.Equal(t, "cannot change loglevel: logger is initialized however logger.inner is nil", err.Error())
 }
 
 func TestGetLogLevel(t *testing.T) {
-	SetupLogger(Default(), WarnStr)
+	SetupLogger(Default(), WarnLvl)
 
 	level, err := GetLogLevel()
 	assert.NoError(t, err)
@@ -709,7 +679,7 @@ func TestGetLogLevelNilLogger(t *testing.T) {
 }
 
 func TestGetLogLevelNilInnerLogger(t *testing.T) {
-	SetupLogger(Default(), DebugStr)
+	SetupLogger(Default(), DebugLvl)
 	logger.Load().inner = nil
 
 	level, err := GetLogLevel()
@@ -719,52 +689,52 @@ func TestGetLogLevelNilInnerLogger(t *testing.T) {
 }
 
 func TestShouldLog(t *testing.T) {
-	SetupLogger(Default(), TraceStr)
+	SetupLogger(Default(), TraceLvl)
 
 	testCases := []struct {
-		logLevelStr string
+		logLevel LogLevel
 		// expected results for each log level in the order
 		// [TraceLvl, DebugLvl, InfoLvl, WarnLvl, ErrorLvl, CriticalLvl, Off]
 		expectedShouldLog []bool
 	}{
 		{
-			TraceStr,
+			TraceLvl,
 			[]bool{true, true, true, true, true, true, true},
 		},
 		{
-			DebugStr,
+			DebugLvl,
 			[]bool{false, true, true, true, true, true, true},
 		},
 		{
-			InfoStr,
+			InfoLvl,
 			[]bool{false, false, true, true, true, true, true},
 		},
 		{
-			WarnStr,
+			WarnLvl,
 			[]bool{false, false, false, true, true, true, true},
 		},
 		{
-			ErrorStr,
+			ErrorLvl,
 			[]bool{false, false, false, false, true, true, true},
 		},
 		{
-			CriticalStr,
+			CriticalLvl,
 			[]bool{false, false, false, false, false, true, true},
 		},
 		{
-			OffStr,
+			Off,
 			[]bool{false, false, false, false, false, false, true},
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run("should log when log level is "+tc.logLevelStr, func(t *testing.T) {
-			changeLogLevel(tc.logLevelStr)
+		t.Run("should log when log level is "+tc.logLevel.String(), func(t *testing.T) {
+			changeLogLevel(tc.logLevel)
 
 			for i, logLevel := range []LogLevel{TraceLvl, DebugLvl, InfoLvl, WarnLvl, ErrorLvl, CriticalLvl, Off} {
 				shouldLog := ShouldLog(logLevel)
 				expected := tc.expectedShouldLog[i]
-				assert.Equal(t, expected, shouldLog, "expected ShouldLog(%s) to be %v when log level is %q", logLevel.String(), expected, tc.logLevelStr)
+				assert.Equal(t, expected, shouldLog, "expected ShouldLog(%s) to be %v when log level is %q", logLevel.String(), expected, tc.logLevel.String())
 			}
 		})
 	}
@@ -802,7 +772,7 @@ func TestValidateLogLevel(t *testing.T) {
 		t.Run("validate "+tc.logLevelStr, func(t *testing.T) {
 			valid, err := ValidateLogLevel(tc.logLevelStr)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expected, valid, "expected ValidateLogLevel(%s) to return %s", tc.logLevelStr, tc.expected)
+			assert.Equal(t, tc.expected, valid.String(), "expected ValidateLogLevel(%s) to return %s", tc.logLevelStr, tc.expected)
 		})
 	}
 }

--- a/pkg/util/log/log_test_init.go
+++ b/pkg/util/log/log_test_init.go
@@ -12,9 +12,13 @@ import (
 )
 
 func init() {
-	level := os.Getenv("DD_LOG_LEVEL")
-	if level == "" {
-		level = "debug"
+	lvl := DebugLvl
+	if level, ok := os.LookupEnv("DD_LOG_LEVEL"); ok {
+		logLevel, err := ValidateLogLevel(level)
+		if err == nil {
+			lvl = logLevel
+		}
 	}
-	SetupLogger(Default(), level)
+
+	SetupLogger(Default(), lvl)
 }

--- a/pkg/util/log/setup/log_nix_test.go
+++ b/pkg/util/log/setup/log_nix_test.go
@@ -10,8 +10,10 @@ package logs
 import (
 	"testing"
 
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/stretchr/testify/assert"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestGetSyslogURI(t *testing.T) {
@@ -37,7 +39,7 @@ func TestGetSyslogURI(t *testing.T) {
 func TestSetupLoggingNowhere(t *testing.T) {
 	// setup logger so that it logs nowhere: i.e.  not to file, not to syslog, not to console
 	mockConfig := configmock.New(t)
-	seelogConfig, _ = buildLoggerConfig("agent", "info", "", "", false, false, false, mockConfig)
+	seelogConfig, _ = buildLoggerConfig("agent", log.InfoLvl, "", "", false, false, false, mockConfig)
 	loggerInterface, err := GenerateLoggerInterface(seelogConfig)
 
 	assert.Nil(t, loggerInterface)

--- a/pkg/util/log/wrapper_test.go
+++ b/pkg/util/log/wrapper_test.go
@@ -25,7 +25,7 @@ func TestWrapperMethods(t *testing.T) {
 	w := bufio.NewWriter(&b)
 
 	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %Msg\n")
-	SetupLogger(l, DebugStr)
+	SetupLogger(l, DebugLvl)
 
 	// log messages using the wrapper
 	wrapper := NewWrapper(3)

--- a/pkg/util/log/zap/zapcore_test.go
+++ b/pkg/util/log/zap/zapcore_test.go
@@ -50,37 +50,37 @@ func TestZapBasicLogging(t *testing.T) {
 	tests := []struct {
 		desc    string
 		log     func(*zap.Logger)
-		level   string
+		level   log.LogLevel
 		message string
 	}{
 		{
 			desc:    "Debug (no fields, debug level)",
 			log:     func(l *zap.Logger) { l.Debug("Simple message") },
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[DEBUG] | test/zapcore_test.go | Simple message",
 		},
 		{
 			desc:    "Info (no fields, debug level)",
 			log:     func(l *zap.Logger) { l.Info("Simple message") },
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[INFO] | test/zapcore_test.go | Simple message",
 		},
 		{
 			desc:    "Warn (no fields, debug level)",
 			log:     func(l *zap.Logger) { l.Warn("Simple message") },
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[WARN] | test/zapcore_test.go | Simple message",
 		},
 		{
 			desc:    "Error (no fields, debug level)",
 			log:     func(l *zap.Logger) { l.Error("Simple message") },
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[ERROR] | test/zapcore_test.go | Simple message",
 		},
 		{
 			desc:    "DPanic (no fields, debug level)",
 			log:     func(l *zap.Logger) { l.DPanic("Development panic") },
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[CRITICAL] | test/zapcore_test.go | Development panic",
 		},
 		{
@@ -90,19 +90,19 @@ func TestZapBasicLogging(t *testing.T) {
 				l.Info("Simple message")
 				l.Warn("Simple message")
 			},
-			level:   "error",
+			level:   log.ErrorLvl,
 			message: "",
 		},
 		{
 			desc:    "Info (fields)",
 			log:     func(l *zap.Logger) { l.Info("Fields", zap.Int("int", 1), zap.String("key", "val")) },
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[INFO] | test/zapcore_test.go | int:1, key:val | Fields",
 		},
 		{
 			desc:    "Error (fields)",
 			log:     func(l *zap.Logger) { l.Error("Fields", zap.Error(fmt.Errorf("an error"))) },
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[ERROR] | test/zapcore_test.go | error:an error | Fields",
 		},
 		{
@@ -111,7 +111,7 @@ func TestZapBasicLogging(t *testing.T) {
 				_ = l.With(zap.Int16("int", 1))
 				l.Info("Fields", zap.Bool("bool", true))
 			},
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[INFO] | test/zapcore_test.go | bool:true | Fields",
 		},
 		{
@@ -120,13 +120,13 @@ func TestZapBasicLogging(t *testing.T) {
 				extra := l.With(zap.Int16("int", 1))
 				extra.Info("Fields", zap.Bool("bool", true))
 			},
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[INFO] | test/zapcore_test.go | int:1, bool:true | Fields",
 		},
 		{
 			desc:    "Namespace",
 			log:     func(l *zap.Logger) { l.Info("Fields", zap.Namespace("ns"), zap.Int("int", 1)) },
-			level:   "debug",
+			level:   log.DebugLvl,
 			message: "[INFO] | test/zapcore_test.go | ns/int:1 | Fields",
 		},
 	}

--- a/pkg/util/winutil/eventlog/subscription/subscription_test.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription_test.go
@@ -31,7 +31,7 @@ var debuglogFlag = flag.Bool("debuglog", false, "Enable seelog debug logging")
 func optEnableDebugLogging() {
 	// Enable logger
 	if *debuglogFlag {
-		pkglog.SetupLogger(pkglog.Default(), "debug")
+		pkglog.SetupLogger(pkglog.Default(), pkglog.DebugLvl)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
- Update `SetupLogger` and `ChangeLogLevel` in `pkg/util/log` to take `LogLevel` instead of strings. `pkg/util/log/setup` still uses strings though.
- Remove the `LogLevelFromString` function in favor of `ValidateLogLevel` (which does extra handling), as having the two was error prone
- `ValidateLogLevel` returns a `LogLevel` instead of a `string`

### Motivation
Make the package api more type safe, and improve isolation for when we change the underlying logger.

### Describe how you validated your changes
CI. 
No functional changes expected.

### Additional Notes
Most changes are in tests, which use a constant log level anyway.
Other changes are `cmd/serverless/main.go` (which also has some specific logic to pick the log level) and `pkg/util/log` itself.
