### PR TITLE
[CWS] skip capabilities test on recent kernels

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -103,6 +103,8 @@ var (
 	Kernel6_10 = kernel.VersionCode(6, 10, 0)
 	// Kernel6_11 is the KernelVersion representation of kernel version 6.11
 	Kernel6_11 = kernel.VersionCode(6, 11, 0)
+	// Kernel6_14 is the KernelVersion representation of kernel version 6.14
+	Kernel6_14 = kernel.VersionCode(6, 14, 0)
 )
 
 // Version defines a kernel version helper

--- a/pkg/security/tests/capabilities_test.go
+++ b/pkg/security/tests/capabilities_test.go
@@ -33,6 +33,10 @@ func TestCapabilitiesEvent(t *testing.T) {
 		return !kv.HasBPFForEachMapElemHelper()
 	})
 
+	checkKernelCompatibility(t, "no override_creds/restore_creds", func(kv *kernel.Version) bool {
+		return kv.Code >= kernel.Kernel6_14
+	})
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_capabilities_used_exec_flush",


### PR DESCRIPTION
### What does this PR do?

override_creds/restore_creds are `static inline` on recent kernels, making them unhookable and preventing the probe from starting when capabilities capture is enabled. Let's skip this test for now on recent kernels. 

### Motivation

### Describe how you validated your changes

### Additional Notes
