### PR TITLE
[ddot] byoc: update dockerfile + tasks backport

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -1,5 +1,5 @@
 ARG AGENT_REPO=datadog/agent
-ARG AGENT_VERSION=7.65.2
+ARG AGENT_VERSION=7.65.2-full
 ARG AGENT_BRANCH=7.65.2
 # Use the Ubuntu Slim AMD64 base image
 FROM ubuntu:24.04 AS builder

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -1,6 +1,6 @@
-ARG AGENT_REPO=datadog/agent-dev
-ARG AGENT_VERSION=nightly-full-main-jmx
-ARG AGENT_BRANCH=main
+ARG AGENT_REPO=datadog/agent
+ARG AGENT_VERSION=7.65.2
+ARG AGENT_BRANCH=7.65.2
 # Use the Ubuntu Slim AMD64 base image
 FROM ubuntu:24.04 AS builder
 

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -28,7 +28,7 @@ def byoc_release(ctx, image=DDOT_DEV_AGENT_TAG, branch=DDOT_DEV_AGENT_BRANCH, re
 
     with open(DDOT_BYOC_DOCKERFILE, 'w') as file:
         for line in contents:
-            if re.search("^ARG AGENT_VERSION=.*$", line):
+            if re.search("^ARG AGENT_REPO=.*$", line):
                 line = f"ARG AGENT_REPO={repo}\n"
             elif re.search("^ARG AGENT_VERSION=.*$", line):
                 line = f"ARG AGENT_VERSION={image}\n"

--- a/tasks/unit_tests/otel_agent_tests.py
+++ b/tasks/unit_tests/otel_agent_tests.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import call, mock_open, patch
+
+from invoke import Context
+
+import tasks.otel_agent as otel_agent
+
+
+class TestOTelAgentTasks(unittest.TestCase):
+    dockerfile = None
+
+    def setUp(self):
+        with open(otel_agent.DDOT_BYOC_DOCKERFILE) as f:
+            self.dockerfile = f.read()
+
+    def tearDown(self):
+        pass
+
+    def assert_mock_with_calls(self, mock, calls):
+        all_calls = mock.mock_calls
+        for c in calls:
+            if c not in all_calls:
+                return False
+
+        return True
+
+    def test_byoc_release(self):
+        image = "foo"
+        branch = "x.y.z"
+        repo = "bar"
+
+        c = Context()
+        m = mock_open(read_data=self.dockerfile)
+        with patch("builtins.open", m):
+            otel_agent.byoc_release(c, image=image, branch=branch, repo=repo)
+
+        expected_calls = [
+            call(otel_agent.DDOT_BYOC_DOCKERFILE, "w"),
+            call().write(f"ARG AGENT_REPO={repo}\n"),
+            call().write(f"ARG AGENT_VERSION={image}\n"),
+            call().write(f"ARG AGENT_BRANCH={branch}\n"),
+        ]
+
+        self.assertEqual(self.assert_mock_with_calls(m, expected_calls), True)


### PR DESCRIPTION
### What does this PR do?
This PR updated the BYOC dockerfile in the release branch to point to the correct stable references for the branch. 

This PR also backports an invoke task that may help in future releases (however unlikely that may be at this stage).

### Motivation
Currently customers need to jump through additional hoops and may inadvertently build an unstable image.

### Describe how you validated your changes
Following the steps described [here](https://docs.datadoghq.com/opentelemetry/setup/ddot_collector/custom_components/), but using the correct docker and manifest file references (documentation to be updated accordingly). Just pull the dockerfile changed here, and the manifest file in this branch and run:

```
docker build . -t agent-ddot --no-cache
```

The build will succeed and be built on top of the correct image.

### Additional Notes
