### PR TITLE
[incident-44652] Temporarily allow `agent_dmg-$arch-a7` jobs to fail

### DIFF
--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -22,6 +22,7 @@
     mkdir -p $GOMODCACHE
 
 .agent_dmg:
+  allow_failure: true  #incident-44652
   stage: package_build
   needs: ["go_mod_tidy_check"]
   rules:


### PR DESCRIPTION
### What does this PR do?
This is to temporarily allow `agent_dmg-$arch-a7` jobs to fail until the Apple subscription for notarization requests is renewed.

### Motivation
#incident-44652.
The Apple subscription for notarization requests expired and is being renewed, which might take some more hours.