### PR TITLE
[INCIDENT-44715] Checkout code from correct base branch in APM benchmark job

### DIFF
--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -3,14 +3,14 @@ benchmark:
   # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:trace-agent_microbenchmarks
   timeout: 1h
-  rules:
-    !reference [.on_trace_agent_changes_or_manual]
+  rules: !reference [.on_trace_agent_changes_or_manual]
   interruptible: true
   needs: ["setup_agent_version"]
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   script:
     - export ARTIFACTS_DIR="$(pwd)/artifacts" && mkdir -p $ARTIFACTS_DIR
     - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
+    - export BASE_BRANCH="$(cat release.json | jq ".base_branch" | tr -d '"')"
     - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     - pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
     - dda self dep sync -f legacy-tasks

--- a/test/benchmarks/apm_scripts/analyze-results.sh
+++ b/test/benchmarks/apm_scripts/analyze-results.sh
@@ -26,12 +26,12 @@ benchmark_analyzer convert \
   }" \
   "$ARTIFACTS_DIR/pr_bench.txt"
 
-git checkout main
+git checkout "${BASE_BRANCH:-main}"
 COMMIT_SHA=$(git rev-parse HEAD)
 COMMIT_DATE=$(git show -s --format=%ct "$COMMIT_SHA")
 benchmark_analyzer convert \
   --framework=GoBench \
-  --outpath="main.json" \
+  --outpath="base.json" \
   --extra-params="{\
     \"baseline_or_candidate\":\"baseline\", \
     \"cpu_model\":\"$CPU_MODEL\", \
@@ -40,11 +40,11 @@ benchmark_analyzer convert \
     \"ci_pipeline_id\":\"$CI_PIPELINE_ID\", \
     \"git_commit_sha\":\"$COMMIT_SHA\", \
     \"git_commit_date\":\"$COMMIT_DATE\", \
-    \"git_branch\":\"main\"\
+    \"git_branch\":\"${BASE_BRANCH:-main}\"\
   }" \
-  "$ARTIFACTS_DIR/main_bench.txt"
+  "$ARTIFACTS_DIR/base_bench.txt"
 
-benchmark_analyzer compare pairwise --outpath "$ARTIFACTS_DIR/report.md" --format md-nodejs main.json pr.json
-benchmark_analyzer compare pairwise --outpath "$ARTIFACTS_DIR/report_full.html" --format html main.json pr.json
+benchmark_analyzer compare pairwise --outpath "$ARTIFACTS_DIR/report.md" --format md-nodejs base.json pr.json
+benchmark_analyzer compare pairwise --outpath "$ARTIFACTS_DIR/report_full.html" --format html base.json pr.json
 
 git checkout "${CI_COMMIT_REF_NAME}" # (Only needed while these changes aren't merged to main)

--- a/test/benchmarks/apm_scripts/analyze-results.sh
+++ b/test/benchmarks/apm_scripts/analyze-results.sh
@@ -10,7 +10,7 @@ if [ -z "$CPU_MODEL" ]; then
 fi
 
 COMMIT_SHA=$(git rev-parse HEAD)
-COMMIT_DATE=$(git show -s --format=%ct $COMMIT_SHA)
+COMMIT_DATE=$(git show -s --format=%ct "$COMMIT_SHA")
 benchmark_analyzer convert \
   --framework=GoBench \
   --outpath="pr.json" \
@@ -28,7 +28,7 @@ benchmark_analyzer convert \
 
 git checkout main
 COMMIT_SHA=$(git rev-parse HEAD)
-COMMIT_DATE=$(git show -s --format=%ct $COMMIT_SHA)
+COMMIT_DATE=$(git show -s --format=%ct "$COMMIT_SHA")
 benchmark_analyzer convert \
   --framework=GoBench \
   --outpath="main.json" \
@@ -44,7 +44,7 @@ benchmark_analyzer convert \
   }" \
   "$ARTIFACTS_DIR/main_bench.txt"
 
-benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report.md --format md-nodejs main.json pr.json
-benchmark_analyzer compare pairwise --outpath $ARTIFACTS_DIR/report_full.html --format html main.json pr.json
+benchmark_analyzer compare pairwise --outpath "$ARTIFACTS_DIR/report.md" --format md-nodejs main.json pr.json
+benchmark_analyzer compare pairwise --outpath "$ARTIFACTS_DIR/report_full.html" --format html main.json pr.json
 
 git checkout "${CI_COMMIT_REF_NAME}" # (Only needed while these changes aren't merged to main)

--- a/test/benchmarks/apm_scripts/capture-hardware-software-info.sh
+++ b/test/benchmarks/apm_scripts/capture-hardware-software-info.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd "${ARTIFACTS_DIR}"
+cd "${ARTIFACTS_DIR}" || exit 1
 
 # Collect software information
 

--- a/test/benchmarks/apm_scripts/post-pr-comment.sh
+++ b/test/benchmarks/apm_scripts/post-pr-comment.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cat $ARTIFACTS_DIR/report.md | pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME" --header="Benchmarks"
+cat "$ARTIFACTS_DIR/report.md" | pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME" --header="Benchmarks"

--- a/test/benchmarks/apm_scripts/run-benchmarks.sh
+++ b/test/benchmarks/apm_scripts/run-benchmarks.sh
@@ -10,6 +10,6 @@ bench_loop_x10 () {
 }
 
 bench_loop_x10 "pr_bench.txt"
-git checkout main && bench_loop_x10 "main_bench.txt"
+git checkout "${BASE_BRANCH:-main}" && bench_loop_x10 "base_bench.txt"
 
 git checkout "${CI_COMMIT_REF_NAME}" # (Only needed while these changes aren't merged to main)

--- a/test/benchmarks/apm_scripts/run-benchmarks.sh
+++ b/test/benchmarks/apm_scripts/run-benchmarks.sh
@@ -3,7 +3,7 @@
 set -e
 
 bench_loop_x10 () {
-  for i in {1..10}; do
+  for _ in {1..10}; do
     dda inv trace-agent.benchmarks --output="/tmp/$1" --bench="BenchmarkAgentTraceProcessing$"
     cat "/tmp/$1" >> "$ARTIFACTS_DIR/$1"
   done

--- a/test/benchmarks/apm_scripts/upload-results-to-s3.sh
+++ b/test/benchmarks/apm_scripts/upload-results-to-s3.sh
@@ -5,4 +5,4 @@ BRANCH="${CI_COMMIT_REF_NAME:-$CI_COMMIT_REF_NAME}"
 
 S3_URL=s3://relenv-benchmarking-data/${PROJECT}/${BRANCH}/${CI_JOB_ID}/
 
-aws s3 cp --recursive --acl bucket-owner-full-control $ARTIFACTS_DIR $S3_URL
+aws s3 cp --recursive --acl bucket-owner-full-control "$ARTIFACTS_DIR" "$S3_URL"


### PR DESCRIPTION
### What does this PR do?

Dynamically determine what the correct base branch is using the `release.json` file, and use that in the `benchmark` CI job instead of relying on a hardcoded `main`.

### Motivation

incident-44715
The APM benchmark job always checks out `main`, which is not always the correct base branch - for example when running in a PR on a release branch.

This can cause issues, for example in the current incident where the `dda` version required on `main` exceeds the version installed for release branch CI pipelines.

### Describe how you validated your changes

Running CI and checking logs.

### Additional Notes
