### PR TITLE
fix(installer): Use installer's user package in all installer methods

### DIFF
--- a/cmd/installer/user/user_nix.go
+++ b/cmd/installer/user/user_nix.go
@@ -10,8 +10,7 @@ package user
 
 import (
 	"fmt"
-	"os/user"
-	"strconv"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
 	"syscall"
 )
 
@@ -27,25 +26,17 @@ func IsRoot() bool {
 // Note that we actually only set dd-agent as the effective user, not the real user, in oder to
 // escalate privileges back when needed.
 func RootToDatadogAgent() error {
-	datadogAgentGroup, err := user.LookupGroup("dd-agent")
+	gid, err := user.GetGroupID("dd-agent")
 	if err != nil {
 		return fmt.Errorf("failed to lookup dd-agent group: %s", err)
-	}
-	gid, err := strconv.Atoi(datadogAgentGroup.Gid)
-	if err != nil {
-		return fmt.Errorf("failed to convert dd-agent group ID to int: %s", err)
 	}
 	err = syscall.Setegid(gid)
 	if err != nil {
 		return fmt.Errorf("failed to setegid: %s", err)
 	}
-	datadogAgentUser, err := user.Lookup("dd-agent")
+	uid, err := user.GetUserID("dd-agent")
 	if err != nil {
 		return fmt.Errorf("failed to lookup dd-agent user: %s", err)
-	}
-	uid, err := strconv.Atoi(datadogAgentUser.Uid)
-	if err != nil {
-		return fmt.Errorf("failed to convert dd-agent user ID to int: %s", err)
 	}
 	err = syscall.Seteuid(uid)
 	if err != nil {

--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -24,6 +24,10 @@ import (
 
 // GetGroupID returns the ID of the given group.
 func GetGroupID(groupName string) (int, error) {
+	if groupName == "root" {
+		return 0, nil
+	}
+
 	if _, err := exec.LookPath("getent"); err == nil {
 		cmd := exec.Command("getent", "group", groupName)
 		output, err := cmd.Output()
@@ -53,6 +57,7 @@ func GetGroupID(groupName string) (int, error) {
 
 // GetUserID returns the ID of the given user.
 func GetUserID(userName string) (int, error) {
+
 	if _, err := exec.LookPath("getent"); err == nil {
 		cmd := exec.Command("getent", "passwd", userName)
 		output, err := cmd.Output()

--- a/pkg/fleet/installer/setup/common/setup_nix.go
+++ b/pkg/fleet/installer/setup/common/setup_nix.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -26,7 +26,7 @@ func (s *Setup) postInstallPackages() (err error) {
 func (s *Setup) addAgentToAdditionalGroups() {
 	for _, group := range s.DdAgentAdditionalGroups {
 		// Add dd-agent user to additional group for permission reason, in particular to enable reading log files not world readable
-		if _, err := user.LookupGroup(group); err != nil {
+		if _, err := user.GetGroupID(group); err != nil {
 			log.Infof("Skipping group %s as it does not exist", group)
 			continue
 		}


### PR DESCRIPTION
### What does this PR do?
Follow-up of https://github.com/DataDog/datadog-agent/pull/42130 to use the new installer's user package in all installer methods

### Motivation

### Describe how you validated your changes

### Additional Notes
