### PR TITLE
[OTEL-2834] Disable successful transaction logging in serializerexporter

### DIFF
--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -450,15 +450,17 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 
 	loggingFrequency := config.GetInt64("logging_frequency")
 
-	if transactionsSuccess.Value() == 1 {
-		log.Infof("Successfully posted payload to %q (%s), the agent will only log transaction success every %d transactions", logURL, resp.Status, loggingFrequency)
-		log.Tracef("Url: %q, response status %s, content length %d, payload: %q", logURL, resp.Status, resp.ContentLength, truncateBodyForLog(body))
-		return resp.StatusCode, body, nil
-	}
-	if transactionsSuccess.Value()%loggingFrequency == 0 {
-		log.Infof("Successfully posted payload to %q (%s)", logURL, resp.Status)
-		log.Tracef("Url: %q, response status %s, content length %d, payload: %q", logURL, resp.Status, resp.ContentLength, truncateBodyForLog(body))
-		return resp.StatusCode, body, nil
+	if loggingFrequency > 0 {
+		if transactionsSuccess.Value() == 1 {
+			log.Infof("Successfully posted payload to %q (%s), the agent will only log transaction success every %d transactions", logURL, resp.Status, loggingFrequency)
+			log.Tracef("Url: %q, response status %s, content length %d, payload: %q", logURL, resp.Status, resp.ContentLength, truncateBodyForLog(body))
+			return resp.StatusCode, body, nil
+		}
+		if transactionsSuccess.Value()%loggingFrequency == 0 {
+			log.Infof("Successfully posted payload to %q (%s)", logURL, resp.Status)
+			log.Tracef("Url: %q, response status %s, content length %d, payload: %q", logURL, resp.Status, resp.ContentLength, truncateBodyForLog(body))
+			return resp.StatusCode, body, nil
+		}
 	}
 	log.Tracef("Successfully posted payload to %q (%s): %q", logURL, resp.Status, truncateBodyForLog(body))
 	return resp.StatusCode, body, nil

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -133,8 +133,12 @@ func InitSerializer(logger *zap.Logger, cfg *ExporterConfig, sourceProvider sour
 			}
 			setupSerializer(pkgconfig, cfg)
 			setupForwarder(pkgconfig)
-			pkgconfig.Set("logging_frequency", int64(500), pkgconfigmodel.SourceDefault)
 			pkgconfig.Set("skip_ssl_validation", cfg.ClientConfig.InsecureSkipVerify, pkgconfigmodel.SourceFile)
+
+			// Disable regular "Successfully posted payload" logs, since flushing is user-controlled and may happen frequently.
+			// Successful export operations can be monitored with exporterhelper metrics.
+			pkgconfig.Set("logging_frequency", int64(0), pkgconfigmodel.SourceAgentRuntime)
+
 			return pkgconfig
 		}),
 		fx.Provide(func(log *zap.Logger) (logdef.Component, error) {


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to fully disable the "Successfully posted payload" log from the metrics forwarder by setting `logging_frequency` to zero (which would currently cause a panic), and sets this config to zero when the OTel serializerexporter instantiates the forwarder.

### Motivation

Some OTel users are [reporting](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43594) that this log is spamming their log storage, which is likely because the Datadog exporter can be configured to flush arbitrarily often, unlike the Agent with its fixed flush frequency.

Since OTel users have other ways of monitoring the successful exporting of metrics (using a `debugexporter`, or the Collector's `otelcol_exporter_sent_metric_points` metric for example), this is likely a better default. If this turns out to introduce a significant gap in observability, we can introduce a way to configure the `logging_frequency` of the underlying forwarder from the exporter's config.

### Describe how you validated your changes

I'm not really sure how to validate this change besides manually.

### Additional Notes
