### PR TITLE
Revert "[incident-44652] Temporarily allow `agent_dmg-$arch-a7` jobs to fail (#42225)"

### DIFF
--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -22,7 +22,6 @@
     mkdir -p $GOMODCACHE
 
 .agent_dmg:
-  allow_failure: true  #incident-44652
   stage: package_build
   needs: ["go_mod_tidy_check"]
   rules:


### PR DESCRIPTION
### What does this PR do?
Undo:
- #42225

### Motivation
Notarization requests work again.