### PR TITLE
Revert "[clusteragent/admission] Decouple default label selectors from APM opts (#41977)"

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -26,7 +26,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -112,11 +111,6 @@ func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (*metav1.LabelSelector, *metav1.LabelSelector) {
 	return common.DefaultLabelSelectors(useNamespaceSelector, common.LabelSelectorsConfig{
 		ExcludeNamespaces: mutatecommon.DefaultDisabledNamespaces(),
-		ShouldAcceptAllFunc: func() bool {
-			return pkgconfigsetup.Datadog().GetBool("admission_controller.mutate_unlabelled") ||
-				pkgconfigsetup.Datadog().GetBool("apm_config.instrumentation.enabled") ||
-				len(pkgconfigsetup.Datadog().GetStringSlice("apm_config.instrumentation.enabled_namespaces")) > 0
-		},
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?
This reverts https://github.com/DataDog/datadog-agent/pull/41977

### Motivation
#incident-44717