### PR TITLE
Fix omnibus PATH being shadowed and using incorrect separator on Windows

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -47,19 +47,14 @@ build do
   # in particular it ignores the PATH from the environment given as argument
   # so we need to call it before setting the PATH
   env = with_embedded_path()
-  if windows_target?
-    env = {
-        'GOPATH' => gopath.to_path,
-        'PATH' => "#{gopath.to_path}/bin;#{env['PATH']}",
-    }
-  else
-    env = {
-        'GOPATH' => gopath.to_path,
-        'PATH' => "#{gopath.to_path}/bin:#{env['PATH']}",
-        "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-        "CGO_CFLAGS" => "-I. -I#{install_dir}/embedded/include",
-        "CGO_LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
-    }
+  env = {
+    'GOPATH' => gopath.to_path,
+    'PATH' => ["#{gopath.to_path}/bin", env['PATH']].join(File::PATH_SEPARATOR),
+  }
+  unless windows_target?
+    env['LDFLAGS'] = "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
+    env['CGO_CFLAGS'] = "-I. -I#{install_dir}/embedded/include"
+    env['CGO_LDFLAGS'] = "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
   end
 
   unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -41,15 +41,21 @@ build do
   gopath = Pathname.new(project_dir) + '../../../..'
   flavor_arg = ENV['AGENT_FLAVOR']
   fips_args = fips_mode? ? "--fips-mode" : ""
+  # include embedded path (mostly for `pkg-config` binary)
+  #
+  # with_embedded_path prepends the embedded path to the PATH from the global environment
+  # in particular it ignores the PATH from the environment given as argument
+  # so we need to call it before setting the PATH
+  env = with_embedded_path()
   if windows_target?
     env = {
         'GOPATH' => gopath.to_path,
-        'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
+        'PATH' => "#{gopath.to_path}/bin;#{env['PATH']}",
     }
   else
     env = {
         'GOPATH' => gopath.to_path,
-        'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
+        'PATH' => "#{gopath.to_path}/bin:#{env['PATH']}",
         "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
         "CGO_CFLAGS" => "-I. -I#{install_dir}/embedded/include",
         "CGO_LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
@@ -61,8 +67,7 @@ build do
     env["GOMODCACHE"] = gomodcache.to_path
   end
 
-  # include embedded path (mostly for `pkg-config` binary)
-  env = with_standard_compiler_flags(with_embedded_path(env))
+  env = with_standard_compiler_flags(env)
 
   # Use msgo toolchain when fips mode is enabled
   if fips_mode?

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -16,10 +16,17 @@ build do
 
   # set GOPATH on the omnibus source dir for this software
   gopath = Pathname.new(project_dir) + '../../../..'
-  env = {
-    'GOPATH' => gopath.to_path,
-    'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
-  }
+  if windows_target?
+    env = {
+      'GOPATH' => gopath.to_path,
+      'PATH' => "#{gopath.to_path}/bin;#{ENV['PATH']}",
+    }
+  else
+    env = {
+      'GOPATH' => gopath.to_path,
+      'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
+    }
+  end
 
   unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
     gomodcache = Pathname.new(ENV["OMNIBUS_GOMODCACHE"])

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -16,17 +16,10 @@ build do
 
   # set GOPATH on the omnibus source dir for this software
   gopath = Pathname.new(project_dir) + '../../../..'
-  if windows_target?
-    env = {
-      'GOPATH' => gopath.to_path,
-      'PATH' => "#{gopath.to_path}/bin;#{ENV['PATH']}",
-    }
-  else
-    env = {
-      'GOPATH' => gopath.to_path,
-      'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
-    }
-  end
+  env = {
+    'GOPATH' => gopath.to_path,
+    'PATH' => ["#{gopath.to_path}/bin", ENV['PATH']].join(File::PATH_SEPARATOR),
+  }
 
   unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
     gomodcache = Pathname.new(ENV["OMNIBUS_GOMODCACHE"])

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -26,7 +26,7 @@ build do
   env = with_embedded_path()
   env = {
     'GOPATH' => gopath.to_path,
-    'PATH' => ["#{gopath.to_path}/bin", ENV['PATH']].join(File::PATH_SEPARATOR),
+    'PATH' => ["#{gopath.to_path}/bin", env['PATH']].join(File::PATH_SEPARATOR),
   }
 
   unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -24,17 +24,10 @@ build do
   # in particular it ignores the PATH from the environment given as argument
   # so we need to call it before setting the PATH
   env = with_embedded_path()
-  if windows_target?
-    env = {
-      'GOPATH' => gopath.to_path,
-      'PATH' => "#{gopath.to_path}/bin;#{env['PATH']}",
-    }
-  else
-    env = {
-      'GOPATH' => gopath.to_path,
-      'PATH' => "#{gopath.to_path}/bin:#{env['PATH']}",
-    }
-  end
+  env = {
+    'GOPATH' => gopath.to_path,
+    'PATH' => ["#{gopath.to_path}/bin", ENV['PATH']].join(File::PATH_SEPARATOR),
+  }
 
   unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
     gomodcache = Pathname.new(ENV["OMNIBUS_GOMODCACHE"])

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -33,7 +33,7 @@ build do
     env = with_embedded_path()
     env = {
         'GOPATH' => gopath.to_path,
-        'PATH' => "#{gopath.to_path}/bin:#{env['PATH']}",
+        'PATH' => ["#{gopath.to_path}/bin", env['PATH']].join(File::PATH_SEPARATOR),
         "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
         "CGO_CFLAGS" => "-I. -I#{install_dir}/embedded/include",
         "CGO_LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -25,9 +25,15 @@ build do
     # set GOPATH on the omnibus source dir for this software
     gopath = Pathname.new(project_dir) + '../../../..'
 
+    # include embedded path (mostly for `pkg-config` binary)
+    #
+    # with_embedded_path prepends the embedded path to the PATH from the global environment
+    # in particular it ignores the PATH from the environment given as argument
+    # so we need to call it before setting the PATH
+    env = with_embedded_path()
     env = {
         'GOPATH' => gopath.to_path,
-        'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
+        'PATH' => "#{gopath.to_path}/bin:#{env['PATH']}",
         "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
         "CGO_CFLAGS" => "-I. -I#{install_dir}/embedded/include",
         "CGO_LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
@@ -38,8 +44,7 @@ build do
         env["GOMODCACHE"] = gomodcache.to_path
     end
 
-    # include embedded path (mostly for `pkg-config` binary)
-    env = with_standard_compiler_flags(with_embedded_path(env))
+    env = with_standard_compiler_flags(env)
 
     if windows_target?
       conf_dir = "#{install_dir}/etc/datadog-agent"

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -29,17 +29,10 @@ build do
   # in particular it ignores the PATH from the environment given as argument
   # so we need to call it before setting the PATH
   env = with_embedded_path()
-  if windows_target?
-    env = {
-      'GOPATH' => gopath.to_path,
-      'PATH' => "#{gopath.to_path}/bin;#{env['PATH']}",
-    }
-  else
-    env = {
-      'GOPATH' => gopath.to_path,
-      'PATH' => "#{gopath.to_path}/bin:#{env['PATH']}",
-    }
-  end
+  env = {
+    'GOPATH' => gopath.to_path,
+    'PATH' => ["#{gopath.to_path}/bin", env['PATH']].join(File::PATH_SEPARATOR),
+  }
 
   unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
     gomodcache = Pathname.new(ENV["OMNIBUS_GOMODCACHE"])

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -23,18 +23,28 @@ build do
   gopath = Pathname.new(project_dir) + '../../../..'
   etc_dir = "/etc/datadog-agent"
   gomodcache = Pathname.new("/modcache")
-  env = {
-    'GOPATH' => gopath.to_path,
-    'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
-  }
+  # include embedded path (mostly for `pkg-config` binary)
+  #
+  # with_embedded_path prepends the embedded path to the PATH from the global environment
+  # in particular it ignores the PATH from the environment given as argument
+  # so we need to call it before setting the PATH
+  env = with_embedded_path()
+  if windows_target?
+    env = {
+      'GOPATH' => gopath.to_path,
+      'PATH' => "#{gopath.to_path}/bin;#{env['PATH']}",
+    }
+  else
+    env = {
+      'GOPATH' => gopath.to_path,
+      'PATH' => "#{gopath.to_path}/bin:#{env['PATH']}",
+    }
+  end
 
   unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
     gomodcache = Pathname.new(ENV["OMNIBUS_GOMODCACHE"])
     env["GOMODCACHE"] = gomodcache.to_path
   end
-
-  # include embedded path (mostly for `pkg-config` binary)
-  env = with_embedded_path(env)
 
   if linux_target?
     command "invoke installer.build --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)


### PR DESCRIPTION
### What does this PR do?
This PR fixes two separate issues: `with_embedded_path` shadowing the provided `PATH` value, and using the incorrect path separator for Windows.

#### with_embedded_path
`with_embedded_path` is an omnibus function which preprends the embedded paths to the `PATH` environment variable, and adds the result to the given `env` map (and returns it).
In particular it doesn't read the value of `PATH` in the `env` argument, it just overrides it, so in our code every time we did the following, we ended up losing `gopath`

```rb
env = {
  'GOPATH' => gopath.to_path,
  'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
}
env = with_embedded_path(env)
```

Since `with_embedded_path` is only about `PATH` we can just call it before creating the `env`, ie. do the following instead:

```rb
env = with_embedded_path()
env = {
  'GOPATH' => gopath.to_path,
  'PATH' => "#{gopath.to_path}/bin:#{env['PATH']}",
}
```

#### Windows path separator
We used the wrong path separator on Windows, so even without the previous issue it wouldn't have worked, we need to use `;` instead of `:`. Overall using `File::PATH_SEPARATOR` avoids even having to think about it.

```rb
if windows_target?
  env = {
      'GOPATH' => gopath.to_path,
      'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
  }
else
```

### Motivation
Being able to use binaries installed in `GOPATH/bin`.

### Describe how you validated your changes
CI.

### Additional Notes
This has been like this for 6 years, I guess no one has needed to use binaries installed in `GOPATH/bin` before.
