### PR TITLE
remoteconfig: add method to stream configs for a RuntimeID

### DIFF
--- a/comp/api/grpcserver/impl-agent/server.go
+++ b/comp/api/grpcserver/impl-agent/server.go
@@ -256,3 +256,12 @@ func (s *serverSecure) StreamConfigEvents(in *pb.ConfigStreamRequest, out pb.Age
 func init() {
 	grpclog.SetLoggerV2(grpc.NewLogger())
 }
+
+func (s *serverSecure) CreateConfigSubscription(stream pb.AgentSecure_CreateConfigSubscriptionServer) error {
+	rcService, isSet := s.configService.Get()
+	if !isSet || rcService == nil {
+		log.Debug(rcNotInitializedErr.Error())
+		return rcNotInitializedErr
+	}
+	return rcService.CreateConfigSubscription(stream)
+}

--- a/comp/remote-config/rcservice/component.go
+++ b/comp/remote-config/rcservice/component.go
@@ -29,4 +29,6 @@ type Component interface {
 	ConfigGetState() (*pbgo.GetStateConfigResponse, error)
 	// ConfigResetState resets the remote configuration state, clearing the local store and reinitializing the uptane client
 	ConfigResetState() (*pbgo.ResetStateConfigResponse, error)
+	// CreateConfigSubscription creates a new config subscription for a client
+	CreateConfigSubscription(stream pbgo.AgentSecure_CreateConfigSubscriptionServer) error
 }

--- a/comp/remote-config/rctelemetryreporter/component.go
+++ b/comp/remote-config/rctelemetryreporter/component.go
@@ -14,4 +14,17 @@ type Component interface {
 	IncTimeout()
 	// IncRateLimit increments the DdRcTelemetryReporter BypassRateLimitCounter counter.
 	IncRateLimit()
+
+	// IncConfigSubscriptionsConnectedCounter increments the
+	// DdRcTelemetryReporter ConfigSubscriptionsConnectedCounter counter.
+	IncConfigSubscriptionsConnectedCounter()
+	// IncConfigSubscriptionsDisconnectedCounter increments the
+	// DdRcTelemetryReporter ConfigSubscriptionsDisconnectedCounter counter.
+	IncConfigSubscriptionsDisconnectedCounter()
+	// SetConfigSubscriptionsActive sets the DdRcTelemetryReporter
+	// ConfigSubscriptionsActive gauge to the given value.
+	SetConfigSubscriptionsActive(value int)
+	// SetConfigSubscriptionClientsTracked sets the DdRcTelemetryReporter
+	// ConfigSubscriptionClientsTracked gauge to the given value.
+	SetConfigSubscriptionClientsTracked(value int)
 }

--- a/comp/remote-config/rctelemetryreporter/rctelemetryreporterimpl/rctelemetryreporter.go
+++ b/comp/remote-config/rctelemetryreporter/rctelemetryreporterimpl/rctelemetryreporter.go
@@ -31,6 +31,11 @@ func Module() fxutil.Module {
 type DdRcTelemetryReporter struct {
 	BypassRateLimitCounter telemetry.Counter
 	BypassTimeoutCounter   telemetry.Counter
+
+	ConfigSubscriptionsActive              telemetry.Gauge
+	ConfigSubscriptionClientsTracked       telemetry.Gauge
+	ConfigSubscriptionsConnectedCounter    telemetry.Counter
+	ConfigSubscriptionsDisconnectedCounter telemetry.Counter
 }
 
 // IncRateLimit increments the DdRcTelemetryReporter BypassRateLimitCounter counter.
@@ -44,6 +49,38 @@ func (r *DdRcTelemetryReporter) IncRateLimit() {
 func (r *DdRcTelemetryReporter) IncTimeout() {
 	if r.BypassTimeoutCounter != nil {
 		r.BypassTimeoutCounter.Inc()
+	}
+}
+
+// IncConfigSubscriptionsConnectedCounter increments the DdRcTelemetryReporter
+// ConfigSubscriptionsConnectedCounter counter.
+func (r *DdRcTelemetryReporter) IncConfigSubscriptionsConnectedCounter() {
+	if r.ConfigSubscriptionsConnectedCounter != nil {
+		r.ConfigSubscriptionsConnectedCounter.Inc()
+	}
+}
+
+// IncConfigSubscriptionsDisconnectedCounter increments the
+// DdRcTelemetryReporter ConfigSubscriptionsDisconnectedCounter counter.
+func (r *DdRcTelemetryReporter) IncConfigSubscriptionsDisconnectedCounter() {
+	if r.ConfigSubscriptionsDisconnectedCounter != nil {
+		r.ConfigSubscriptionsDisconnectedCounter.Inc()
+	}
+}
+
+// SetConfigSubscriptionsActive sets the DdRcTelemetryReporter
+// ConfigSubscriptionsActive gauge to the given value.
+func (r *DdRcTelemetryReporter) SetConfigSubscriptionsActive(value int) {
+	if r.ConfigSubscriptionsActive != nil {
+		r.ConfigSubscriptionsActive.Set(float64(value))
+	}
+}
+
+// SetConfigSubscriptionClientsTracked sets the DdRcTelemetryReporter
+// ConfigSubscriptionClientsTracked gauge to the given value.
+func (r *DdRcTelemetryReporter) SetConfigSubscriptionClientsTracked(value int) {
+	if r.ConfigSubscriptionClientsTracked != nil {
+		r.ConfigSubscriptionClientsTracked.Set(float64(value))
 	}
 }
 
@@ -63,6 +100,34 @@ func newDdRcTelemetryReporter(deps dependencies) rctelemetryreporter.Component {
 			"cache_bypass_timeout",
 			[]string{},
 			"Number of Remote Configuration cache bypass requests that timeout.",
+			commonOpts,
+		),
+		ConfigSubscriptionsActive: deps.Telemetry.NewGaugeWithOpts(
+			"remoteconfig",
+			"config_subscriptions_active",
+			[]string{},
+			"Number of Remote Configuration subscriptions active.",
+			commonOpts,
+		),
+		ConfigSubscriptionClientsTracked: deps.Telemetry.NewGaugeWithOpts(
+			"remoteconfig",
+			"config_subscription_clients_tracked",
+			[]string{},
+			"Number of Remote Configuration clients tracked by active subscriptions.",
+			commonOpts,
+		),
+		ConfigSubscriptionsConnectedCounter: deps.Telemetry.NewCounterWithOpts(
+			"remoteconfig",
+			"config_subscriptions_connected_counter",
+			[]string{},
+			"Number of Remote Configuration subscriptions connected.",
+			commonOpts,
+		),
+		ConfigSubscriptionsDisconnectedCounter: deps.Telemetry.NewCounterWithOpts(
+			"remoteconfig",
+			"config_subscriptions_disconnected_counter",
+			[]string{},
+			"Number of Remote Configuration subscriptions disconnected.",
 			commonOpts,
 		),
 	}

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -21,6 +21,9 @@ const (
 	ProductAPMTracing Product = "APM_TRACING"
 	// ProductLiveDebugging is the dynamic instrumentation product
 	ProductLiveDebugging = "LIVE_DEBUGGING"
+	// ProductLiveDebuggingSymbolDB manages the dynamic instrumentation product
+	// symbol database upload process.
+	ProductLiveDebuggingSymbolDB = "LIVE_DEBUGGING_SYMBOL_DB"
 	// ProductTesting1 is a testing product
 	ProductTesting1 Product = "TESTING1"
 	// ProductAgentTask is to receive agent task instruction, like a flare

--- a/pkg/config/remote/go.mod
+++ b/pkg/config/remote/go.mod
@@ -120,7 +120,7 @@ require (
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
+	golang.org/x/time v0.14.0
 	google.golang.org/api v0.239.0 // indirect
 	google.golang.org/genproto v0.0.0-20250505200425-f936aa4a68b2 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -192,7 +192,7 @@ func uptaneFactoryOption(coreAgentUptane *mockCoreAgentUptane) Option {
 	})
 }
 
-func newTestService(t *testing.T, api *mockAPI, coreAgentUptane *mockCoreAgentUptane, clock clock.Clock) *CoreAgentService {
+func newTestService(t *testing.T, api *mockAPI, coreAgentUptane *mockCoreAgentUptane, clock clock.Clock, opts ...Option) *CoreAgentService {
 	cfg := configmock.New(t)
 	cfg.SetWithoutSource("hostname", "test-hostname")
 
@@ -210,6 +210,7 @@ func newTestService(t *testing.T, api *mockAPI, coreAgentUptane *mockCoreAgentUp
 		WithTraceAgentEnv(traceAgentEnv),
 		WithAPIKey("abc"),
 	}
+	options = append(options, opts...)
 	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", getHostTags, mockTelemetryReporter, agentVersion, options...)
 	require.NoError(t, err)
 	t.Cleanup(func() { service.Stop() })

--- a/pkg/config/remote/service/subscriptions.go
+++ b/pkg/config/remote/service/subscriptions.go
@@ -1,0 +1,358 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package service
+
+import (
+	"slices"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	rdata "github.com/DataDog/datadog-agent/pkg/config/remote/data"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// Maximum number of responses that can be queued per subscription.
+	//
+	// This number is arbitrary, but should bound the memory usage and avoid
+	// quadratic runtime when interacting with the queue. Generally we don't
+	// expect much queueing of updates at all -- it would only happen if the
+	// system-probe fell behind or couldn't keep up with the rate of updates.
+	// Given the polling by clients happens on the order of seconds, this is
+	// very unlikely to happen. Even if it does, the subscription will get
+	// notified on the next poll.
+	defaultMaxSubscriptionQueueSize = 16
+
+	// The maximum number of config subscriptions that may be active at the
+	// same time. We only expect there to ever be one in a real production
+	// setting: the system-probe, but perhaps for testing or debugging use
+	// cases it may be beneficial to allow for an additional subscription.
+	defaultMaxConcurrentSubscriptions = 2
+
+	// The maximum number of runtime IDs that may be tracked per subscription.
+	// This limit exists to bound the memory use due to a subscription -- at the
+	// cost of breaking subscriptions if there are too many such processes.
+	//
+	// Note that the memory usage per tracked runtime ID is roughly 36 bytes
+	// for the runtime ID string bytes, 16 bytes for the string header, and
+	// 8 bytes for the trackedClient value so 60 bytes per runtime ID and then
+	// some additional overhead for the map. Call it 100 bytes max.
+	defaultMaxTrackedRuntimeIDsPerSubscription = 16 << 10 // 16K
+)
+
+// trackedClient holds the state for a single tracked client in a
+// subscription.
+type trackedClient struct {
+	seenAny  bool
+	products pbgo.ConfigSubscriptionProducts
+}
+
+// subscriptionID is a unique identifier for a subscription.
+type subscriptionID int
+
+// subscription represents a single active config subscription stream.
+// All methods must be called while holding CoreAgentService.mu.
+type subscription struct {
+	id subscriptionID
+
+	// trackedClients maps runtime_id -> tracked client state
+	//
+	// Note that while it might be more convenient to use a pointer value, we
+	// save memory by using a value type. This makes updates a bit trickier, but
+	// this map is the largest in memory object in the subscription, so it's
+	// worth optimizing for memory.
+	trackedClients map[string]trackedClient
+	// pendingQueue is a queue of responses waiting to be sent.
+	pendingQueue []*pbgo.ConfigSubscriptionResponse
+	// maxQueueSize is the maximum number of responses that can be queued.
+	// This bounds the memory usage of the subscription in the face of a
+	// stuck or slow client.
+	maxQueueSize int
+	// updateSignal is used to notify the sender goroutine that there are
+	// pending updates to send.
+	updateSignal chan<- struct{}
+}
+
+// newSubscription creates a new subscription. The caller is responsible for
+// starting the sender goroutine.
+func newSubscription(id subscriptionID, maxQueueSize int) (*subscription, <-chan struct{}) {
+	updateSignal := make(chan struct{}, 1)
+	return &subscription{
+		id:             id,
+		trackedClients: make(map[string]trackedClient),
+		maxQueueSize:   maxQueueSize,
+		updateSignal:   updateSignal,
+	}, updateSignal
+}
+
+// track adds a client to the subscription's tracked clients.
+// Must be called while holding CoreAgentService.mu.
+func (s *subscription) track(runtimeID string, products pbgo.ConfigSubscriptionProducts) {
+	s.trackedClients[runtimeID] = trackedClient{
+		seenAny:  false,
+		products: products,
+	}
+}
+
+// untrack removes a client from the subscription's tracked clients and
+// removes any pending updates for that client from the queue.
+// Must be called while holding CoreAgentService.mu.
+func (s *subscription) untrack(runtimeID string) {
+	delete(s.trackedClients, runtimeID)
+
+	// Remove any pending updates for this runtime_id from the queue.
+	s.removeFromQueue(runtimeID)
+}
+
+// removeFromQueue removes all responses for the given runtime_id from the
+// pending queue.
+// Must be called while holding CoreAgentService.mu.
+func (s *subscription) removeFromQueue(runtimeID string) {
+	s.pendingQueue = slices.DeleteFunc(s.pendingQueue, func(
+		response *pbgo.ConfigSubscriptionResponse,
+	) bool {
+		return getRuntimeIDFromClient(response.Client) == runtimeID
+	})
+}
+
+// If we have a stuck subscription client, rate limit logging about it to avoid
+// spamming the logs.
+var queueFullLogLimiter = rate.NewLimiter(rate.Every(10*time.Minute), 10)
+
+// enqueueUpdate enqueues an update for a tracked runtime_id with the provided
+// files. If the runtime_id is not tracked, this is a no-op.  If the queue is
+// full, the update, and all pending updates for this runtime_id will be
+// dropped. Subsequent polls for this runtime_id will resend all the files.
+func (s *subscription) enqueueUpdate(
+	client *pbgo.Client,
+	matchedConfigs []string,
+	files []*pbgo.File,
+) {
+	runtimeID := getRuntimeIDFromClient(client)
+	if runtimeID == "" {
+		return
+	}
+
+	// If the client is no longer tracked, this is a no-op.
+	tracked, ok := s.trackedClients[runtimeID]
+	if !ok {
+		return
+	}
+
+	// Check if queue is full, and if so, we're going to drop the update.
+	if len(s.pendingQueue) >= s.maxQueueSize {
+		if queueFullLogLimiter.Allow() {
+			log.Warnf(
+				"subscription %d: queue is full (%d), dropping update for runtime_id %s",
+				s.id, s.maxQueueSize, runtimeID,
+			)
+		} else {
+			log.Debugf(
+				"subscription %d: queue is full (%d), dropping update for runtime_id %s",
+				s.id, s.maxQueueSize, runtimeID,
+			)
+		}
+		// Remove any existing update for this runtime_id from the queue. The
+		// next poll that occurs for this client will resend all the files.
+		s.removeFromQueue(runtimeID)
+		tracked.seenAny = false
+		s.trackedClients[runtimeID] = tracked
+		return
+	}
+
+	response := &pbgo.ConfigSubscriptionResponse{
+		Client:         client,
+		MatchedConfigs: matchedConfigs,
+		TargetFiles:    files,
+	}
+
+	s.pendingQueue = append(s.pendingQueue, response)
+
+	// Signal the sender goroutine (non-blocking).
+	select {
+	case s.updateSignal <- struct{}{}:
+	default:
+		// Already signaled, which is fine.
+	}
+}
+
+// subscriptions manages all active config subscriptions.
+// All methods must be called while holding CoreAgentService.mu.
+type subscriptions struct {
+	idAlloc                  subscriptionID
+	subs                     map[subscriptionID]*subscription
+	productsMappings         productsMappings
+	maxSubscriptionQueueSize int
+}
+
+type productSet = map[rdata.Product]struct{}
+
+type productsMappings = map[pbgo.ConfigSubscriptionProducts]productSet
+
+// newSubscriptions creates a new subscriptions manager.
+func newSubscriptions(pm productsMappings, maxSubscriptionQueueSize int) *subscriptions {
+	return &subscriptions{
+		idAlloc:                  0,
+		subs:                     make(map[subscriptionID]*subscription),
+		productsMappings:         pm,
+		maxSubscriptionQueueSize: maxSubscriptionQueueSize,
+	}
+}
+
+// add adds a subscription to the manager and returns it.
+// Must be called while holding CoreAgentService.mu.
+func (s *subscriptions) newSubscription() (
+	_ subscriptionID, updateSignal <-chan struct{},
+) {
+	s.idAlloc++
+	id := s.idAlloc
+	sub, updateSignal := newSubscription(id, s.maxSubscriptionQueueSize)
+	s.subs[id] = sub
+	return id, updateSignal
+}
+
+// remove removes a subscription from the manager.
+// Must be called while holding CoreAgentService.mu.
+func (s *subscriptions) remove(id subscriptionID) {
+	delete(s.subs, id)
+}
+
+// interestedSubscriptions returns the IDs of subscriptions tracking the given
+// runtime_id along with the set of products that still require a full payload
+// (i.e. the subscriptions have never seen this client and need all files for
+// those products). Must be called while holding CoreAgentService.mu.
+func (s *subscriptions) interestedSubscriptions(
+	client *pbgo.Client,
+) (interestedSubs []subscriptionID, needCompleteProducts productSet) {
+	runtimeID := getRuntimeIDFromClient(client)
+	if runtimeID == "" {
+		return nil, nil
+	}
+
+	var needProducts productSet
+	for subID, sub := range s.subs {
+		// Check if this subscription is tracking this runtime_id.
+		tracked, ok := sub.trackedClients[runtimeID]
+		if !ok {
+			// Not tracking this runtime_id.
+			continue
+		}
+
+		// This subscription is interested.
+		interestedSubs = append(interestedSubs, subID)
+
+		// If this subscription hasn't seen this client before, it needs the
+		// complete set of configs for the tracked products.
+		if !tracked.seenAny {
+			if needProducts == nil {
+				needProducts = make(productSet)
+			}
+			for product := range s.productsMappings[tracked.products] {
+				needProducts[product] = struct{}{}
+			}
+		}
+	}
+
+	return interestedSubs, needProducts
+}
+
+// client. Each subscription receives only the configs and files matching its
+// tracked products.
+func (s *subscriptions) notify(
+	toNotify []subscriptionID,
+	client *pbgo.Client,
+	matchedClientConfigs []string,
+	responseFiles, allFiles []*pbgo.File,
+) {
+	runtimeID := getRuntimeIDFromClient(client)
+	if runtimeID == "" {
+		return
+	}
+
+	for _, id := range toNotify {
+		sub := s.subs[id]
+		if sub == nil {
+			continue
+		}
+
+		tracked, ok := sub.trackedClients[runtimeID]
+		if !ok {
+			continue
+		}
+
+		// If this subscription hasn't seen this client before, it needs all
+		// files, not just the new target files.
+		files := responseFiles
+		if !tracked.seenAny {
+			files = allFiles
+		}
+		products := s.productsMappings[tracked.products]
+		files = filtered(files, func(file *pbgo.File) bool {
+			return contains(products, productFromPath(file.Path))
+		})
+		configs := filtered(matchedClientConfigs, func(config string) bool {
+			return contains(products, productFromPath(config))
+		})
+		sub.enqueueUpdate(client, configs, files)
+	}
+}
+
+// popUpdate pops one update from the subscription's queue.
+func (s *subscriptions) popUpdate(
+	id subscriptionID,
+) *pbgo.ConfigSubscriptionResponse {
+	sub := s.subs[id]
+	if sub == nil || len(sub.pendingQueue) == 0 {
+		return nil
+	}
+	for len(sub.pendingQueue) > 0 {
+		update := sub.pendingQueue[0]
+		sub.pendingQueue[0], sub.pendingQueue = nil, sub.pendingQueue[1:]
+		runtimeID := getRuntimeIDFromClient(update.Client)
+		tracked, ok := sub.trackedClients[runtimeID]
+		if !ok {
+			continue
+		}
+		tracked.seenAny = true
+		sub.trackedClients[runtimeID] = tracked
+		return update
+	}
+	return nil
+}
+
+// filtered returns a new slice containing only the items that satisfy the
+// predicate.
+func filtered[T any](slice []T, predicate func(T) bool) []T {
+	var filtered []T
+	for _, item := range slice {
+		if predicate(item) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func contains[M ~map[K]V, K comparable, V any](m M, key K) bool {
+	_, ok := m[key]
+	return ok
+}
+
+func getRuntimeIDFromClient(client *pbgo.Client) string {
+	if !client.IsTracer || client.ClientTracer == nil {
+		return ""
+	}
+	return client.ClientTracer.RuntimeId
+}
+
+func productFromPath(path string) rdata.Product {
+	parsed, err := rdata.ParseConfigPath(path)
+	if err != nil {
+		return ""
+	}
+	return rdata.Product(parsed.Product)
+}

--- a/pkg/config/remote/service/subscriptions_test.go
+++ b/pkg/config/remote/service/subscriptions_test.go
@@ -322,18 +322,18 @@ func TestSubscriptionGetsConfigRemovalUpdate(t *testing.T) {
 			Once(),
 	)
 
-	uptaneClient.On("TargetFiles", mock.Anything).
-		Run(func(args mock.Arguments) {
-			require.ElementsMatch(
-				t,
-				[]string{configPath},
-				args.Get(0).([]string),
-			)
-		}).
-		Return(map[string][]byte{
-			configPath: []byte("config"),
-		}, nil).
-		Once()
+	mock.InOrder(
+		uptaneClient.
+			On("TargetFiles", []string{configPath}).
+			Return(map[string][]byte{
+				configPath: []byte("config"),
+			}, nil).
+			Once(),
+		uptaneClient.
+			On("TargetFiles", []string(nil)).
+			Return(map[string][]byte(nil), nil).
+			Once(),
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/config/remote/service/subscriptions_test.go
+++ b/pkg/config/remote/service/subscriptions_test.go
@@ -1,0 +1,1244 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"maps"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/DataDog/go-tuf/data"
+
+	rdata "github.com/DataDog/datadog-agent/pkg/config/remote/data"
+	"github.com/DataDog/datadog-agent/pkg/config/remote/uptane"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+func TestSubscriptionTrackAndUntrack(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+
+	service := newTestService(t, api, uptaneClient, clock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := runTestingService(t, service)
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+
+	const runtimeID = "test-runtime-1"
+
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: runtimeID,
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	require.Eventually(t, func() bool {
+		return subscriptionIsRegistered(service, runtimeID)
+	}, 1*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_UNTRACK,
+		RuntimeId: "test-runtime-1",
+	}))
+	require.Eventually(t, func() bool {
+		return !subscriptionIsRegistered(service, runtimeID)
+	}, 1*time.Second, 10*time.Millisecond)
+	require.NoError(t, stream.CloseSend())
+}
+
+// Ensures that a subscription will receive all files, including client cached
+// files on the first poll, but will not receive those files on subsequent
+// polls.
+func TestSubscriptionGetsInitialUpdate(t *testing.T) {
+	apmCachedPath := "datadog/2/APM_TRACING/config-abc/cached.json"
+	apmConfigPath := "datadog/2/APM_TRACING/config-123/config.json"
+	liveDebuggingPath := "datadog/2/LIVE_DEBUGGING/config-456/debugging.json"
+	targetFileData := map[string][]byte{
+		apmCachedPath:     []byte("cached"),
+		apmConfigPath:     []byte("config"),
+		liveDebuggingPath: []byte("debugging"),
+	}
+	files := newTargetFiles(targetFileData)
+
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock,
+		withSubscriptionProductMappings(productMappingsWithApmTracingProducts))
+	uptaneClient.On("TUFVersionState").
+		Return(uptane.TUFVersions{
+			DirectorRoot:    1,
+			DirectorTargets: 1,
+		}, nil)
+	uptaneClient.On("DirectorRoot", uint64(1)).
+		Return([]byte("root1"), nil)
+	uptaneClient.On("Targets").
+		Return(files, nil)
+	uptaneClient.On("TargetsMeta").
+		Return([]byte("targets-meta"), nil)
+	mock.InOrder(
+		uptaneClient.On("TargetFiles", []string{apmConfigPath, apmCachedPath}).
+			Return(map[string][]byte{
+				apmCachedPath: []byte("cached"),
+				apmConfigPath: []byte("config"),
+			}, nil),
+		uptaneClient.On("TargetFiles", []string{apmConfigPath}).
+			Return(map[string][]byte{
+				apmConfigPath: []byte("config"),
+			}, nil),
+	)
+	uptaneClient.On("TimestampExpires").
+		Return(time.Now().Add(1*time.Hour), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := runTestingService(t, service)
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  apmTracingProducts,
+	}))
+
+	require.Eventually(t, func() bool {
+		return subscriptionIsRegistered(service, "runtime-123")
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// Simulate a client polling for configs (with cached files)
+	tracerClient := &pbgo.Client{
+		Id: "client-456",
+		State: &pbgo.ClientState{
+			RootVersion:    1,
+			TargetsVersion: 0,
+		},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-123",
+			Language:  "go",
+		},
+		Products: []string{"APM_TRACING"},
+	}
+
+	// Mark client as active to avoid cache bypass
+	service.clients.seen(tracerClient)
+
+	resp1, err := service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client: tracerClient,
+			CachedTargetFiles: []*pbgo.TargetFileMeta{
+				uptaneToCore(apmCachedPath, files[apmCachedPath]),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t, fileNames(resp1.TargetFiles), []string{apmConfigPath},
+	)
+
+	// Subscription should receive an update with cached files
+	streamResp, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, streamResp)
+	require.ElementsMatch(
+		t, fileNames(streamResp.TargetFiles), []string{apmCachedPath, apmConfigPath},
+	)
+	require.ElementsMatch(
+		t, streamResp.MatchedConfigs, []string{apmCachedPath, apmConfigPath},
+	)
+
+	resp2, err := service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client: tracerClient,
+			CachedTargetFiles: []*pbgo.TargetFileMeta{
+				uptaneToCore(apmCachedPath, files[apmCachedPath]),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t, fileNames(resp2.TargetFiles), []string{apmConfigPath},
+	)
+
+	streamResp2, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, streamResp2)
+	require.ElementsMatch(
+		t, fileNames(streamResp2.TargetFiles), []string{apmConfigPath},
+	)
+	require.ElementsMatch(
+		t, streamResp2.MatchedConfigs, []string{apmCachedPath, apmConfigPath},
+	)
+}
+
+// Ensures that a subscription receives an update even when no configs match its
+// products so it can clear previously applied configs.
+func TestSubscriptionGetsEmptyMatchedConfigsUpdate(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock)
+
+	const cachedPath = "datadog/2/APM_TRACING/config-abc/cached.json"
+	const uncachedPath = "datadog/2/APM_TRACING/config-123/config.json"
+	const differentProductPath = "datadog/2/LIVE_DEBUGGING/config-456/debugging.json"
+	targetFileData := map[string][]byte{
+		cachedPath:           []byte("cached"),
+		uncachedPath:         []byte("config"),
+		differentProductPath: []byte("debugging"),
+	}
+	files := newTargetFiles(targetFileData)
+	targetFiles := map[string][]byte{}
+	apmKeys := []string{cachedPath, uncachedPath}
+	for _, path := range apmKeys {
+		targetFiles[path] = []byte(targetFileData[path])
+	}
+	uptaneClient.On("TUFVersionState").Return(uptane.TUFVersions{
+		DirectorRoot:    1,
+		DirectorTargets: 1,
+	}, nil)
+	uptaneClient.On("DirectorRoot", uint64(1)).Return([]byte("root1"), nil)
+	uptaneClient.On("Targets").Return(files, nil)
+	uptaneClient.On("TargetsMeta").Return([]byte("targets-meta"), nil)
+	uptaneClient.On("TargetFiles", mock.Anything).Return(targetFiles, nil)
+	uptaneClient.On("TimestampExpires").Return(time.Now().Add(1*time.Hour), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := runTestingService(t, service)
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+
+	// Track a product that the client doesn't have
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	require.Eventually(t, func() bool {
+		return subscriptionIsRegistered(service, "runtime-123")
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// Client polls with different product
+	tracerClient := &pbgo.Client{
+		Id: "client-456",
+		State: &pbgo.ClientState{
+			RootVersion:    1,
+			TargetsVersion: 0,
+		},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-123",
+			Language:  "go",
+		},
+		Products: []string{"APM_TRACING"},
+	}
+
+	// Mark client as active to avoid cache bypass
+	service.clients.seen(tracerClient)
+
+	_, err = service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client:            tracerClient,
+			CachedTargetFiles: nil,
+		},
+	)
+	require.NoError(t, err)
+
+	// Subscription should receive an update with no matched configs/files.
+	update, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, update)
+	require.Empty(t, update.TargetFiles)
+	require.Empty(t, update.MatchedConfigs)
+}
+
+// Ensure a subscription gets an explicit update when previously matched configs
+// disappear so clients can clean up.
+func TestSubscriptionGetsConfigRemovalUpdate(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock)
+
+	const configPath = "datadog/2/LIVE_DEBUGGING/config-123/debugging.json"
+	initialTargets := newTargetFiles(map[string][]byte{
+		configPath: []byte("config"),
+	})
+	emptyTargets := newTargetFiles(map[string][]byte{})
+
+	uptaneClient.On("TUFVersionState").
+		Return(uptane.TUFVersions{
+			DirectorRoot:    1,
+			DirectorTargets: 1,
+		}, nil).Once()
+	uptaneClient.On("TUFVersionState").
+		Return(uptane.TUFVersions{
+			DirectorRoot:    1,
+			DirectorTargets: 2,
+		}, nil).Once()
+
+	uptaneClient.On("TargetsMeta").
+		Return([]byte("targets-meta"), nil).
+		Twice()
+	uptaneClient.On("TimestampExpires").
+		Return(time.Now().Add(1*time.Hour), nil).
+		Twice()
+
+	mock.InOrder(
+		uptaneClient.On("Targets").
+			Return(initialTargets, nil).
+			Once(),
+		uptaneClient.On("Targets").
+			Return(emptyTargets, nil).
+			Once(),
+	)
+
+	uptaneClient.On("TargetFiles", mock.Anything).
+		Run(func(args mock.Arguments) {
+			require.ElementsMatch(
+				t,
+				[]string{configPath},
+				args.Get(0).([]string),
+			)
+		}).
+		Return(map[string][]byte{
+			configPath: []byte("config"),
+		}, nil).
+		Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := runTestingService(t, service)
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	require.Eventually(t, func() bool {
+		return subscriptionIsRegistered(service, "runtime-123")
+	}, 1*time.Second, 10*time.Millisecond)
+
+	tracerClient := &pbgo.Client{
+		Id: "client-456",
+		State: &pbgo.ClientState{
+			RootVersion:    1,
+			TargetsVersion: 0,
+		},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-123",
+			Language:  "go",
+		},
+		Products: []string{"LIVE_DEBUGGING"},
+	}
+	service.clients.seen(tracerClient)
+
+	_, err = service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client:            tracerClient,
+			CachedTargetFiles: nil,
+		},
+	)
+	require.NoError(t, err)
+
+	firstUpdate, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, firstUpdate)
+	require.ElementsMatch(t, firstUpdate.MatchedConfigs, []string{configPath})
+	require.ElementsMatch(t, fileNames(firstUpdate.TargetFiles), []string{configPath})
+
+	// Simulate the client updating to the latest targets version.
+	tracerClient.State.TargetsVersion = 1
+
+	_, err = service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client:            tracerClient,
+			CachedTargetFiles: nil,
+		},
+	)
+	require.NoError(t, err)
+
+	removalUpdate, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, removalUpdate)
+	require.Empty(t, removalUpdate.TargetFiles)
+	require.Empty(t, removalUpdate.MatchedConfigs)
+}
+
+// Ensures subscriptions get initial data even when the polling client has no
+// new configs.
+func TestSubscriptionReceivesCachedFilesWhenClientUpToDate(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock)
+
+	const configPath = "datadog/2/LIVE_DEBUGGING/config-123/debugging.json"
+	targetFileData := map[string][]byte{
+		configPath: []byte("config"),
+	}
+	files := newTargetFiles(targetFileData)
+
+	uptaneClient.On("TUFVersionState").
+		Return(uptane.TUFVersions{
+			DirectorRoot:    1,
+			DirectorTargets: 1,
+		}, nil)
+	uptaneClient.On("Targets").
+		Return(files, nil)
+	uptaneClient.On("TargetFiles", []string{configPath}).
+		Return(map[string][]byte{
+			configPath: []byte("config"),
+		}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := runTestingService(t, service)
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	require.Eventually(t, func() bool {
+		return subscriptionIsRegistered(service, "runtime-123")
+	}, 1*time.Second, 10*time.Millisecond)
+
+	tracerClient := &pbgo.Client{
+		Id: "client-456",
+		State: &pbgo.ClientState{
+			RootVersion:    1,
+			TargetsVersion: 1,
+		},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-123",
+			Language:  "go",
+		},
+		Products: []string{"LIVE_DEBUGGING", "APM_TRACING"},
+	}
+	service.clients.seen(tracerClient)
+
+	resp, err := service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client: tracerClient,
+			CachedTargetFiles: []*pbgo.TargetFileMeta{
+				uptaneToCore(configPath, files[configPath]),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, resp.TargetFiles)
+	require.Empty(t, resp.ClientConfigs)
+
+	streamResp, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, streamResp)
+	require.ElementsMatch(t, fileNames(streamResp.TargetFiles), []string{configPath})
+	require.ElementsMatch(t, streamResp.MatchedConfigs, []string{configPath})
+}
+
+// Ensures that once a subscription has already seen a client, a subsequent poll
+// without any new configs does not enqueue another update.
+func TestSubscriptionNoUpdateDoesNotNotify(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock)
+
+	const configPath = "datadog/2/LIVE_DEBUGGING/config-123/debugging.json"
+	targetFileData := map[string][]byte{
+		configPath: []byte("config"),
+	}
+	files := newTargetFiles(targetFileData)
+
+	uptaneClient.On("TUFVersionState").
+		Return(uptane.TUFVersions{
+			DirectorRoot:    1,
+			DirectorTargets: 1,
+		}, nil).
+		Twice()
+	uptaneClient.On("Targets").
+		Return(files, nil).
+		Once()
+	uptaneClient.On("TargetsMeta").
+		Return([]byte("targets-meta"), nil).
+		Once()
+	uptaneClient.On("TargetFiles", []string{configPath}).
+		Return(map[string][]byte{
+			configPath: []byte("config"),
+		}, nil).
+		Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := runTestingService(t, service)
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	require.Eventually(t, func() bool {
+		return subscriptionIsRegistered(service, "runtime-123")
+	}, 1*time.Second, 10*time.Millisecond)
+
+	tracerClient := &pbgo.Client{
+		Id: "client-456",
+		State: &pbgo.ClientState{
+			RootVersion:    1,
+			TargetsVersion: 0,
+		},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-123",
+			Language:  "go",
+		},
+		Products: []string{"LIVE_DEBUGGING", "APM_TRACING"},
+	}
+	service.clients.seen(tracerClient)
+
+	resp1, err := service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client:            tracerClient,
+			CachedTargetFiles: nil,
+		},
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t, fileNames(resp1.TargetFiles), []string{configPath},
+	)
+
+	firstUpdate, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, firstUpdate)
+	require.ElementsMatch(
+		t, fileNames(firstUpdate.TargetFiles), []string{configPath},
+	)
+	require.ElementsMatch(
+		t, firstUpdate.MatchedConfigs, []string{configPath},
+	)
+
+	// Client is now aligned with the server targets version and caches.
+	tracerClient.State.TargetsVersion = 1
+
+	resp2, err := service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client: tracerClient,
+			CachedTargetFiles: []*pbgo.TargetFileMeta{
+				uptaneToCore(configPath, files[configPath]),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, resp2.TargetFiles)
+	require.Empty(t, resp2.ClientConfigs)
+
+	respCh := make(chan *pbgo.ConfigSubscriptionResponse, 1)
+	go func() {
+		resp, _ := stream.Recv()
+		respCh <- resp
+	}()
+	select {
+	case resp := <-respCh:
+		t.Fatalf("should not receive update: %v", resp)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// Ensures that multiple subscriptions can be created for the same runtime_id
+// with different products, and that each subscription will receive the files
+// that it is interested in.
+func TestSubscriptionCanTrackSameRuntimeIDWithDifferentProducts(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock,
+		withSubscriptionProductMappings(productMappingsWithApmTracingProducts))
+
+	const apmPath = "datadog/2/APM_TRACING/config-abc/cached.json"
+	const liveDebuggingPath = "datadog/2/LIVE_DEBUGGING/config-456/debugging.json"
+	targetFileData := map[string][]byte{
+		apmPath:           []byte("apm"),
+		liveDebuggingPath: []byte("debugging"),
+	}
+	files := newTargetFiles(targetFileData)
+	uptaneClient.On("TUFVersionState").Return(uptane.TUFVersions{
+		DirectorRoot:    1,
+		DirectorTargets: 1,
+	}, nil)
+	uptaneClient.On("DirectorRoot", uint64(1)).Return([]byte("root1"), nil)
+	uptaneClient.On("Targets").Return(files, nil)
+	uptaneClient.On("TargetsMeta").Return([]byte("targets-meta"), nil)
+	targetFiles := map[string][]byte{
+		apmPath:           []byte(targetFileData[apmPath]),
+		liveDebuggingPath: []byte(targetFileData[liveDebuggingPath]),
+	}
+	uptaneClient.On("TargetFiles", mock.Anything).Return(targetFiles, nil)
+	uptaneClient.On("TimestampExpires").Return(time.Now().Add(1*time.Hour), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := runTestingService(t, service)
+	stream1, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+	stream2, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+
+	// Both track the same runtime_id with different products.
+	require.NoError(t, stream1.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  apmTracingProducts,
+	}))
+	require.NoError(t, stream2.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	require.Eventually(t, func() bool {
+		return numSubscriptionsRegisteredForRuntimeID(service, "runtime-123") == 2
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// Client polls.
+	tracerClient := &pbgo.Client{
+		Id: "client-456",
+		State: &pbgo.ClientState{
+			RootVersion:    1,
+			TargetsVersion: 0,
+		},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-123",
+			Language:  "go",
+		},
+		Products: []string{"APM_TRACING", "LIVE_DEBUGGING"},
+	}
+
+	// Mark client as active to avoid cache bypass.
+	service.clients.seen(tracerClient)
+
+	resp1, err := service.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client:            tracerClient,
+			CachedTargetFiles: nil,
+		},
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(t, fileNames(resp1.TargetFiles), []string{apmPath, liveDebuggingPath})
+
+	// Both subscriptions should receive updates.
+	streamResp1, err := stream1.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, streamResp1)
+	require.ElementsMatch(t, fileNames(streamResp1.TargetFiles), []string{apmPath})
+	require.ElementsMatch(t, streamResp1.MatchedConfigs, []string{apmPath})
+
+	streamResp2, err := stream2.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, streamResp2)
+	require.ElementsMatch(t, fileNames(streamResp2.TargetFiles), []string{liveDebuggingPath})
+	require.ElementsMatch(t, streamResp2.MatchedConfigs, []string{liveDebuggingPath})
+}
+
+func TestSubscriptionInvalidRequests(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock)
+
+	tests := []struct {
+		name    string
+		request *pbgo.ConfigSubscriptionRequest
+	}{
+		{
+			name: "track with empty runtime_id",
+			request: &pbgo.ConfigSubscriptionRequest{
+				Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+				RuntimeId: "",
+				Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+			},
+		},
+		{
+			name: "untrack with empty runtime_id",
+			request: &pbgo.ConfigSubscriptionRequest{
+				Action:    pbgo.ConfigSubscriptionRequest_UNTRACK,
+				RuntimeId: "",
+				Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+			},
+		},
+		{
+			name: "invalid action",
+			request: &pbgo.ConfigSubscriptionRequest{
+				Action:    42,
+				RuntimeId: "runtime-123",
+				Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+			},
+		},
+		{
+			name: "TRACK with no products",
+			request: &pbgo.ConfigSubscriptionRequest{
+				Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+				RuntimeId: "runtime-123",
+				Products:  0,
+			},
+		},
+		{
+			name: "TRACK with no invalid products",
+			request: &pbgo.ConfigSubscriptionRequest{
+				Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+				RuntimeId: "runtime-123",
+				Products:  42,
+			},
+		},
+		{
+			name:    "nil request",
+			request: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := runTestingService(t, service)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			stream, err := client.CreateConfigSubscription(ctx)
+			require.NoError(t, err)
+
+			require.NoError(t, stream.Send(tt.request))
+			_, err = stream.Recv()
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// Ensures that only tracked clients receive updates.
+func TestSubscriptionOnlyTrackedClientsGetUpdates(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock,
+		withSubscriptionProductMappings(productMappingsWithApmTracingProducts))
+
+	targetFileData := map[string][]byte{
+		"datadog/2/APM_TRACING/config-abc/cached.json":       []byte("cached"),
+		"datadog/2/APM_TRACING/config-123/config.json":       []byte("config"),
+		"datadog/2/LIVE_DEBUGGING/config-456/debugging.json": []byte("debugging"),
+	}
+	files := newTargetFiles(targetFileData)
+
+	uptaneClient.On("TUFVersionState").Return(uptane.TUFVersions{
+		DirectorRoot:    1,
+		DirectorTargets: 1,
+	}, nil)
+	uptaneClient.On("DirectorRoot", uint64(1)).Return([]byte("root1"), nil)
+	uptaneClient.On("Targets").Return(files, nil)
+	uptaneClient.On("TargetsMeta").Return([]byte("targets-meta"), nil)
+	targetsFiles := make(map[string][]byte)
+	for path, content := range targetFileData {
+		targetsFiles[path] = []byte(content)
+	}
+	uptaneClient.On(
+		"TargetFiles",
+		mock.Anything,
+	).Return(map[string][]byte{
+		"datadog/2/APM_TRACING/config-abc/cached.json": []byte("cached"),
+		"datadog/2/APM_TRACING/config-123/config.json": []byte("config"),
+	}, nil)
+	uptaneClient.On("TimestampExpires").Return(
+		time.Now().Add(1*time.Hour),
+		nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := runTestingService(t, service)
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  apmTracingProducts,
+	}))
+
+	require.Eventually(t, func() bool {
+		return subscriptionIsRegistered(service, "runtime-123")
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// Different client polls (runtime-456)
+	otherClient := &pbgo.Client{
+		Id: "client-789",
+		State: &pbgo.ClientState{
+			RootVersion:    1,
+			TargetsVersion: 0,
+		},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-456",
+			Language:  "go",
+		},
+		Products: []string{"APM_TRACING"},
+	}
+
+	// Mark client as active to avoid cache bypass
+	service.clients.seen(otherClient)
+
+	_, err = client.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client:            otherClient,
+			CachedTargetFiles: nil,
+		},
+	)
+	require.NoError(t, err)
+
+	respCh := make(chan *pbgo.ConfigSubscriptionResponse, 1)
+	go func() {
+		resp, _ := stream.Recv()
+		respCh <- resp
+	}()
+
+	select {
+	case resp := <-respCh:
+		t.Fatalf("should not receive update for non-tracked client: %v", resp)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestSubscriptionsLimits(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock, func(o *options) {
+		o.maxConcurrentSubscriptions = 1
+	})
+	client := runTestingService(t, service)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+	_, err = stream.Header()
+	require.NoError(t, err)
+
+	stream2, err2 := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err2) // this is about dialing
+	_, err2 = stream2.Recv()
+	require.Equal(t, codes.ResourceExhausted, status.Code(err2))
+	require.ErrorContains(t, err2, "maximum number of subscriptions reached (1)")
+
+	require.NoError(t, stream.CloseSend())
+	require.NoError(t, err)
+	_, err = stream.Recv()
+	require.ErrorIs(t, err, io.EOF)
+
+	stream3, err3 := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err3)
+	_, err3 = stream3.Header()
+	require.NoError(t, err3)
+}
+
+func TestTrackLimitPerSubscription(t *testing.T) {
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock,
+		func(o *options) {
+			o.maxTrackedRuntimeIDsPerSubscription = 2
+		})
+	client := runTestingService(t, service)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+	_, err = stream.Header()
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-456",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-789",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+	_, err = stream.Recv()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "maximum number of runtime IDs per subscription reached (2)")
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+type statsHandlerFunc func(ctx context.Context, stats stats.RPCStats)
+
+func (statsHandlerFunc) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (f statsHandlerFunc) HandleRPC(ctx context.Context, stats stats.RPCStats) {
+	f(ctx, stats)
+}
+
+func (statsHandlerFunc) HandleConn(context.Context, stats.ConnStats) {
+}
+
+func (statsHandlerFunc) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+// TestSlowReceiverOverwritesPendingUpdatesAndResendsAllFiles tests that in
+// the situation where our client connection is so slow that we see two
+// differnet polls and by the time the second poll arrives we still haven't
+// sent the first poll's response, we overwrite the pending updates with the
+// second poll's response and resend all the files.
+//
+// We don't really expect this to happen in real life, but the logic is
+// important for correctness while bounding memory usage, so it needs to be
+// tested.
+func TestSlowReceiver(t *testing.T) {
+	config1Path := "datadog/2/LIVE_DEBUGGING/config-1/config1.json"
+	config2Path := "datadog/2/LIVE_DEBUGGING/config-2/config2.json"
+	config3Path := "datadog/2/LIVE_DEBUGGING/config-3/config3.json"
+	config4Path := "datadog/2/LIVE_DEBUGGING/config-4/config4.json"
+	targetFileData := map[string][]byte{
+		config1Path: bytes.Repeat([]byte("a"), 128<<10),
+		config2Path: bytes.Repeat([]byte("b"), 128<<10),
+		config3Path: bytes.Repeat([]byte("c"), 128<<10),
+		config4Path: bytes.Repeat([]byte("d"), 128<<10),
+	}
+	filesData := func(names ...string) map[string][]byte {
+		files := make(map[string][]byte)
+		for _, name := range names {
+			files[name] = targetFileData[name]
+		}
+		return files
+	}
+	files1 := newTargetFiles(filesData(config1Path))
+	files2 := newTargetFiles(filesData(config1Path, config2Path))
+	files3 := newTargetFiles(filesData(config1Path, config2Path, config3Path))
+	files4 := newTargetFiles(filesData(config1Path, config2Path, config3Path, config4Path))
+
+	api := &mockAPI{}
+	uptaneClient := &mockCoreAgentUptane{}
+	clock := clock.NewMock()
+	service := newTestService(t, api, uptaneClient, clock, func(o *options) {
+		o.maxSubscriptionQueueSize = 1
+	})
+	tufVersions := func(v int) uptane.TUFVersions {
+		return uptane.TUFVersions{DirectorRoot: 1, DirectorTargets: uint64(v)}
+	}
+	mock.InOrder(
+		uptaneClient.On("TUFVersionState").Return(tufVersions(1), nil).Once(),
+		uptaneClient.On("TUFVersionState").Return(tufVersions(2), nil).Once(),
+		uptaneClient.On("TUFVersionState").Return(tufVersions(3), nil).Once(),
+		uptaneClient.On("TUFVersionState").Return(tufVersions(4), nil).Twice(),
+	)
+	uptaneClient.On("DirectorRoot", uint64(1)).
+		Return([]byte("root1"), nil)
+	mock.InOrder(
+		uptaneClient.On("Targets").Return(files1, nil).Once(),
+		uptaneClient.On("Targets").Return(files2, nil).Once(),
+		uptaneClient.On("Targets").Return(files3, nil).Once(),
+		uptaneClient.On("Targets").Return(files4, nil).Twice(),
+	)
+	uptaneClient.On("TargetsMeta").
+		Return([]byte("targets-meta"), nil)
+	mock.InOrder(
+		uptaneClient.On("TargetFiles", []string{config1Path}).
+			Return(filesData(config1Path), nil),
+		uptaneClient.On("TargetFiles", []string{config2Path}).
+			Return(filesData(config2Path), nil),
+		uptaneClient.On("TargetFiles", []string{config3Path}).
+			Return(filesData(config3Path), nil),
+		uptaneClient.On("TargetFiles", []string{config4Path}).
+			Return(filesData(config4Path), nil),
+		uptaneClient.On("TargetFiles", []string{config1Path, config2Path, config3Path, config4Path}).
+			Return(filesData(config1Path, config2Path, config3Path, config4Path), nil),
+	)
+	uptaneClient.On("TimestampExpires").
+		Return(time.Now().Add(1*time.Hour), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var responsesSent atomic.Int32
+	client := runTestingService(t, service, grpc.StatsHandler(statsHandlerFunc(func(
+		_ context.Context, s stats.RPCStats,
+	) {
+		out, ok := s.(*stats.OutPayload)
+		if !ok {
+			return
+		}
+		if _, ok := out.Payload.(*pbgo.ConfigSubscriptionResponse); ok {
+			responsesSent.Add(1)
+		}
+	})))
+	stream, err := client.CreateConfigSubscription(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&pbgo.ConfigSubscriptionRequest{
+		Action:    pbgo.ConfigSubscriptionRequest_TRACK,
+		RuntimeId: "runtime-123",
+		Products:  pbgo.ConfigSubscriptionProducts_LIVE_DEBUGGING,
+	}))
+
+	_, err = stream.Header()
+	require.NoError(t, err)
+
+	// Simulate a client polling for configs (with cached files)
+	tracerClient := &pbgo.Client{
+		Id: "client-456",
+		State: &pbgo.ClientState{
+			RootVersion:    1,
+			TargetsVersion: 0,
+		},
+		IsTracer: true,
+		ClientTracer: &pbgo.ClientTracer{
+			RuntimeId: "runtime-123",
+			Language:  "go",
+		},
+		Products: []string{"LIVE_DEBUGGING"},
+	}
+
+	// Mark client as active to avoid cache bypass
+	service.clients.seen(tracerClient)
+
+	// The first poll won't result in any files being returned because the
+	// client, but should send a message to the subscription.
+	resp1, err := client.ClientGetConfigs(
+		context.Background(),
+		&pbgo.ClientGetConfigsRequest{
+			Client: tracerClient,
+			CachedTargetFiles: []*pbgo.TargetFileMeta{
+				uptaneToCore(config1Path, files1[config1Path]),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, resp1.TargetFiles)
+	tracerClient.State.TargetsVersion = 1
+
+	require.Eventually(t, func() bool {
+		return responsesSent.Load() == 1
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// Client intentionally doesn't call Recv.
+	resp2, err := client.ClientGetConfigs(ctx, &pbgo.ClientGetConfigsRequest{
+		Client: tracerClient,
+		CachedTargetFiles: []*pbgo.TargetFileMeta{
+			uptaneToCore(config1Path, files1[config1Path]),
+		},
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, fileNames(resp2.TargetFiles), []string{config2Path})
+
+	tracerClient.State.TargetsVersion = 2
+	resp3, err := client.ClientGetConfigs(ctx, &pbgo.ClientGetConfigsRequest{
+		Client: tracerClient,
+		CachedTargetFiles: []*pbgo.TargetFileMeta{
+			uptaneToCore(config1Path, files1[config1Path]),
+			uptaneToCore(config2Path, files2[config2Path]),
+		},
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, fileNames(resp3.TargetFiles), []string{config3Path})
+
+	tracerClient.State.TargetsVersion = 3
+	resp4, err := client.ClientGetConfigs(ctx, &pbgo.ClientGetConfigsRequest{
+		Client: tracerClient,
+		CachedTargetFiles: []*pbgo.TargetFileMeta{
+			uptaneToCore(config1Path, files1[config1Path]),
+			uptaneToCore(config2Path, files2[config2Path]),
+			uptaneToCore(config3Path, files3[config3Path]),
+		},
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, fileNames(resp4.TargetFiles), []string{config4Path})
+
+	streamResp, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, streamResp)
+	require.ElementsMatch(t, fileNames(streamResp.TargetFiles), []string{config1Path})
+
+	streamResp2, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, streamResp2)
+	require.ElementsMatch(t, fileNames(streamResp2.TargetFiles), []string{config2Path})
+
+	tracerClient.State.TargetsVersion = 4
+	resp5, err := client.ClientGetConfigs(ctx, &pbgo.ClientGetConfigsRequest{
+		Client: tracerClient,
+		CachedTargetFiles: []*pbgo.TargetFileMeta{
+			uptaneToCore(config1Path, files1[config1Path]),
+			uptaneToCore(config2Path, files2[config2Path]),
+			uptaneToCore(config3Path, files3[config3Path]),
+			uptaneToCore(config4Path, files4[config4Path]),
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp5.TargetFiles)
+
+	streamResp3, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, streamResp3)
+	require.ElementsMatch(t, fileNames(streamResp3.TargetFiles), []string{
+		config1Path, config2Path, config3Path, config4Path,
+	})
+}
+
+func runTestingService(t *testing.T, service *CoreAgentService, opts ...grpc.ServerOption) pbgo.AgentSecureClient {
+	const bufSize = 1 << 10 // 1KiB
+	l := bufconn.Listen(bufSize)
+	s := grpc.NewServer(opts...)
+	type embeddedUnimplementedAgentSecureServer struct {
+		pbgo.UnimplementedAgentSecureServer
+	}
+	var v struct {
+		*CoreAgentService
+		embeddedUnimplementedAgentSecureServer
+	}
+	v.CoreAgentService = service
+	pbgo.RegisterAgentSecureServer(s, &v)
+	t.Cleanup(func() { s.Stop() })
+	go s.Serve(l)
+
+	dialOpts := []grpc.DialOption{
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return l.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithReadBufferSize(1 << 10),
+		grpc.WithInitialWindowSize(64 << 10),
+		grpc.WithStaticConnWindowSize(64 << 10),
+		grpc.WithStaticStreamWindowSize(64 << 10),
+	}
+	conn, err := grpc.NewClient("passthrough://bufnet", dialOpts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	client := pbgo.NewAgentSecureClient(conn)
+	return client
+}
+
+func newTargetFiles(tf map[string][]byte) data.TargetFiles {
+	targets := make(data.TargetFiles)
+	for path, content := range tf {
+		sha256Hash := sha256.Sum256([]byte(content))
+		targets[path] = data.TargetFileMeta{
+			FileMeta: data.FileMeta{
+				Length: int64(len(content)),
+				Hashes: data.Hashes{
+					"sha256": sha256Hash[:],
+				},
+			},
+		}
+	}
+	return targets
+}
+
+func withSubscriptionProductMappings(productsMappings productsMappings) Option {
+	return func(o *options) {
+		o.subscriptionProductMappings = productsMappings
+	}
+}
+
+// A fake enum value that we'll use for testing to ensure that all the
+// infrastructure supports working with multiple sets of products.
+const apmTracingProducts pbgo.ConfigSubscriptionProducts = 2
+
+var productMappingsWithApmTracingProducts = func() productsMappings {
+	mappings := maps.Clone(defaultSubscriptionProductMappings)
+	mappings[apmTracingProducts] = map[rdata.Product]struct{}{
+		rdata.ProductAPMTracing: {},
+	}
+	return mappings
+}()
+
+func uptaneToCore(path string, m data.TargetFileMeta) *pbgo.TargetFileMeta {
+	hashes := make([]*pbgo.TargetFileHash, 0, len(m.Hashes))
+	for algorithm, hash := range m.Hashes {
+		hashes = append(hashes, &pbgo.TargetFileHash{
+			Algorithm: algorithm,
+			Hash:      hex.EncodeToString(hash),
+		})
+	}
+
+	return &pbgo.TargetFileMeta{
+		Path:   path,
+		Length: m.Length,
+		Hashes: hashes,
+	}
+}
+
+func subscriptionIsRegistered(service *CoreAgentService, runtimeID string) bool {
+	return numSubscriptionsRegisteredForRuntimeID(service, runtimeID) > 0
+}
+
+func numSubscriptionsRegisteredForRuntimeID(service *CoreAgentService, runtimeID string) int {
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	count := 0
+	for _, sub := range service.mu.subscriptions.subs {
+		if _, ok := sub.trackedClients[runtimeID]; ok {
+			count++
+		}
+	}
+	return count
+}
+
+func fileNames(files []*pbgo.File) (fileNames []string) {
+	for _, file := range files {
+		fileNames = append(fileNames, file.Path)
+	}
+	return fileNames
+}

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -218,4 +218,17 @@ func printRemoteConfigStateContents(w io.Writer, state *pbgo.GetStateConfigRespo
 	if len(state.ActiveClients) == 0 {
 		fmt.Fprintln(w, "No active clients")
 	}
+
+	if len(state.ConfigSubscriptionStates) > 0 {
+		fmt.Fprintln(w, "\nRemote config active subscriptions")
+		fmt.Fprintln(w, strings.Repeat("-", 34))
+		for _, subscription := range state.ConfigSubscriptionStates {
+			fmt.Fprintf(w, "\n- Subscription %d\n", subscription.SubscriptionId)
+			for _, trackedClient := range subscription.TrackedClients {
+				fmt.Fprintf(w, "    - Tracked client %s - Seen any: %t - Products: %s\n",
+					trackedClient.RuntimeId, trackedClient.SeenAny, trackedClient.Products.String(),
+				)
+			}
+		}
+	}
 }

--- a/pkg/proto/datadog/api/v1/api.proto
+++ b/pkg/proto/datadog/api/v1/api.proto
@@ -43,6 +43,8 @@ service AgentSecure {
 
     rpc GetConfigStateHA(google.protobuf.Empty) returns (datadog.config.GetStateConfigResponse);
 
+    rpc CreateConfigSubscription(stream datadog.config.ConfigSubscriptionRequest) returns (stream datadog.config.ConfigSubscriptionResponse);
+
     rpc ResetConfigState(google.protobuf.Empty) returns (datadog.config.ResetStateConfigResponse);
 
     // Subscribes to added, removed, or changed entities in the Workloadmeta and

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -259,6 +259,23 @@ message GetStateConfigResponse {
   map<string, FileMetaState> director_state = 2;
   map<string, string> target_filenames = 3;
   repeated Client active_clients = 4;
+  repeated ConfigSubscriptionState config_subscription_states = 5;
+}
+
+// ConfigSubscriptionState describes the state of a config subscription.
+message ConfigSubscriptionState {
+  message TrackedClient {
+    string runtime_id = 1;
+    bool seen_any = 2;
+    ConfigSubscriptionProducts products = 3;
+  }
+
+  // SubscriptionID is a process-unique identifier for the subscription.
+  uint64 subscription_id = 1;
+
+  // TrackedClients is the list of clients that are currently tracked by the
+  // subscription.
+  repeated TrackedClient tracked_clients = 2;
 }
 
 message ResetStateConfigResponse {}

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -178,6 +178,57 @@ message TargetFileMeta {
   repeated TargetFileHash hashes = 3;
 }
 
+// ConfigSubscriptionProducts is used to targets specific products for tracking
+// with a ConfigSubscriptionRequest.
+enum ConfigSubscriptionProducts {
+  INVALID = 0;
+
+  // LIVE_DEBUGGING corresponds to the LIVE_DEBUGING and LIVE_DEBUGGING_SYMBOLDB
+  // products.
+  LIVE_DEBUGGING = 1;
+}
+
+// ConfigSubscriptionRequest is used to manage the state of the stream created
+// using CreateConfigSubscription.
+message ConfigSubscriptionRequest {
+
+  enum Action {
+    INVALID = 0;
+    TRACK = 1;
+    UNTRACK = 2;
+  }
+
+
+  // RuntimeID of the client to track or untrack.
+  string runtime_id = 1;
+
+  // Action indicates the action to take for the client with the given
+  // runtime_id.
+  Action action = 2;
+
+  // If action is TRACK, products indicates the set of products for which the
+  // client is interested in receiving updates.
+  ConfigSubscriptionProducts products = 3;
+}
+
+// ConfigSubscriptionResponse is streamed from CreateConfigSubscription with
+// updates for matching clients and products.
+message ConfigSubscriptionResponse {
+
+  // Client is the client that was tracked or untracked.
+  Client client = 1;
+
+  // Matched configs are all configs that were matched for the client given
+  // the subscription request.
+  //
+  // If a previously reported config is no longer matched, it will not be
+  // included in the response.
+  repeated string matched_configs = 2;
+
+  // Target files are the target files that needs to be sent to the client.
+  repeated File target_files = 3;
+}
+
 message ClientGetConfigsRequest {
   Client client = 1;
   repeated TargetFileMeta cached_target_files = 2;

--- a/pkg/proto/pbgo/core/api.pb.go
+++ b/pkg/proto/pbgo/core/api.pb.go
@@ -31,7 +31,7 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\n" +
 	"\x18datadog/api/v1/api.proto\x12\x0edatadog.api.v1\x1a\x1cdatadog/model/v1/model.proto\x1a%datadog/remoteagent/remoteagent.proto\x1a'datadog/remoteconfig/remoteconfig.proto\x1a'datadog/workloadmeta/workloadmeta.proto\x1a)datadog/autodiscovery/autodiscovery.proto\x1a\x1bgoogle/protobuf/empty.proto2Z\n" +
 	"\x05Agent\x12Q\n" +
-	"\vGetHostname\x12!.datadog.model.v1.HostnameRequest\x1a\x1f.datadog.model.v1.HostnameReply2\xaf\r\n" +
+	"\vGetHostname\x12!.datadog.model.v1.HostnameRequest\x1a\x1f.datadog.model.v1.HostnameReply2\xa6\x0e\n" +
 	"\vAgentSecure\x12c\n" +
 	"\x14TaggerStreamEntities\x12#.datadog.model.v1.StreamTagsRequest\x1a$.datadog.model.v1.StreamTagsResponse0\x01\x12\xa2\x01\n" +
 	"'TaggerGenerateContainerIDFromOriginInfo\x12:.datadog.model.v1.GenerateContainerIDFromOriginInfoRequest\x1a;.datadog.model.v1.GenerateContainerIDFromOriginInfoResponse\x12`\n" +
@@ -41,7 +41,8 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x10ClientGetConfigs\x12'.datadog.config.ClientGetConfigsRequest\x1a(.datadog.config.ClientGetConfigsResponse\x12P\n" +
 	"\x0eGetConfigState\x12\x16.google.protobuf.Empty\x1a&.datadog.config.GetStateConfigResponse\x12g\n" +
 	"\x12ClientGetConfigsHA\x12'.datadog.config.ClientGetConfigsRequest\x1a(.datadog.config.ClientGetConfigsResponse\x12R\n" +
-	"\x10GetConfigStateHA\x12\x16.google.protobuf.Empty\x1a&.datadog.config.GetStateConfigResponse\x12T\n" +
+	"\x10GetConfigStateHA\x12\x16.google.protobuf.Empty\x1a&.datadog.config.GetStateConfigResponse\x12u\n" +
+	"\x18CreateConfigSubscription\x12).datadog.config.ConfigSubscriptionRequest\x1a*.datadog.config.ConfigSubscriptionResponse(\x010\x01\x12T\n" +
 	"\x10ResetConfigState\x12\x16.google.protobuf.Empty\x1a(.datadog.config.ResetStateConfigResponse\x12\x81\x01\n" +
 	"\x1aWorkloadmetaStreamEntities\x12/.datadog.workloadmeta.WorkloadmetaStreamRequest\x1a0.datadog.workloadmeta.WorkloadmetaStreamResponse0\x01\x12~\n" +
 	"\x13RegisterRemoteAgent\x122.datadog.remoteagent.v1.RegisterRemoteAgentRequest\x1a3.datadog.remoteagent.v1.RegisterRemoteAgentResponse\x12{\n" +
@@ -59,26 +60,28 @@ var file_datadog_api_v1_api_proto_goTypes = []any{
 	(*TaggerState)(nil),                               // 5: datadog.model.v1.TaggerState
 	(*ClientGetConfigsRequest)(nil),                   // 6: datadog.config.ClientGetConfigsRequest
 	(*empty.Empty)(nil),                               // 7: google.protobuf.Empty
-	(*WorkloadmetaStreamRequest)(nil),                 // 8: datadog.workloadmeta.WorkloadmetaStreamRequest
-	(*RegisterRemoteAgentRequest)(nil),                // 9: datadog.remoteagent.v1.RegisterRemoteAgentRequest
-	(*RefreshRemoteAgentRequest)(nil),                 // 10: datadog.remoteagent.v1.RefreshRemoteAgentRequest
-	(*HostTagRequest)(nil),                            // 11: datadog.model.v1.HostTagRequest
-	(*ConfigStreamRequest)(nil),                       // 12: datadog.model.v1.ConfigStreamRequest
-	(*HostnameReply)(nil),                             // 13: datadog.model.v1.HostnameReply
-	(*StreamTagsResponse)(nil),                        // 14: datadog.model.v1.StreamTagsResponse
-	(*GenerateContainerIDFromOriginInfoResponse)(nil), // 15: datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
-	(*FetchEntityResponse)(nil),                       // 16: datadog.model.v1.FetchEntityResponse
-	(*CaptureTriggerResponse)(nil),                    // 17: datadog.model.v1.CaptureTriggerResponse
-	(*TaggerStateResponse)(nil),                       // 18: datadog.model.v1.TaggerStateResponse
-	(*ClientGetConfigsResponse)(nil),                  // 19: datadog.config.ClientGetConfigsResponse
-	(*GetStateConfigResponse)(nil),                    // 20: datadog.config.GetStateConfigResponse
-	(*ResetStateConfigResponse)(nil),                  // 21: datadog.config.ResetStateConfigResponse
-	(*WorkloadmetaStreamResponse)(nil),                // 22: datadog.workloadmeta.WorkloadmetaStreamResponse
-	(*RegisterRemoteAgentResponse)(nil),               // 23: datadog.remoteagent.v1.RegisterRemoteAgentResponse
-	(*RefreshRemoteAgentResponse)(nil),                // 24: datadog.remoteagent.v1.RefreshRemoteAgentResponse
-	(*AutodiscoveryStreamResponse)(nil),               // 25: datadog.autodiscovery.AutodiscoveryStreamResponse
-	(*HostTagReply)(nil),                              // 26: datadog.model.v1.HostTagReply
-	(*ConfigEvent)(nil),                               // 27: datadog.model.v1.ConfigEvent
+	(*ConfigSubscriptionRequest)(nil),                 // 8: datadog.config.ConfigSubscriptionRequest
+	(*WorkloadmetaStreamRequest)(nil),                 // 9: datadog.workloadmeta.WorkloadmetaStreamRequest
+	(*RegisterRemoteAgentRequest)(nil),                // 10: datadog.remoteagent.v1.RegisterRemoteAgentRequest
+	(*RefreshRemoteAgentRequest)(nil),                 // 11: datadog.remoteagent.v1.RefreshRemoteAgentRequest
+	(*HostTagRequest)(nil),                            // 12: datadog.model.v1.HostTagRequest
+	(*ConfigStreamRequest)(nil),                       // 13: datadog.model.v1.ConfigStreamRequest
+	(*HostnameReply)(nil),                             // 14: datadog.model.v1.HostnameReply
+	(*StreamTagsResponse)(nil),                        // 15: datadog.model.v1.StreamTagsResponse
+	(*GenerateContainerIDFromOriginInfoResponse)(nil), // 16: datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
+	(*FetchEntityResponse)(nil),                       // 17: datadog.model.v1.FetchEntityResponse
+	(*CaptureTriggerResponse)(nil),                    // 18: datadog.model.v1.CaptureTriggerResponse
+	(*TaggerStateResponse)(nil),                       // 19: datadog.model.v1.TaggerStateResponse
+	(*ClientGetConfigsResponse)(nil),                  // 20: datadog.config.ClientGetConfigsResponse
+	(*GetStateConfigResponse)(nil),                    // 21: datadog.config.GetStateConfigResponse
+	(*ConfigSubscriptionResponse)(nil),                // 22: datadog.config.ConfigSubscriptionResponse
+	(*ResetStateConfigResponse)(nil),                  // 23: datadog.config.ResetStateConfigResponse
+	(*WorkloadmetaStreamResponse)(nil),                // 24: datadog.workloadmeta.WorkloadmetaStreamResponse
+	(*RegisterRemoteAgentResponse)(nil),               // 25: datadog.remoteagent.v1.RegisterRemoteAgentResponse
+	(*RefreshRemoteAgentResponse)(nil),                // 26: datadog.remoteagent.v1.RefreshRemoteAgentResponse
+	(*AutodiscoveryStreamResponse)(nil),               // 27: datadog.autodiscovery.AutodiscoveryStreamResponse
+	(*HostTagReply)(nil),                              // 28: datadog.model.v1.HostTagReply
+	(*ConfigEvent)(nil),                               // 29: datadog.model.v1.ConfigEvent
 }
 var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	0,  // 0: datadog.api.v1.Agent.GetHostname:input_type -> datadog.model.v1.HostnameRequest
@@ -91,32 +94,34 @@ var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	7,  // 7: datadog.api.v1.AgentSecure.GetConfigState:input_type -> google.protobuf.Empty
 	6,  // 8: datadog.api.v1.AgentSecure.ClientGetConfigsHA:input_type -> datadog.config.ClientGetConfigsRequest
 	7,  // 9: datadog.api.v1.AgentSecure.GetConfigStateHA:input_type -> google.protobuf.Empty
-	7,  // 10: datadog.api.v1.AgentSecure.ResetConfigState:input_type -> google.protobuf.Empty
-	8,  // 11: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:input_type -> datadog.workloadmeta.WorkloadmetaStreamRequest
-	9,  // 12: datadog.api.v1.AgentSecure.RegisterRemoteAgent:input_type -> datadog.remoteagent.v1.RegisterRemoteAgentRequest
-	10, // 13: datadog.api.v1.AgentSecure.RefreshRemoteAgent:input_type -> datadog.remoteagent.v1.RefreshRemoteAgentRequest
-	7,  // 14: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:input_type -> google.protobuf.Empty
-	11, // 15: datadog.api.v1.AgentSecure.GetHostTags:input_type -> datadog.model.v1.HostTagRequest
-	12, // 16: datadog.api.v1.AgentSecure.StreamConfigEvents:input_type -> datadog.model.v1.ConfigStreamRequest
-	13, // 17: datadog.api.v1.Agent.GetHostname:output_type -> datadog.model.v1.HostnameReply
-	14, // 18: datadog.api.v1.AgentSecure.TaggerStreamEntities:output_type -> datadog.model.v1.StreamTagsResponse
-	15, // 19: datadog.api.v1.AgentSecure.TaggerGenerateContainerIDFromOriginInfo:output_type -> datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
-	16, // 20: datadog.api.v1.AgentSecure.TaggerFetchEntity:output_type -> datadog.model.v1.FetchEntityResponse
-	17, // 21: datadog.api.v1.AgentSecure.DogstatsdCaptureTrigger:output_type -> datadog.model.v1.CaptureTriggerResponse
-	18, // 22: datadog.api.v1.AgentSecure.DogstatsdSetTaggerState:output_type -> datadog.model.v1.TaggerStateResponse
-	19, // 23: datadog.api.v1.AgentSecure.ClientGetConfigs:output_type -> datadog.config.ClientGetConfigsResponse
-	20, // 24: datadog.api.v1.AgentSecure.GetConfigState:output_type -> datadog.config.GetStateConfigResponse
-	19, // 25: datadog.api.v1.AgentSecure.ClientGetConfigsHA:output_type -> datadog.config.ClientGetConfigsResponse
-	20, // 26: datadog.api.v1.AgentSecure.GetConfigStateHA:output_type -> datadog.config.GetStateConfigResponse
-	21, // 27: datadog.api.v1.AgentSecure.ResetConfigState:output_type -> datadog.config.ResetStateConfigResponse
-	22, // 28: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:output_type -> datadog.workloadmeta.WorkloadmetaStreamResponse
-	23, // 29: datadog.api.v1.AgentSecure.RegisterRemoteAgent:output_type -> datadog.remoteagent.v1.RegisterRemoteAgentResponse
-	24, // 30: datadog.api.v1.AgentSecure.RefreshRemoteAgent:output_type -> datadog.remoteagent.v1.RefreshRemoteAgentResponse
-	25, // 31: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:output_type -> datadog.autodiscovery.AutodiscoveryStreamResponse
-	26, // 32: datadog.api.v1.AgentSecure.GetHostTags:output_type -> datadog.model.v1.HostTagReply
-	27, // 33: datadog.api.v1.AgentSecure.StreamConfigEvents:output_type -> datadog.model.v1.ConfigEvent
-	17, // [17:34] is the sub-list for method output_type
-	0,  // [0:17] is the sub-list for method input_type
+	8,  // 10: datadog.api.v1.AgentSecure.CreateConfigSubscription:input_type -> datadog.config.ConfigSubscriptionRequest
+	7,  // 11: datadog.api.v1.AgentSecure.ResetConfigState:input_type -> google.protobuf.Empty
+	9,  // 12: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:input_type -> datadog.workloadmeta.WorkloadmetaStreamRequest
+	10, // 13: datadog.api.v1.AgentSecure.RegisterRemoteAgent:input_type -> datadog.remoteagent.v1.RegisterRemoteAgentRequest
+	11, // 14: datadog.api.v1.AgentSecure.RefreshRemoteAgent:input_type -> datadog.remoteagent.v1.RefreshRemoteAgentRequest
+	7,  // 15: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:input_type -> google.protobuf.Empty
+	12, // 16: datadog.api.v1.AgentSecure.GetHostTags:input_type -> datadog.model.v1.HostTagRequest
+	13, // 17: datadog.api.v1.AgentSecure.StreamConfigEvents:input_type -> datadog.model.v1.ConfigStreamRequest
+	14, // 18: datadog.api.v1.Agent.GetHostname:output_type -> datadog.model.v1.HostnameReply
+	15, // 19: datadog.api.v1.AgentSecure.TaggerStreamEntities:output_type -> datadog.model.v1.StreamTagsResponse
+	16, // 20: datadog.api.v1.AgentSecure.TaggerGenerateContainerIDFromOriginInfo:output_type -> datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
+	17, // 21: datadog.api.v1.AgentSecure.TaggerFetchEntity:output_type -> datadog.model.v1.FetchEntityResponse
+	18, // 22: datadog.api.v1.AgentSecure.DogstatsdCaptureTrigger:output_type -> datadog.model.v1.CaptureTriggerResponse
+	19, // 23: datadog.api.v1.AgentSecure.DogstatsdSetTaggerState:output_type -> datadog.model.v1.TaggerStateResponse
+	20, // 24: datadog.api.v1.AgentSecure.ClientGetConfigs:output_type -> datadog.config.ClientGetConfigsResponse
+	21, // 25: datadog.api.v1.AgentSecure.GetConfigState:output_type -> datadog.config.GetStateConfigResponse
+	20, // 26: datadog.api.v1.AgentSecure.ClientGetConfigsHA:output_type -> datadog.config.ClientGetConfigsResponse
+	21, // 27: datadog.api.v1.AgentSecure.GetConfigStateHA:output_type -> datadog.config.GetStateConfigResponse
+	22, // 28: datadog.api.v1.AgentSecure.CreateConfigSubscription:output_type -> datadog.config.ConfigSubscriptionResponse
+	23, // 29: datadog.api.v1.AgentSecure.ResetConfigState:output_type -> datadog.config.ResetStateConfigResponse
+	24, // 30: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:output_type -> datadog.workloadmeta.WorkloadmetaStreamResponse
+	25, // 31: datadog.api.v1.AgentSecure.RegisterRemoteAgent:output_type -> datadog.remoteagent.v1.RegisterRemoteAgentResponse
+	26, // 32: datadog.api.v1.AgentSecure.RefreshRemoteAgent:output_type -> datadog.remoteagent.v1.RefreshRemoteAgentResponse
+	27, // 33: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:output_type -> datadog.autodiscovery.AutodiscoveryStreamResponse
+	28, // 34: datadog.api.v1.AgentSecure.GetHostTags:output_type -> datadog.model.v1.HostTagReply
+	29, // 35: datadog.api.v1.AgentSecure.StreamConfigEvents:output_type -> datadog.model.v1.ConfigEvent
+	18, // [18:36] is the sub-list for method output_type
+	0,  // [0:18] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -251,6 +256,7 @@ type AgentSecureClient interface {
 	GetConfigState(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*GetStateConfigResponse, error)
 	ClientGetConfigsHA(ctx context.Context, in *ClientGetConfigsRequest, opts ...grpc.CallOption) (*ClientGetConfigsResponse, error)
 	GetConfigStateHA(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*GetStateConfigResponse, error)
+	CreateConfigSubscription(ctx context.Context, opts ...grpc.CallOption) (AgentSecure_CreateConfigSubscriptionClient, error)
 	ResetConfigState(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*ResetStateConfigResponse, error)
 	// Subscribes to added, removed, or changed entities in the Workloadmeta and
 	// streams them to clients as events.
@@ -379,6 +385,37 @@ func (c *agentSecureClient) GetConfigStateHA(ctx context.Context, in *empty.Empt
 	return out, nil
 }
 
+func (c *agentSecureClient) CreateConfigSubscription(ctx context.Context, opts ...grpc.CallOption) (AgentSecure_CreateConfigSubscriptionClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_AgentSecure_serviceDesc.Streams[1], "/datadog.api.v1.AgentSecure/CreateConfigSubscription", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &agentSecureCreateConfigSubscriptionClient{stream}
+	return x, nil
+}
+
+type AgentSecure_CreateConfigSubscriptionClient interface {
+	Send(*ConfigSubscriptionRequest) error
+	Recv() (*ConfigSubscriptionResponse, error)
+	grpc.ClientStream
+}
+
+type agentSecureCreateConfigSubscriptionClient struct {
+	grpc.ClientStream
+}
+
+func (x *agentSecureCreateConfigSubscriptionClient) Send(m *ConfigSubscriptionRequest) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *agentSecureCreateConfigSubscriptionClient) Recv() (*ConfigSubscriptionResponse, error) {
+	m := new(ConfigSubscriptionResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 func (c *agentSecureClient) ResetConfigState(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*ResetStateConfigResponse, error) {
 	out := new(ResetStateConfigResponse)
 	err := c.cc.Invoke(ctx, "/datadog.api.v1.AgentSecure/ResetConfigState", in, out, opts...)
@@ -389,7 +426,7 @@ func (c *agentSecureClient) ResetConfigState(ctx context.Context, in *empty.Empt
 }
 
 func (c *agentSecureClient) WorkloadmetaStreamEntities(ctx context.Context, in *WorkloadmetaStreamRequest, opts ...grpc.CallOption) (AgentSecure_WorkloadmetaStreamEntitiesClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_AgentSecure_serviceDesc.Streams[1], "/datadog.api.v1.AgentSecure/WorkloadmetaStreamEntities", opts...)
+	stream, err := c.cc.NewStream(ctx, &_AgentSecure_serviceDesc.Streams[2], "/datadog.api.v1.AgentSecure/WorkloadmetaStreamEntities", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +476,7 @@ func (c *agentSecureClient) RefreshRemoteAgent(ctx context.Context, in *RefreshR
 }
 
 func (c *agentSecureClient) AutodiscoveryStreamConfig(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (AgentSecure_AutodiscoveryStreamConfigClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_AgentSecure_serviceDesc.Streams[2], "/datadog.api.v1.AgentSecure/AutodiscoveryStreamConfig", opts...)
+	stream, err := c.cc.NewStream(ctx, &_AgentSecure_serviceDesc.Streams[3], "/datadog.api.v1.AgentSecure/AutodiscoveryStreamConfig", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +517,7 @@ func (c *agentSecureClient) GetHostTags(ctx context.Context, in *HostTagRequest,
 }
 
 func (c *agentSecureClient) StreamConfigEvents(ctx context.Context, in *ConfigStreamRequest, opts ...grpc.CallOption) (AgentSecure_StreamConfigEventsClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_AgentSecure_serviceDesc.Streams[3], "/datadog.api.v1.AgentSecure/StreamConfigEvents", opts...)
+	stream, err := c.cc.NewStream(ctx, &_AgentSecure_serviceDesc.Streams[4], "/datadog.api.v1.AgentSecure/StreamConfigEvents", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -528,6 +565,7 @@ type AgentSecureServer interface {
 	GetConfigState(context.Context, *empty.Empty) (*GetStateConfigResponse, error)
 	ClientGetConfigsHA(context.Context, *ClientGetConfigsRequest) (*ClientGetConfigsResponse, error)
 	GetConfigStateHA(context.Context, *empty.Empty) (*GetStateConfigResponse, error)
+	CreateConfigSubscription(AgentSecure_CreateConfigSubscriptionServer) error
 	ResetConfigState(context.Context, *empty.Empty) (*ResetStateConfigResponse, error)
 	// Subscribes to added, removed, or changed entities in the Workloadmeta and
 	// streams them to clients as events.
@@ -574,6 +612,9 @@ func (*UnimplementedAgentSecureServer) ClientGetConfigsHA(context.Context, *Clie
 }
 func (*UnimplementedAgentSecureServer) GetConfigStateHA(context.Context, *empty.Empty) (*GetStateConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetConfigStateHA not implemented")
+}
+func (*UnimplementedAgentSecureServer) CreateConfigSubscription(AgentSecure_CreateConfigSubscriptionServer) error {
+	return status.Errorf(codes.Unimplemented, "method CreateConfigSubscription not implemented")
 }
 func (*UnimplementedAgentSecureServer) ResetConfigState(context.Context, *empty.Empty) (*ResetStateConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ResetConfigState not implemented")
@@ -764,6 +805,32 @@ func _AgentSecure_GetConfigStateHA_Handler(srv interface{}, ctx context.Context,
 		return srv.(AgentSecureServer).GetConfigStateHA(ctx, req.(*empty.Empty))
 	}
 	return interceptor(ctx, in, info, handler)
+}
+
+func _AgentSecure_CreateConfigSubscription_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(AgentSecureServer).CreateConfigSubscription(&agentSecureCreateConfigSubscriptionServer{stream})
+}
+
+type AgentSecure_CreateConfigSubscriptionServer interface {
+	Send(*ConfigSubscriptionResponse) error
+	Recv() (*ConfigSubscriptionRequest, error)
+	grpc.ServerStream
+}
+
+type agentSecureCreateConfigSubscriptionServer struct {
+	grpc.ServerStream
+}
+
+func (x *agentSecureCreateConfigSubscriptionServer) Send(m *ConfigSubscriptionResponse) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *agentSecureCreateConfigSubscriptionServer) Recv() (*ConfigSubscriptionRequest, error) {
+	m := new(ConfigSubscriptionRequest)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func _AgentSecure_ResetConfigState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -959,6 +1026,12 @@ var _AgentSecure_serviceDesc = grpc.ServiceDesc{
 			StreamName:    "TaggerStreamEntities",
 			Handler:       _AgentSecure_TaggerStreamEntities_Handler,
 			ServerStreams: true,
+		},
+		{
+			StreamName:    "CreateConfigSubscription",
+			Handler:       _AgentSecure_CreateConfigSubscription_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
 		},
 		{
 			StreamName:    "WorkloadmetaStreamEntities",

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -2003,13 +2003,14 @@ func (x *FileMetaState) GetHash() string {
 }
 
 type GetStateConfigResponse struct {
-	state           protoimpl.MessageState    `protogen:"open.v1"`
-	ConfigState     map[string]*FileMetaState `protobuf:"bytes,1,rep,name=config_state,json=configState,proto3" json:"config_state,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	DirectorState   map[string]*FileMetaState `protobuf:"bytes,2,rep,name=director_state,json=directorState,proto3" json:"director_state,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	TargetFilenames map[string]string         `protobuf:"bytes,3,rep,name=target_filenames,json=targetFilenames,proto3" json:"target_filenames,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	ActiveClients   []*Client                 `protobuf:"bytes,4,rep,name=active_clients,json=activeClients,proto3" json:"active_clients,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state                    protoimpl.MessageState     `protogen:"open.v1"`
+	ConfigState              map[string]*FileMetaState  `protobuf:"bytes,1,rep,name=config_state,json=configState,proto3" json:"config_state,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	DirectorState            map[string]*FileMetaState  `protobuf:"bytes,2,rep,name=director_state,json=directorState,proto3" json:"director_state,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	TargetFilenames          map[string]string          `protobuf:"bytes,3,rep,name=target_filenames,json=targetFilenames,proto3" json:"target_filenames,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ActiveClients            []*Client                  `protobuf:"bytes,4,rep,name=active_clients,json=activeClients,proto3" json:"active_clients,omitempty"`
+	ConfigSubscriptionStates []*ConfigSubscriptionState `protobuf:"bytes,5,rep,name=config_subscription_states,json=configSubscriptionStates,proto3" json:"config_subscription_states,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *GetStateConfigResponse) Reset() {
@@ -2070,6 +2071,69 @@ func (x *GetStateConfigResponse) GetActiveClients() []*Client {
 	return nil
 }
 
+func (x *GetStateConfigResponse) GetConfigSubscriptionStates() []*ConfigSubscriptionState {
+	if x != nil {
+		return x.ConfigSubscriptionStates
+	}
+	return nil
+}
+
+// ConfigSubscriptionState describes the state of a config subscription.
+type ConfigSubscriptionState struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// SubscriptionID is a process-unique identifier for the subscription.
+	SubscriptionId uint64 `protobuf:"varint,1,opt,name=subscription_id,json=subscriptionId,proto3" json:"subscription_id,omitempty"`
+	// TrackedClients is the list of clients that are currently tracked by the
+	// subscription.
+	TrackedClients []*ConfigSubscriptionState_TrackedClient `protobuf:"bytes,2,rep,name=tracked_clients,json=trackedClients,proto3" json:"tracked_clients,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ConfigSubscriptionState) Reset() {
+	*x = ConfigSubscriptionState{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigSubscriptionState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigSubscriptionState) ProtoMessage() {}
+
+func (x *ConfigSubscriptionState) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigSubscriptionState.ProtoReflect.Descriptor instead.
+func (*ConfigSubscriptionState) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *ConfigSubscriptionState) GetSubscriptionId() uint64 {
+	if x != nil {
+		return x.SubscriptionId
+	}
+	return 0
+}
+
+func (x *ConfigSubscriptionState) GetTrackedClients() []*ConfigSubscriptionState_TrackedClient {
+	if x != nil {
+		return x.TrackedClients
+	}
+	return nil
+}
+
 type ResetStateConfigResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2078,7 +2142,7 @@ type ResetStateConfigResponse struct {
 
 func (x *ResetStateConfigResponse) Reset() {
 	*x = ResetStateConfigResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2090,7 +2154,7 @@ func (x *ResetStateConfigResponse) String() string {
 func (*ResetStateConfigResponse) ProtoMessage() {}
 
 func (x *ResetStateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2103,7 +2167,7 @@ func (x *ResetStateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetStateConfigResponse.ProtoReflect.Descriptor instead.
 func (*ResetStateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{27}
 }
 
 type TracerPredicateV1 struct {
@@ -2121,7 +2185,7 @@ type TracerPredicateV1 struct {
 
 func (x *TracerPredicateV1) Reset() {
 	*x = TracerPredicateV1{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2133,7 +2197,7 @@ func (x *TracerPredicateV1) String() string {
 func (*TracerPredicateV1) ProtoMessage() {}
 
 func (x *TracerPredicateV1) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2146,7 +2210,7 @@ func (x *TracerPredicateV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerPredicateV1.ProtoReflect.Descriptor instead.
 func (*TracerPredicateV1) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{27}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TracerPredicateV1) GetClientID() string {
@@ -2207,7 +2271,7 @@ type TracerPredicates struct {
 
 func (x *TracerPredicates) Reset() {
 	*x = TracerPredicates{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2219,7 +2283,7 @@ func (x *TracerPredicates) String() string {
 func (*TracerPredicates) ProtoMessage() {}
 
 func (x *TracerPredicates) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2232,7 +2296,7 @@ func (x *TracerPredicates) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerPredicates.ProtoReflect.Descriptor instead.
 func (*TracerPredicates) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *TracerPredicates) GetTracerPredicatesV1() []*TracerPredicateV1 {
@@ -2240,6 +2304,66 @@ func (x *TracerPredicates) GetTracerPredicatesV1() []*TracerPredicateV1 {
 		return x.TracerPredicatesV1
 	}
 	return nil
+}
+
+type ConfigSubscriptionState_TrackedClient struct {
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	RuntimeId     string                     `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	SeenAny       bool                       `protobuf:"varint,2,opt,name=seen_any,json=seenAny,proto3" json:"seen_any,omitempty"`
+	Products      ConfigSubscriptionProducts `protobuf:"varint,3,opt,name=products,proto3,enum=datadog.config.ConfigSubscriptionProducts" json:"products,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigSubscriptionState_TrackedClient) Reset() {
+	*x = ConfigSubscriptionState_TrackedClient{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigSubscriptionState_TrackedClient) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigSubscriptionState_TrackedClient) ProtoMessage() {}
+
+func (x *ConfigSubscriptionState_TrackedClient) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigSubscriptionState_TrackedClient.ProtoReflect.Descriptor instead.
+func (*ConfigSubscriptionState_TrackedClient) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26, 0}
+}
+
+func (x *ConfigSubscriptionState_TrackedClient) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *ConfigSubscriptionState_TrackedClient) GetSeenAny() bool {
+	if x != nil {
+		return x.SeenAny
+	}
+	return false
+}
+
+func (x *ConfigSubscriptionState_TrackedClient) GetProducts() ConfigSubscriptionProducts {
+	if x != nil {
+		return x.Products
+	}
+	return ConfigSubscriptionProducts_INVALID
 }
 
 var File_datadog_remoteconfig_remoteconfig_proto protoreflect.FileDescriptor
@@ -2400,12 +2524,13 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\rconfig_status\x18\x05 \x01(\x0e2\x1c.datadog.config.ConfigStatusR\fconfigStatus\"=\n" +
 	"\rFileMetaState\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x04R\aversion\x12\x12\n" +
-	"\x04hash\x18\x02 \x01(\tR\x04hash\"\x81\x05\n" +
+	"\x04hash\x18\x02 \x01(\tR\x04hash\"\xe8\x05\n" +
 	"\x16GetStateConfigResponse\x12Z\n" +
 	"\fconfig_state\x18\x01 \x03(\v27.datadog.config.GetStateConfigResponse.ConfigStateEntryR\vconfigState\x12`\n" +
 	"\x0edirector_state\x18\x02 \x03(\v29.datadog.config.GetStateConfigResponse.DirectorStateEntryR\rdirectorState\x12f\n" +
 	"\x10target_filenames\x18\x03 \x03(\v2;.datadog.config.GetStateConfigResponse.TargetFilenamesEntryR\x0ftargetFilenames\x12=\n" +
-	"\x0eactive_clients\x18\x04 \x03(\v2\x16.datadog.config.ClientR\ractiveClients\x1a]\n" +
+	"\x0eactive_clients\x18\x04 \x03(\v2\x16.datadog.config.ClientR\ractiveClients\x12e\n" +
+	"\x1aconfig_subscription_states\x18\x05 \x03(\v2'.datadog.config.ConfigSubscriptionStateR\x18configSubscriptionStates\x1a]\n" +
 	"\x10ConfigStateEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x123\n" +
 	"\x05value\x18\x02 \x01(\v2\x1d.datadog.config.FileMetaStateR\x05value:\x028\x01\x1a_\n" +
@@ -2414,7 +2539,15 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x1d.datadog.config.FileMetaStateR\x05value:\x028\x01\x1aB\n" +
 	"\x14TargetFilenamesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x1a\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb6\x02\n" +
+	"\x17ConfigSubscriptionState\x12'\n" +
+	"\x0fsubscription_id\x18\x01 \x01(\x04R\x0esubscriptionId\x12^\n" +
+	"\x0ftracked_clients\x18\x02 \x03(\v25.datadog.config.ConfigSubscriptionState.TrackedClientR\x0etrackedClients\x1a\x91\x01\n" +
+	"\rTrackedClient\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x19\n" +
+	"\bseen_any\x18\x02 \x01(\bR\aseenAny\x12F\n" +
+	"\bproducts\x18\x03 \x01(\x0e2*.datadog.config.ConfigSubscriptionProductsR\bproducts\"\x1a\n" +
 	"\x18ResetStateConfigResponse\"\xeb\x01\n" +
 	"\x11TracerPredicateV1\x12\x1a\n" +
 	"\bclientID\x18\x01 \x01(\tR\bclientID\x12\x18\n" +
@@ -2454,44 +2587,46 @@ func file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_remoteconfig_remoteconfig_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_datadog_remoteconfig_remoteconfig_proto_goTypes = []any{
-	(TaskState)(0),                        // 0: datadog.config.TaskState
-	(ConfigSubscriptionProducts)(0),       // 1: datadog.config.ConfigSubscriptionProducts
-	(ConfigStatus)(0),                     // 2: datadog.config.ConfigStatus
-	(ConfigSubscriptionRequest_Action)(0), // 3: datadog.config.ConfigSubscriptionRequest.Action
-	(*ConfigMetas)(nil),                   // 4: datadog.config.ConfigMetas
-	(*DirectorMetas)(nil),                 // 5: datadog.config.DirectorMetas
-	(*DelegatedMeta)(nil),                 // 6: datadog.config.DelegatedMeta
-	(*TopMeta)(nil),                       // 7: datadog.config.TopMeta
-	(*File)(nil),                          // 8: datadog.config.File
-	(*LatestConfigsRequest)(nil),          // 9: datadog.config.LatestConfigsRequest
-	(*LatestConfigsResponse)(nil),         // 10: datadog.config.LatestConfigsResponse
-	(*OrgDataResponse)(nil),               // 11: datadog.config.OrgDataResponse
-	(*OrgStatusResponse)(nil),             // 12: datadog.config.OrgStatusResponse
-	(*Client)(nil),                        // 13: datadog.config.Client
-	(*ClientTracer)(nil),                  // 14: datadog.config.ClientTracer
-	(*ClientAgent)(nil),                   // 15: datadog.config.ClientAgent
-	(*ClientUpdater)(nil),                 // 16: datadog.config.ClientUpdater
-	(*PackageState)(nil),                  // 17: datadog.config.PackageState
-	(*PackageStateTask)(nil),              // 18: datadog.config.PackageStateTask
-	(*TaskError)(nil),                     // 19: datadog.config.TaskError
-	(*ConfigState)(nil),                   // 20: datadog.config.ConfigState
-	(*ClientState)(nil),                   // 21: datadog.config.ClientState
-	(*TargetFileHash)(nil),                // 22: datadog.config.TargetFileHash
-	(*TargetFileMeta)(nil),                // 23: datadog.config.TargetFileMeta
-	(*ConfigSubscriptionRequest)(nil),     // 24: datadog.config.ConfigSubscriptionRequest
-	(*ConfigSubscriptionResponse)(nil),    // 25: datadog.config.ConfigSubscriptionResponse
-	(*ClientGetConfigsRequest)(nil),       // 26: datadog.config.ClientGetConfigsRequest
-	(*ClientGetConfigsResponse)(nil),      // 27: datadog.config.ClientGetConfigsResponse
-	(*FileMetaState)(nil),                 // 28: datadog.config.FileMetaState
-	(*GetStateConfigResponse)(nil),        // 29: datadog.config.GetStateConfigResponse
-	(*ResetStateConfigResponse)(nil),      // 30: datadog.config.ResetStateConfigResponse
-	(*TracerPredicateV1)(nil),             // 31: datadog.config.TracerPredicateV1
-	(*TracerPredicates)(nil),              // 32: datadog.config.TracerPredicates
-	nil,                                   // 33: datadog.config.GetStateConfigResponse.ConfigStateEntry
-	nil,                                   // 34: datadog.config.GetStateConfigResponse.DirectorStateEntry
-	nil,                                   // 35: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	(TaskState)(0),                                // 0: datadog.config.TaskState
+	(ConfigSubscriptionProducts)(0),               // 1: datadog.config.ConfigSubscriptionProducts
+	(ConfigStatus)(0),                             // 2: datadog.config.ConfigStatus
+	(ConfigSubscriptionRequest_Action)(0),         // 3: datadog.config.ConfigSubscriptionRequest.Action
+	(*ConfigMetas)(nil),                           // 4: datadog.config.ConfigMetas
+	(*DirectorMetas)(nil),                         // 5: datadog.config.DirectorMetas
+	(*DelegatedMeta)(nil),                         // 6: datadog.config.DelegatedMeta
+	(*TopMeta)(nil),                               // 7: datadog.config.TopMeta
+	(*File)(nil),                                  // 8: datadog.config.File
+	(*LatestConfigsRequest)(nil),                  // 9: datadog.config.LatestConfigsRequest
+	(*LatestConfigsResponse)(nil),                 // 10: datadog.config.LatestConfigsResponse
+	(*OrgDataResponse)(nil),                       // 11: datadog.config.OrgDataResponse
+	(*OrgStatusResponse)(nil),                     // 12: datadog.config.OrgStatusResponse
+	(*Client)(nil),                                // 13: datadog.config.Client
+	(*ClientTracer)(nil),                          // 14: datadog.config.ClientTracer
+	(*ClientAgent)(nil),                           // 15: datadog.config.ClientAgent
+	(*ClientUpdater)(nil),                         // 16: datadog.config.ClientUpdater
+	(*PackageState)(nil),                          // 17: datadog.config.PackageState
+	(*PackageStateTask)(nil),                      // 18: datadog.config.PackageStateTask
+	(*TaskError)(nil),                             // 19: datadog.config.TaskError
+	(*ConfigState)(nil),                           // 20: datadog.config.ConfigState
+	(*ClientState)(nil),                           // 21: datadog.config.ClientState
+	(*TargetFileHash)(nil),                        // 22: datadog.config.TargetFileHash
+	(*TargetFileMeta)(nil),                        // 23: datadog.config.TargetFileMeta
+	(*ConfigSubscriptionRequest)(nil),             // 24: datadog.config.ConfigSubscriptionRequest
+	(*ConfigSubscriptionResponse)(nil),            // 25: datadog.config.ConfigSubscriptionResponse
+	(*ClientGetConfigsRequest)(nil),               // 26: datadog.config.ClientGetConfigsRequest
+	(*ClientGetConfigsResponse)(nil),              // 27: datadog.config.ClientGetConfigsResponse
+	(*FileMetaState)(nil),                         // 28: datadog.config.FileMetaState
+	(*GetStateConfigResponse)(nil),                // 29: datadog.config.GetStateConfigResponse
+	(*ConfigSubscriptionState)(nil),               // 30: datadog.config.ConfigSubscriptionState
+	(*ResetStateConfigResponse)(nil),              // 31: datadog.config.ResetStateConfigResponse
+	(*TracerPredicateV1)(nil),                     // 32: datadog.config.TracerPredicateV1
+	(*TracerPredicates)(nil),                      // 33: datadog.config.TracerPredicates
+	nil,                                           // 34: datadog.config.GetStateConfigResponse.ConfigStateEntry
+	nil,                                           // 35: datadog.config.GetStateConfigResponse.DirectorStateEntry
+	nil,                                           // 36: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	(*ConfigSubscriptionState_TrackedClient)(nil), // 37: datadog.config.ConfigSubscriptionState.TrackedClient
 }
 var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	7,  // 0: datadog.config.ConfigMetas.roots:type_name -> datadog.config.TopMeta
@@ -2525,18 +2660,21 @@ var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	23, // 28: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
 	8,  // 29: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
 	2,  // 30: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
-	33, // 31: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
-	34, // 32: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
-	35, // 33: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	34, // 31: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
+	35, // 32: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
+	36, // 33: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
 	13, // 34: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
-	31, // 35: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
-	28, // 36: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
-	28, // 37: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
-	38, // [38:38] is the sub-list for method output_type
-	38, // [38:38] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	30, // 35: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
+	37, // 36: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
+	32, // 37: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
+	28, // 38: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
+	28, // 39: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
+	1,  // 40: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	41, // [41:41] is the sub-list for method output_type
+	41, // [41:41] is the sub-list for method input_type
+	41, // [41:41] is the sub-list for extension type_name
+	41, // [41:41] is the sub-list for extension extendee
+	0,  // [0:41] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteconfig_remoteconfig_proto_init() }
@@ -2550,7 +2688,7 @@ func file_datadog_remoteconfig_remoteconfig_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_remoteconfig_remoteconfig_proto_rawDesc), len(file_datadog_remoteconfig_remoteconfig_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   32,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -76,6 +76,56 @@ func (TaskState) EnumDescriptor() ([]byte, []int) {
 	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{0}
 }
 
+// ConfigSubscriptionProducts is used to targets specific products for tracking
+// with a ConfigSubscriptionRequest.
+type ConfigSubscriptionProducts int32
+
+const (
+	ConfigSubscriptionProducts_INVALID ConfigSubscriptionProducts = 0
+	// LIVE_DEBUGGING corresponds to the LIVE_DEBUGING and LIVE_DEBUGGING_SYMBOLDB
+	// products.
+	ConfigSubscriptionProducts_LIVE_DEBUGGING ConfigSubscriptionProducts = 1
+)
+
+// Enum value maps for ConfigSubscriptionProducts.
+var (
+	ConfigSubscriptionProducts_name = map[int32]string{
+		0: "INVALID",
+		1: "LIVE_DEBUGGING",
+	}
+	ConfigSubscriptionProducts_value = map[string]int32{
+		"INVALID":        0,
+		"LIVE_DEBUGGING": 1,
+	}
+)
+
+func (x ConfigSubscriptionProducts) Enum() *ConfigSubscriptionProducts {
+	p := new(ConfigSubscriptionProducts)
+	*p = x
+	return p
+}
+
+func (x ConfigSubscriptionProducts) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ConfigSubscriptionProducts) Descriptor() protoreflect.EnumDescriptor {
+	return file_datadog_remoteconfig_remoteconfig_proto_enumTypes[1].Descriptor()
+}
+
+func (ConfigSubscriptionProducts) Type() protoreflect.EnumType {
+	return &file_datadog_remoteconfig_remoteconfig_proto_enumTypes[1]
+}
+
+func (x ConfigSubscriptionProducts) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ConfigSubscriptionProducts.Descriptor instead.
+func (ConfigSubscriptionProducts) EnumDescriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{1}
+}
+
 type ConfigStatus int32
 
 const (
@@ -106,11 +156,11 @@ func (x ConfigStatus) String() string {
 }
 
 func (ConfigStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_datadog_remoteconfig_remoteconfig_proto_enumTypes[1].Descriptor()
+	return file_datadog_remoteconfig_remoteconfig_proto_enumTypes[2].Descriptor()
 }
 
 func (ConfigStatus) Type() protoreflect.EnumType {
-	return &file_datadog_remoteconfig_remoteconfig_proto_enumTypes[1]
+	return &file_datadog_remoteconfig_remoteconfig_proto_enumTypes[2]
 }
 
 func (x ConfigStatus) Number() protoreflect.EnumNumber {
@@ -119,7 +169,56 @@ func (x ConfigStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ConfigStatus.Descriptor instead.
 func (ConfigStatus) EnumDescriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{1}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{2}
+}
+
+type ConfigSubscriptionRequest_Action int32
+
+const (
+	ConfigSubscriptionRequest_INVALID ConfigSubscriptionRequest_Action = 0
+	ConfigSubscriptionRequest_TRACK   ConfigSubscriptionRequest_Action = 1
+	ConfigSubscriptionRequest_UNTRACK ConfigSubscriptionRequest_Action = 2
+)
+
+// Enum value maps for ConfigSubscriptionRequest_Action.
+var (
+	ConfigSubscriptionRequest_Action_name = map[int32]string{
+		0: "INVALID",
+		1: "TRACK",
+		2: "UNTRACK",
+	}
+	ConfigSubscriptionRequest_Action_value = map[string]int32{
+		"INVALID": 0,
+		"TRACK":   1,
+		"UNTRACK": 2,
+	}
+)
+
+func (x ConfigSubscriptionRequest_Action) Enum() *ConfigSubscriptionRequest_Action {
+	p := new(ConfigSubscriptionRequest_Action)
+	*p = x
+	return p
+}
+
+func (x ConfigSubscriptionRequest_Action) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ConfigSubscriptionRequest_Action) Descriptor() protoreflect.EnumDescriptor {
+	return file_datadog_remoteconfig_remoteconfig_proto_enumTypes[3].Descriptor()
+}
+
+func (ConfigSubscriptionRequest_Action) Type() protoreflect.EnumType {
+	return &file_datadog_remoteconfig_remoteconfig_proto_enumTypes[3]
+}
+
+func (x ConfigSubscriptionRequest_Action) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ConfigSubscriptionRequest_Action.Descriptor instead.
+func (ConfigSubscriptionRequest_Action) EnumDescriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{20, 0}
 }
 
 type ConfigMetas struct {
@@ -1587,6 +1686,142 @@ func (x *TargetFileMeta) GetHashes() []*TargetFileHash {
 	return nil
 }
 
+// ConfigSubscriptionRequest is used to manage the state of the stream created
+// using CreateConfigSubscription.
+type ConfigSubscriptionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// RuntimeID of the client to track or untrack.
+	RuntimeId string `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	// Action indicates the action to take for the client with the given
+	// runtime_id.
+	Action ConfigSubscriptionRequest_Action `protobuf:"varint,2,opt,name=action,proto3,enum=datadog.config.ConfigSubscriptionRequest_Action" json:"action,omitempty"`
+	// If action is TRACK, products indicates the set of products for which the
+	// client is interested in receiving updates.
+	Products      ConfigSubscriptionProducts `protobuf:"varint,3,opt,name=products,proto3,enum=datadog.config.ConfigSubscriptionProducts" json:"products,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigSubscriptionRequest) Reset() {
+	*x = ConfigSubscriptionRequest{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigSubscriptionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigSubscriptionRequest) ProtoMessage() {}
+
+func (x *ConfigSubscriptionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigSubscriptionRequest.ProtoReflect.Descriptor instead.
+func (*ConfigSubscriptionRequest) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ConfigSubscriptionRequest) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *ConfigSubscriptionRequest) GetAction() ConfigSubscriptionRequest_Action {
+	if x != nil {
+		return x.Action
+	}
+	return ConfigSubscriptionRequest_INVALID
+}
+
+func (x *ConfigSubscriptionRequest) GetProducts() ConfigSubscriptionProducts {
+	if x != nil {
+		return x.Products
+	}
+	return ConfigSubscriptionProducts_INVALID
+}
+
+// ConfigSubscriptionResponse is streamed from CreateConfigSubscription with
+// updates for matching clients and products.
+type ConfigSubscriptionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Client is the client that was tracked or untracked.
+	Client *Client `protobuf:"bytes,1,opt,name=client,proto3" json:"client,omitempty"`
+	// Matched configs are all configs that were matched for the client given
+	// the subscription request.
+	//
+	// If a previously reported config is no longer matched, it will not be
+	// included in the response.
+	MatchedConfigs []string `protobuf:"bytes,2,rep,name=matched_configs,json=matchedConfigs,proto3" json:"matched_configs,omitempty"`
+	// Target files are the target files that needs to be sent to the client.
+	TargetFiles   []*File `protobuf:"bytes,3,rep,name=target_files,json=targetFiles,proto3" json:"target_files,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigSubscriptionResponse) Reset() {
+	*x = ConfigSubscriptionResponse{}
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigSubscriptionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigSubscriptionResponse) ProtoMessage() {}
+
+func (x *ConfigSubscriptionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigSubscriptionResponse.ProtoReflect.Descriptor instead.
+func (*ConfigSubscriptionResponse) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ConfigSubscriptionResponse) GetClient() *Client {
+	if x != nil {
+		return x.Client
+	}
+	return nil
+}
+
+func (x *ConfigSubscriptionResponse) GetMatchedConfigs() []string {
+	if x != nil {
+		return x.MatchedConfigs
+	}
+	return nil
+}
+
+func (x *ConfigSubscriptionResponse) GetTargetFiles() []*File {
+	if x != nil {
+		return x.TargetFiles
+	}
+	return nil
+}
+
 type ClientGetConfigsRequest struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	Client            *Client                `protobuf:"bytes,1,opt,name=client,proto3" json:"client,omitempty"`
@@ -1597,7 +1832,7 @@ type ClientGetConfigsRequest struct {
 
 func (x *ClientGetConfigsRequest) Reset() {
 	*x = ClientGetConfigsRequest{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1609,7 +1844,7 @@ func (x *ClientGetConfigsRequest) String() string {
 func (*ClientGetConfigsRequest) ProtoMessage() {}
 
 func (x *ClientGetConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[20]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1622,7 +1857,7 @@ func (x *ClientGetConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientGetConfigsRequest.ProtoReflect.Descriptor instead.
 func (*ClientGetConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{20}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ClientGetConfigsRequest) GetClient() *Client {
@@ -1652,7 +1887,7 @@ type ClientGetConfigsResponse struct {
 
 func (x *ClientGetConfigsResponse) Reset() {
 	*x = ClientGetConfigsResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1664,7 +1899,7 @@ func (x *ClientGetConfigsResponse) String() string {
 func (*ClientGetConfigsResponse) ProtoMessage() {}
 
 func (x *ClientGetConfigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[21]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1677,7 +1912,7 @@ func (x *ClientGetConfigsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientGetConfigsResponse.ProtoReflect.Descriptor instead.
 func (*ClientGetConfigsResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{21}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ClientGetConfigsResponse) GetRoots() [][]byte {
@@ -1725,7 +1960,7 @@ type FileMetaState struct {
 
 func (x *FileMetaState) Reset() {
 	*x = FileMetaState{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1737,7 +1972,7 @@ func (x *FileMetaState) String() string {
 func (*FileMetaState) ProtoMessage() {}
 
 func (x *FileMetaState) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[22]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1750,7 +1985,7 @@ func (x *FileMetaState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileMetaState.ProtoReflect.Descriptor instead.
 func (*FileMetaState) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{22}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *FileMetaState) GetVersion() uint64 {
@@ -1779,7 +2014,7 @@ type GetStateConfigResponse struct {
 
 func (x *GetStateConfigResponse) Reset() {
 	*x = GetStateConfigResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1791,7 +2026,7 @@ func (x *GetStateConfigResponse) String() string {
 func (*GetStateConfigResponse) ProtoMessage() {}
 
 func (x *GetStateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[23]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1804,7 +2039,7 @@ func (x *GetStateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStateConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetStateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{23}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetStateConfigResponse) GetConfigState() map[string]*FileMetaState {
@@ -1843,7 +2078,7 @@ type ResetStateConfigResponse struct {
 
 func (x *ResetStateConfigResponse) Reset() {
 	*x = ResetStateConfigResponse{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1855,7 +2090,7 @@ func (x *ResetStateConfigResponse) String() string {
 func (*ResetStateConfigResponse) ProtoMessage() {}
 
 func (x *ResetStateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[24]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1868,7 +2103,7 @@ func (x *ResetStateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetStateConfigResponse.ProtoReflect.Descriptor instead.
 func (*ResetStateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{24}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26}
 }
 
 type TracerPredicateV1 struct {
@@ -1886,7 +2121,7 @@ type TracerPredicateV1 struct {
 
 func (x *TracerPredicateV1) Reset() {
 	*x = TracerPredicateV1{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1898,7 +2133,7 @@ func (x *TracerPredicateV1) String() string {
 func (*TracerPredicateV1) ProtoMessage() {}
 
 func (x *TracerPredicateV1) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[25]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1911,7 +2146,7 @@ func (x *TracerPredicateV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerPredicateV1.ProtoReflect.Descriptor instead.
 func (*TracerPredicateV1) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{25}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *TracerPredicateV1) GetClientID() string {
@@ -1972,7 +2207,7 @@ type TracerPredicates struct {
 
 func (x *TracerPredicates) Reset() {
 	*x = TracerPredicates{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1984,7 +2219,7 @@ func (x *TracerPredicates) String() string {
 func (*TracerPredicates) ProtoMessage() {}
 
 func (x *TracerPredicates) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[26]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1997,7 +2232,7 @@ func (x *TracerPredicates) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerPredicates.ProtoReflect.Descriptor instead.
 func (*TracerPredicates) Descriptor() ([]byte, []int) {
-	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{26}
+	return file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TracerPredicates) GetTracerPredicatesV1() []*TracerPredicateV1 {
@@ -2140,7 +2375,20 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x0eTargetFileMeta\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x16\n" +
 	"\x06length\x18\x02 \x01(\x03R\x06length\x126\n" +
-	"\x06hashes\x18\x03 \x03(\v2\x1e.datadog.config.TargetFileHashR\x06hashes\"\x99\x01\n" +
+	"\x06hashes\x18\x03 \x03(\v2\x1e.datadog.config.TargetFileHashR\x06hashes\"\xfb\x01\n" +
+	"\x19ConfigSubscriptionRequest\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12H\n" +
+	"\x06action\x18\x02 \x01(\x0e20.datadog.config.ConfigSubscriptionRequest.ActionR\x06action\x12F\n" +
+	"\bproducts\x18\x03 \x01(\x0e2*.datadog.config.ConfigSubscriptionProductsR\bproducts\"-\n" +
+	"\x06Action\x12\v\n" +
+	"\aINVALID\x10\x00\x12\t\n" +
+	"\x05TRACK\x10\x01\x12\v\n" +
+	"\aUNTRACK\x10\x02\"\xae\x01\n" +
+	"\x1aConfigSubscriptionResponse\x12.\n" +
+	"\x06client\x18\x01 \x01(\v2\x16.datadog.config.ClientR\x06client\x12'\n" +
+	"\x0fmatched_configs\x18\x02 \x03(\tR\x0ematchedConfigs\x127\n" +
+	"\ftarget_files\x18\x03 \x03(\v2\x14.datadog.config.FileR\vtargetFiles\"\x99\x01\n" +
 	"\x17ClientGetConfigsRequest\x12.\n" +
 	"\x06client\x18\x01 \x01(\v2\x16.datadog.config.ClientR\x06client\x12N\n" +
 	"\x13cached_target_files\x18\x02 \x03(\v2\x1e.datadog.config.TargetFileMetaR\x11cachedTargetFiles\"\xed\x01\n" +
@@ -2185,7 +2433,10 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\aRUNNING\x10\x01\x12\b\n" +
 	"\x04DONE\x10\x02\x12\x11\n" +
 	"\rINVALID_STATE\x10\x03\x12\t\n" +
-	"\x05ERROR\x10\x04*?\n" +
+	"\x05ERROR\x10\x04*=\n" +
+	"\x1aConfigSubscriptionProducts\x12\v\n" +
+	"\aINVALID\x10\x00\x12\x12\n" +
+	"\x0eLIVE_DEBUGGING\x10\x01*?\n" +
 	"\fConfigStatus\x12\x14\n" +
 	"\x10CONFIG_STATUS_OK\x10\x00\x12\x19\n" +
 	"\x15CONFIG_STATUS_EXPIRED\x10\x01B\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
@@ -2202,82 +2453,90 @@ func file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP() []byte {
 	return file_datadog_remoteconfig_remoteconfig_proto_rawDescData
 }
 
-var file_datadog_remoteconfig_remoteconfig_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
+var file_datadog_remoteconfig_remoteconfig_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_datadog_remoteconfig_remoteconfig_proto_goTypes = []any{
-	(TaskState)(0),                   // 0: datadog.config.TaskState
-	(ConfigStatus)(0),                // 1: datadog.config.ConfigStatus
-	(*ConfigMetas)(nil),              // 2: datadog.config.ConfigMetas
-	(*DirectorMetas)(nil),            // 3: datadog.config.DirectorMetas
-	(*DelegatedMeta)(nil),            // 4: datadog.config.DelegatedMeta
-	(*TopMeta)(nil),                  // 5: datadog.config.TopMeta
-	(*File)(nil),                     // 6: datadog.config.File
-	(*LatestConfigsRequest)(nil),     // 7: datadog.config.LatestConfigsRequest
-	(*LatestConfigsResponse)(nil),    // 8: datadog.config.LatestConfigsResponse
-	(*OrgDataResponse)(nil),          // 9: datadog.config.OrgDataResponse
-	(*OrgStatusResponse)(nil),        // 10: datadog.config.OrgStatusResponse
-	(*Client)(nil),                   // 11: datadog.config.Client
-	(*ClientTracer)(nil),             // 12: datadog.config.ClientTracer
-	(*ClientAgent)(nil),              // 13: datadog.config.ClientAgent
-	(*ClientUpdater)(nil),            // 14: datadog.config.ClientUpdater
-	(*PackageState)(nil),             // 15: datadog.config.PackageState
-	(*PackageStateTask)(nil),         // 16: datadog.config.PackageStateTask
-	(*TaskError)(nil),                // 17: datadog.config.TaskError
-	(*ConfigState)(nil),              // 18: datadog.config.ConfigState
-	(*ClientState)(nil),              // 19: datadog.config.ClientState
-	(*TargetFileHash)(nil),           // 20: datadog.config.TargetFileHash
-	(*TargetFileMeta)(nil),           // 21: datadog.config.TargetFileMeta
-	(*ClientGetConfigsRequest)(nil),  // 22: datadog.config.ClientGetConfigsRequest
-	(*ClientGetConfigsResponse)(nil), // 23: datadog.config.ClientGetConfigsResponse
-	(*FileMetaState)(nil),            // 24: datadog.config.FileMetaState
-	(*GetStateConfigResponse)(nil),   // 25: datadog.config.GetStateConfigResponse
-	(*ResetStateConfigResponse)(nil), // 26: datadog.config.ResetStateConfigResponse
-	(*TracerPredicateV1)(nil),        // 27: datadog.config.TracerPredicateV1
-	(*TracerPredicates)(nil),         // 28: datadog.config.TracerPredicates
-	nil,                              // 29: datadog.config.GetStateConfigResponse.ConfigStateEntry
-	nil,                              // 30: datadog.config.GetStateConfigResponse.DirectorStateEntry
-	nil,                              // 31: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	(TaskState)(0),                        // 0: datadog.config.TaskState
+	(ConfigSubscriptionProducts)(0),       // 1: datadog.config.ConfigSubscriptionProducts
+	(ConfigStatus)(0),                     // 2: datadog.config.ConfigStatus
+	(ConfigSubscriptionRequest_Action)(0), // 3: datadog.config.ConfigSubscriptionRequest.Action
+	(*ConfigMetas)(nil),                   // 4: datadog.config.ConfigMetas
+	(*DirectorMetas)(nil),                 // 5: datadog.config.DirectorMetas
+	(*DelegatedMeta)(nil),                 // 6: datadog.config.DelegatedMeta
+	(*TopMeta)(nil),                       // 7: datadog.config.TopMeta
+	(*File)(nil),                          // 8: datadog.config.File
+	(*LatestConfigsRequest)(nil),          // 9: datadog.config.LatestConfigsRequest
+	(*LatestConfigsResponse)(nil),         // 10: datadog.config.LatestConfigsResponse
+	(*OrgDataResponse)(nil),               // 11: datadog.config.OrgDataResponse
+	(*OrgStatusResponse)(nil),             // 12: datadog.config.OrgStatusResponse
+	(*Client)(nil),                        // 13: datadog.config.Client
+	(*ClientTracer)(nil),                  // 14: datadog.config.ClientTracer
+	(*ClientAgent)(nil),                   // 15: datadog.config.ClientAgent
+	(*ClientUpdater)(nil),                 // 16: datadog.config.ClientUpdater
+	(*PackageState)(nil),                  // 17: datadog.config.PackageState
+	(*PackageStateTask)(nil),              // 18: datadog.config.PackageStateTask
+	(*TaskError)(nil),                     // 19: datadog.config.TaskError
+	(*ConfigState)(nil),                   // 20: datadog.config.ConfigState
+	(*ClientState)(nil),                   // 21: datadog.config.ClientState
+	(*TargetFileHash)(nil),                // 22: datadog.config.TargetFileHash
+	(*TargetFileMeta)(nil),                // 23: datadog.config.TargetFileMeta
+	(*ConfigSubscriptionRequest)(nil),     // 24: datadog.config.ConfigSubscriptionRequest
+	(*ConfigSubscriptionResponse)(nil),    // 25: datadog.config.ConfigSubscriptionResponse
+	(*ClientGetConfigsRequest)(nil),       // 26: datadog.config.ClientGetConfigsRequest
+	(*ClientGetConfigsResponse)(nil),      // 27: datadog.config.ClientGetConfigsResponse
+	(*FileMetaState)(nil),                 // 28: datadog.config.FileMetaState
+	(*GetStateConfigResponse)(nil),        // 29: datadog.config.GetStateConfigResponse
+	(*ResetStateConfigResponse)(nil),      // 30: datadog.config.ResetStateConfigResponse
+	(*TracerPredicateV1)(nil),             // 31: datadog.config.TracerPredicateV1
+	(*TracerPredicates)(nil),              // 32: datadog.config.TracerPredicates
+	nil,                                   // 33: datadog.config.GetStateConfigResponse.ConfigStateEntry
+	nil,                                   // 34: datadog.config.GetStateConfigResponse.DirectorStateEntry
+	nil,                                   // 35: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
 }
 var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
-	5,  // 0: datadog.config.ConfigMetas.roots:type_name -> datadog.config.TopMeta
-	5,  // 1: datadog.config.ConfigMetas.timestamp:type_name -> datadog.config.TopMeta
-	5,  // 2: datadog.config.ConfigMetas.snapshot:type_name -> datadog.config.TopMeta
-	5,  // 3: datadog.config.ConfigMetas.topTargets:type_name -> datadog.config.TopMeta
-	4,  // 4: datadog.config.ConfigMetas.delegatedTargets:type_name -> datadog.config.DelegatedMeta
-	5,  // 5: datadog.config.DirectorMetas.roots:type_name -> datadog.config.TopMeta
-	5,  // 6: datadog.config.DirectorMetas.timestamp:type_name -> datadog.config.TopMeta
-	5,  // 7: datadog.config.DirectorMetas.snapshot:type_name -> datadog.config.TopMeta
-	5,  // 8: datadog.config.DirectorMetas.targets:type_name -> datadog.config.TopMeta
-	11, // 9: datadog.config.LatestConfigsRequest.active_clients:type_name -> datadog.config.Client
-	2,  // 10: datadog.config.LatestConfigsResponse.config_metas:type_name -> datadog.config.ConfigMetas
-	3,  // 11: datadog.config.LatestConfigsResponse.director_metas:type_name -> datadog.config.DirectorMetas
-	6,  // 12: datadog.config.LatestConfigsResponse.target_files:type_name -> datadog.config.File
-	19, // 13: datadog.config.Client.state:type_name -> datadog.config.ClientState
-	12, // 14: datadog.config.Client.client_tracer:type_name -> datadog.config.ClientTracer
-	13, // 15: datadog.config.Client.client_agent:type_name -> datadog.config.ClientAgent
-	14, // 16: datadog.config.Client.client_updater:type_name -> datadog.config.ClientUpdater
-	15, // 17: datadog.config.ClientUpdater.packages:type_name -> datadog.config.PackageState
-	16, // 18: datadog.config.PackageState.task:type_name -> datadog.config.PackageStateTask
+	7,  // 0: datadog.config.ConfigMetas.roots:type_name -> datadog.config.TopMeta
+	7,  // 1: datadog.config.ConfigMetas.timestamp:type_name -> datadog.config.TopMeta
+	7,  // 2: datadog.config.ConfigMetas.snapshot:type_name -> datadog.config.TopMeta
+	7,  // 3: datadog.config.ConfigMetas.topTargets:type_name -> datadog.config.TopMeta
+	6,  // 4: datadog.config.ConfigMetas.delegatedTargets:type_name -> datadog.config.DelegatedMeta
+	7,  // 5: datadog.config.DirectorMetas.roots:type_name -> datadog.config.TopMeta
+	7,  // 6: datadog.config.DirectorMetas.timestamp:type_name -> datadog.config.TopMeta
+	7,  // 7: datadog.config.DirectorMetas.snapshot:type_name -> datadog.config.TopMeta
+	7,  // 8: datadog.config.DirectorMetas.targets:type_name -> datadog.config.TopMeta
+	13, // 9: datadog.config.LatestConfigsRequest.active_clients:type_name -> datadog.config.Client
+	4,  // 10: datadog.config.LatestConfigsResponse.config_metas:type_name -> datadog.config.ConfigMetas
+	5,  // 11: datadog.config.LatestConfigsResponse.director_metas:type_name -> datadog.config.DirectorMetas
+	8,  // 12: datadog.config.LatestConfigsResponse.target_files:type_name -> datadog.config.File
+	21, // 13: datadog.config.Client.state:type_name -> datadog.config.ClientState
+	14, // 14: datadog.config.Client.client_tracer:type_name -> datadog.config.ClientTracer
+	15, // 15: datadog.config.Client.client_agent:type_name -> datadog.config.ClientAgent
+	16, // 16: datadog.config.Client.client_updater:type_name -> datadog.config.ClientUpdater
+	17, // 17: datadog.config.ClientUpdater.packages:type_name -> datadog.config.PackageState
+	18, // 18: datadog.config.PackageState.task:type_name -> datadog.config.PackageStateTask
 	0,  // 19: datadog.config.PackageStateTask.state:type_name -> datadog.config.TaskState
-	17, // 20: datadog.config.PackageStateTask.error:type_name -> datadog.config.TaskError
-	18, // 21: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
-	20, // 22: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
-	11, // 23: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
-	21, // 24: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
-	6,  // 25: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
-	1,  // 26: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
-	29, // 27: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
-	30, // 28: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
-	31, // 29: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
-	11, // 30: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
-	27, // 31: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
-	24, // 32: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
-	24, // 33: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
-	34, // [34:34] is the sub-list for method output_type
-	34, // [34:34] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	19, // 20: datadog.config.PackageStateTask.error:type_name -> datadog.config.TaskError
+	20, // 21: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
+	22, // 22: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
+	3,  // 23: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
+	1,  // 24: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	13, // 25: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
+	8,  // 26: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
+	13, // 27: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
+	23, // 28: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
+	8,  // 29: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
+	2,  // 30: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
+	33, // 31: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
+	34, // 32: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
+	35, // 33: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	13, // 34: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
+	31, // 35: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
+	28, // 36: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
+	28, // 37: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
+	38, // [38:38] is the sub-list for method output_type
+	38, // [38:38] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteconfig_remoteconfig_proto_init() }
@@ -2290,8 +2549,8 @@ func file_datadog_remoteconfig_remoteconfig_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_remoteconfig_remoteconfig_proto_rawDesc), len(file_datadog_remoteconfig_remoteconfig_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   30,
+			NumEnums:      4,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/core/remoteconfig_gen.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen.go
@@ -2044,6 +2044,227 @@ func (z *ConfigSubscriptionResponse) Msgsize() (s int) {
 }
 
 // MarshalMsg implements msgp.Marshaler
+func (z *ConfigSubscriptionState) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "SubscriptionId"
+	o = append(o, 0x82, 0xae, 0x53, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64)
+	o = msgp.AppendUint64(o, z.SubscriptionId)
+	// string "TrackedClients"
+	o = append(o, 0xae, 0x54, 0x72, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.TrackedClients)))
+	for za0001 := range z.TrackedClients {
+		if z.TrackedClients[za0001] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			// map header, size 3
+			// string "RuntimeId"
+			o = append(o, 0x83, 0xa9, 0x52, 0x75, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x49, 0x64)
+			o = msgp.AppendString(o, z.TrackedClients[za0001].RuntimeId)
+			// string "SeenAny"
+			o = append(o, 0xa7, 0x53, 0x65, 0x65, 0x6e, 0x41, 0x6e, 0x79)
+			o = msgp.AppendBool(o, z.TrackedClients[za0001].SeenAny)
+			// string "Products"
+			o = append(o, 0xa8, 0x50, 0x72, 0x6f, 0x64, 0x75, 0x63, 0x74, 0x73)
+			o = msgp.AppendInt32(o, int32(z.TrackedClients[za0001].Products))
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ConfigSubscriptionState) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "SubscriptionId":
+			z.SubscriptionId, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SubscriptionId")
+				return
+			}
+		case "TrackedClients":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TrackedClients")
+				return
+			}
+			if cap(z.TrackedClients) >= int(zb0002) {
+				z.TrackedClients = (z.TrackedClients)[:zb0002]
+			} else {
+				z.TrackedClients = make([]*ConfigSubscriptionState_TrackedClient, zb0002)
+			}
+			for za0001 := range z.TrackedClients {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.TrackedClients[za0001] = nil
+				} else {
+					if z.TrackedClients[za0001] == nil {
+						z.TrackedClients[za0001] = new(ConfigSubscriptionState_TrackedClient)
+					}
+					var zb0003 uint32
+					zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "TrackedClients", za0001)
+						return
+					}
+					for zb0003 > 0 {
+						zb0003--
+						field, bts, err = msgp.ReadMapKeyZC(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "TrackedClients", za0001)
+							return
+						}
+						switch msgp.UnsafeString(field) {
+						case "RuntimeId":
+							z.TrackedClients[za0001].RuntimeId, bts, err = msgp.ReadStringBytes(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "TrackedClients", za0001, "RuntimeId")
+								return
+							}
+						case "SeenAny":
+							z.TrackedClients[za0001].SeenAny, bts, err = msgp.ReadBoolBytes(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "TrackedClients", za0001, "SeenAny")
+								return
+							}
+						case "Products":
+							{
+								var zb0004 int32
+								zb0004, bts, err = msgp.ReadInt32Bytes(bts)
+								if err != nil {
+									err = msgp.WrapError(err, "TrackedClients", za0001, "Products")
+									return
+								}
+								z.TrackedClients[za0001].Products = ConfigSubscriptionProducts(zb0004)
+							}
+						default:
+							bts, err = msgp.Skip(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "TrackedClients", za0001)
+								return
+							}
+						}
+					}
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *ConfigSubscriptionState) Msgsize() (s int) {
+	s = 1 + 15 + msgp.Uint64Size + 15 + msgp.ArrayHeaderSize
+	for za0001 := range z.TrackedClients {
+		if z.TrackedClients[za0001] == nil {
+			s += msgp.NilSize
+		} else {
+			s += 1 + 10 + msgp.StringPrefixSize + len(z.TrackedClients[za0001].RuntimeId) + 8 + msgp.BoolSize + 9 + msgp.Int32Size
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z ConfigSubscriptionState_TrackedClient) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "RuntimeId"
+	o = append(o, 0x83, 0xa9, 0x52, 0x75, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x49, 0x64)
+	o = msgp.AppendString(o, z.RuntimeId)
+	// string "SeenAny"
+	o = append(o, 0xa7, 0x53, 0x65, 0x65, 0x6e, 0x41, 0x6e, 0x79)
+	o = msgp.AppendBool(o, z.SeenAny)
+	// string "Products"
+	o = append(o, 0xa8, 0x50, 0x72, 0x6f, 0x64, 0x75, 0x63, 0x74, 0x73)
+	o = msgp.AppendInt32(o, int32(z.Products))
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ConfigSubscriptionState_TrackedClient) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "RuntimeId":
+			z.RuntimeId, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RuntimeId")
+				return
+			}
+		case "SeenAny":
+			z.SeenAny, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SeenAny")
+				return
+			}
+		case "Products":
+			{
+				var zb0002 int32
+				zb0002, bts, err = msgp.ReadInt32Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Products")
+					return
+				}
+				z.Products = ConfigSubscriptionProducts(zb0002)
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z ConfigSubscriptionState_TrackedClient) Msgsize() (s int) {
+	s = 1 + 10 + msgp.StringPrefixSize + len(z.RuntimeId) + 8 + msgp.BoolSize + 9 + msgp.Int32Size
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
 func (z *DelegatedMeta) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 3
@@ -2558,9 +2779,9 @@ func (z FileMetaState) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *GetStateConfigResponse) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
+	// map header, size 5
 	// string "ConfigState"
-	o = append(o, 0x84, 0xab, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x53, 0x74, 0x61, 0x74, 0x65)
+	o = append(o, 0x85, 0xab, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x53, 0x74, 0x61, 0x74, 0x65)
 	o = msgp.AppendMapHeader(o, uint32(len(z.ConfigState)))
 	for za0001, za0002 := range z.ConfigState {
 		o = msgp.AppendString(o, za0001)
@@ -2611,6 +2832,38 @@ func (z *GetStateConfigResponse) MarshalMsg(b []byte) (o []byte, err error) {
 			if err != nil {
 				err = msgp.WrapError(err, "ActiveClients", za0007)
 				return
+			}
+		}
+	}
+	// string "ConfigSubscriptionStates"
+	o = append(o, 0xb8, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x53, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.ConfigSubscriptionStates)))
+	for za0008 := range z.ConfigSubscriptionStates {
+		if z.ConfigSubscriptionStates[za0008] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			// map header, size 2
+			// string "SubscriptionId"
+			o = append(o, 0x82, 0xae, 0x53, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64)
+			o = msgp.AppendUint64(o, z.ConfigSubscriptionStates[za0008].SubscriptionId)
+			// string "TrackedClients"
+			o = append(o, 0xae, 0x54, 0x72, 0x61, 0x63, 0x6b, 0x65, 0x64, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x73)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.ConfigSubscriptionStates[za0008].TrackedClients)))
+			for za0009 := range z.ConfigSubscriptionStates[za0008].TrackedClients {
+				if z.ConfigSubscriptionStates[za0008].TrackedClients[za0009] == nil {
+					o = msgp.AppendNil(o)
+				} else {
+					// map header, size 3
+					// string "RuntimeId"
+					o = append(o, 0x83, 0xa9, 0x52, 0x75, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x49, 0x64)
+					o = msgp.AppendString(o, z.ConfigSubscriptionStates[za0008].TrackedClients[za0009].RuntimeId)
+					// string "SeenAny"
+					o = append(o, 0xa7, 0x53, 0x65, 0x65, 0x6e, 0x41, 0x6e, 0x79)
+					o = msgp.AppendBool(o, z.ConfigSubscriptionStates[za0008].TrackedClients[za0009].SeenAny)
+					// string "Products"
+					o = append(o, 0xa8, 0x50, 0x72, 0x6f, 0x64, 0x75, 0x63, 0x74, 0x73)
+					o = msgp.AppendInt32(o, int32(z.ConfigSubscriptionStates[za0008].TrackedClients[za0009].Products))
+				}
 			}
 		}
 	}
@@ -2829,6 +3082,128 @@ func (z *GetStateConfigResponse) UnmarshalMsg(bts []byte) (o []byte, err error) 
 					}
 				}
 			}
+		case "ConfigSubscriptionStates":
+			var zb0008 uint32
+			zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ConfigSubscriptionStates")
+				return
+			}
+			if cap(z.ConfigSubscriptionStates) >= int(zb0008) {
+				z.ConfigSubscriptionStates = (z.ConfigSubscriptionStates)[:zb0008]
+			} else {
+				z.ConfigSubscriptionStates = make([]*ConfigSubscriptionState, zb0008)
+			}
+			for za0008 := range z.ConfigSubscriptionStates {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.ConfigSubscriptionStates[za0008] = nil
+				} else {
+					if z.ConfigSubscriptionStates[za0008] == nil {
+						z.ConfigSubscriptionStates[za0008] = new(ConfigSubscriptionState)
+					}
+					var zb0009 uint32
+					zb0009, bts, err = msgp.ReadMapHeaderBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008)
+						return
+					}
+					for zb0009 > 0 {
+						zb0009--
+						field, bts, err = msgp.ReadMapKeyZC(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008)
+							return
+						}
+						switch msgp.UnsafeString(field) {
+						case "SubscriptionId":
+							z.ConfigSubscriptionStates[za0008].SubscriptionId, bts, err = msgp.ReadUint64Bytes(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008, "SubscriptionId")
+								return
+							}
+						case "TrackedClients":
+							var zb0010 uint32
+							zb0010, bts, err = msgp.ReadArrayHeaderBytes(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008, "TrackedClients")
+								return
+							}
+							if cap(z.ConfigSubscriptionStates[za0008].TrackedClients) >= int(zb0010) {
+								z.ConfigSubscriptionStates[za0008].TrackedClients = (z.ConfigSubscriptionStates[za0008].TrackedClients)[:zb0010]
+							} else {
+								z.ConfigSubscriptionStates[za0008].TrackedClients = make([]*ConfigSubscriptionState_TrackedClient, zb0010)
+							}
+							for za0009 := range z.ConfigSubscriptionStates[za0008].TrackedClients {
+								if msgp.IsNil(bts) {
+									bts, err = msgp.ReadNilBytes(bts)
+									if err != nil {
+										return
+									}
+									z.ConfigSubscriptionStates[za0008].TrackedClients[za0009] = nil
+								} else {
+									if z.ConfigSubscriptionStates[za0008].TrackedClients[za0009] == nil {
+										z.ConfigSubscriptionStates[za0008].TrackedClients[za0009] = new(ConfigSubscriptionState_TrackedClient)
+									}
+									var zb0011 uint32
+									zb0011, bts, err = msgp.ReadMapHeaderBytes(bts)
+									if err != nil {
+										err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008, "TrackedClients", za0009)
+										return
+									}
+									for zb0011 > 0 {
+										zb0011--
+										field, bts, err = msgp.ReadMapKeyZC(bts)
+										if err != nil {
+											err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008, "TrackedClients", za0009)
+											return
+										}
+										switch msgp.UnsafeString(field) {
+										case "RuntimeId":
+											z.ConfigSubscriptionStates[za0008].TrackedClients[za0009].RuntimeId, bts, err = msgp.ReadStringBytes(bts)
+											if err != nil {
+												err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008, "TrackedClients", za0009, "RuntimeId")
+												return
+											}
+										case "SeenAny":
+											z.ConfigSubscriptionStates[za0008].TrackedClients[za0009].SeenAny, bts, err = msgp.ReadBoolBytes(bts)
+											if err != nil {
+												err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008, "TrackedClients", za0009, "SeenAny")
+												return
+											}
+										case "Products":
+											{
+												var zb0012 int32
+												zb0012, bts, err = msgp.ReadInt32Bytes(bts)
+												if err != nil {
+													err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008, "TrackedClients", za0009, "Products")
+													return
+												}
+												z.ConfigSubscriptionStates[za0008].TrackedClients[za0009].Products = ConfigSubscriptionProducts(zb0012)
+											}
+										default:
+											bts, err = msgp.Skip(bts)
+											if err != nil {
+												err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008, "TrackedClients", za0009)
+												return
+											}
+										}
+									}
+								}
+							}
+						default:
+							bts, err = msgp.Skip(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "ConfigSubscriptionStates", za0008)
+								return
+							}
+						}
+					}
+				}
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -2880,6 +3255,21 @@ func (z *GetStateConfigResponse) Msgsize() (s int) {
 			s += msgp.NilSize
 		} else {
 			s += z.ActiveClients[za0007].Msgsize()
+		}
+	}
+	s += 25 + msgp.ArrayHeaderSize
+	for za0008 := range z.ConfigSubscriptionStates {
+		if z.ConfigSubscriptionStates[za0008] == nil {
+			s += msgp.NilSize
+		} else {
+			s += 1 + 15 + msgp.Uint64Size + 15 + msgp.ArrayHeaderSize
+			for za0009 := range z.ConfigSubscriptionStates[za0008].TrackedClients {
+				if z.ConfigSubscriptionStates[za0008].TrackedClients[za0009] == nil {
+					s += msgp.NilSize
+				} else {
+					s += 1 + 10 + msgp.StringPrefixSize + len(z.ConfigSubscriptionStates[za0008].TrackedClients[za0009].RuntimeId) + 8 + msgp.BoolSize + 9 + msgp.Int32Size
+				}
+			}
 		}
 	}
 	return

--- a/pkg/proto/pbgo/core/remoteconfig_gen.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen.go
@@ -1722,6 +1722,328 @@ func (z ConfigStatus) Msgsize() (s int) {
 }
 
 // MarshalMsg implements msgp.Marshaler
+func (z ConfigSubscriptionProducts) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	o = msgp.AppendInt32(o, int32(z))
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ConfigSubscriptionProducts) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var zb0001 int32
+		zb0001, bts, err = msgp.ReadInt32Bytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		(*z) = ConfigSubscriptionProducts(zb0001)
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z ConfigSubscriptionProducts) Msgsize() (s int) {
+	s = msgp.Int32Size
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z ConfigSubscriptionRequest) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "RuntimeId"
+	o = append(o, 0x83, 0xa9, 0x52, 0x75, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x49, 0x64)
+	o = msgp.AppendString(o, z.RuntimeId)
+	// string "Action"
+	o = append(o, 0xa6, 0x41, 0x63, 0x74, 0x69, 0x6f, 0x6e)
+	o = msgp.AppendInt32(o, int32(z.Action))
+	// string "Products"
+	o = append(o, 0xa8, 0x50, 0x72, 0x6f, 0x64, 0x75, 0x63, 0x74, 0x73)
+	o = msgp.AppendInt32(o, int32(z.Products))
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ConfigSubscriptionRequest) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "RuntimeId":
+			z.RuntimeId, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "RuntimeId")
+				return
+			}
+		case "Action":
+			{
+				var zb0002 int32
+				zb0002, bts, err = msgp.ReadInt32Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Action")
+					return
+				}
+				z.Action = ConfigSubscriptionRequest_Action(zb0002)
+			}
+		case "Products":
+			{
+				var zb0003 int32
+				zb0003, bts, err = msgp.ReadInt32Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Products")
+					return
+				}
+				z.Products = ConfigSubscriptionProducts(zb0003)
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z ConfigSubscriptionRequest) Msgsize() (s int) {
+	s = 1 + 10 + msgp.StringPrefixSize + len(z.RuntimeId) + 7 + msgp.Int32Size + 9 + msgp.Int32Size
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z ConfigSubscriptionRequest_Action) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	o = msgp.AppendInt32(o, int32(z))
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ConfigSubscriptionRequest_Action) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var zb0001 int32
+		zb0001, bts, err = msgp.ReadInt32Bytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		(*z) = ConfigSubscriptionRequest_Action(zb0001)
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z ConfigSubscriptionRequest_Action) Msgsize() (s int) {
+	s = msgp.Int32Size
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *ConfigSubscriptionResponse) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 3
+	// string "Client"
+	o = append(o, 0x83, 0xa6, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74)
+	if z.Client == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o, err = z.Client.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Client")
+			return
+		}
+	}
+	// string "MatchedConfigs"
+	o = append(o, 0xae, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x65, 0x64, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.MatchedConfigs)))
+	for za0001 := range z.MatchedConfigs {
+		o = msgp.AppendString(o, z.MatchedConfigs[za0001])
+	}
+	// string "TargetFiles"
+	o = append(o, 0xab, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x46, 0x69, 0x6c, 0x65, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.TargetFiles)))
+	for za0002 := range z.TargetFiles {
+		if z.TargetFiles[za0002] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			// map header, size 2
+			// string "Path"
+			o = append(o, 0x82, 0xa4, 0x50, 0x61, 0x74, 0x68)
+			o = msgp.AppendString(o, z.TargetFiles[za0002].Path)
+			// string "Raw"
+			o = append(o, 0xa3, 0x52, 0x61, 0x77)
+			o = msgp.AppendBytes(o, z.TargetFiles[za0002].Raw)
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ConfigSubscriptionResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Client":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Client = nil
+			} else {
+				if z.Client == nil {
+					z.Client = new(Client)
+				}
+				bts, err = z.Client.UnmarshalMsg(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Client")
+					return
+				}
+			}
+		case "MatchedConfigs":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "MatchedConfigs")
+				return
+			}
+			if cap(z.MatchedConfigs) >= int(zb0002) {
+				z.MatchedConfigs = (z.MatchedConfigs)[:zb0002]
+			} else {
+				z.MatchedConfigs = make([]string, zb0002)
+			}
+			for za0001 := range z.MatchedConfigs {
+				z.MatchedConfigs[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "MatchedConfigs", za0001)
+					return
+				}
+			}
+		case "TargetFiles":
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TargetFiles")
+				return
+			}
+			if cap(z.TargetFiles) >= int(zb0003) {
+				z.TargetFiles = (z.TargetFiles)[:zb0003]
+			} else {
+				z.TargetFiles = make([]*File, zb0003)
+			}
+			for za0002 := range z.TargetFiles {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.TargetFiles[za0002] = nil
+				} else {
+					if z.TargetFiles[za0002] == nil {
+						z.TargetFiles[za0002] = new(File)
+					}
+					var zb0004 uint32
+					zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "TargetFiles", za0002)
+						return
+					}
+					for zb0004 > 0 {
+						zb0004--
+						field, bts, err = msgp.ReadMapKeyZC(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "TargetFiles", za0002)
+							return
+						}
+						switch msgp.UnsafeString(field) {
+						case "Path":
+							z.TargetFiles[za0002].Path, bts, err = msgp.ReadStringBytes(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "TargetFiles", za0002, "Path")
+								return
+							}
+						case "Raw":
+							z.TargetFiles[za0002].Raw, bts, err = msgp.ReadBytesBytes(bts, z.TargetFiles[za0002].Raw)
+							if err != nil {
+								err = msgp.WrapError(err, "TargetFiles", za0002, "Raw")
+								return
+							}
+						default:
+							bts, err = msgp.Skip(bts)
+							if err != nil {
+								err = msgp.WrapError(err, "TargetFiles", za0002)
+								return
+							}
+						}
+					}
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *ConfigSubscriptionResponse) Msgsize() (s int) {
+	s = 1 + 7
+	if z.Client == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.Client.Msgsize()
+	}
+	s += 15 + msgp.ArrayHeaderSize
+	for za0001 := range z.MatchedConfigs {
+		s += msgp.StringPrefixSize + len(z.MatchedConfigs[za0001])
+	}
+	s += 12 + msgp.ArrayHeaderSize
+	for za0002 := range z.TargetFiles {
+		if z.TargetFiles[za0002] == nil {
+			s += msgp.NilSize
+		} else {
+			s += 1 + 5 + msgp.StringPrefixSize + len(z.TargetFiles[za0002].Path) + 4 + msgp.BytesPrefixSize + len(z.TargetFiles[za0002].Raw)
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
 func (z *DelegatedMeta) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 3

--- a/pkg/proto/pbgo/core/remoteconfig_gen_test.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen_test.go
@@ -530,6 +530,122 @@ func BenchmarkUnmarshalConfigState(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalConfigSubscriptionRequest(t *testing.T) {
+	v := ConfigSubscriptionRequest{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgConfigSubscriptionRequest(b *testing.B) {
+	v := ConfigSubscriptionRequest{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgConfigSubscriptionRequest(b *testing.B) {
+	v := ConfigSubscriptionRequest{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalConfigSubscriptionRequest(b *testing.B) {
+	v := ConfigSubscriptionRequest{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalConfigSubscriptionResponse(t *testing.T) {
+	v := ConfigSubscriptionResponse{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgConfigSubscriptionResponse(b *testing.B) {
+	v := ConfigSubscriptionResponse{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgConfigSubscriptionResponse(b *testing.B) {
+	v := ConfigSubscriptionResponse{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalConfigSubscriptionResponse(b *testing.B) {
+	v := ConfigSubscriptionResponse{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalDelegatedMeta(t *testing.T) {
 	v := DelegatedMeta{}
 	bts, err := v.MarshalMsg(nil)

--- a/pkg/proto/pbgo/core/remoteconfig_gen_test.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen_test.go
@@ -646,6 +646,122 @@ func BenchmarkUnmarshalConfigSubscriptionResponse(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalConfigSubscriptionState(t *testing.T) {
+	v := ConfigSubscriptionState{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgConfigSubscriptionState(b *testing.B) {
+	v := ConfigSubscriptionState{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgConfigSubscriptionState(b *testing.B) {
+	v := ConfigSubscriptionState{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalConfigSubscriptionState(b *testing.B) {
+	v := ConfigSubscriptionState{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalConfigSubscriptionState_TrackedClient(t *testing.T) {
+	v := ConfigSubscriptionState_TrackedClient{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgConfigSubscriptionState_TrackedClient(b *testing.B) {
+	v := ConfigSubscriptionState_TrackedClient{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgConfigSubscriptionState_TrackedClient(b *testing.B) {
+	v := ConfigSubscriptionState_TrackedClient{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalConfigSubscriptionState_TrackedClient(b *testing.B) {
+	v := ConfigSubscriptionState_TrackedClient{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalDelegatedMeta(t *testing.T) {
 	v := DelegatedMeta{}
 	bts, err := v.MarshalMsg(nil)

--- a/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
+++ b/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
@@ -179,6 +179,26 @@ func (mr *MockAgentSecureClientMockRecorder) ClientGetConfigsHA(ctx, in interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientGetConfigsHA", reflect.TypeOf((*MockAgentSecureClient)(nil).ClientGetConfigsHA), varargs...)
 }
 
+// CreateConfigSubscription mocks base method.
+func (m *MockAgentSecureClient) CreateConfigSubscription(ctx context.Context, opts ...grpc.CallOption) (core.AgentSecure_CreateConfigSubscriptionClient, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateConfigSubscription", varargs...)
+	ret0, _ := ret[0].(core.AgentSecure_CreateConfigSubscriptionClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateConfigSubscription indicates an expected call of CreateConfigSubscription.
+func (mr *MockAgentSecureClientMockRecorder) CreateConfigSubscription(ctx interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConfigSubscription", reflect.TypeOf((*MockAgentSecureClient)(nil).CreateConfigSubscription), varargs...)
+}
+
 // DogstatsdCaptureTrigger mocks base method.
 func (m *MockAgentSecureClient) DogstatsdCaptureTrigger(ctx context.Context, in *core.CaptureTriggerRequest, opts ...grpc.CallOption) (*core.CaptureTriggerResponse, error) {
 	m.ctrl.T.Helper()
@@ -560,6 +580,143 @@ func (m *MockAgentSecure_TaggerStreamEntitiesClient) Trailer() metadata.MD {
 func (mr *MockAgentSecure_TaggerStreamEntitiesClientMockRecorder) Trailer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trailer", reflect.TypeOf((*MockAgentSecure_TaggerStreamEntitiesClient)(nil).Trailer))
+}
+
+// MockAgentSecure_CreateConfigSubscriptionClient is a mock of AgentSecure_CreateConfigSubscriptionClient interface.
+type MockAgentSecure_CreateConfigSubscriptionClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder
+}
+
+// MockAgentSecure_CreateConfigSubscriptionClientMockRecorder is the mock recorder for MockAgentSecure_CreateConfigSubscriptionClient.
+type MockAgentSecure_CreateConfigSubscriptionClientMockRecorder struct {
+	mock *MockAgentSecure_CreateConfigSubscriptionClient
+}
+
+// NewMockAgentSecure_CreateConfigSubscriptionClient creates a new mock instance.
+func NewMockAgentSecure_CreateConfigSubscriptionClient(ctrl *gomock.Controller) *MockAgentSecure_CreateConfigSubscriptionClient {
+	mock := &MockAgentSecure_CreateConfigSubscriptionClient{ctrl: ctrl}
+	mock.recorder = &MockAgentSecure_CreateConfigSubscriptionClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAgentSecure_CreateConfigSubscriptionClient) EXPECT() *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder {
+	return m.recorder
+}
+
+// CloseSend mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionClient) CloseSend() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseSend")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseSend indicates an expected call of CloseSend.
+func (mr *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder) CloseSend() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseSend", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionClient)(nil).CloseSend))
+}
+
+// Context mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionClient) Context() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Context")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// Context indicates an expected call of Context.
+func (mr *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionClient)(nil).Context))
+}
+
+// Header mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionClient) Header() (metadata.MD, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Header")
+	ret0, _ := ret[0].(metadata.MD)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Header indicates an expected call of Header.
+func (mr *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder) Header() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionClient)(nil).Header))
+}
+
+// Recv mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionClient) Recv() (*core.ConfigSubscriptionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Recv")
+	ret0, _ := ret[0].(*core.ConfigSubscriptionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Recv indicates an expected call of Recv.
+func (mr *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder) Recv() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recv", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionClient)(nil).Recv))
+}
+
+// RecvMsg mocks base method.
+func (m_2 *MockAgentSecure_CreateConfigSubscriptionClient) RecvMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "RecvMsg", m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecvMsg indicates an expected call of RecvMsg.
+func (mr *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder) RecvMsg(m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionClient)(nil).RecvMsg), m)
+}
+
+// Send mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionClient) Send(arg0 *core.ConfigSubscriptionRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Send", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Send indicates an expected call of Send.
+func (mr *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder) Send(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionClient)(nil).Send), arg0)
+}
+
+// SendMsg mocks base method.
+func (m_2 *MockAgentSecure_CreateConfigSubscriptionClient) SendMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "SendMsg", m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendMsg indicates an expected call of SendMsg.
+func (mr *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder) SendMsg(m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionClient)(nil).SendMsg), m)
+}
+
+// Trailer mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionClient) Trailer() metadata.MD {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Trailer")
+	ret0, _ := ret[0].(metadata.MD)
+	return ret0
+}
+
+// Trailer indicates an expected call of Trailer.
+func (mr *MockAgentSecure_CreateConfigSubscriptionClientMockRecorder) Trailer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trailer", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionClient)(nil).Trailer))
 }
 
 // MockAgentSecure_WorkloadmetaStreamEntitiesClient is a mock of AgentSecure_WorkloadmetaStreamEntitiesClient interface.
@@ -998,6 +1155,20 @@ func (mr *MockAgentSecureServerMockRecorder) ClientGetConfigsHA(arg0, arg1 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientGetConfigsHA", reflect.TypeOf((*MockAgentSecureServer)(nil).ClientGetConfigsHA), arg0, arg1)
 }
 
+// CreateConfigSubscription mocks base method.
+func (m *MockAgentSecureServer) CreateConfigSubscription(arg0 core.AgentSecure_CreateConfigSubscriptionServer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateConfigSubscription", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateConfigSubscription indicates an expected call of CreateConfigSubscription.
+func (mr *MockAgentSecureServerMockRecorder) CreateConfigSubscription(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConfigSubscription", reflect.TypeOf((*MockAgentSecureServer)(nil).CreateConfigSubscription), arg0)
+}
+
 // DogstatsdCaptureTrigger mocks base method.
 func (m *MockAgentSecureServer) DogstatsdCaptureTrigger(arg0 context.Context, arg1 *core.CaptureTriggerRequest) (*core.CaptureTriggerResponse, error) {
 	m.ctrl.T.Helper()
@@ -1307,6 +1478,140 @@ func (m *MockAgentSecure_TaggerStreamEntitiesServer) SetTrailer(arg0 metadata.MD
 func (mr *MockAgentSecure_TaggerStreamEntitiesServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockAgentSecure_TaggerStreamEntitiesServer)(nil).SetTrailer), arg0)
+}
+
+// MockAgentSecure_CreateConfigSubscriptionServer is a mock of AgentSecure_CreateConfigSubscriptionServer interface.
+type MockAgentSecure_CreateConfigSubscriptionServer struct {
+	ctrl     *gomock.Controller
+	recorder *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder
+}
+
+// MockAgentSecure_CreateConfigSubscriptionServerMockRecorder is the mock recorder for MockAgentSecure_CreateConfigSubscriptionServer.
+type MockAgentSecure_CreateConfigSubscriptionServerMockRecorder struct {
+	mock *MockAgentSecure_CreateConfigSubscriptionServer
+}
+
+// NewMockAgentSecure_CreateConfigSubscriptionServer creates a new mock instance.
+func NewMockAgentSecure_CreateConfigSubscriptionServer(ctrl *gomock.Controller) *MockAgentSecure_CreateConfigSubscriptionServer {
+	mock := &MockAgentSecure_CreateConfigSubscriptionServer{ctrl: ctrl}
+	mock.recorder = &MockAgentSecure_CreateConfigSubscriptionServerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAgentSecure_CreateConfigSubscriptionServer) EXPECT() *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder {
+	return m.recorder
+}
+
+// Context mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionServer) Context() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Context")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// Context indicates an expected call of Context.
+func (mr *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionServer)(nil).Context))
+}
+
+// Recv mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionServer) Recv() (*core.ConfigSubscriptionRequest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Recv")
+	ret0, _ := ret[0].(*core.ConfigSubscriptionRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Recv indicates an expected call of Recv.
+func (mr *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder) Recv() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recv", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionServer)(nil).Recv))
+}
+
+// RecvMsg mocks base method.
+func (m_2 *MockAgentSecure_CreateConfigSubscriptionServer) RecvMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "RecvMsg", m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecvMsg indicates an expected call of RecvMsg.
+func (mr *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder) RecvMsg(m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionServer)(nil).RecvMsg), m)
+}
+
+// Send mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionServer) Send(arg0 *core.ConfigSubscriptionResponse) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Send", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Send indicates an expected call of Send.
+func (mr *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder) Send(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionServer)(nil).Send), arg0)
+}
+
+// SendHeader mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionServer) SendHeader(arg0 metadata.MD) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendHeader", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendHeader indicates an expected call of SendHeader.
+func (mr *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder) SendHeader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeader", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionServer)(nil).SendHeader), arg0)
+}
+
+// SendMsg mocks base method.
+func (m_2 *MockAgentSecure_CreateConfigSubscriptionServer) SendMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "SendMsg", m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendMsg indicates an expected call of SendMsg.
+func (mr *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder) SendMsg(m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionServer)(nil).SendMsg), m)
+}
+
+// SetHeader mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionServer) SetHeader(arg0 metadata.MD) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetHeader", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetHeader indicates an expected call of SetHeader.
+func (mr *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder) SetHeader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionServer)(nil).SetHeader), arg0)
+}
+
+// SetTrailer mocks base method.
+func (m *MockAgentSecure_CreateConfigSubscriptionServer) SetTrailer(arg0 metadata.MD) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTrailer", arg0)
+}
+
+// SetTrailer indicates an expected call of SetTrailer.
+func (mr *MockAgentSecure_CreateConfigSubscriptionServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockAgentSecure_CreateConfigSubscriptionServer)(nil).SetTrailer), arg0)
 }
 
 // MockAgentSecure_WorkloadmetaStreamEntitiesServer is a mock of AgentSecure_WorkloadmetaStreamEntitiesServer interface.


### PR DESCRIPTION
### What does this PR do?

This commit introduces the CreateConfigSubscription to the AgentSecure service. This method can be used to create a stateful stream to subscribe to updates for an evolving set of tracer's by runtimeID.

### Motivation

See [this rfc](https://docs.google.com/document/d/1Krv5mdRiPxY0b-HsJ0vGn8GnUcll0RM4__2-SIdLcEw/edit?tab=t.0#heading=h.4t5xapveah86)

### Describe how you validated your changes

There's relatively comprehensive testing, subsequent PRs will have more integration tests (and the system-tests will exercise the integration too).

### Additional Notes

[DEBUG-4590](https://datadoghq.atlassian.net/browse/DEBUG-4590)

[DEBUG-4590]: https://datadoghq.atlassian.net/browse/DEBUG-4590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ