### PR TITLE
Fix escape sequences in macOS DMG build script

### DIFF
--- a/.gitlab/build/package_build/build_agent_dmg.sh
+++ b/.gitlab/build/package_build/build_agent_dmg.sh
@@ -124,7 +124,7 @@ echo Built packages using omnibus
 
 # --- Notarization ---
 if [ "$SIGN" = true ]; then
-    echo -e "\e[0Ksection_start:`date +%s`:notarization\r\e[0KDoing notarization"
+    printf "\033[0Ksection_start:%s:notarization\r\033[0KDoing notarization\n" "$(date +%s)"
     unset LATEST_DMG
 
     # Find latest .dmg file in $GOPATH/src/github.com/Datadog/datadog-agent/omnibus/pkg
@@ -173,7 +173,7 @@ if [ "$SIGN" = true ]; then
     }
     export -f check_notarization_status
     tools/ci/retry.sh -n "$NOTARIZATION_ATTEMPTS" check_notarization_status "$SUBMISSION_ID"
-    echo -e "\e[0Ksection_end:`date +%s`:notarization\r\e[0K"
+    printf "\033[0Ksection_end:%s:notarization\r\033[0K\n" "$(date +%s)"
 fi
 
 if [ "$SIGN" = true ]; then


### PR DESCRIPTION
### What does this do?
Replace `echo -e "\e..."` with `printf "\033...\n"` for GitLab CI section markers in the macOS DMG build script.

### Motivation
The `\e` escape sequence is known to pose portability issues and is rendering literally in GitLab CI console output instead of being interpreted as ANSI escape codes. This causes section markers like `\e[0Ksection_start:...` to appear as raw text instead of creating collapsible sections ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1364468403#L1611)).

The `\033` octal notation is more portable across different bash versions and shell implementations.

### Describe how you validated your changes
Check GitLab CI job logs for macOS DMG builds: the "Doing notarization" section now renders as a properly collapsible section ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1369561937#L1854)) instead of showing raw escape sequences.