### PR TITLE
service discovery: Remove unused field

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -694,7 +694,6 @@ func makeModelService(pid int32, name string) model.Service {
 				ServiceName:    name + "-service",
 			},
 		},
-		DDService:          "dd-model-" + name,
 		TCPPorts:           []uint16{3000, 4000},
 		APMInstrumentation: true,
 		Language:           "python",

--- a/pkg/collector/corechecks/servicediscovery/model/model.go
+++ b/pkg/collector/corechecks/servicediscovery/model/model.go
@@ -18,7 +18,6 @@ type Service struct {
 	GeneratedNameSource      string                          `json:"generated_name_source"`
 	AdditionalGeneratedNames []string                        `json:"additional_generated_names"`
 	TracerMetadata           []tracermetadata.TracerMetadata `json:"tracer_metadata,omitempty"`
-	DDService                string                          `json:"dd_service"`
 	TCPPorts                 []uint16                        `json:"tcp_ports,omitempty"`
 	UDPPorts                 []uint16                        `json:"udp_ports,omitempty"`
 	APMInstrumentation       bool                            `json:"apm_instrumentation"`


### PR DESCRIPTION
### What does this PR do?

The DDService field is not used and was replaced by UST.Service.

### Motivation

Code clean up.

### Describe how you validated your changes

Covered by existing tests.
