### PR TITLE
[workloadmeta/collectors/crio] Use configmock in tests

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/crio/crio_test.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/crio_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -25,13 +24,8 @@ import (
 )
 
 func TestPull(t *testing.T) {
-	configmock.New(t)
-
-	const envVarName = "DD_CONTAINER_IMAGE_ENABLED"
-	originalValue := os.Getenv(envVarName)
-	defer os.Setenv(envVarName, originalValue)
-
-	os.Setenv(envVarName, "false")
+	config := configmock.New(t)
+	config.SetWithoutSource("container_image.enabled", false)
 
 	createTime := time.Now().Add(-10 * time.Minute).UnixNano()
 	startTime := time.Now().Add(-5 * time.Minute).UnixNano()
@@ -531,11 +525,8 @@ func TestGenerateImageEventFromContainer(t *testing.T) {
 }
 
 func TestOptimizedImageCollection(t *testing.T) {
-	const envVarName = "DD_CONTAINER_IMAGE_ENABLED"
-	originalValue := os.Getenv(envVarName)
-	defer os.Setenv(envVarName, originalValue)
-
-	os.Setenv(envVarName, "true")
+	config := configmock.New(t)
+	config.SetWithoutSource("container_image.enabled", true)
 
 	tests := []struct {
 		name                     string
@@ -670,12 +661,9 @@ func TestOptimizedImageCollection(t *testing.T) {
 }
 
 func TestPullWithImageCollectionEnabled(t *testing.T) {
-	const envVarName = "DD_CONTAINER_IMAGE_ENABLED"
-	originalValue := os.Getenv(envVarName)
-	defer os.Setenv(envVarName, originalValue)
-
+	config := configmock.New(t)
 	// Enable image collection to test the optimized image collection path
-	os.Setenv(envVarName, "true")
+	config.SetWithoutSource("container_image.enabled", true)
 
 	createTime := time.Now().Add(-10 * time.Minute).UnixNano()
 	startTime := time.Now().Add(-5 * time.Minute).UnixNano()


### PR DESCRIPTION
### What does this PR do?

This PR is a small cleanup in the crio workloadmeta collector. This PR changes the tests to use a config mock instead of setting/unsetting envs. It's a small cleanup opportunity that I saw while reviewing https://github.com/DataDog/datadog-agent/pull/42210

### Describe how you validated your changes

CI