### PR TITLE
Use a distinct cache key prefix for `bazel` binaries

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -1,7 +1,7 @@
 .bazel:defs:
   cache:
     - key:
-        prefix: bazel-$CI_RUNNER_DESCRIPTION
+        prefix: bazelversion-$CI_RUNNER_DESCRIPTION
         files: [ .bazelversion ]
       paths:
         - .cache/bazelisk

--- a/tools/bazel
+++ b/tools/bazel
@@ -7,13 +7,6 @@ if [ -z "${BAZEL_REAL:-}" ] || [ "${BAZELISK_SKIP_WRAPPER:-}" != "true" ]; then
   exit 1
 fi
 
-# Restore `bazel`'s executable bit if it was not preserved (observed on macOS after zip extraction)
-if [ ! -x "$BAZEL_REAL" ]; then
-  >&2 echo "🟡 Make bazel executable again"
-  >&2 ls -l "$BAZEL_REAL"
-  chmod +x "$BAZEL_REAL"
-fi
-
 # Not in CI: simply execute `bazel` - done
 if [ -z "${CI_PROJECT_DIR:-}" ]; then
   exec "$BAZEL_REAL" "$@"


### PR DESCRIPTION
### What does this PR do?
This reverts PR "Warn and restore `$BAZEL_REAL`'s exec bit if lost (#41799)" (commit e4dda50b81e8e37f53efd75c96e2877d4c2cdb17) and instead proposes to use a cache _key prefix_ for `bazel` version-dependent binaries distinct from the cache _key_ used for `bazel` data.

### Motivation
Hotfixing mod bits wasn't that a good idea (my bad) because disregarding their alteration just hides the root cause, which clearly looks like a data corruption:
> [...] file is invalid or corrupted (missing end of central directory record)
> [...] Cannot find central directory
> [...] Input/output error

Surprisingly, GitLab only logs an error message `FATAL: zip: not a valid zip file` (collapsed) but then continues!

Whether the corruption results from a faulty hardware or a bug is unclear at the moment, but we should then let `bazelisk` fail right away because corrupted `bazel` binaries are unlikely to work deterministically.

That's why the change proposes to use a cache _key prefix_ for version-dependent binaries that doesn't look like the other cache _key_: eliminate a _potential_ culprit: in case GitLab's code confuses both caches.

### Additional Notes
See:
- discussion with CI infra: https://dd.slack.com/archives/C06TGQ49U1Z/p1760622170669979
- GitLab-logged data corruptions: https://tinyurl.com/cd4bz8yt
- workaround doesn't help: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1193699369