### PR TITLE
logs were not consuming DD_EXTRA_TAGS

### DIFF
--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -349,10 +350,10 @@ func TestGetHostnameLambda(t *testing.T) {
 
 func TestGetHostname(t *testing.T) {
 	p := &Processor{
-		hostname: nil, // Use nil to test the fallback
+		hostname: hostnameComponent, // Use nil to test the fallback
 	}
 	m := message.NewMessage([]byte("hello"), nil, "", 0)
-	assert.Equal(t, "unknown", p.GetHostname(m))
+	assert.Equal(t, "testHostnameFromEnvVar", p.GetHostname(m))
 }
 
 // DD_EXTRA_TAGS tests

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -349,8 +349,9 @@ func TestGetHostnameLambda(t *testing.T) {
 }
 
 func TestGetHostname(t *testing.T) {
+	hostnameComponent, _ := hostnameinterface.NewMock("testHostnameFromEnvVar")
 	p := &Processor{
-		hostname: hostnameComponent, // Use nil to test the fallback
+		hostname: hostnameComponent,
 	}
 	m := message.NewMessage([]byte("hello"), nil, "", 0)
 	assert.Equal(t, "testHostnameFromEnvVar", p.GetHostname(m))


### PR DESCRIPTION
### What does this PR do?

This PR patches the log processor to honor extra tags, like those provided via DD_EXTRA_TAGS env vars.

### Motivation

We need to push logs to a platform other than Datadog (Cribl) for ETL work before re-sending to different Datadog indexes. When doing this path, not all tags are present on the logs so filtering logs at the Cribl level gets a lot harder. By having the ability of having these logs carrying DD_EXTRA_TAGS we can filter and process logs correctly before sending it to Datadog. 

### Describe how you validated your changes

Ran the agent locally and pointed to Cribl.
Agent Config was:
```
api_key: YOUR_TEST_API_KEY  # or use a dummy key for local testing

site: ddog-gov.com

# Log collection settings matching your K8s config
logs_enabled: true
logs_config:
  use_http: true
  logs_no_ssl: true
  logs_dd_url: "cribl-endpoint:9080"
  auto_multi_line_detection: true
  compression_level: 6
  compression_kind: gzip
  container_collect_all: true

logs:
  - type: file
    path: /tmp/datadog-test-logs/*.log
    service: test-app
    source: custom
    sourcecategory: application
```

Started the agent: `dda env dev run -- bash -c 'DD_EXTRA_TAGS=\"environment:local extra_tag:is_extra_tag\" DD_HOSTNAME=roliveira-datadog-test-local ./bin/agent/agent run -c ./bin/agent/dist/datadog.yaml'`

Then in Cribl:  
<img width="2820" height="1376" alt="image" src="https://github.com/user-attachments/assets/28d9c1fa-78dd-466e-828b-c058e4148dab" />

### Additional Notes
