### PR TITLE
UnmarshalKey can unmarshal to a map whose key is a type alias

### DIFF
--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -390,11 +390,13 @@ func copyMap(target reflect.Value, input nodetreemodel.Node, currPath []string, 
 		if child == nil {
 			continue
 		}
+		// Convert to the target key type, supports type aliases like map[ResourceType]string
+		realkey := reflect.ValueOf(mkey).Convert(ktype)
 		if scalar, ok := child.(nodetreemodel.LeafNode); ok {
 			if mval, err := cast.ToStringE(scalar.Get()); vtype == reflect.TypeOf("") && err == nil {
-				results.SetMapIndex(reflect.ValueOf(mkey), reflect.ValueOf(mval))
+				results.SetMapIndex(realkey, reflect.ValueOf(mval))
 			} else if bval, err := cast.ToBoolE(scalar.Get()); vtype == reflect.TypeOf(true) && err == nil {
-				results.SetMapIndex(reflect.ValueOf(mkey), reflect.ValueOf(bval))
+				results.SetMapIndex(realkey, reflect.ValueOf(bval))
 			} else {
 				elem := reflect.New(vtype).Elem()
 				nextPath := append(currPath, mkey)
@@ -402,7 +404,7 @@ func copyMap(target reflect.Value, input nodetreemodel.Node, currPath []string, 
 				if err != nil {
 					return err
 				}
-				results.SetMapIndex(reflect.ValueOf(mkey), elem)
+				results.SetMapIndex(realkey, elem)
 			}
 		}
 	}

--- a/pkg/config/structure/unmarshal_test.go
+++ b/pkg/config/structure/unmarshal_test.go
@@ -1629,3 +1629,24 @@ func TestUnmarshalKeyOnSliceOfMap(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []map[string]string{{"a": "1", "b": "1"}, {"a": "2", "b": "2"}}, data)
 }
+
+type ResourceType string
+
+type myStruct struct {
+	Resources map[ResourceType]string
+}
+
+func TestUnmarshalMapWithTypeAlias(t *testing.T) {
+	confYaml := `
+some_config:
+  resources:
+    memory: 5g
+`
+	mockConfig := newConfigFromYaml(t, confYaml)
+	mockConfig.SetKnown("some_config.resources.memory")
+
+	var res myStruct
+	err := unmarshalKeyReflection(mockConfig, "some_config", &res)
+	assert.NoError(t, err)
+	assert.Equal(t, map[ResourceType]string{"memory": "5g"}, res.Resources)
+}

--- a/pkg/config/structure/unmarshal_test.go
+++ b/pkg/config/structure/unmarshal_test.go
@@ -1643,7 +1643,7 @@ some_config:
     memory: 5g
 `
 	mockConfig := newConfigFromYaml(t, confYaml)
-	mockConfig.SetKnown("some_config.resources.memory")
+	mockConfig.SetKnown("some_config.resources.memory") //nolint:forbidigo, using SetKnown to test behavior
 
 	var res myStruct
 	err := unmarshalKeyReflection(mockConfig, "some_config", &res)


### PR DESCRIPTION
### What does this PR do?

UnmarshalKey can unmarshal to a map whose key is a type alias. Before this PR, trying to unmarshal to such a map would panic.

When running with `DD_CONF_NODETREEMODEL=enable` this fixes the unit tests for `comp/core/workloadfilter/impl`, once https://github.com/DataDog/datadog-agent/pull/42196 is also merged.

### Motivation

Remove our dependency on viper

### Describe how you validated your changes

Unit tests cover this change

### Additional Notes
