### PR TITLE
[Serverless] Fix AAS Duplicated logs on restart

### DIFF
--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -34,6 +34,9 @@ const (
 	aasLoggingDescriptor  = "DD_AAS_INSTANCE_LOG_FILE_DESCRIPTOR"
 	sourceEnvVar          = "DD_SOURCE"
 	sourceName            = "Datadog Agent"
+	// Log files are persisted between instance restarts in AAS, so we want to start tailing logs from the end to prevent duplicates.
+	// For ephemeral environments (Cloud Run, Azure Container Apps, etc.), we also want "end".
+	tailingMode = "end"
 )
 
 // Config holds the log configuration
@@ -72,28 +75,29 @@ func SetupLogAgent(conf *Config, tags map[string]string, tagger tagger.Component
 }
 
 func addFileTailing(logsAgent logsAgent.ServerlessLogsAgent, source string, tags []string, origin string) {
-
 	appServiceDefaultLoggingEnabled := origin == "appservice" && isInstanceTailingEnabled()
 	// The Azure App Service log volume is shared across all instances. This leads to every instance tailing the same files.
 	// To avoid this, we want to add the azure instance ID to the filepath so each instance tails their respective system log files.
 	// Users can also add $COMPUTERNAME to their custom files to achieve the same result.
 	if appServiceDefaultLoggingEnabled {
 		src := sources.NewLogSource("aas-instance-file-tail", &logConfig.LogsConfig{
-			Type:    logConfig.FileType,
-			Path:    setAasInstanceTailingPath(),
-			Service: os.Getenv("DD_SERVICE"),
-			Tags:    tags,
-			Source:  source,
+			Type:        logConfig.FileType,
+			Path:        setAasInstanceTailingPath(),
+			TailingMode: tailingMode,
+			Service:     os.Getenv("DD_SERVICE"),
+			Tags:        tags,
+			Source:      source,
 		})
 		logsAgent.GetSources().AddSource(src)
 		// If we are not in Azure or the aas instance env var is not set, we fall back to the previous behavior
 	} else if filePath, set := os.LookupEnv(envVarTailFilePath); set {
 		src := sources.NewLogSource("serverless-file-tail", &logConfig.LogsConfig{
-			Type:    logConfig.FileType,
-			Path:    filePath,
-			Service: os.Getenv("DD_SERVICE"),
-			Tags:    tags,
-			Source:  source,
+			Type:        logConfig.FileType,
+			Path:        filePath,
+			TailingMode: tailingMode,
+			Service:     os.Getenv("DD_SERVICE"),
+			Tags:        tags,
+			Source:      source,
 		})
 		logsAgent.GetSources().AddSource(src)
 	}

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -61,3 +61,13 @@ func TestSetAasInstanceTailingPath(t *testing.T) {
 	t.Setenv("DD_AAS_INSTANCE_LOG_FILE_DESCRIPTOR", "_custominfix")
 	assert.Equal(t, "/home/LogFiles/*testInstance*_custominfix.log", setAasInstanceTailingPath())
 }
+
+func TestCreateFileTailingSourceUsesEndMode(t *testing.T) {
+	t.Setenv("DD_SERVERLESS_LOG_PATH", "/tmp/test.log")
+
+	src := createFileTailingSource("test-source", []string{"tag1"}, "appservice")
+
+	assert.NotNil(t, src)
+	assert.Equal(t, "end", src.Config.TailingMode)
+	assert.Equal(t, "/tmp/test.log", src.Config.Path)
+}

--- a/releasenotes/notes/fix-aas-duplicated-logs-on-restart-db12d988157ed60e.yaml
+++ b/releasenotes/notes/fix-aas-duplicated-logs-on-restart-db12d988157ed60e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix duplicated logs in Azure App Services after application restart.


### PR DESCRIPTION
### What does this PR do?

Duplicated logs were being sent after serverless-init restarts in Azure App Service (AAS) sidecar mode.

1. In the regular agent, file offsets are saved to `registry.json` to solve this problem. In AAS, the sidecar is stateless, so serverless-init uses [`NullAuditor`](https://github.com/DataDog/datadog-agent/blob/8a7d1f55fafcbcd097cdfca66f5d06dbea1d9e48/comp/logs/auditor/impl-none/auditor_noop.go#L31-L34) resulting in no offset persistence.
2. In AAS, a new log file is created each day, with a format such as `2025_10_22_*.log`. Wildcard file selection uses [reverse lexicographical ordering](https://github.com/DataDog/datadog-agent/blob/3d175eea8f79839b3855a74fb65e936af0ac68d2/pkg/logs/launchers/file/provider/file_provider.go#L344-L360), which prioritizes files with the most recent dates in their name. This prevents the agent from resending logs from old files, but it doesn't help with duplicates from today's log file.
3. When files are discovered during startup, they [default to beginning mode](https://github.com/DataDog/datadog-agent/blob/3d175eea8f79839b3855a74fb65e936af0ac68d2/pkg/logs/launchers/file/launcher.go#L304). 

Since we had no offset persistence and `beginning` tailing mode, all logs from today are resent on restart.

This change uses `TailingMode: end` for App Services. This means that on restart during file discovery, we ignore existing log lines in the log file.

### Motivation

https://datadoghq.atlassian.net/browse/SLES-2263

### Describe how you validated your changes

Deployed and tested manually on an Azure App Service container. 

### Additional Notes
