### PR TITLE
CI: mark new-e2e-alp as allowed to fail

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -533,6 +533,8 @@ new-e2e-alp:
   variables:
     TARGETS: ./tests/agent-log-pipelines
     TEAM: agent-log-pipelines
+  # Temporary for #incident-44744
+  allow_failure: true
 
 new-e2e-cws:
   extends: .new_e2e_template


### PR DESCRIPTION
### What does this PR do?

Mark a flaky test as allowed to fail

### Motivation

Stop being paged for a flaky test until the team is able to investigate once innovation week is done

### Describe how you validated your changes

### Additional Notes
