### PR TITLE
[autodiscovery/providers/kube_endpoints_file] Fix flaky test

### DIFF
--- a/comp/core/autodiscovery/providers/kube_endpoints_file_test.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file_test.go
@@ -311,7 +311,7 @@ func TestStoreGenerateConfigs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &store{epConfigs: tt.epConfigs}
 
-			assert.EqualValues(t, tt.want, s.generateConfigs())
+			assert.ElementsMatch(t, tt.want, s.generateConfigs())
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky test in `comp/core/autodiscovery/providers/kube_endpoints_file_test.go`
The test was assuming order in an array when it should not.

### Describe how you validated your changes

CI
