### PR TITLE
[CWS] un-split `TestNetDevice`

### DIFF
--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -67,88 +67,87 @@ func TestNetDevice(t *testing.T) {
 		_ = exec.Command(executable, "link", "delete", "host-eth0").Run()
 	}()
 
-	t.Run("register_netdevice", func(t *testing.T) {
-		err = test.GetProbeEvent(func() error {
-			cmd := exec.Command(executable, "netns", "add", "test_netns")
-			if err = cmd.Run(); err != nil {
-				return err
-			}
+	// those tests are dependend on each other, they can't be run in isolation
 
-			// retrieve new netnsid
-			fi, err := os.Stat("/var/run/netns/test_netns")
-			if err != nil {
-				return err
-			}
-			stat, ok := fi.Sys().(*syscall.Stat_t)
-			if !ok {
-				return fmt.Errorf("couldn't parse test_netns inum")
-			}
-			testNetns = uint32(stat.Ino)
-
-			return nil
-		}, func(event *model.Event) bool {
-			if !assert.Equal(t, "net_device", event.GetType(), "wrong event type") {
-				return true
-			}
-
-			return assert.Equal(t, "lo", event.NetDevice.Device.Name, "wrong interface name") &&
-				assert.Equal(t, testNetns, event.NetDevice.Device.NetNS, "wrong network namespace ID")
-		}, 3*time.Second, model.NetDeviceEventType)
-		if err != nil {
-			t.Error(err)
-		}
-	})
-
-	t.Run("veth_newlink", func(t *testing.T) {
-		err = test.GetProbeEvent(func() error {
-			cmd := exec.Command(executable, "link", "add", "host-eth0", "type", "veth", "peer", "name", "ns-eth0", "netns", "test_netns")
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				t.Logf("ip output: %s", string(out))
-			}
+	// register_netdevice
+	err = test.GetProbeEvent(func() error {
+		cmd := exec.Command(executable, "netns", "add", "test_netns")
+		if err = cmd.Run(); err != nil {
 			return err
-		}, func(event *model.Event) bool {
-			if !assert.Equal(t, "veth_pair", event.GetType(), "wrong event type") {
-				return true
-			}
-
-			return assert.Equal(t, "host-eth0", event.VethPair.HostDevice.Name, "wrong interface name") &&
-				assert.Equal(t, currentNetns, event.VethPair.HostDevice.NetNS, "wrong network namespace ID") &&
-				assert.Equal(t, "ns-eth0", event.VethPair.PeerDevice.Name, "wrong peer interface name") &&
-				assert.Equal(t, testNetns, event.VethPair.PeerDevice.NetNS, "wrong peer network namespace ID")
-		}, 10*time.Second, model.VethPairEventType)
-		if err != nil {
-			t.Error(err)
 		}
-	})
 
-	t.Run("veth_newlink_dev_change_netns", func(t *testing.T) {
-		err = test.GetProbeEvent(func() error {
-			cmd := exec.Command(executable, "link", "add", "host-eth1", "type", "veth", "peer", "name", "ns-eth1")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("couldn't create veth pair (out=%s): %w", string(out), err)
-			}
-
-			cmd = exec.Command(executable, "link", "set", "ns-eth1", "netns", "test_netns")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("couldn't set netns (out=%s): %w", string(out), err)
-			}
-
-			return nil
-		}, func(event *model.Event) bool {
-			if !assert.Equal(t, "veth_pair_ns", event.GetType(), "wrong event type") {
-				return true
-			}
-
-			return assert.Equal(t, "host-eth1", event.VethPair.HostDevice.Name, "wrong interface name") &&
-				assert.Equal(t, currentNetns, event.VethPair.HostDevice.NetNS, "wrong network namespace ID") &&
-				assert.Equal(t, "ns-eth1", event.VethPair.PeerDevice.Name, "wrong peer interface name") &&
-				assert.Equal(t, testNetns, event.VethPair.PeerDevice.NetNS, "wrong peer network namespace ID")
-		}, 10*time.Second, model.VethPairNsEventType)
+		// retrieve new netnsid
+		fi, err := os.Stat("/var/run/netns/test_netns")
 		if err != nil {
-			t.Error(err)
+			return err
 		}
-	})
+		stat, ok := fi.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("couldn't parse test_netns inum")
+		}
+		testNetns = uint32(stat.Ino)
+
+		return nil
+	}, func(event *model.Event) bool {
+		if !assert.Equal(t, "net_device", event.GetType(), "wrong event type") {
+			return true
+		}
+
+		return assert.Equal(t, "lo", event.NetDevice.Device.Name, "wrong interface name") &&
+			assert.Equal(t, testNetns, event.NetDevice.Device.NetNS, "wrong network namespace ID")
+	}, 3*time.Second, model.NetDeviceEventType)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// veth_newlink
+	err = test.GetProbeEvent(func() error {
+		cmd := exec.Command(executable, "link", "add", "host-eth0", "type", "veth", "peer", "name", "ns-eth0", "netns", "test_netns")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Logf("ip output: %s", string(out))
+		}
+		return err
+	}, func(event *model.Event) bool {
+		if !assert.Equal(t, "veth_pair", event.GetType(), "wrong event type") {
+			return true
+		}
+
+		return assert.Equal(t, "host-eth0", event.VethPair.HostDevice.Name, "wrong interface name") &&
+			assert.Equal(t, currentNetns, event.VethPair.HostDevice.NetNS, "wrong network namespace ID") &&
+			assert.Equal(t, "ns-eth0", event.VethPair.PeerDevice.Name, "wrong peer interface name") &&
+			assert.Equal(t, testNetns, event.VethPair.PeerDevice.NetNS, "wrong peer network namespace ID")
+	}, 10*time.Second, model.VethPairEventType)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// veth_newlink_dev_change_netns
+	err = test.GetProbeEvent(func() error {
+		cmd := exec.Command(executable, "link", "add", "host-eth1", "type", "veth", "peer", "name", "ns-eth1")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("couldn't create veth pair (out=%s): %w", string(out), err)
+		}
+
+		cmd = exec.Command(executable, "link", "set", "ns-eth1", "netns", "test_netns")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("couldn't set netns (out=%s): %w", string(out), err)
+		}
+
+		return nil
+	}, func(event *model.Event) bool {
+		if !assert.Equal(t, "veth_pair_ns", event.GetType(), "wrong event type") {
+			return true
+		}
+
+		return assert.Equal(t, "host-eth1", event.VethPair.HostDevice.Name, "wrong interface name") &&
+			assert.Equal(t, currentNetns, event.VethPair.HostDevice.NetNS, "wrong network namespace ID") &&
+			assert.Equal(t, "ns-eth1", event.VethPair.PeerDevice.Name, "wrong peer interface name") &&
+			assert.Equal(t, testNetns, event.VethPair.PeerDevice.NetNS, "wrong peer network namespace ID")
+	}, 10*time.Second, model.VethPairNsEventType)
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestTCFilters(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

The current 3 sub-tests of `TestNetDevice` are not independent, you can't run them on their owns. As such this PR un-split them making `TestNetDevice` a big test on it's own. This PR also improves the error reporting when the `ip` command fails.

### Motivation

### Describe how you validated your changes

### Additional Notes
