### PR TITLE
fix(windows_certificate): populate thumbprint when filtering by subject

### DIFF
--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
@@ -608,10 +608,18 @@ func findCertificatesInStore(storeHandle windows.Handle, subjectFilters []string
 				}
 			}
 
+			// >>> ADD: populate thumbprint on the filtered path <<<
+			certThumbprint, err := getCertThumbprint(certContext)
+			if err != nil {
+				log.Errorf("Error getting certificate thumbprint: %v", err)
+				// keep or 'continue' depending on desired behavior; keeping matches enumerate path semantics only if err is rare
+			}
+
 			certificates = append(certificates, certInfo{
 				Certificate:      cert,
 				TrustStatusError: trustStatusError,
 				ChainPolicyError: chainPolicyError,
+				Thumbprint:       certThumbprint,
 			})
 		}
 	}

--- a/releasenotes/notes/windows-certificate-thumbprint-filtered-525157fe8f6b90d1.yaml
+++ b/releasenotes/notes/windows-certificate-thumbprint-filtered-525157fe8f6b90d1.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+     Windows: `windows_certificate` now populates the `certificate_thumbprint` tag
+     when `certificate_subjects` filters are used. Previously, the tag was empty,
+     making it impossible to uniquely scope monitors in environments with duplicate subjects.


### PR DESCRIPTION
- **windows_certificate: populate thumbprint on filtered subject path**
- **windows_certificate: add tests**
- **changelog: add reno note for windows_certificate thumbprint fix**

### What does this PR do?
Populate certificate_thumbprint when windows_certificate uses subject filters (certificate_subjects).

### Motivation
In the filtered path (findCertificatesInStore), the check didn’t call getCertThumbprint, so certInfo.Thumbprint remained empty and the emitted certificate_thumbprint: tag had no value. This broke unique scoping in environments with duplicate subjects. As found in https://datadoghq.atlassian.net/browse/AGENT-14833

### Describe how you validated your changes
Added two unit tests.
- TestFindCertificatesInStore_PopulatesThumbprint
- TestRun_WithSubjectFilters_EmitsThumbprintTag

Both pass locally with go test -tags test ./pkg/collector/corechecks/system/windowscertificate -v

### Additional Notes
Low risk, mirrors the enumerate-all path behavior; no behavior changes beyond fixing missing tag.
