### PR TITLE
Drop expensive legacy ELF-based Go APM instrumentation detection

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/apm/detect.go
+++ b/pkg/collector/corechecks/servicediscovery/apm/detect.go
@@ -20,10 +20,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/language"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/usm"
 	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
-	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // Instrumentation represents the state of APM instrumentation for a service.
@@ -44,7 +42,6 @@ var (
 		language.Java:   javaDetector,
 		language.Node:   nodeDetector,
 		language.Python: pythonDetector,
-		language.Go:     goDetector,
 	}
 
 	nodeAPMCheckRegex = regexp.MustCompile(`"dd-trace"`)
@@ -64,52 +61,6 @@ func Detect(lang language.Language, ctx usm.DetectionContext, tracerMetadata *tr
 	}
 
 	return None
-}
-
-const (
-	// ddTraceGoPrefix(V2) is the prefix of the dd-trace-go symbols. The symbols
-	// we are looking for are for example:
-	//    gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.init
-	//  github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.init
-	//
-	// We use an infix instead of a specific symbol name in an attempt to make
-	// it future-proof.
-	ddTraceGoPrefix    = "gopkg.in/DataDog/dd-trace-go"
-	ddTraceGoPrefixV2  = "github.com/DataDog/dd-trace-go/v2/"
-	ddTraceGoMinLength = min(len(ddTraceGoPrefix), len(ddTraceGoPrefixV2))
-	ddTraceGoInfix     = "DataDog/dd-trace-go"
-
-	// ddTraceGoMaxLength is the maximum length of the dd-trace-go symbols which
-	// we look for. The max length is an optimization in bininspect to avoid
-	// reading unnecesssary symbols.  As of writing, most non-internal symbols
-	// in dd-trace-go are under 100 chars. The tracer.init example above at
-	// 51/53 chars is one of the shortest.
-	ddTraceGoMaxLength = 100
-)
-
-// goDetector detects APM instrumentation for Go binaries by checking for
-// the presence of the dd-trace-go symbols in the ELF. This only works for
-// unstripped binaries.
-func goDetector(ctx usm.DetectionContext) Instrumentation {
-	exePath := kernel.HostProc(strconv.Itoa(ctx.Pid), "exe")
-
-	elfFile, err := safeelf.Open(exePath)
-	if err != nil {
-		log.Debugf("Unable to open exe %s: %v", exePath, err)
-		return None
-	}
-	defer elfFile.Close()
-
-	if _, err = bininspect.GetAnySymbolWithInfix(elfFile, ddTraceGoInfix, ddTraceGoMinLength, ddTraceGoMaxLength); err == nil {
-		return Provided
-	}
-
-	// We failed to find symbols in the regular symbols section, now we can try the pclntab
-	if _, err = bininspect.GetAnySymbolWithInfixPCLNTAB(elfFile, ddTraceGoInfix, ddTraceGoMinLength, ddTraceGoMaxLength); err == nil {
-		return Provided
-	}
-	return None
-
 }
 
 func pythonDetectorFromMapsReader(reader io.Reader) Instrumentation {

--- a/pkg/collector/corechecks/servicediscovery/apm/detect_nix_test.go
+++ b/pkg/collector/corechecks/servicediscovery/apm/detect_nix_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/envs"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/usm"


### PR DESCRIPTION
### What does this PR do?
[DSCVR-211](https://datadoghq.atlassian.net/browse/DSCVR-211) : This PR removes the ELF-based Go APM detection (goDetector).
### Motivation
The ELF-based Go APM detection is CPU-intensive, consuming most of the service discovery resources. Since dd-trace-go now exposes a memfd, we can replace it to reduce overhead and simplify the system-probe.
### Describe how you validated your changes
Tested locally (also I have removed a test)
### Additional Notes


[DSCVR-211]: https://datadoghq.atlassian.net/browse/DSCVR-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ