### PR TITLE
[CWS] Remove root container/cgroup context/ids

### DIFF
--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -180,13 +180,6 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 
 | Property | Definition |
 | -------- | ------------- |
-| [`cgroup.file.inode`](#common-pathkey-inode-doc) | Inode of the file |
-| [`cgroup.file.mount_id`](#common-pathkey-mount_id-doc) | Mount ID of the file |
-| [`cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
-| [`cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
-| [`container.created_at`](#container-created_at-doc) | Timestamp of the creation of the container |
-| [`container.id`](#container-id-doc) | ID of the container |
-| [`container.tags`](#container-tags-doc) | Tags of the container |
 | [`event.async`](#event-async-doc) | True if the syscall was asynchronous |
 | [`event.hostname`](#event-hostname-doc) | Hostname associated with the event |
 | [`event.origin`](#event-origin-doc) | Origin of the event |
@@ -211,7 +204,9 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.ancestors.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`process.ancestors.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`process.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`process.ancestors.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`process.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`process.ancestors.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -311,7 +306,9 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`process.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`process.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`process.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`process.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`process.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -399,7 +396,9 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.parent.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`process.parent.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`process.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`process.parent.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`process.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`process.parent.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -773,7 +772,9 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`exec.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`exec.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`exec.container.id`](#common-process-container-id-doc) | Container ID |
+| [`exec.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`exec.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`exec.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`exec.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`exec.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`exec.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -890,7 +891,9 @@ A process was terminated
 | [`exit.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`exit.code`](#exit-code-doc) | Exit code of the process or number of the signal that caused the process to terminate |
 | [`exit.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`exit.container.id`](#common-process-container-id-doc) | Container ID |
+| [`exit.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`exit.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`exit.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`exit.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`exit.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`exit.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -1339,7 +1342,9 @@ A ptrace command was executed
 | [`ptrace.tracee.ancestors.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`ptrace.tracee.ancestors.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`ptrace.tracee.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`ptrace.tracee.ancestors.container.id`](#common-process-container-id-doc) | Container ID |
+| [`ptrace.tracee.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`ptrace.tracee.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`ptrace.tracee.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`ptrace.tracee.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`ptrace.tracee.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`ptrace.tracee.ancestors.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -1439,7 +1444,9 @@ A ptrace command was executed
 | [`ptrace.tracee.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`ptrace.tracee.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`ptrace.tracee.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`ptrace.tracee.container.id`](#common-process-container-id-doc) | Container ID |
+| [`ptrace.tracee.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`ptrace.tracee.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`ptrace.tracee.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`ptrace.tracee.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`ptrace.tracee.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`ptrace.tracee.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -1527,7 +1534,9 @@ A ptrace command was executed
 | [`ptrace.tracee.parent.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`ptrace.tracee.parent.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`ptrace.tracee.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`ptrace.tracee.parent.container.id`](#common-process-container-id-doc) | Container ID |
+| [`ptrace.tracee.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`ptrace.tracee.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`ptrace.tracee.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`ptrace.tracee.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`ptrace.tracee.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`ptrace.tracee.parent.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -1809,7 +1818,9 @@ A setrlimit command was executed
 | [`setrlimit.target.ancestors.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`setrlimit.target.ancestors.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`setrlimit.target.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`setrlimit.target.ancestors.container.id`](#common-process-container-id-doc) | Container ID |
+| [`setrlimit.target.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`setrlimit.target.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`setrlimit.target.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`setrlimit.target.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`setrlimit.target.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`setrlimit.target.ancestors.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -1909,7 +1920,9 @@ A setrlimit command was executed
 | [`setrlimit.target.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`setrlimit.target.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`setrlimit.target.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`setrlimit.target.container.id`](#common-process-container-id-doc) | Container ID |
+| [`setrlimit.target.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`setrlimit.target.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`setrlimit.target.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`setrlimit.target.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`setrlimit.target.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`setrlimit.target.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -1997,7 +2010,9 @@ A setrlimit command was executed
 | [`setrlimit.target.parent.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`setrlimit.target.parent.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`setrlimit.target.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`setrlimit.target.parent.container.id`](#common-process-container-id-doc) | Container ID |
+| [`setrlimit.target.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`setrlimit.target.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`setrlimit.target.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`setrlimit.target.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`setrlimit.target.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`setrlimit.target.parent.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -2184,7 +2199,9 @@ A signal was sent
 | [`signal.target.ancestors.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`signal.target.ancestors.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`signal.target.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`signal.target.ancestors.container.id`](#common-process-container-id-doc) | Container ID |
+| [`signal.target.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`signal.target.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`signal.target.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`signal.target.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`signal.target.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`signal.target.ancestors.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -2284,7 +2301,9 @@ A signal was sent
 | [`signal.target.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`signal.target.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`signal.target.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`signal.target.container.id`](#common-process-container-id-doc) | Container ID |
+| [`signal.target.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`signal.target.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`signal.target.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`signal.target.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`signal.target.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`signal.target.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -2372,7 +2391,9 @@ A signal was sent
 | [`signal.target.parent.cgroup.id`](#common-cgroupcontext-id-doc) | ID of the cgroup |
 | [`signal.target.parent.cgroup.version`](#common-cgroupcontext-version-doc) | [Experimental] Version of the cgroup API |
 | [`signal.target.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
-| [`signal.target.parent.container.id`](#common-process-container-id-doc) | Container ID |
+| [`signal.target.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`signal.target.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`signal.target.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`signal.target.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`signal.target.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
 | [`signal.target.parent.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
@@ -2781,13 +2802,13 @@ Definition: Comm attribute of the process
 `exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `setrlimit.target` `setrlimit.target.ancestors` `setrlimit.target.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
 
 
-### `*.container.id` {#common-process-container-id-doc}
-Type: string
+### `*.created_at` {#common-containercontext-created_at-doc}
+Type: int
 
-Definition: Container ID
+Definition: Timestamp of the creation of the container
 
-`*.container.id` has 14 possible prefixes:
-`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `setrlimit.target` `setrlimit.target.ancestors` `setrlimit.target.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+`*.created_at` has 14 possible prefixes:
+`exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container` `ptrace.tracee.ancestors.container` `ptrace.tracee.container` `ptrace.tracee.parent.container` `setrlimit.target.ancestors.container` `setrlimit.target.container` `setrlimit.target.parent.container` `signal.target.ancestors.container` `signal.target.container` `signal.target.parent.container`
 
 
 ### `*.created_at` {#common-process-created_at-doc}
@@ -2993,8 +3014,17 @@ Type: string
 
 Definition: ID of the cgroup
 
-`*.id` has 15 possible prefixes:
-`cgroup` `exec.cgroup` `exit.cgroup` `process.ancestors.cgroup` `process.cgroup` `process.parent.cgroup` `ptrace.tracee.ancestors.cgroup` `ptrace.tracee.cgroup` `ptrace.tracee.parent.cgroup` `setrlimit.target.ancestors.cgroup` `setrlimit.target.cgroup` `setrlimit.target.parent.cgroup` `signal.target.ancestors.cgroup` `signal.target.cgroup` `signal.target.parent.cgroup`
+`*.id` has 14 possible prefixes:
+`exec.cgroup` `exit.cgroup` `process.ancestors.cgroup` `process.cgroup` `process.parent.cgroup` `ptrace.tracee.ancestors.cgroup` `ptrace.tracee.cgroup` `ptrace.tracee.parent.cgroup` `setrlimit.target.ancestors.cgroup` `setrlimit.target.cgroup` `setrlimit.target.parent.cgroup` `signal.target.ancestors.cgroup` `signal.target.cgroup` `signal.target.parent.cgroup`
+
+
+### `*.id` {#common-containercontext-id-doc}
+Type: string
+
+Definition: ID of the container
+
+`*.id` has 14 possible prefixes:
+`exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container` `ptrace.tracee.ancestors.container` `ptrace.tracee.container` `ptrace.tracee.parent.container` `setrlimit.target.ancestors.container` `setrlimit.target.container` `setrlimit.target.parent.container` `signal.target.ancestors.container` `signal.target.container` `signal.target.parent.container`
 
 
 ### `*.id` {#common-usersessioncontext-id-doc}
@@ -3029,8 +3059,8 @@ Type: int
 
 Definition: Inode of the file
 
-`*.inode` has 61 possible prefixes:
-`cgroup.file` `cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.cgroup.file` `exec.file` `exec.interpreter.file` `exit.cgroup.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.cgroup.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.cgroup.file` `process.file` `process.interpreter.file` `process.parent.cgroup.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.cgroup.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.cgroup.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.cgroup.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.cgroup.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.cgroup.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.cgroup.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.cgroup.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.cgroup.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.cgroup.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+`*.inode` has 60 possible prefixes:
+`cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.cgroup.file` `exec.file` `exec.interpreter.file` `exit.cgroup.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.cgroup.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.cgroup.file` `process.file` `process.interpreter.file` `process.parent.cgroup.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.cgroup.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.cgroup.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.cgroup.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.cgroup.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.cgroup.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.cgroup.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.cgroup.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.cgroup.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.cgroup.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
 
 
 ### `*.ip` {#common-ipportcontext-ip-doc}
@@ -3173,8 +3203,8 @@ Type: int
 
 Definition: Mount ID of the file
 
-`*.mount_id` has 61 possible prefixes:
-`cgroup.file` `cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.cgroup.file` `exec.file` `exec.interpreter.file` `exit.cgroup.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.cgroup.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.cgroup.file` `process.file` `process.interpreter.file` `process.parent.cgroup.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.cgroup.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.cgroup.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.cgroup.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.cgroup.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.cgroup.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.cgroup.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.cgroup.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.cgroup.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.cgroup.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+`*.mount_id` has 60 possible prefixes:
+`cgroup_write.file` `chdir.file` `chmod.file` `chown.file` `exec.cgroup.file` `exec.file` `exec.interpreter.file` `exit.cgroup.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.cgroup.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.cgroup.file` `process.file` `process.interpreter.file` `process.parent.cgroup.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.cgroup.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.cgroup.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.cgroup.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setrlimit.target.ancestors.cgroup.file` `setrlimit.target.ancestors.file` `setrlimit.target.ancestors.interpreter.file` `setrlimit.target.cgroup.file` `setrlimit.target.file` `setrlimit.target.interpreter.file` `setrlimit.target.parent.cgroup.file` `setrlimit.target.parent.file` `setrlimit.target.parent.interpreter.file` `setxattr.file` `signal.target.ancestors.cgroup.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.cgroup.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.cgroup.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
 
 
 ### `*.mount_visible` {#common-fileevent-mount_visible-doc}
@@ -3383,6 +3413,15 @@ Definition: Size in bytes of the network packet
 `network` `packet`
 
 
+### `*.tags` {#common-containercontext-tags-doc}
+Type: string
+
+Definition: Tags of the container
+
+`*.tags` has 14 possible prefixes:
+`exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container` `ptrace.tracee.ancestors.container` `ptrace.tracee.container` `ptrace.tracee.parent.container` `setrlimit.target.ancestors.container` `setrlimit.target.container` `setrlimit.target.parent.container` `signal.target.ancestors.container` `signal.target.container` `signal.target.parent.container`
+
+
 ### `*.tid` {#common-pidcontext-tid-doc}
 Type: int
 
@@ -3463,8 +3502,8 @@ Type: int
 
 Definition: [Experimental] Version of the cgroup API
 
-`*.version` has 15 possible prefixes:
-`cgroup` `exec.cgroup` `exit.cgroup` `process.ancestors.cgroup` `process.cgroup` `process.parent.cgroup` `ptrace.tracee.ancestors.cgroup` `ptrace.tracee.cgroup` `ptrace.tracee.parent.cgroup` `setrlimit.target.ancestors.cgroup` `setrlimit.target.cgroup` `setrlimit.target.parent.cgroup` `signal.target.ancestors.cgroup` `signal.target.cgroup` `signal.target.parent.cgroup`
+`*.version` has 14 possible prefixes:
+`exec.cgroup` `exit.cgroup` `process.ancestors.cgroup` `process.cgroup` `process.parent.cgroup` `ptrace.tracee.ancestors.cgroup` `ptrace.tracee.cgroup` `ptrace.tracee.parent.cgroup` `setrlimit.target.ancestors.cgroup` `setrlimit.target.cgroup` `setrlimit.target.parent.cgroup` `signal.target.ancestors.cgroup` `signal.target.cgroup` `signal.target.parent.cgroup`
 
 
 ### `accept.addr.family` {#accept-addr-family-doc}
@@ -3721,27 +3760,6 @@ Definition: Address hostname (if available)
 Type: int
 
 Definition: Socket Protocol
-
-
-
-### `container.created_at` {#container-created_at-doc}
-Type: int
-
-Definition: Timestamp of the creation of the container
-
-
-
-### `container.id` {#container-id-doc}
-Type: string
-
-Definition: ID of the container
-
-
-
-### `container.tags` {#container-tags-doc}
-Type: string
-
-Definition: Tags of the container
 
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -8,41 +8,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "cgroup.file.inode",
-          "definition": "Inode of the file",
-          "property_doc_link": "common-pathkey-inode-doc"
-        },
-        {
-          "name": "cgroup.file.mount_id",
-          "definition": "Mount ID of the file",
-          "property_doc_link": "common-pathkey-mount_id-doc"
-        },
-        {
-          "name": "cgroup.id",
-          "definition": "ID of the cgroup",
-          "property_doc_link": "common-cgroupcontext-id-doc"
-        },
-        {
-          "name": "cgroup.version",
-          "definition": "[Experimental] Version of the cgroup API",
-          "property_doc_link": "common-cgroupcontext-version-doc"
-        },
-        {
-          "name": "container.created_at",
-          "definition": "Timestamp of the creation of the container",
-          "property_doc_link": "container-created_at-doc"
-        },
-        {
-          "name": "container.id",
-          "definition": "ID of the container",
-          "property_doc_link": "container-id-doc"
-        },
-        {
-          "name": "container.tags",
-          "definition": "Tags of the container",
-          "property_doc_link": "container-tags-doc"
-        },
-        {
           "name": "event.async",
           "definition": "True if the syscall was asynchronous",
           "property_doc_link": "event-async-doc"
@@ -163,9 +128,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "process.ancestors.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "process.ancestors.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "process.ancestors.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "process.ancestors.created_at",
@@ -663,9 +638,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "process.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "process.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "process.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "process.created_at",
@@ -1103,9 +1088,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "process.parent.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "process.parent.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "process.parent.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "process.parent.created_at",
@@ -2641,9 +2636,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "exec.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "exec.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "exec.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "exec.created_at",
@@ -3200,9 +3205,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "exit.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "exit.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "exit.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "exit.created_at",
@@ -5123,9 +5138,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "ptrace.tracee.ancestors.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "ptrace.tracee.ancestors.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.created_at",
@@ -5623,9 +5648,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "ptrace.tracee.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "ptrace.tracee.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "ptrace.tracee.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "ptrace.tracee.created_at",
@@ -6063,9 +6098,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "ptrace.tracee.parent.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "ptrace.tracee.parent.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "ptrace.tracee.parent.created_at",
@@ -7317,9 +7362,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "setrlimit.target.ancestors.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "setrlimit.target.ancestors.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "setrlimit.target.ancestors.created_at",
@@ -7817,9 +7872,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "setrlimit.target.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "setrlimit.target.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "setrlimit.target.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "setrlimit.target.created_at",
@@ -8257,9 +8322,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "setrlimit.target.parent.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "setrlimit.target.parent.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "setrlimit.target.parent.created_at",
@@ -9088,9 +9163,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "signal.target.ancestors.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "signal.target.ancestors.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "signal.target.ancestors.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "signal.target.ancestors.created_at",
@@ -9588,9 +9673,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "signal.target.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "signal.target.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "signal.target.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "signal.target.created_at",
@@ -10028,9 +10123,19 @@
           "property_doc_link": "common-process-comm-doc"
         },
         {
+          "name": "signal.target.parent.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "signal.target.parent.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "signal.target.parent.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "signal.target.parent.created_at",
@@ -11438,25 +11543,25 @@
       "examples": []
     },
     {
-      "name": "*.container.id",
-      "link": "common-process-container-id-doc",
-      "type": "string",
-      "definition": "Container ID",
+      "name": "*.created_at",
+      "link": "common-containercontext-created_at-doc",
+      "type": "int",
+      "definition": "Timestamp of the creation of the container",
       "prefixes": [
-        "exec",
-        "exit",
-        "process",
-        "process.ancestors",
-        "process.parent",
-        "ptrace.tracee",
-        "ptrace.tracee.ancestors",
-        "ptrace.tracee.parent",
-        "setrlimit.target",
-        "setrlimit.target.ancestors",
-        "setrlimit.target.parent",
-        "signal.target",
-        "signal.target.ancestors",
-        "signal.target.parent"
+        "exec.container",
+        "exit.container",
+        "process.ancestors.container",
+        "process.container",
+        "process.parent.container",
+        "ptrace.tracee.ancestors.container",
+        "ptrace.tracee.container",
+        "ptrace.tracee.parent.container",
+        "setrlimit.target.ancestors.container",
+        "setrlimit.target.container",
+        "setrlimit.target.parent.container",
+        "signal.target.ancestors.container",
+        "signal.target.container",
+        "signal.target.parent.container"
       ],
       "constants": "",
       "constants_link": "",
@@ -12142,7 +12247,6 @@
       "type": "string",
       "definition": "ID of the cgroup",
       "prefixes": [
-        "cgroup",
         "exec.cgroup",
         "exit.cgroup",
         "process.ancestors.cgroup",
@@ -12157,6 +12261,31 @@
         "signal.target.ancestors.cgroup",
         "signal.target.cgroup",
         "signal.target.parent.cgroup"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.id",
+      "link": "common-containercontext-id-doc",
+      "type": "string",
+      "definition": "ID of the container",
+      "prefixes": [
+        "exec.container",
+        "exit.container",
+        "process.ancestors.container",
+        "process.container",
+        "process.parent.container",
+        "ptrace.tracee.ancestors.container",
+        "ptrace.tracee.container",
+        "ptrace.tracee.parent.container",
+        "setrlimit.target.ancestors.container",
+        "setrlimit.target.container",
+        "setrlimit.target.parent.container",
+        "signal.target.ancestors.container",
+        "signal.target.container",
+        "signal.target.parent.container"
       ],
       "constants": "",
       "constants_link": "",
@@ -12264,7 +12393,6 @@
       "type": "int",
       "definition": "Inode of the file",
       "prefixes": [
-        "cgroup.file",
         "cgroup_write.file",
         "chdir.file",
         "chmod.file",
@@ -12832,7 +12960,6 @@
       "type": "int",
       "definition": "Mount ID of the file",
       "prefixes": [
-        "cgroup.file",
         "cgroup_write.file",
         "chdir.file",
         "chmod.file",
@@ -13712,6 +13839,31 @@
       "examples": []
     },
     {
+      "name": "*.tags",
+      "link": "common-containercontext-tags-doc",
+      "type": "string",
+      "definition": "Tags of the container",
+      "prefixes": [
+        "exec.container",
+        "exit.container",
+        "process.ancestors.container",
+        "process.container",
+        "process.parent.container",
+        "ptrace.tracee.ancestors.container",
+        "ptrace.tracee.container",
+        "ptrace.tracee.parent.container",
+        "setrlimit.target.ancestors.container",
+        "setrlimit.target.container",
+        "setrlimit.target.parent.container",
+        "signal.target.ancestors.container",
+        "signal.target.container",
+        "signal.target.parent.container"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
       "name": "*.tid",
       "link": "common-pidcontext-tid-doc",
       "type": "int",
@@ -13949,7 +14101,6 @@
       "type": "int",
       "definition": "[Experimental] Version of the cgroup API",
       "prefixes": [
-        "cgroup",
         "exec.cgroup",
         "exit.cgroup",
         "process.ancestors.cgroup",
@@ -14348,42 +14499,6 @@
       "definition": "Socket Protocol",
       "prefixes": [
         "connect"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "container.created_at",
-      "link": "container-created_at-doc",
-      "type": "int",
-      "definition": "Timestamp of the creation of the container",
-      "prefixes": [
-        "container"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "container.id",
-      "link": "container-id-doc",
-      "type": "string",
-      "definition": "ID of the container",
-      "prefixes": [
-        "container"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "container.tags",
-      "link": "container-tags-doc",
-      "type": "string",
-      "definition": "Tags of the container",
-      "prefixes": [
-        "container"
       ],
       "constants": "",
       "constants_link": "",

--- a/docs/cloud-workload-security/secl_windows.json
+++ b/docs/cloud-workload-security/secl_windows.json
@@ -8,21 +8,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "container.created_at",
-          "definition": "Timestamp of the creation of the container",
-          "property_doc_link": "container-created_at-doc"
-        },
-        {
-          "name": "container.id",
-          "definition": "ID of the container",
-          "property_doc_link": "container-id-doc"
-        },
-        {
-          "name": "container.tags",
-          "definition": "Tags of the container",
-          "property_doc_link": "container-tags-doc"
-        },
-        {
           "name": "event.hostname",
           "definition": "Hostname associated with the event",
           "property_doc_link": "event-hostname-doc"
@@ -63,9 +48,19 @@
           "property_doc_link": "common-process-cmdline-doc"
         },
         {
+          "name": "process.ancestors.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "process.ancestors.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "process.ancestors.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "process.ancestors.created_at",
@@ -138,9 +133,19 @@
           "property_doc_link": "common-process-cmdline-doc"
         },
         {
+          "name": "process.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "process.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "process.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "process.created_at",
@@ -188,9 +193,19 @@
           "property_doc_link": "common-process-cmdline-doc"
         },
         {
+          "name": "process.parent.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "process.parent.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "process.parent.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "process.parent.created_at",
@@ -512,9 +527,19 @@
           "property_doc_link": "common-process-cmdline-doc"
         },
         {
+          "name": "exec.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "exec.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "exec.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "exec.created_at",
@@ -601,9 +626,19 @@
           "property_doc_link": "exit-code-doc"
         },
         {
+          "name": "exit.container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "common-containercontext-created_at-doc"
+        },
+        {
           "name": "exit.container.id",
-          "definition": "Container ID",
-          "property_doc_link": "common-process-container-id-doc"
+          "definition": "ID of the container",
+          "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "exit.container.tags",
+          "definition": "Tags of the container",
+          "property_doc_link": "common-containercontext-tags-doc"
         },
         {
           "name": "exit.created_at",
@@ -946,16 +981,16 @@
       ]
     },
     {
-      "name": "*.container.id",
-      "link": "common-process-container-id-doc",
-      "type": "string",
-      "definition": "Container ID",
+      "name": "*.created_at",
+      "link": "common-containercontext-created_at-doc",
+      "type": "int",
+      "definition": "Timestamp of the creation of the container",
       "prefixes": [
-        "exec",
-        "exit",
-        "process",
-        "process.ancestors",
-        "process.parent"
+        "exec.container",
+        "exit.container",
+        "process.ancestors.container",
+        "process.container",
+        "process.parent.container"
       ],
       "constants": "",
       "constants_link": "",
@@ -1057,6 +1092,22 @@
         "rename.file",
         "rename.file.destination",
         "write.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.id",
+      "link": "common-containercontext-id-doc",
+      "type": "string",
+      "definition": "ID of the container",
+      "prefixes": [
+        "exec.container",
+        "exit.container",
+        "process.ancestors.container",
+        "process.container",
+        "process.parent.container"
       ],
       "constants": "",
       "constants_link": "",
@@ -1285,6 +1336,22 @@
       "examples": []
     },
     {
+      "name": "*.tags",
+      "link": "common-containercontext-tags-doc",
+      "type": "string",
+      "definition": "Tags of the container",
+      "prefixes": [
+        "exec.container",
+        "exit.container",
+        "process.ancestors.container",
+        "process.container",
+        "process.parent.container"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
       "name": "*.user",
       "link": "common-process-user-doc",
       "type": "string",
@@ -1396,42 +1463,6 @@
       "definition": "Username of the permission change author",
       "prefixes": [
         "change_permission"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "container.created_at",
-      "link": "container-created_at-doc",
-      "type": "int",
-      "definition": "Timestamp of the creation of the container",
-      "prefixes": [
-        "container"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "container.id",
-      "link": "container-id-doc",
-      "type": "string",
-      "definition": "ID of the container",
-      "prefixes": [
-        "container"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "container.tags",
-      "link": "container-tags-doc",
-      "type": "string",
-      "definition": "Tags of the container",
-      "prefixes": [
-        "container"
       ],
       "constants": "",
       "constants_link": "",

--- a/docs/cloud-workload-security/windows_expressions.md
+++ b/docs/cloud-workload-security/windows_expressions.md
@@ -64,9 +64,6 @@ List of the available variables:
 
 | Property | Definition |
 | -------- | ------------- |
-| [`container.created_at`](#container-created_at-doc) | Timestamp of the creation of the container |
-| [`container.id`](#container-id-doc) | ID of the container |
-| [`container.tags`](#container-tags-doc) | Tags of the container |
 | [`event.hostname`](#event-hostname-doc) | Hostname associated with the event |
 | [`event.origin`](#event-origin-doc) | Origin of the event |
 | [`event.os`](#event-os-doc) | Operating system of the event |
@@ -75,7 +72,9 @@ List of the available variables:
 | [`event.source`](#event-source-doc) | [Experimental] Source of the event. Can be either 'runtime' or 'snapshot'. |
 | [`event.timestamp`](#event-timestamp-doc) | Timestamp of the event |
 | [`process.ancestors.cmdline`](#common-process-cmdline-doc) | Command line of the process |
-| [`process.ancestors.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`process.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.ancestors.envp`](#common-process-envp-doc) | Environment variables of the process |
 | [`process.ancestors.envs`](#common-process-envs-doc) | Environment variable names of the process |
@@ -90,7 +89,9 @@ List of the available variables:
 | [`process.ancestors.user`](#common-process-user-doc) | User name |
 | [`process.ancestors.user_sid`](#common-process-user_sid-doc) | Sid of the user of the process |
 | [`process.cmdline`](#common-process-cmdline-doc) | Command line of the process |
-| [`process.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`process.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.envp`](#common-process-envp-doc) | Environment variables of the process |
 | [`process.envs`](#common-process-envs-doc) | Environment variable names of the process |
@@ -100,7 +101,9 @@ List of the available variables:
 | [`process.file.path`](#common-fileevent-path-doc) | File's path |
 | [`process.file.path.length`](#common-string-length-doc) | Length of the corresponding element |
 | [`process.parent.cmdline`](#common-process-cmdline-doc) | Command line of the process |
-| [`process.parent.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`process.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.parent.envp`](#common-process-envp-doc) | Environment variables of the process |
 | [`process.parent.envs`](#common-process-envs-doc) | Environment variable names of the process |
@@ -196,7 +199,9 @@ A process was executed or forked
 | Property | Definition |
 | -------- | ------------- |
 | [`exec.cmdline`](#common-process-cmdline-doc) | Command line of the process |
-| [`exec.container.id`](#common-process-container-id-doc) | Container ID |
+| [`exec.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`exec.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`exec.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`exec.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`exec.envp`](#common-process-envp-doc) | Environment variables of the process |
 | [`exec.envs`](#common-process-envs-doc) | Environment variable names of the process |
@@ -219,7 +224,9 @@ A process was terminated
 | [`exit.cause`](#exit-cause-doc) | Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED) |
 | [`exit.cmdline`](#common-process-cmdline-doc) | Command line of the process |
 | [`exit.code`](#exit-code-doc) | Exit code of the process or number of the signal that caused the process to terminate |
-| [`exit.container.id`](#common-process-container-id-doc) | Container ID |
+| [`exit.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
+| [`exit.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`exit.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`exit.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`exit.envp`](#common-process-envp-doc) | Environment variables of the process |
 | [`exit.envs`](#common-process-envs-doc) | Environment variable names of the process |
@@ -334,13 +341,13 @@ exec.cmdline =~ "* -F * http*"
 
 Matches any process that has the "-F" argument anywhere before an argument starting with "http".
 
-### `*.container.id` {#common-process-container-id-doc}
-Type: string
+### `*.created_at` {#common-containercontext-created_at-doc}
+Type: int
 
-Definition: Container ID
+Definition: Timestamp of the creation of the container
 
-`*.container.id` has 5 possible prefixes:
-`exec` `exit` `process` `process.ancestors` `process.parent`
+`*.created_at` has 5 possible prefixes:
+`exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container`
 
 
 ### `*.created_at` {#common-process-created_at-doc}
@@ -404,6 +411,15 @@ Definition: File's extension
 
 `*.extension` has 5 possible prefixes:
 `create.file` `delete.file` `rename.file` `rename.file.destination` `write.file`
+
+
+### `*.id` {#common-containercontext-id-doc}
+Type: string
+
+Definition: ID of the container
+
+`*.id` has 5 possible prefixes:
+`exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container`
 
 
 ### `*.key_name` {#common-registryevent-key_name-doc}
@@ -532,6 +548,15 @@ Definition: Registry's value name
 `set` `set_key_value`
 
 
+### `*.tags` {#common-containercontext-tags-doc}
+Type: string
+
+Definition: Tags of the container
+
+`*.tags` has 5 possible prefixes:
+`exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container`
+
+
 ### `*.user` {#common-process-user-doc}
 Type: string
 
@@ -598,27 +623,6 @@ Definition: Domain name of the permission change author
 Type: string
 
 Definition: Username of the permission change author
-
-
-
-### `container.created_at` {#container-created_at-doc}
-Type: int
-
-Definition: Timestamp of the creation of the container
-
-
-
-### `container.id` {#container-id-doc}
-Type: string
-
-Definition: ID of the container
-
-
-
-### `container.tags` {#container-tags-doc}
-Type: string
-
-Definition: Tags of the container
 
 
 

--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -160,7 +160,7 @@ func (h *eventConsumerWrapper) Copy(ev *model.Event) any {
 		p.Tags = append(p.Tags, intern.GetByString(tag))
 	}
 
-	if cid := ev.GetContainerId(); cid != "" {
+	if cid := ev.GetContainerID(); cid != "" {
 		p.ContainerID = intern.GetByString(cid)
 	}
 

--- a/pkg/network/events/monitor_test.go
+++ b/pkg/network/events/monitor_test.go
@@ -29,6 +29,12 @@ func TestEventConsumerWrapperCopy(t *testing.T) {
 				Type: uint32(model.ExecEventType),
 				ProcessContext: &model.ProcessContext{
 					Process: model.Process{
+						ContainerContext: model.ContainerContext{
+							ContainerID: "cid_exec",
+						},
+						CGroup: model.CGroupContext{
+							CGroupID: "cid_exec",
+						},
 						PIDContext: model.PIDContext{
 							Pid: 2233,
 						},
@@ -40,13 +46,7 @@ func TestEventConsumerWrapperCopy(t *testing.T) {
 						},
 					},
 				},
-				ContainerContext: &model.ContainerContext{
-					ContainerID: "cid_exec",
-				},
 				FieldHandlers: &model.FakeFieldHandlers{},
-			},
-			CGroupContext: &model.CGroupContext{
-				CGroupID: "cid_exec",
 			},
 		}
 		evHandler := &eventConsumerWrapper{}
@@ -71,6 +71,12 @@ func TestEventConsumerWrapperCopy(t *testing.T) {
 				Type: uint32(model.ForkEventType),
 				ProcessContext: &model.ProcessContext{
 					Process: model.Process{
+						ContainerContext: model.ContainerContext{
+							ContainerID: "cid_fork",
+						},
+						CGroup: model.CGroupContext{
+							CGroupID: "cid_fork",
+						},
 						PIDContext: model.PIDContext{
 							Pid: 2244,
 						},
@@ -82,13 +88,7 @@ func TestEventConsumerWrapperCopy(t *testing.T) {
 						},
 					},
 				},
-				ContainerContext: &model.ContainerContext{
-					ContainerID: "cid_fork",
-				},
 				FieldHandlers: &model.FakeFieldHandlers{},
-			},
-			CGroupContext: &model.CGroupContext{
-				CGroupID: "cid_fork",
 			},
 		}
 		evHandler := &eventConsumerWrapper{}
@@ -122,6 +122,12 @@ func TestEventConsumerWrapperCopy(t *testing.T) {
 				Type: uint32(model.TracerMemfdSealEventType),
 				ProcessContext: &model.ProcessContext{
 					Process: model.Process{
+						ContainerContext: model.ContainerContext{
+							ContainerID: "cid_tracer_memfd",
+						},
+						CGroup: model.CGroupContext{
+							CGroupID: "cid_tracer_memfd",
+						},
 						PIDContext: model.PIDContext{
 							Pid: 1234,
 						},
@@ -134,13 +140,7 @@ func TestEventConsumerWrapperCopy(t *testing.T) {
 						},
 					},
 				},
-				ContainerContext: &model.ContainerContext{
-					ContainerID: "cid_tracer_memfd",
-				},
 				FieldHandlers: &model.FakeFieldHandlers{},
-			},
-			CGroupContext: &model.CGroupContext{
-				CGroupID: "cid_tracer_memfd",
 			},
 			TracerMemfdSeal: model.TracerMemfdSealEvent{
 				Fd: 5,
@@ -247,6 +247,9 @@ func TestEventHandleTracerTags(t *testing.T) {
 				Type: uint32(model.ExecEventType),
 				ProcessContext: &model.ProcessContext{
 					Process: model.Process{
+						ContainerContext: model.ContainerContext{
+							ContainerID: "test-container",
+						},
 						PIDContext: model.PIDContext{
 							Pid: 1234,
 						},
@@ -261,9 +264,6 @@ func TestEventHandleTracerTags(t *testing.T) {
 							"entrypoint.name:my-entrypoint",
 						},
 					},
-				},
-				ContainerContext: &model.ContainerContext{
-					ContainerID: "test-container",
 				},
 				FieldHandlers: &model.FakeFieldHandlers{},
 			},

--- a/pkg/process/events/consumer/event_copy_linux.go
+++ b/pkg/process/events/consumer/event_copy_linux.go
@@ -24,7 +24,7 @@ func (p *ProcessConsumer) Copy(event *smodel.Event) any {
 	valueCollectionTime := event.GetTimestamp()
 	result.CollectionTime = valueCollectionTime
 
-	valueContainerID := event.GetContainerId()
+	valueContainerID := event.GetContainerID()
 	result.ContainerID = valueContainerID
 
 	valuePpid := event.GetProcessPpid()

--- a/pkg/process/events/consumer/event_copy_windows.go
+++ b/pkg/process/events/consumer/event_copy_windows.go
@@ -24,7 +24,7 @@ func (p *ProcessConsumer) Copy(event *smodel.Event) any {
 	valueCollectionTime := event.GetTimestamp()
 	result.CollectionTime = valueCollectionTime
 
-	valueContainerID := event.GetContainerId()
+	valueContainerID := event.GetContainerID()
 	result.ContainerID = valueContainerID
 
 	valuePpid := event.GetProcessPpid()

--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -177,9 +177,8 @@ func eventFromTestData(testData TestData) (eval.Event, error) {
 
 	event := &model.Event{
 		BaseEvent: model.BaseEvent{
-			Type:             uint32(kind),
-			FieldHandlers:    &model.FakeFieldHandlers{},
-			ContainerContext: &model.ContainerContext{},
+			Type:          uint32(kind),
+			FieldHandlers: &model.FakeFieldHandlers{},
 		},
 	}
 	event.Init()

--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -56,11 +56,11 @@ func getProcessService(config *config.Config, entry *model.ProcessCacheEntry) (s
 		}
 	}
 
-	inContainer := entry.ContainerID != ""
+	inContainer := entry.ProcessContext.ContainerContext.ContainerID != ""
 
 	// while in container check for each ancestor
 	for ancestor := entry.Ancestor; ancestor != nil; ancestor = ancestor.Ancestor {
-		if inContainer && ancestor.ContainerID == "" {
+		if inContainer && ancestor.ContainerContext.ContainerID == "" {
 			break
 		}
 

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -178,14 +178,14 @@ func (fh *EBPFLessFieldHandlers) ResolveCGroupVersion(_ *model.Event, _ *model.C
 
 // ResolveContainerContext retrieve the ContainerContext of the event
 func (fh *EBPFLessFieldHandlers) ResolveContainerContext(ev *model.Event) (*model.ContainerContext, bool) {
-	return ev.ContainerContext, ev.ContainerContext != nil
+	return &ev.ProcessContext.ContainerContext, true
 }
 
 // ResolveContainerID resolves the container ID of the event
 func (fh *EBPFLessFieldHandlers) ResolveContainerID(ev *model.Event, e *model.ContainerContext) string {
 	if len(e.ContainerID) == 0 {
 		if entry, _ := fh.ResolveProcessCacheEntry(ev, nil); entry != nil {
-			e.ContainerID = containerutils.ContainerID(entry.ContainerID)
+			e.ContainerID = containerutils.ContainerID(entry.ProcessContext.Process.ContainerContext.ContainerID)
 		}
 	}
 	return string(e.ContainerID)
@@ -211,7 +211,7 @@ func (fh *EBPFLessFieldHandlers) ResolveContainerTags(_ *model.Event, e *model.C
 
 // ResolveProcessContainerID resolves the container ID of the event
 func (fh *EBPFLessFieldHandlers) ResolveProcessContainerID(ev *model.Event, _ *model.Process) string {
-	return fh.ResolveContainerID(ev, ev.ContainerContext)
+	return fh.ResolveContainerID(ev, &ev.ProcessContext.Process.ContainerContext)
 }
 
 // ResolveProcessCreatedAt resolves process creation time

--- a/pkg/security/probe/field_handlers_windows.go
+++ b/pkg/security/probe/field_handlers_windows.go
@@ -108,7 +108,10 @@ func (fh *FieldHandlers) ResolveUser(_ *model.Event, process *model.Process) str
 
 // ResolveContainerContext retrieve the ContainerContext of the event
 func (fh *FieldHandlers) ResolveContainerContext(ev *model.Event) (*model.ContainerContext, bool) {
-	return ev.ContainerContext, ev.ContainerContext != nil
+	if ev.ProcessContext == nil {
+		return nil, false
+	}
+	return &ev.ProcessContext.Process.ContainerContext, true
 }
 
 // ResolveContainerRuntime retrieves the container runtime managing the container

--- a/pkg/security/probe/file_hasher.go
+++ b/pkg/security/probe/file_hasher.go
@@ -120,7 +120,7 @@ func (p *FileHasher) HashAndReport(rule *rules.Rule, action *rules.HashDefinitio
 	report := &HashActionReport{
 		rule:      rule,
 		pid:       ev.ProcessContext.Pid,
-		crtID:     ev.ProcessContext.ContainerID,
+		crtID:     ev.ProcessContext.Process.ContainerContext.ContainerID,
 		seenAt:    ev.Timestamp,
 		fileEvent: *fileEvent,
 		eventType: eventType,

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -844,7 +844,7 @@ func (p *EBPFProbe) playSnapshot(notifyConsumers bool) {
 }
 
 func (p *EBPFProbe) sendAnomalyDetection(event *model.Event) {
-	tags := p.probe.GetEventTags(event.ContainerContext.ContainerID)
+	tags := p.probe.GetEventTags(event.ProcessContext.Process.ContainerContext.ContainerID)
 	if service := p.probe.GetService(event); service != "" {
 		tags = append(tags, "service:"+service)
 	}
@@ -885,10 +885,10 @@ func (p *EBPFProbe) DispatchEvent(event *model.Event, notifyConsumers bool) {
 	if event.IsAnomalyDetectionEvent() {
 		var workloadID containerutils.WorkloadID
 		var imageTag string
-		if containerID := event.FieldHandlers.ResolveContainerID(event, event.ContainerContext); containerID != "" {
+		if containerID := event.FieldHandlers.ResolveContainerID(event, &event.ProcessContext.Process.ContainerContext); containerID != "" {
 			workloadID = containerID
-			imageTag = utils.GetTagValue("image_tag", event.ContainerContext.Tags)
-		} else if cgroupID := event.FieldHandlers.ResolveCGroupID(event, event.CGroupContext); cgroupID != "" {
+			imageTag = utils.GetTagValue("image_tag", event.ProcessContext.Process.ContainerContext.Tags)
+		} else if cgroupID := event.FieldHandlers.ResolveCGroupID(event, &event.ProcessContext.Process.CGroup); cgroupID != "" {
 			workloadID = containerutils.CGroupID(cgroupID)
 			tags, err := p.Resolvers.TagsResolver.ResolveWithErr(workloadID)
 			if err != nil {
@@ -948,7 +948,7 @@ func (p *EBPFProbe) EventMarshallerCtor(event *model.Event) func() events.EventM
 }
 
 func (p *EBPFProbe) unmarshalContexts(data []byte, event *model.Event) (int, error) {
-	read, err := model.UnmarshalBinary(data, &event.PIDContext, &event.SpanContext, event.CGroupContext)
+	read, err := model.UnmarshalBinary(data, &event.PIDContext, &event.SpanContext, &event.ProcessContext.Process.CGroup)
 	if err != nil {
 		return 0, err
 	}
@@ -991,11 +991,9 @@ func (p *EBPFProbe) unmarshalProcessCacheEntry(ev *model.Event, data []byte) (in
 		return n, err
 	}
 
-	entry.Process.ContainerID = ev.ContainerContext.ContainerID
-	entry.ContainerID = ev.ContainerContext.ContainerID
+	entry.Process.ContainerContext.ContainerID = ev.ProcessContext.Process.ContainerContext.ContainerID
 
-	entry.Process.CGroup.Merge(ev.CGroupContext)
-	entry.CGroup.Merge(ev.CGroupContext)
+	entry.Process.CGroup.Merge(&ev.ProcessContext.Process.CGroup)
 
 	entry.Source = model.ProcessCacheEntryFromEvent
 
@@ -1023,9 +1021,6 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 		panic("should always return a process context")
 	}
 
-	// do the same with cgroup context
-	event.CGroupContext = &event.ProcessCacheEntry.CGroup
-
 	if process.IsKThread(event.ProcessContext.PPid, event.ProcessContext.Pid) {
 		return false
 	}
@@ -1049,6 +1044,7 @@ func (p *EBPFProbe) zeroEvent() *model.Event {
 	probeEventZeroer(p.event)
 	p.event.FieldHandlers = p.fieldHandlers
 	p.event.Origin = EBPFOrigin
+	p.event.ProcessContext = &model.ProcessContext{}
 	return p.event
 }
 
@@ -1157,7 +1153,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 	}
 
 	// resolve the container context
-	event.ContainerContext, _ = p.fieldHandlers.ResolveContainerContext(event)
+	_, _ = p.fieldHandlers.ResolveContainerContext(event)
 
 	// handle regular events
 	if !p.handleRegularEvent(event, offset, dataLen, data, newEntryCb) {
@@ -1203,7 +1199,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		// TODO: this should be moved in the resolver itself in order to handle the fallbacks
 		if event.Mount.GetFSType() == "nsfs" {
 			nsid := uint32(event.Mount.RootPathKey.Inode)
-			mountPath, _, _, err := p.Resolvers.MountResolver.ResolveMountPath(event.Mount.MountID, event.Mount.Device, event.PIDContext.Pid, event.ContainerContext.ContainerID)
+			mountPath, _, _, err := p.Resolvers.MountResolver.ResolveMountPath(event.Mount.MountID, event.Mount.Device, event.PIDContext.Pid, event.ProcessContext.Process.ContainerContext.ContainerID)
 			if err != nil {
 				seclog.Debugf("failed to get mount path: %v", err)
 			} else {
@@ -1218,7 +1214,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		}
 
 		// we can skip this error as this is for the umount only and there is no impact on the filepath resolution
-		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(event.Umount.MountID, 0, event.PIDContext.Pid, event.ContainerContext.ContainerID)
+		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(event.Umount.MountID, 0, event.PIDContext.Pid, event.ProcessContext.Process.ContainerContext.ContainerID)
 		if mount != nil && mount.GetFSType() == "nsfs" {
 			nsid := uint32(mount.RootPathKey.Inode)
 			if namespace := p.Resolvers.NamespaceResolver.ResolveNetworkNamespace(nsid); namespace != nil {
@@ -1485,7 +1481,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		}
 		event.NetworkContext = event.RawPacket.NetworkContext
 
-		tags := p.probe.GetEventTags(event.ContainerContext.ContainerID)
+		tags := p.probe.GetEventTags(event.ProcessContext.Process.ContainerContext.ContainerID)
 		if service := p.probe.GetService(event); service != "" {
 			tags = append(tags, "service:"+service)
 		}
@@ -1653,7 +1649,7 @@ func (p *EBPFProbe) handleEarlyReturnEvents(event *model.Event, offset int, data
 			seclog.Debugf("Failed to resolve cgroup: %s", err.Error())
 		} else {
 			event.CgroupTracing.CGroupContext = *cgroupContext
-			event.CGroupContext = cgroupContext
+			event.ProcessContext.Process.CGroup = *cgroupContext
 			containerID := containerutils.FindContainerID(cgroupContext.CGroupID)
 			if containerID != "" {
 				event.CgroupTracing.ContainerContext.ContainerID = containerID
@@ -1710,7 +1706,7 @@ func resolveTraceProcessContext(event *model.Event, p *EBPFProbe, newEntryCb fun
 		pidToResolve := event.PTrace.PID
 
 		if pidToResolve == 0 { // resolve the PID given as argument instead
-			containerID := p.fieldHandlers.ResolveContainerID(event, event.ContainerContext)
+			containerID := p.fieldHandlers.ResolveContainerID(event, &event.ProcessContext.Process.ContainerContext)
 			if containerID == "" && event.PTrace.Request != unix.PTRACE_ATTACH {
 				pidToResolve = event.PTrace.NSPID
 			} else {
@@ -3311,11 +3307,11 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 
 		switch {
 		case action.InternalCallback != nil && rule.ID == bundled.RefreshUserCacheRuleID:
-			_ = p.RefreshUserCache(ev.ContainerContext.ContainerID)
+			_ = p.RefreshUserCache(ev.ProcessContext.Process.ContainerContext.ContainerID)
 
-		case action.InternalCallback != nil && rule.ID == bundled.RefreshSBOMRuleID && p.Resolvers.SBOMResolver != nil && len(ev.ContainerContext.ContainerID) > 0:
-			if err := p.Resolvers.SBOMResolver.RefreshSBOM(ev.ContainerContext.ContainerID); err != nil {
-				seclog.Warnf("failed to refresh SBOM for container %s, triggered by %s: %s", ev.ContainerContext.ContainerID, ev.ProcessContext.Comm, err)
+		case action.InternalCallback != nil && rule.ID == bundled.RefreshSBOMRuleID && p.Resolvers.SBOMResolver != nil && len(ev.ProcessContext.Process.ContainerContext.ContainerID) > 0:
+			if err := p.Resolvers.SBOMResolver.RefreshSBOM(ev.ProcessContext.Process.ContainerContext.ContainerID); err != nil {
+				seclog.Warnf("failed to refresh SBOM for container %s, triggered by %s: %s", ev.ProcessContext.Process.ContainerContext.ContainerID, ev.ProcessContext.Comm, err)
 			}
 
 		case action.Def.Kill != nil:
@@ -3357,7 +3353,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				}
 
 				if action.Def.NetworkFilter.Scope == "cgroup" {
-					dropActionFilter.CGroupPathKey = ev.CGroupContext.CGroupFile
+					dropActionFilter.CGroupPathKey = ev.ProcessContext.Process.CGroup.CGroupFile
 				} else {
 					dropActionFilter.Pid = ev.ProcessContext.Pid
 				}
@@ -3405,9 +3401,8 @@ func (p *EBPFProbe) newEBPFPooledEventFromPCE(entry *model.ProcessCacheEntry) *m
 	event.ProcessCacheEntry = entry
 	event.ProcessContext = &entry.ProcessContext
 	event.Exec.Process = &entry.Process
-	event.ProcessContext.Process.ContainerID = entry.ContainerID
+	event.ProcessContext.Process.ContainerContext.ContainerID = entry.ContainerContext.ContainerID
 	event.ProcessContext.Process.CGroup = entry.CGroup
-	event.CGroupContext = &entry.CGroup
 
 	return event
 }
@@ -3419,7 +3414,7 @@ func (p *EBPFProbe) newBindEventFromSnapshot(entry *model.ProcessCacheEntry, sna
 	event.Type = uint32(model.BindEventType)
 	event.ProcessCacheEntry = entry
 	event.ProcessContext = &entry.ProcessContext
-	event.ProcessContext.Process.ContainerID = entry.ContainerID
+	event.ProcessContext.Process.ContainerContext.ContainerID = entry.ContainerContext.ContainerID
 	event.ProcessContext.Process.CGroup = entry.CGroup
 
 	event.Bind.SyscallEvent.Retval = 0

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -366,9 +366,9 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 	}
 
 	// container context
-	event.ContainerContext.ContainerID = containerutils.ContainerID(syscallMsg.ContainerID)
+	event.ProcessContext.ContainerContext.ContainerID = containerutils.ContainerID(syscallMsg.ContainerID)
 	if containerContext, exists := p.containerContexts[syscallMsg.ContainerID]; exists {
-		event.ContainerContext.CreatedAt = containerContext.CreatedAt
+		event.ProcessContext.ContainerContext.CreatedAt = containerContext.CreatedAt
 	}
 
 	// copy span context if any
@@ -699,6 +699,7 @@ func (p *EBPFLessProbe) zeroEvent() *model.Event {
 	probeEventZeroer(p.event)
 	p.event.FieldHandlers = p.fieldHandlers
 	p.event.Origin = EBPFLessOrigin
+	p.event.ProcessContext = &model.ProcessContext{}
 	return p.event
 }
 

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -298,7 +298,7 @@ func (p *ProcessKiller) KillAndReport(kill *rules.KillDefinition, rule *rules.Ru
 
 	// if a rule with a kill container scope is triggered outside a container,
 	// don't kill anything
-	containerID := ev.FieldHandlers.ResolveContainerID(ev, ev.ContainerContext)
+	containerID := ev.FieldHandlers.ResolveContainerID(ev, &ev.ProcessContext.Process.ContainerContext)
 	if containerID == "" && scope == "container" {
 		return false
 	}

--- a/pkg/security/probe/process_killer_linux.go
+++ b/pkg/security/probe/process_killer_linux.go
@@ -81,7 +81,7 @@ func (p *ProcessKillerLinux) Kill(sig uint32, pc *killContext) error {
 
 // TODO: do a better job than returning only the direct lineage
 func (p *ProcessKillerLinux) getProcesses(scope string, ev *model.Event, entry *model.ProcessCacheEntry) ([]killContext, error) {
-	if entry.ContainerID != "" && scope == "container" {
+	if entry.ContainerContext.ContainerID != "" && scope == "container" {
 		pcs := []killContext{}
 		pids, paths := entry.GetContainerPIDs()
 		l := min(len(pids), len(paths))

--- a/pkg/security/probe/process_killer_test.go
+++ b/pkg/security/probe/process_killer_test.go
@@ -36,7 +36,7 @@ func (fpk *FakeProcessKillerOS) getProcesses(scope string, ev *model.Event, entr
 			path: ev.ProcessContext.FileEvent.PathnameStr,
 		},
 	}
-	if entry.ContainerID != "" && scope == "container" {
+	if entry.Process.ContainerContext.ContainerID != "" && scope == "container" {
 		kcs = append(kcs, []killContext{
 			{
 				pid:  int(ev.ProcessContext.Pid + 1),
@@ -152,13 +152,12 @@ func craftKillRule(id, scope string) *rules.Rule {
 
 func craftFakeEvent(containerID, executable string, pid uint32) *model.Event {
 	event := model.NewFakeEvent()
-	event.ContainerContext = &model.ContainerContext{
-		ContainerID: containerutils.ContainerID(containerID),
-	}
 	event.ProcessCacheEntry = &model.ProcessCacheEntry{
 		ProcessContext: model.ProcessContext{
 			Process: model.Process{
-				ContainerID: containerutils.ContainerID(containerID),
+				ContainerContext: model.ContainerContext{
+					ContainerID: containerutils.ContainerID(containerID),
+				},
 				FileEvent: model.FileEvent{
 					PathnameStr: executable,
 				},

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -202,12 +202,12 @@ func (cr *Resolver) cleanupPidsWithMultipleCgroups(pids []uint32, currentCgroup 
 
 func (cr *Resolver) pushNewCacheEntry(process *model.ProcessCacheEntry) {
 	// create new entry now
-	newCGroup := cgroupModel.NewCacheEntry(process.ContainerID, &process.CGroup, process.Pid)
+	newCGroup := cgroupModel.NewCacheEntry(process.ContainerContext.ContainerID, &process.CGroup, process.Pid)
 	newCGroup.CreatedAt = uint64(process.ProcessContext.ExecTime.UnixNano())
 
 	// add the new CGroup to the cache
-	if process.ContainerID != "" {
-		cr.containerWorkloads.Add(process.ContainerID, newCGroup)
+	if process.ContainerContext.ContainerID != "" {
+		cr.containerWorkloads.Add(process.ContainerContext.ContainerID, newCGroup)
 	} else {
 		cr.hostWorkloads.Add(process.CGroup.CGroupID, newCGroup)
 	}
@@ -226,7 +226,7 @@ func (cr *Resolver) resolvePidCgroupFallback(process *model.ProcessCacheEntry) b
 		process.CGroup.CGroupFile.MountID = cgroup.CGroupFileMountID
 		process.CGroup.CGroupFile.Inode = cgroup.CGroupFileInode
 		process.CGroup.CGroupID = cgroup.CGroupID
-		process.ContainerID = cid
+		process.ContainerContext.ContainerID = cid
 		seclog.Infof("Fallback to resolve cgroup for pid %d: %s", process.Pid, cgroup.CGroupID)
 		return true
 	}
@@ -244,7 +244,7 @@ func (cr *Resolver) resolvePidCgroupFallback(process *model.ProcessCacheEntry) b
 			process.CGroup.CGroupFile.MountID = cgroup.CGroupFile.MountID
 			process.CGroup.CGroupFile.Inode = cgroup.CGroupFile.Inode
 			process.CGroup.CGroupID = cgroup.CGroupID
-			process.ContainerID = containerutils.FindContainerID(cgroup.CGroupID)
+			process.ContainerContext.ContainerID = containerutils.FindContainerID(cgroup.CGroupID)
 			seclog.Infof("Fallback to resolve cgroup for pid %d from parent: %d", process.Pid, process.PPid)
 			return true
 		}
@@ -256,7 +256,7 @@ func (cr *Resolver) resolvePidCgroupFallback(process *model.ProcessCacheEntry) b
 		process.CGroup.CGroupFile.MountID = cgroup.CGroupFileMountID
 		process.CGroup.CGroupFile.Inode = cgroup.CGroupFileInode
 		process.CGroup.CGroupID = cgroup.CGroupID
-		process.ContainerID = cid
+		process.ContainerContext.ContainerID = cid
 		seclog.Infof("Fallback to resolve parent cgroup for ppid %d: %s", process.PPid, cgroup.CGroupID)
 		return true
 	}

--- a/pkg/security/resolvers/cgroup/resolver_test.go
+++ b/pkg/security/resolvers/cgroup/resolver_test.go
@@ -52,8 +52,10 @@ func createTestProcess(pid, ppid uint32, containerID containerutils.ContainerID)
 				PIDContext: model.PIDContext{
 					Pid: pid,
 				},
-				PPid:        ppid,
-				ContainerID: containerID,
+				PPid: ppid,
+				ContainerContext: model.ContainerContext{
+					ContainerID: containerID,
+				},
 				CGroup: model.CGroupContext{
 					CGroupID: "",
 					CGroupFile: model.PathKey{
@@ -91,7 +93,7 @@ func TestResolvePidCgroupFallback_SuccessDirectResolution(t *testing.T) {
 	assert.Equal(t, containerutils.CGroupID("test-cgroup-id"), process.CGroup.CGroupID)
 	assert.Equal(t, uint32(42), process.CGroup.CGroupFile.MountID)
 	assert.Equal(t, uint64(9876), process.CGroup.CGroupFile.Inode)
-	assert.Equal(t, containerutils.ContainerID("container-123"), process.ContainerID)
+	assert.Equal(t, containerutils.ContainerID("container-123"), process.ContainerContext.ContainerID)
 
 	mockFS.AssertExpectations(t)
 }
@@ -196,7 +198,7 @@ func TestResolvePidCgroupFallback_SuccessFromParentProc(t *testing.T) {
 	assert.Equal(t, containerutils.CGroupID("parent-cgroup-id"), process.CGroup.CGroupID)
 	assert.Equal(t, uint32(567), process.CGroup.CGroupFile.MountID)
 	assert.Equal(t, uint64(8888), process.CGroup.CGroupFile.Inode)
-	assert.Equal(t, containerutils.ContainerID("parent-container-456"), process.ContainerID)
+	assert.Equal(t, containerutils.ContainerID("parent-container-456"), process.ContainerContext.ContainerID)
 
 	mockFS.AssertExpectations(t)
 }
@@ -267,7 +269,7 @@ func TestResolvePidCgroupFallback_HistoryFoundButCgroupMissing(t *testing.T) {
 	assert.Equal(t, containerutils.CGroupID("fallback-cgroup-id"), process.CGroup.CGroupID)
 	assert.Equal(t, uint32(789), process.CGroup.CGroupFile.MountID)
 	assert.Equal(t, uint64(7777), process.CGroup.CGroupFile.Inode)
-	assert.Equal(t, containerutils.ContainerID("fallback-container-789"), process.ContainerID)
+	assert.Equal(t, containerutils.ContainerID("fallback-container-789"), process.ContainerContext.ContainerID)
 
 	mockFS.AssertExpectations(t)
 }

--- a/pkg/security/resolvers/file/resolver_linux.go
+++ b/pkg/security/resolvers/file/resolver_linux.go
@@ -100,8 +100,8 @@ func (r *Resolver) ResolveFileMetadata(event *model.Event, file *model.FileEvent
 	// add pid one for hash resolution outside of a container
 	process := event.ProcessContext.Process
 	rootPIDs := []uint32{process.Pid, 1}
-	if process.ContainerID != "" && r.cgroupResolver != nil {
-		w, ok := r.cgroupResolver.GetWorkload(process.ContainerID)
+	if process.ContainerContext.ContainerID != "" && r.cgroupResolver != nil {
+		w, ok := r.cgroupResolver.GetWorkload(process.ContainerContext.ContainerID)
 		if ok {
 			rootPIDs = w.GetPIDs()
 		}
@@ -132,7 +132,7 @@ func (r *Resolver) ResolveFileMetadata(event *model.Event, file *model.FileEvent
 
 		// init the cache key to lookup
 		key := LRUCacheKey{
-			containerID: process.ContainerID,
+			containerID: process.ContainerContext.ContainerID,
 			path:        path,
 			mTime:       fileInfo.ModTime().UnixNano(),
 		}

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -161,7 +161,7 @@ func (resolver *Resolver) ComputeHashesFromEvent(event *model.Event, file *model
 	event.FieldHandlers.ResolveFilePath(event, file)
 
 	process := event.ProcessContext.Process
-	resolver.HashFileEvent(event.GetEventType(), process.ContainerID, process.Pid, file)
+	resolver.HashFileEvent(event.GetEventType(), process.ContainerContext.ContainerID, process.Pid, file)
 
 	return file.Hashes
 }
@@ -173,7 +173,7 @@ func (resolver *Resolver) ComputeHashes(eventType model.EventType, process *mode
 		return nil
 	}
 
-	resolver.HashFileEvent(eventType, process.ContainerID, process.Pid, file)
+	resolver.HashFileEvent(eventType, process.ContainerContext.ContainerID, process.Pid, file)
 
 	return file.Hashes
 }

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -137,7 +137,7 @@ func (p *EBPFLessResolver) NewEntry(key CacheResolverKey, ppid uint32, file stri
 		entry.Process.FileEvent.PathnameStr = file
 		entry.Process.FileEvent.BasenameStr = filepath.Base(entry.Process.FileEvent.PathnameStr)
 	}
-	entry.Process.ContainerID = containerutils.ContainerID(ctrID)
+	entry.Process.ContainerContext.ContainerID = containerutils.ContainerID(ctrID)
 
 	entry.ExecTime = time.Unix(0, int64(ts))
 

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -893,6 +893,6 @@ func TestCGroupContext(t *testing.T) {
 		}, nil)
 
 		assert.Equal(t, cgroupID, node.ProcessCacheEntry.CGroup.CGroupID)
-		assert.Equal(t, containerID, node.ProcessCacheEntry.ContainerID)
+		assert.Equal(t, containerID, node.ProcessCacheEntry.ContainerContext.ContainerID)
 	})
 }

--- a/pkg/security/rules/autosuppression/autosuppression.go
+++ b/pkg/security/rules/autosuppression/autosuppression.go
@@ -69,7 +69,7 @@ func (as *AutoSuppression) Init(opts Opts) {
 
 // Suppresses returns true if the event should be suppressed for the given rule, false otherwise. It also counts statistics depending on this result
 func (as *AutoSuppression) Suppresses(rule *rules.Rule, event *model.Event) bool {
-	if isAllowAutosuppressionRule(rule) && event.ContainerContext.ContainerID != "" && slices.Contains(as.opts.EventTypes, event.GetEventType()) {
+	if isAllowAutosuppressionRule(rule) && event.ProcessContext.Process.ContainerContext.ContainerID != "" && slices.Contains(as.opts.EventTypes, event.GetEventType()) {
 		if as.opts.ActivityDumpEnabled && as.opts.ActivityDumpAutoSuppressionEnabled {
 			if event.HasActiveActivityDump() {
 				as.count(rule.ID, activityDumpSuppressionType)

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -483,7 +483,7 @@ func (e *RuleEngine) RuleMatch(ctx *eval.Context, rule *rules.Rule, event eval.E
 	ev := event.(*model.Event)
 
 	// add matched rules before any auto suppression check to ensure that this information is available in activity dumps
-	if ev.ContainerContext.ContainerID != "" && (e.config.ActivityDumpTagRulesEnabled || e.config.AnomalyDetectionTagRulesEnabled) {
+	if ev.ProcessContext.Process.ContainerContext.ContainerID != "" && (e.config.ActivityDumpTagRulesEnabled || e.config.AnomalyDetectionTagRulesEnabled) {
 		ev.Rules = append(ev.Rules, model.NewMatchedRule(rule.Def.ID, rule.Def.Version, rule.Def.Tags, rule.Policy.Name, rule.Policy.Version))
 	}
 
@@ -498,9 +498,9 @@ func (e *RuleEngine) RuleMatch(ctx *eval.Context, rule *rules.Rule, event eval.E
 	}
 
 	// ensure that all the fields are resolved before sending
-	ev.FieldHandlers.ResolveContainerID(ev, ev.ContainerContext)
-	ev.FieldHandlers.ResolveContainerTags(ev, ev.ContainerContext)
-	ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.ContainerContext)
+	ev.FieldHandlers.ResolveContainerID(ev, &ev.ProcessContext.Process.ContainerContext)
+	ev.FieldHandlers.ResolveContainerTags(ev, &ev.ProcessContext.Process.ContainerContext)
+	ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.ProcessContext.Process.ContainerContext)
 
 	// do not send event if a anomaly detection event will be sent
 	if e.config.AnomalyDetectionSilentRuleEventsEnabled && ev.IsAnomalyDetectionEvent() {
@@ -513,9 +513,9 @@ func (e *RuleEngine) RuleMatch(ctx *eval.Context, rule *rules.Rule, event eval.E
 
 	var extTagsCb func() ([]string, bool)
 
-	if ev.ContainerContext.ContainerID != "" {
+	if ev.ProcessContext.Process.ContainerContext.ContainerID != "" {
 		// copy the container ID here to avoid later data race
-		containerID := ev.ContainerContext.ContainerID
+		containerID := ev.ProcessContext.Process.ContainerContext.ContainerID
 
 		extTagsCb = func() ([]string, bool) {
 			return e.probe.GetEventTags(containerID), true

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -377,50 +377,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "cgroup.file.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.CGroupContext.CGroupFile.Inode)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
-	case "cgroup.file.mount_id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.CGroupContext.CGroupFile.MountID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
-	case "cgroup.id":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveCGroupID(ev, ev.CGroupContext)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "cgroup.version":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveCGroupVersion(ev, ev.CGroupContext)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
 	case "cgroup_write.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1878,39 +1834,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "container.created_at":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "container.id":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "container.tags":
-		return &eval.StringArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []string {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
-			},
-			Field:  field,
-			Weight: 9999 * eval.HandlerWeight,
-			Offset: offset,
-		}, nil
 	case "dns.id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2268,15 +2191,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exec.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exec.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exec.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, ev.Exec.Process)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.Exec.Process.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exec.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "exec.created_at":
@@ -3636,15 +3581,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exit.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exit.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exit.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, ev.Exit.Process)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.Exit.Process.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exit.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "exit.created_at":
@@ -8262,6 +8229,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "process.ancestors.container.created_at":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &element.ProcessContext.Process.ContainerContext))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &current.ProcessContext.Process.ContainerContext))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.ancestors.container.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -8273,20 +8267,47 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveProcessContainerID(ev, &element.ProcessContext.Process)
+					result := ev.FieldHandlers.ResolveContainerID(ev, &element.ProcessContext.Process.ContainerContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveProcessContainerID(ev, &current.ProcessContext.Process)
+					return ev.FieldHandlers.ResolveContainerID(ev, &current.ProcessContext.Process.ContainerContext)
 				})
 				ctx.StringCache[field] = results
 				return results
 			},
 			Field:  field,
 			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveContainerTags(ev, &element.ProcessContext.Process.ContainerContext)
+					return result
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIteratorArray(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
+					return ev.FieldHandlers.ResolveContainerTags(ev, &current.ProcessContext.Process.ContainerContext)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: 9999 * eval.IteratorWeight,
 			Offset: offset,
 		}, nil
 	case "process.ancestors.created_at":
@@ -10998,15 +11019,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, &ev.BaseEvent.ProcessContext.Process)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "process.created_at":
@@ -12172,6 +12215,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.parent.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.parent.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -12180,10 +12237,24 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, ev.BaseEvent.ProcessContext.Parent)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "process.parent.created_at":
@@ -14055,6 +14126,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.ancestors.container.created_at":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &element.ProcessContext.Process.ContainerContext))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &current.ProcessContext.Process.ContainerContext))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.ancestors.container.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -14066,20 +14164,47 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveProcessContainerID(ev, &element.ProcessContext.Process)
+					result := ev.FieldHandlers.ResolveContainerID(ev, &element.ProcessContext.Process.ContainerContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveProcessContainerID(ev, &current.ProcessContext.Process)
+					return ev.FieldHandlers.ResolveContainerID(ev, &current.ProcessContext.Process.ContainerContext)
 				})
 				ctx.StringCache[field] = results
 				return results
 			},
 			Field:  field,
 			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveContainerTags(ev, &element.ProcessContext.Process.ContainerContext)
+					return result
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIteratorArray(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
+					return ev.FieldHandlers.ResolveContainerTags(ev, &current.ProcessContext.Process.ContainerContext)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: 9999 * eval.IteratorWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.ancestors.created_at":
@@ -16791,15 +16916,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.PTrace.Tracee.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, &ev.PTrace.Tracee.Process)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.PTrace.Tracee.Process.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.PTrace.Tracee.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.created_at":
@@ -17965,6 +18112,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.parent.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.PTrace.Tracee.Parent.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.parent.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -17973,10 +18134,24 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, ev.PTrace.Tracee.Parent)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.PTrace.Tracee.Parent.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.PTrace.Tracee.Parent.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.parent.created_at":
@@ -21272,6 +21447,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.ancestors.container.created_at":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &element.ProcessContext.Process.ContainerContext))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &current.ProcessContext.Process.ContainerContext))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.ancestors.container.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -21283,20 +21485,47 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveProcessContainerID(ev, &element.ProcessContext.Process)
+					result := ev.FieldHandlers.ResolveContainerID(ev, &element.ProcessContext.Process.ContainerContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveProcessContainerID(ev, &current.ProcessContext.Process)
+					return ev.FieldHandlers.ResolveContainerID(ev, &current.ProcessContext.Process.ContainerContext)
 				})
 				ctx.StringCache[field] = results
 				return results
 			},
 			Field:  field,
 			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveContainerTags(ev, &element.ProcessContext.Process.ContainerContext)
+					return result
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIteratorArray(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
+					return ev.FieldHandlers.ResolveContainerTags(ev, &current.ProcessContext.Process.ContainerContext)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: 9999 * eval.IteratorWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.ancestors.created_at":
@@ -24008,15 +24237,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Setrlimit.Target.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, &ev.Setrlimit.Target.Process)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.Setrlimit.Target.Process.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.Setrlimit.Target.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.created_at":
@@ -25182,6 +25433,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.parent.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Setrlimit.Target.Parent.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.parent.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -25190,10 +25455,24 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, ev.Setrlimit.Target.Parent)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.Setrlimit.Target.Parent.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.Setrlimit.Target.Parent.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.parent.created_at":
@@ -27586,6 +27865,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.ancestors.container.created_at":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &element.ProcessContext.Process.ContainerContext))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &current.ProcessContext.Process.ContainerContext))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.ancestors.container.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -27597,20 +27903,47 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveProcessContainerID(ev, &element.ProcessContext.Process)
+					result := ev.FieldHandlers.ResolveContainerID(ev, &element.ProcessContext.Process.ContainerContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveProcessContainerID(ev, &current.ProcessContext.Process)
+					return ev.FieldHandlers.ResolveContainerID(ev, &current.ProcessContext.Process.ContainerContext)
 				})
 				ctx.StringCache[field] = results
 				return results
 			},
 			Field:  field,
 			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveContainerTags(ev, &element.ProcessContext.Process.ContainerContext)
+					return result
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIteratorArray(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
+					return ev.FieldHandlers.ResolveContainerTags(ev, &current.ProcessContext.Process.ContainerContext)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: 9999 * eval.IteratorWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.ancestors.created_at":
@@ -30322,15 +30655,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Signal.Target.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, &ev.Signal.Target.Process)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.Signal.Target.Process.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.Signal.Target.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.created_at":
@@ -31496,6 +31851,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.parent.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Signal.Target.Parent.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.parent.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -31504,10 +31873,24 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveProcessContainerID(ev, ev.Signal.Target.Parent)
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.Signal.Target.Parent.ContainerContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.Signal.Target.Parent.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.parent.created_at":
@@ -34089,10 +34472,6 @@ func (ev *Event) GetFields() []eval.Field {
 		"capabilities.used",
 		"capset.cap_effective",
 		"capset.cap_permitted",
-		"cgroup.file.inode",
-		"cgroup.file.mount_id",
-		"cgroup.id",
-		"cgroup.version",
 		"cgroup_write.file.change_time",
 		"cgroup_write.file.extension",
 		"cgroup_write.file.filesystem",
@@ -34224,9 +34603,6 @@ func (ev *Event) GetFields() []eval.Field {
 		"connect.addr.port",
 		"connect.protocol",
 		"connect.retval",
-		"container.created_at",
-		"container.id",
-		"container.tags",
 		"dns.id",
 		"dns.question.class",
 		"dns.question.count",
@@ -34259,7 +34635,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.cgroup.id",
 		"exec.cgroup.version",
 		"exec.comm",
+		"exec.container.created_at",
 		"exec.container.id",
+		"exec.container.tags",
 		"exec.created_at",
 		"exec.egid",
 		"exec.egroup",
@@ -34369,7 +34747,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.cgroup.version",
 		"exit.code",
 		"exit.comm",
+		"exit.container.created_at",
 		"exit.container.id",
+		"exit.container.tags",
 		"exit.created_at",
 		"exit.egid",
 		"exit.egroup",
@@ -34731,7 +35111,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.cgroup.id",
 		"process.ancestors.cgroup.version",
 		"process.ancestors.comm",
+		"process.ancestors.container.created_at",
 		"process.ancestors.container.id",
+		"process.ancestors.container.tags",
 		"process.ancestors.created_at",
 		"process.ancestors.egid",
 		"process.ancestors.egroup",
@@ -34831,7 +35213,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.cgroup.id",
 		"process.cgroup.version",
 		"process.comm",
+		"process.container.created_at",
 		"process.container.id",
+		"process.container.tags",
 		"process.created_at",
 		"process.egid",
 		"process.egroup",
@@ -34919,7 +35303,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.cgroup.id",
 		"process.parent.cgroup.version",
 		"process.parent.comm",
+		"process.parent.container.created_at",
 		"process.parent.container.id",
+		"process.parent.container.tags",
 		"process.parent.created_at",
 		"process.parent.egid",
 		"process.parent.egroup",
@@ -35031,7 +35417,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.ancestors.cgroup.id",
 		"ptrace.tracee.ancestors.cgroup.version",
 		"ptrace.tracee.ancestors.comm",
+		"ptrace.tracee.ancestors.container.created_at",
 		"ptrace.tracee.ancestors.container.id",
+		"ptrace.tracee.ancestors.container.tags",
 		"ptrace.tracee.ancestors.created_at",
 		"ptrace.tracee.ancestors.egid",
 		"ptrace.tracee.ancestors.egroup",
@@ -35131,7 +35519,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.cgroup.id",
 		"ptrace.tracee.cgroup.version",
 		"ptrace.tracee.comm",
+		"ptrace.tracee.container.created_at",
 		"ptrace.tracee.container.id",
+		"ptrace.tracee.container.tags",
 		"ptrace.tracee.created_at",
 		"ptrace.tracee.egid",
 		"ptrace.tracee.egroup",
@@ -35219,7 +35609,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.parent.cgroup.id",
 		"ptrace.tracee.parent.cgroup.version",
 		"ptrace.tracee.parent.comm",
+		"ptrace.tracee.parent.container.created_at",
 		"ptrace.tracee.parent.container.id",
+		"ptrace.tracee.parent.container.tags",
 		"ptrace.tracee.parent.created_at",
 		"ptrace.tracee.parent.egid",
 		"ptrace.tracee.parent.egroup",
@@ -35459,7 +35851,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.ancestors.cgroup.id",
 		"setrlimit.target.ancestors.cgroup.version",
 		"setrlimit.target.ancestors.comm",
+		"setrlimit.target.ancestors.container.created_at",
 		"setrlimit.target.ancestors.container.id",
+		"setrlimit.target.ancestors.container.tags",
 		"setrlimit.target.ancestors.created_at",
 		"setrlimit.target.ancestors.egid",
 		"setrlimit.target.ancestors.egroup",
@@ -35559,7 +35953,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.cgroup.id",
 		"setrlimit.target.cgroup.version",
 		"setrlimit.target.comm",
+		"setrlimit.target.container.created_at",
 		"setrlimit.target.container.id",
+		"setrlimit.target.container.tags",
 		"setrlimit.target.created_at",
 		"setrlimit.target.egid",
 		"setrlimit.target.egroup",
@@ -35647,7 +36043,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.parent.cgroup.id",
 		"setrlimit.target.parent.cgroup.version",
 		"setrlimit.target.parent.comm",
+		"setrlimit.target.parent.container.created_at",
 		"setrlimit.target.parent.container.id",
+		"setrlimit.target.parent.container.tags",
 		"setrlimit.target.parent.created_at",
 		"setrlimit.target.parent.egid",
 		"setrlimit.target.parent.egroup",
@@ -35806,7 +36204,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.ancestors.cgroup.id",
 		"signal.target.ancestors.cgroup.version",
 		"signal.target.ancestors.comm",
+		"signal.target.ancestors.container.created_at",
 		"signal.target.ancestors.container.id",
+		"signal.target.ancestors.container.tags",
 		"signal.target.ancestors.created_at",
 		"signal.target.ancestors.egid",
 		"signal.target.ancestors.egroup",
@@ -35906,7 +36306,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.cgroup.id",
 		"signal.target.cgroup.version",
 		"signal.target.comm",
+		"signal.target.container.created_at",
 		"signal.target.container.id",
+		"signal.target.container.tags",
 		"signal.target.created_at",
 		"signal.target.egid",
 		"signal.target.egroup",
@@ -35994,7 +36396,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.parent.cgroup.id",
 		"signal.target.parent.cgroup.version",
 		"signal.target.parent.comm",
+		"signal.target.parent.container.created_at",
 		"signal.target.parent.container.id",
+		"signal.target.parent.container.tags",
 		"signal.target.parent.created_at",
 		"signal.target.parent.egid",
 		"signal.target.parent.egroup",
@@ -36244,14 +36648,6 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "capset", reflect.Int, "int", nil
 	case "capset.cap_permitted":
 		return "capset", reflect.Int, "int", nil
-	case "cgroup.file.inode":
-		return "", reflect.Int, "int", nil
-	case "cgroup.file.mount_id":
-		return "", reflect.Int, "int", nil
-	case "cgroup.id":
-		return "", reflect.String, "string", nil
-	case "cgroup.version":
-		return "", reflect.Int, "int", nil
 	case "cgroup_write.file.change_time":
 		return "cgroup_write", reflect.Int, "int", nil
 	case "cgroup_write.file.extension":
@@ -36514,12 +36910,6 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "connect", reflect.Int, "int", nil
 	case "connect.retval":
 		return "connect", reflect.Int, "int", nil
-	case "container.created_at":
-		return "", reflect.Int, "int", nil
-	case "container.id":
-		return "", reflect.String, "string", nil
-	case "container.tags":
-		return "", reflect.String, "string", nil
 	case "dns.id":
 		return "dns", reflect.Int, "int", nil
 	case "dns.question.class":
@@ -36584,7 +36974,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.Int, "int", nil
 	case "exec.comm":
 		return "exec", reflect.String, "string", nil
+	case "exec.container.created_at":
+		return "exec", reflect.Int, "int", nil
 	case "exec.container.id":
+		return "exec", reflect.String, "string", nil
+	case "exec.container.tags":
 		return "exec", reflect.String, "string", nil
 	case "exec.created_at":
 		return "exec", reflect.Int, "int", nil
@@ -36804,7 +37198,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.Int, "int", nil
 	case "exit.comm":
 		return "exit", reflect.String, "string", nil
+	case "exit.container.created_at":
+		return "exit", reflect.Int, "int", nil
 	case "exit.container.id":
+		return "exit", reflect.String, "string", nil
+	case "exit.container.tags":
 		return "exit", reflect.String, "string", nil
 	case "exit.created_at":
 		return "exit", reflect.Int, "int", nil
@@ -37528,7 +37926,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", nil
 	case "process.ancestors.comm":
 		return "", reflect.String, "string", nil
+	case "process.ancestors.container.created_at":
+		return "", reflect.Int, "int", nil
 	case "process.ancestors.container.id":
+		return "", reflect.String, "string", nil
+	case "process.ancestors.container.tags":
 		return "", reflect.String, "string", nil
 	case "process.ancestors.created_at":
 		return "", reflect.Int, "int", nil
@@ -37728,7 +38130,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", nil
 	case "process.comm":
 		return "", reflect.String, "string", nil
+	case "process.container.created_at":
+		return "", reflect.Int, "int", nil
 	case "process.container.id":
+		return "", reflect.String, "string", nil
+	case "process.container.tags":
 		return "", reflect.String, "string", nil
 	case "process.created_at":
 		return "", reflect.Int, "int", nil
@@ -37904,7 +38310,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", nil
 	case "process.parent.comm":
 		return "", reflect.String, "string", nil
+	case "process.parent.container.created_at":
+		return "", reflect.Int, "int", nil
 	case "process.parent.container.id":
+		return "", reflect.String, "string", nil
+	case "process.parent.container.tags":
 		return "", reflect.String, "string", nil
 	case "process.parent.created_at":
 		return "", reflect.Int, "int", nil
@@ -38128,7 +38538,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.ancestors.comm":
 		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.ancestors.container.created_at":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.ancestors.container.id":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.ancestors.container.tags":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.ancestors.created_at":
 		return "ptrace", reflect.Int, "int", nil
@@ -38328,7 +38742,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.comm":
 		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.container.created_at":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.container.id":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.container.tags":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.created_at":
 		return "ptrace", reflect.Int, "int", nil
@@ -38504,7 +38922,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.parent.comm":
 		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.parent.container.created_at":
+		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.parent.container.id":
+		return "ptrace", reflect.String, "string", nil
+	case "ptrace.tracee.parent.container.tags":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.parent.created_at":
 		return "ptrace", reflect.Int, "int", nil
@@ -38984,7 +39406,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.ancestors.comm":
 		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.ancestors.container.created_at":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.ancestors.container.id":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.ancestors.container.tags":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.ancestors.created_at":
 		return "setrlimit", reflect.Int, "int", nil
@@ -39184,7 +39610,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.comm":
 		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.container.created_at":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.container.id":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.container.tags":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.created_at":
 		return "setrlimit", reflect.Int, "int", nil
@@ -39360,7 +39790,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.parent.comm":
 		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.parent.container.created_at":
+		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.parent.container.id":
+		return "setrlimit", reflect.String, "string", nil
+	case "setrlimit.target.parent.container.tags":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.parent.created_at":
 		return "setrlimit", reflect.Int, "int", nil
@@ -39678,7 +40112,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", nil
 	case "signal.target.ancestors.comm":
 		return "signal", reflect.String, "string", nil
+	case "signal.target.ancestors.container.created_at":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.ancestors.container.id":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.ancestors.container.tags":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.ancestors.created_at":
 		return "signal", reflect.Int, "int", nil
@@ -39878,7 +40316,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", nil
 	case "signal.target.comm":
 		return "signal", reflect.String, "string", nil
+	case "signal.target.container.created_at":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.container.id":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.container.tags":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.created_at":
 		return "signal", reflect.Int, "int", nil
@@ -40054,7 +40496,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", nil
 	case "signal.target.parent.comm":
 		return "signal", reflect.String, "string", nil
+	case "signal.target.parent.container.created_at":
+		return "signal", reflect.Int, "int", nil
 	case "signal.target.parent.container.id":
+		return "signal", reflect.String, "string", nil
+	case "signal.target.parent.container.tags":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.parent.created_at":
 		return "signal", reflect.Int, "int", nil
@@ -40524,31 +40970,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint64FieldValue("capset.cap_effective", &ev.Capset.CapEffective, value)
 	case "capset.cap_permitted":
 		return ev.setUint64FieldValue("capset.cap_permitted", &ev.Capset.CapPermitted, value)
-	case "cgroup.file.inode":
-		if ev.CGroupContext == nil {
-			ev.CGroupContext = &CGroupContext{}
-		}
-		return ev.setUint64FieldValue("cgroup.file.inode", &ev.CGroupContext.CGroupFile.Inode, value)
-	case "cgroup.file.mount_id":
-		if ev.CGroupContext == nil {
-			ev.CGroupContext = &CGroupContext{}
-		}
-		return ev.setUint32FieldValue("cgroup.file.mount_id", &ev.CGroupContext.CGroupFile.MountID, value)
-	case "cgroup.id":
-		if ev.CGroupContext == nil {
-			ev.CGroupContext = &CGroupContext{}
-		}
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "cgroup.id"}
-		}
-		ev.CGroupContext.CGroupID = containerutils.CGroupID(rv)
-		return nil
-	case "cgroup.version":
-		if ev.CGroupContext == nil {
-			ev.CGroupContext = &CGroupContext{}
-		}
-		return ev.setIntFieldValue("cgroup.version", &ev.CGroupContext.CGroupVersion, value)
 	case "cgroup_write.file.change_time":
 		return ev.setUint64FieldValue("cgroup_write.file.change_time", &ev.CgroupWrite.File.FileFields.CTime, value)
 	case "cgroup_write.file.extension":
@@ -40816,26 +41237,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint16FieldValue("connect.protocol", &ev.Connect.Protocol, value)
 	case "connect.retval":
 		return ev.setInt64FieldValue("connect.retval", &ev.Connect.SyscallEvent.Retval, value)
-	case "container.created_at":
-		if ev.BaseEvent.ContainerContext == nil {
-			ev.BaseEvent.ContainerContext = &ContainerContext{}
-		}
-		return ev.setUint64FieldValue("container.created_at", &ev.BaseEvent.ContainerContext.CreatedAt, value)
-	case "container.id":
-		if ev.BaseEvent.ContainerContext == nil {
-			ev.BaseEvent.ContainerContext = &ContainerContext{}
-		}
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "container.id"}
-		}
-		ev.BaseEvent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
-		return nil
-	case "container.tags":
-		if ev.BaseEvent.ContainerContext == nil {
-			ev.BaseEvent.ContainerContext = &ContainerContext{}
-		}
-		return ev.setStringArrayFieldValue("container.tags", &ev.BaseEvent.ContainerContext.Tags, value)
 	case "dns.id":
 		return ev.setUint16FieldValue("dns.id", &ev.DNS.ID, value)
 	case "dns.question.class":
@@ -40908,13 +41309,17 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setIntFieldValue("exec.cgroup.version", &ev.Exec.Process.CGroup.CGroupVersion, value)
 	case "exec.comm":
 		return ev.setStringFieldValue("exec.comm", &ev.Exec.Process.Comm, value)
+	case "exec.container.created_at":
+		return ev.setUint64FieldValue("exec.container.created_at", &ev.Exec.Process.ContainerContext.CreatedAt, value)
 	case "exec.container.id":
 		rv, ok := value.(string)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "exec.container.id"}
 		}
-		ev.Exec.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.Exec.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "exec.container.tags":
+		return ev.setStringArrayFieldValue("exec.container.tags", &ev.Exec.Process.ContainerContext.Tags, value)
 	case "exec.created_at":
 		return ev.setUint64FieldValue("exec.created_at", &ev.Exec.Process.CreatedAt, value)
 	case "exec.egid":
@@ -41286,6 +41691,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Exit.Process = &Process{}
 		}
 		return ev.setStringFieldValue("exit.comm", &ev.Exit.Process.Comm, value)
+	case "exit.container.created_at":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setUint64FieldValue("exit.container.created_at", &ev.Exit.Process.ContainerContext.CreatedAt, value)
 	case "exit.container.id":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -41294,8 +41704,13 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "exit.container.id"}
 		}
-		ev.Exit.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.Exit.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "exit.container.tags":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setStringArrayFieldValue("exit.container.tags", &ev.Exit.Process.ContainerContext.Tags, value)
 	case "exit.created_at":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -42438,13 +42853,17 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setIntFieldValue("process.ancestors.cgroup.version", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.CGroup.CGroupVersion, value)
 	case "process.ancestors.comm":
 		return ev.setStringFieldValue("process.ancestors.comm", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Comm, value)
+	case "process.ancestors.container.created_at":
+		return ev.setUint64FieldValue("process.ancestors.container.created_at", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.CreatedAt, value)
 	case "process.ancestors.container.id":
 		rv, ok := value.(string)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "process.ancestors.container.id"}
 		}
-		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.ancestors.container.tags":
+		return ev.setStringArrayFieldValue("process.ancestors.container.tags", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.Tags, value)
 	case "process.ancestors.created_at":
 		return ev.setUint64FieldValue("process.ancestors.created_at", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.CreatedAt, value)
 	case "process.ancestors.egid":
@@ -42748,13 +43167,17 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setIntFieldValue("process.cgroup.version", &ev.BaseEvent.ProcessContext.Process.CGroup.CGroupVersion, value)
 	case "process.comm":
 		return ev.setStringFieldValue("process.comm", &ev.BaseEvent.ProcessContext.Process.Comm, value)
+	case "process.container.created_at":
+		return ev.setUint64FieldValue("process.container.created_at", &ev.BaseEvent.ProcessContext.Process.ContainerContext.CreatedAt, value)
 	case "process.container.id":
 		rv, ok := value.(string)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "process.container.id"}
 		}
-		ev.BaseEvent.ProcessContext.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.BaseEvent.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.container.tags":
+		return ev.setStringArrayFieldValue("process.container.tags", &ev.BaseEvent.ProcessContext.Process.ContainerContext.Tags, value)
 	case "process.created_at":
 		return ev.setUint64FieldValue("process.created_at", &ev.BaseEvent.ProcessContext.Process.CreatedAt, value)
 	case "process.egid":
@@ -43034,13 +43457,17 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setIntFieldValue("process.parent.cgroup.version", &ev.BaseEvent.ProcessContext.Parent.CGroup.CGroupVersion, value)
 	case "process.parent.comm":
 		return ev.setStringFieldValue("process.parent.comm", &ev.BaseEvent.ProcessContext.Parent.Comm, value)
+	case "process.parent.container.created_at":
+		return ev.setUint64FieldValue("process.parent.container.created_at", &ev.BaseEvent.ProcessContext.Parent.ContainerContext.CreatedAt, value)
 	case "process.parent.container.id":
 		rv, ok := value.(string)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "process.parent.container.id"}
 		}
-		ev.BaseEvent.ProcessContext.Parent.ContainerID = containerutils.ContainerID(rv)
+		ev.BaseEvent.ProcessContext.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.parent.container.tags":
+		return ev.setStringArrayFieldValue("process.parent.container.tags", &ev.BaseEvent.ProcessContext.Parent.ContainerContext.Tags, value)
 	case "process.parent.created_at":
 		return ev.setUint64FieldValue("process.parent.created_at", &ev.BaseEvent.ProcessContext.Parent.CreatedAt, value)
 	case "process.parent.egid":
@@ -43464,6 +43891,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.ancestors.comm", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.Comm, value)
+	case "ptrace.tracee.ancestors.container.created_at":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.ancestors.container.created_at", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.ContainerContext.CreatedAt, value)
 	case "ptrace.tracee.ancestors.container.id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -43475,8 +43910,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.ancestors.container.id"}
 		}
-		ev.PTrace.Tracee.Ancestor.ProcessContext.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.PTrace.Tracee.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "ptrace.tracee.ancestors.container.tags":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringArrayFieldValue("ptrace.tracee.ancestors.container.tags", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.ContainerContext.Tags, value)
 	case "ptrace.tracee.ancestors.created_at":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -44326,6 +44769,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.comm", &ev.PTrace.Tracee.Process.Comm, value)
+	case "ptrace.tracee.container.created_at":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.container.created_at", &ev.PTrace.Tracee.Process.ContainerContext.CreatedAt, value)
 	case "ptrace.tracee.container.id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -44334,8 +44782,13 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.container.id"}
 		}
-		ev.PTrace.Tracee.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.PTrace.Tracee.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "ptrace.tracee.container.tags":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setStringArrayFieldValue("ptrace.tracee.container.tags", &ev.PTrace.Tracee.Process.ContainerContext.Tags, value)
 	case "ptrace.tracee.created_at":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -44924,6 +45377,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.parent.comm", &ev.PTrace.Tracee.Parent.Comm, value)
+	case "ptrace.tracee.parent.container.created_at":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.parent.container.created_at", &ev.PTrace.Tracee.Parent.ContainerContext.CreatedAt, value)
 	case "ptrace.tracee.parent.container.id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -44935,8 +45396,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.parent.container.id"}
 		}
-		ev.PTrace.Tracee.Parent.ContainerID = containerutils.ContainerID(rv)
+		ev.PTrace.Tracee.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "ptrace.tracee.parent.container.tags":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setStringArrayFieldValue("ptrace.tracee.parent.container.tags", &ev.PTrace.Tracee.Parent.ContainerContext.Tags, value)
 	case "ptrace.tracee.parent.created_at":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -46141,6 +46610,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.ancestors.comm", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.Comm, value)
+	case "setrlimit.target.ancestors.container.created_at":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.ancestors.container.created_at", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.ContainerContext.CreatedAt, value)
 	case "setrlimit.target.ancestors.container.id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -46152,8 +46629,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.ancestors.container.id"}
 		}
-		ev.Setrlimit.Target.Ancestor.ProcessContext.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.Setrlimit.Target.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "setrlimit.target.ancestors.container.tags":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringArrayFieldValue("setrlimit.target.ancestors.container.tags", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.ContainerContext.Tags, value)
 	case "setrlimit.target.ancestors.created_at":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -47003,6 +47488,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.comm", &ev.Setrlimit.Target.Process.Comm, value)
+	case "setrlimit.target.container.created_at":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.container.created_at", &ev.Setrlimit.Target.Process.ContainerContext.CreatedAt, value)
 	case "setrlimit.target.container.id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -47011,8 +47501,13 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.container.id"}
 		}
-		ev.Setrlimit.Target.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.Setrlimit.Target.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "setrlimit.target.container.tags":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setStringArrayFieldValue("setrlimit.target.container.tags", &ev.Setrlimit.Target.Process.ContainerContext.Tags, value)
 	case "setrlimit.target.created_at":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -47601,6 +48096,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.parent.comm", &ev.Setrlimit.Target.Parent.Comm, value)
+	case "setrlimit.target.parent.container.created_at":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.parent.container.created_at", &ev.Setrlimit.Target.Parent.ContainerContext.CreatedAt, value)
 	case "setrlimit.target.parent.container.id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -47612,8 +48115,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.parent.container.id"}
 		}
-		ev.Setrlimit.Target.Parent.ContainerID = containerutils.ContainerID(rv)
+		ev.Setrlimit.Target.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "setrlimit.target.parent.container.tags":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setStringArrayFieldValue("setrlimit.target.parent.container.tags", &ev.Setrlimit.Target.Parent.ContainerContext.Tags, value)
 	case "setrlimit.target.parent.created_at":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48666,6 +49177,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("signal.target.ancestors.comm", &ev.Signal.Target.Ancestor.ProcessContext.Process.Comm, value)
+	case "signal.target.ancestors.container.created_at":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("signal.target.ancestors.container.created_at", &ev.Signal.Target.Ancestor.ProcessContext.Process.ContainerContext.CreatedAt, value)
 	case "signal.target.ancestors.container.id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -48677,8 +49196,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "signal.target.ancestors.container.id"}
 		}
-		ev.Signal.Target.Ancestor.ProcessContext.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.Signal.Target.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "signal.target.ancestors.container.tags":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringArrayFieldValue("signal.target.ancestors.container.tags", &ev.Signal.Target.Ancestor.ProcessContext.Process.ContainerContext.Tags, value)
 	case "signal.target.ancestors.created_at":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -49528,6 +50055,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("signal.target.comm", &ev.Signal.Target.Process.Comm, value)
+	case "signal.target.container.created_at":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("signal.target.container.created_at", &ev.Signal.Target.Process.ContainerContext.CreatedAt, value)
 	case "signal.target.container.id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -49536,8 +50068,13 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "signal.target.container.id"}
 		}
-		ev.Signal.Target.Process.ContainerID = containerutils.ContainerID(rv)
+		ev.Signal.Target.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "signal.target.container.tags":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setStringArrayFieldValue("signal.target.container.tags", &ev.Signal.Target.Process.ContainerContext.Tags, value)
 	case "signal.target.created_at":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -50126,6 +50663,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("signal.target.parent.comm", &ev.Signal.Target.Parent.Comm, value)
+	case "signal.target.parent.container.created_at":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("signal.target.parent.container.created_at", &ev.Signal.Target.Parent.ContainerContext.CreatedAt, value)
 	case "signal.target.parent.container.id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -50137,8 +50682,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "signal.target.parent.container.id"}
 		}
-		ev.Signal.Target.Parent.ContainerID = containerutils.ContainerID(rv)
+		ev.Signal.Target.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "signal.target.parent.container.tags":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setStringArrayFieldValue("signal.target.parent.container.tags", &ev.Signal.Target.Parent.ContainerContext.Tags, value)
 	case "signal.target.parent.created_at":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}

--- a/pkg/security/secl/model/field_accessors_unix.go
+++ b/pkg/security/secl/model/field_accessors_unix.go
@@ -19,22 +19,6 @@ var _ = time.Time{}
 var _ = net.IP{}
 var _ = eval.NewContext
 
-// GetContainerCreatedAt returns the value of the field, resolving if necessary
-func (ev *Event) GetContainerCreatedAt() int {
-	if ev.BaseEvent.ContainerContext == nil {
-		return 0
-	}
-	return ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)
-}
-
-// GetContainerId returns the value of the field, resolving if necessary
-func (ev *Event) GetContainerId() string {
-	if ev.BaseEvent.ContainerContext == nil {
-		return ""
-	}
-	return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
-}
-
 // GetEventService returns the value of the field, resolving if necessary
 func (ev *Event) GetEventService() string {
 	return ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)

--- a/pkg/security/secl/model/field_accessors_windows.go
+++ b/pkg/security/secl/model/field_accessors_windows.go
@@ -19,14 +19,6 @@ var _ = time.Time{}
 var _ = net.IP{}
 var _ = eval.NewContext
 
-// GetContainerId returns the value of the field, resolving if necessary
-func (ev *Event) GetContainerId() string {
-	if ev.BaseEvent.ContainerContext == nil {
-		return ""
-	}
-	return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
-}
-
 // GetEventService returns the value of the field, resolving if necessary
 func (ev *Event) GetEventService() string {
 	return ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -24,13 +24,6 @@ func (ev *Event) ResolveFieldsForAD() {
 func (ev *Event) resolveFields(forADs bool) {
 	eventType := ev.GetEventType().String()
 	// resolve context fields that are not related to any event type
-	_ = ev.FieldHandlers.ResolveCGroupID(ev, ev.CGroupContext)
-	_ = ev.FieldHandlers.ResolveCGroupVersion(ev, ev.CGroupContext)
-	_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)
-	_ = ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
-	if !forADs {
-		_ = ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
-	}
 	_ = ev.FieldHandlers.ResolveAsync(ev)
 	_ = ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent)
 	if !forADs {
@@ -55,7 +48,11 @@ func (ev *Event) resolveFields(forADs bool) {
 	_ = ev.FieldHandlers.ResolveProcessArgv0(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveCGroupID(ev, &ev.BaseEvent.ProcessContext.Process.CGroup)
 	_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.BaseEvent.ProcessContext.Process.CGroup)
-	_ = ev.FieldHandlers.ResolveProcessContainerID(ev, &ev.BaseEvent.ProcessContext.Process)
+	_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	if !forADs {
+		_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	}
 	_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process)
@@ -170,7 +167,13 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.BaseEvent.ProcessContext.Parent.CGroup)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() {
-		_ = ev.FieldHandlers.ResolveProcessContainerID(ev, ev.BaseEvent.ProcessContext.Parent)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
+	}
+	if !forADs && ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() {
 		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.BaseEvent.ProcessContext.Parent)
@@ -455,7 +458,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		_ = ev.FieldHandlers.ResolveCGroupID(ev, &ev.Exec.Process.CGroup)
 		_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.Exec.Process.CGroup)
-		_ = ev.FieldHandlers.ResolveProcessContainerID(ev, ev.Exec.Process)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Exec.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exec.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exec.Process.ContainerContext)
+		}
 		if ev.Exec.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Exec.Process.LinuxBinprm.FileEvent.FileFields)
 		}
@@ -590,7 +597,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		_ = ev.FieldHandlers.ResolveCGroupID(ev, &ev.Exit.Process.CGroup)
 		_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.Exit.Process.CGroup)
-		_ = ev.FieldHandlers.ResolveProcessContainerID(ev, ev.Exit.Process)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Exit.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exit.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exit.Process.ContainerContext)
+		}
 		if ev.Exit.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Exit.Process.LinuxBinprm.FileEvent.FileFields)
 		}
@@ -869,7 +880,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		_ = ev.FieldHandlers.ResolveCGroupID(ev, &ev.PTrace.Tracee.Process.CGroup)
 		_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.PTrace.Tracee.Process.CGroup)
-		_ = ev.FieldHandlers.ResolveProcessContainerID(ev, &ev.PTrace.Tracee.Process)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.PTrace.Tracee.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.PTrace.Tracee.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.PTrace.Tracee.Process.ContainerContext)
+		}
 		if ev.PTrace.Tracee.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.FileFields)
 		}
@@ -981,7 +996,13 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.PTrace.Tracee.Parent.CGroup)
 		}
 		if ev.PTrace.Tracee.HasParent() {
-			_ = ev.FieldHandlers.ResolveProcessContainerID(ev, ev.PTrace.Tracee.Parent)
+			_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.PTrace.Tracee.Parent.ContainerContext)
+		}
+		if ev.PTrace.Tracee.HasParent() {
+			_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.PTrace.Tracee.Parent.ContainerContext)
+		}
+		if !forADs && ev.PTrace.Tracee.HasParent() {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.PTrace.Tracee.Parent.ContainerContext)
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.FileFields)
@@ -1200,7 +1221,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		_ = ev.FieldHandlers.ResolveCGroupID(ev, &ev.Setrlimit.Target.Process.CGroup)
 		_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.Setrlimit.Target.Process.CGroup)
-		_ = ev.FieldHandlers.ResolveProcessContainerID(ev, &ev.Setrlimit.Target.Process)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Setrlimit.Target.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Setrlimit.Target.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Setrlimit.Target.Process.ContainerContext)
+		}
 		if ev.Setrlimit.Target.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Setrlimit.Target.Process.LinuxBinprm.FileEvent.FileFields)
 		}
@@ -1312,7 +1337,13 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.Setrlimit.Target.Parent.CGroup)
 		}
 		if ev.Setrlimit.Target.HasParent() {
-			_ = ev.FieldHandlers.ResolveProcessContainerID(ev, ev.Setrlimit.Target.Parent)
+			_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Setrlimit.Target.Parent.ContainerContext)
+		}
+		if ev.Setrlimit.Target.HasParent() {
+			_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Setrlimit.Target.Parent.ContainerContext)
+		}
+		if !forADs && ev.Setrlimit.Target.HasParent() {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Setrlimit.Target.Parent.ContainerContext)
 		}
 		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent.FileFields)
@@ -1471,7 +1502,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		_ = ev.FieldHandlers.ResolveCGroupID(ev, &ev.Signal.Target.Process.CGroup)
 		_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.Signal.Target.Process.CGroup)
-		_ = ev.FieldHandlers.ResolveProcessContainerID(ev, &ev.Signal.Target.Process)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Signal.Target.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Signal.Target.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Signal.Target.Process.ContainerContext)
+		}
 		if ev.Signal.Target.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent.FileFields)
 		}
@@ -1583,7 +1618,13 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveCGroupVersion(ev, &ev.Signal.Target.Parent.CGroup)
 		}
 		if ev.Signal.Target.HasParent() {
-			_ = ev.FieldHandlers.ResolveProcessContainerID(ev, ev.Signal.Target.Parent)
+			_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Signal.Target.Parent.ContainerContext)
+		}
+		if ev.Signal.Target.HasParent() {
+			_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Signal.Target.Parent.ContainerContext)
+		}
+		if !forADs && ev.Signal.Target.HasParent() {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Signal.Target.Parent.ContainerContext)
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.FileFields)
@@ -1808,7 +1849,6 @@ type FieldHandlers interface {
 	ResolveProcessArgv0(ev *Event, e *Process) string
 	ResolveProcessArgvScrubbed(ev *Event, e *Process) []string
 	ResolveProcessCmdArgv(ev *Event, e *Process) []string
-	ResolveProcessContainerID(ev *Event, e *Process) string
 	ResolveProcessCreatedAt(ev *Event, e *Process) int
 	ResolveProcessEnvp(ev *Event, e *Process) []string
 	ResolveProcessEnvs(ev *Event, e *Process) []string
@@ -2043,9 +2083,6 @@ func (dfh *FakeFieldHandlers) ResolveProcessArgvScrubbed(ev *Event, e *Process) 
 }
 func (dfh *FakeFieldHandlers) ResolveProcessCmdArgv(ev *Event, e *Process) []string {
 	return []string(e.Argv)
-}
-func (dfh *FakeFieldHandlers) ResolveProcessContainerID(ev *Event, e *Process) string {
-	return string(e.ContainerID)
 }
 func (dfh *FakeFieldHandlers) ResolveProcessCreatedAt(ev *Event, e *Process) int {
 	return int(e.CreatedAt)

--- a/pkg/security/secl/model/field_handlers_windows.go
+++ b/pkg/security/secl/model/field_handlers_windows.go
@@ -24,11 +24,6 @@ func (ev *Event) ResolveFieldsForAD() {
 func (ev *Event) resolveFields(forADs bool) {
 	eventType := ev.GetEventType().String()
 	// resolve context fields that are not related to any event type
-	_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)
-	_ = ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
-	if !forADs {
-		_ = ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
-	}
 	_ = ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent)
 	if !forADs {
 		_ = ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)
@@ -36,6 +31,11 @@ func (ev *Event) resolveFields(forADs bool) {
 	_ = ev.FieldHandlers.ResolveSource(ev, &ev.BaseEvent)
 	_ = ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
 	_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, &ev.BaseEvent.ProcessContext.Process)
+	_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	if !forADs {
+		_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	}
 	_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process)
@@ -44,6 +44,15 @@ func (ev *Event) resolveFields(forADs bool) {
 	_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
 	if ev.BaseEvent.ProcessContext.HasParent() {
 		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.BaseEvent.ProcessContext.Parent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
+	}
+	if !forADs && ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() {
 		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.BaseEvent.ProcessContext.Parent)
@@ -88,6 +97,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent)
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Exec.Process.FileEvent)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Exec.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exec.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exec.Process.ContainerContext)
+		}
 		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exec.Process)
 		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exec.Process)
 		_ = ev.FieldHandlers.ResolveUser(ev, ev.Exec.Process)
@@ -97,6 +111,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent)
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Exit.Process.FileEvent)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Exit.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exit.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exit.Process.ContainerContext)
+		}
 		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exit.Process)
 		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exit.Process)
 		_ = ev.FieldHandlers.ResolveUser(ev, ev.Exit.Process)

--- a/pkg/security/secl/model/legacy_secl.go
+++ b/pkg/security/secl/model/legacy_secl.go
@@ -11,7 +11,14 @@ import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 // SECLLegacyFields contains the list of the legacy attributes we need to support
 var SECLLegacyFields = map[eval.Field]eval.Field{
 	// event
-	"async": "event.async",
+	"async":                "event.async",
+	"container.id":         "process.container.id",
+	"container.created_at": "process.container.created_at",
+	"container.tags":       "process.container.tags",
+	"cgroup.id":            "process.cgroup.id",
+	"cgroup.version":       "process.cgroup.version",
+	"cgroup.file.inode":    "process.cgroup.file.inode",
+	"cgroup.file.mount_id": "process.cgroup.file.mount_id",
 
 	// chmod
 	"chmod.filename": "chmod.file.path",

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -24,8 +24,6 @@ type Model struct {
 	ExtraValidateFieldFnc func(field eval.Field, fieldValue eval.FieldValue) error
 }
 
-var containerContextZero ContainerContext
-
 // Releasable represents an object than can be released
 type Releasable struct {
 	onReleaseCallbacks []func() `field:"-"`
@@ -154,7 +152,6 @@ type BaseEvent struct {
 
 	// context shared with all event types
 	ProcessContext         *ProcessContext        `field:"process"`
-	ContainerContext       *ContainerContext      `field:"container"`
 	SecurityProfileContext SecurityProfileContext `field:"-"`
 
 	// internal usage
@@ -265,8 +262,8 @@ func (e *Event) GetTags() []string {
 	tags := []string{"type:" + e.GetType()}
 
 	// should already be resolved at this stage
-	if len(e.ContainerContext.Tags) > 0 {
-		tags = append(tags, e.ContainerContext.Tags...)
+	if e.ProcessContext != nil && len(e.ProcessContext.Process.ContainerContext.Tags) > 0 {
+		tags = append(tags, e.ProcessContext.Process.ContainerContext.Tags...)
 	}
 	return tags
 }
@@ -445,7 +442,7 @@ type ProcessCacheEntry struct {
 
 // IsContainerRoot returns whether this is a top level process in the container ID
 func (pc *ProcessCacheEntry) IsContainerRoot() bool {
-	return pc.ContainerID != "" && pc.Ancestor != nil && pc.Ancestor.ContainerID == ""
+	return pc.Process.ContainerContext.ContainerID != "" && pc.Ancestor != nil && pc.Ancestor.ContainerContext.ContainerID == ""
 }
 
 // Reset the entry

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -20,8 +20,7 @@ import (
 func (m *Model) NewEvent() eval.Event {
 	return &Event{
 		BaseEvent: BaseEvent{
-			ContainerContext: &ContainerContext{},
-			Os:               runtime.GOOS,
+			Os: runtime.GOOS,
 		},
 	}
 }
@@ -30,9 +29,8 @@ func (m *Model) NewEvent() eval.Event {
 func NewFakeEvent() *Event {
 	return &Event{
 		BaseEvent: BaseEvent{
-			FieldHandlers:    &FakeFieldHandlers{},
-			ContainerContext: &ContainerContext{},
-			Os:               runtime.GOOS,
+			FieldHandlers: &FakeFieldHandlers{},
+			Os:            runtime.GOOS,
 		},
 	}
 }
@@ -61,8 +59,6 @@ func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) erro
 
 // Event represents an event sent from the kernel
 // genaccessors
-// gengetter: GetContainerId
-// gengetter: GetContainerId
 // gengetter: GetEventService
 // gengetter: GetExecFilePath
 // gengetter: GetExitCode
@@ -96,12 +92,19 @@ type Event struct {
 
 // NewEventZeroer returns a function that can be used to zero an Event
 func NewEventZeroer() func(*Event) {
-	var eventZero = Event{BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}, Os: runtime.GOOS}}
+	var eventZero = Event{BaseEvent: BaseEvent{Os: runtime.GOOS}}
 
 	return func(e *Event) {
 		*e = eventZero
-		*e.BaseEvent.ContainerContext = containerContextZero
 	}
+}
+
+// GetContainerID returns event's process container ID if any
+func (e *Event) GetContainerID() string {
+	if e.ProcessContext == nil {
+		return ""
+	}
+	return string(e.ProcessContext.Process.ContainerContext.ContainerID)
 }
 
 // FileEvent is the common file event type
@@ -133,7 +136,7 @@ type Process struct {
 
 	FileEvent FileEvent `field:"file"`
 
-	ContainerID string `field:"container.id"` // SECLDoc[container.id] Definition:`Container ID`
+	ContainerContext ContainerContext `field:"container"` // SECLDoc[container] Definition:`Container`
 
 	ExitTime time.Time `field:"exit_time,opts:getters_only|gen_getters"`
 	ExecTime time.Time `field:"exec_time,opts:getters_only|gen_getters"`

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -43,7 +43,7 @@ func hasValidLineage(pc *ProcessCacheEntry) (bool, error) {
 			return *pc.hasValidLineage, pc.lineageError
 		}
 
-		pid, ppid, ctrID = pc.Pid, pc.PPid, pc.ContainerID
+		pid, ppid, ctrID = pc.Pid, pc.PPid, pc.ContainerContext.ContainerID
 
 		if pc.IsParentMissing {
 			err = &ErrProcessMissingParentNode{PID: pid, PPID: ppid, ContainerID: string(ctrID)}
@@ -80,8 +80,8 @@ func copyProcessContext(parent, child *ProcessCacheEntry) {
 	// the proc_cache LRU ejects an entry.
 	// WARNING: this is why the user space cache should not be used to detect container breakouts. Dedicated
 	// in-kernel probes will need to be added.
-	if len(parent.ContainerID) > 0 && len(child.ContainerID) == 0 {
-		child.ContainerID = parent.ContainerID
+	if len(parent.ContainerContext.ContainerID) > 0 && len(child.ContainerContext.ContainerID) == 0 {
+		child.ContainerContext.ContainerID = parent.ContainerContext.ContainerID
 	}
 
 	if len(parent.CGroup.CGroupID) > 0 && len(child.CGroup.CGroupID) == 0 {
@@ -128,7 +128,7 @@ func (pc *ProcessCacheEntry) GetContainerPIDs() ([]uint32, []string) {
 	)
 
 	for pc != nil {
-		if pc.ContainerID == "" {
+		if pc.ContainerContext.ContainerID == "" {
 			break
 		}
 		pids = append(pids, pc.Pid)
@@ -168,7 +168,7 @@ func (pc *ProcessCacheEntry) Fork(childEntry *ProcessCacheEntry) {
 	childEntry.TTYName = pc.TTYName
 	childEntry.Comm = pc.Comm
 	childEntry.FileEvent = pc.FileEvent
-	childEntry.ContainerID = pc.ContainerID
+	childEntry.ContainerContext.ContainerID = pc.ContainerContext.ContainerID
 	childEntry.CGroup = pc.CGroup
 	childEntry.ExecTime = pc.ExecTime
 	childEntry.Credentials = pc.Credentials

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -418,8 +418,12 @@ func TestActionSetVariableTTL(t *testing.T) {
 	event.Type = uint32(model.FileOpenEventType)
 	processCacheEntry := &model.ProcessCacheEntry{}
 	processCacheEntry.Retain()
-	event.ContainerContext = &model.ContainerContext{
-		ContainerID: "0123456789abcdef",
+	event.ProcessContext = &model.ProcessContext{
+		Process: model.Process{
+			ContainerContext: model.ContainerContext{
+				ContainerID: "0123456789abcdef",
+			},
+		},
 	}
 	event.ProcessCacheEntry = processCacheEntry
 	event.SetFieldValue("open.file.path", "/tmp/test")
@@ -2245,8 +2249,12 @@ func TestActionSetVariableLength(t *testing.T) {
 	event.Type = uint32(model.FileOpenEventType)
 	processCacheEntry := &model.ProcessCacheEntry{}
 	processCacheEntry.Retain()
-	event.ContainerContext = &model.ContainerContext{
-		ContainerID: "0123456789abcdef",
+	event.ProcessContext = &model.ProcessContext{
+		Process: model.Process{
+			ContainerContext: model.ContainerContext{
+				ContainerID: "0123456789abcdef",
+			},
+		},
 	}
 	event.ProcessCacheEntry = processCacheEntry
 	event.SetFieldValue("open.file.path", "/tmp/test")

--- a/pkg/security/secl/rules/scope.go
+++ b/pkg/security/secl/rules/scope.go
@@ -62,8 +62,8 @@ func getCommonVariableScopers() map[Scope]*eval.VariableScoper {
 			return nil, fmt.Errorf("failed to get process scope")
 		}),
 		ScopeContainer: eval.NewVariableScoper(eval.ContainerScoperType, func(ctx *eval.Context) (eval.VariableScope, error) {
-			if cc := ctx.Event.(*model.Event).ContainerContext; cc != nil {
-				return cc, nil
+			if ctx.Event.(*model.Event).ProcessContext != nil {
+				return &ctx.Event.(*model.Event).ProcessContext.ContainerContext, nil
 			}
 			return nil, fmt.Errorf("failed to get container scope")
 		}),

--- a/pkg/security/secl/rules/scope_linux.go
+++ b/pkg/security/secl/rules/scope_linux.go
@@ -17,10 +17,10 @@ import (
 func DefaultVariableScopers() map[Scope]*eval.VariableScoper {
 	variableScopers := getCommonVariableScopers()
 	variableScopers[ScopeCGroup] = eval.NewVariableScoper(eval.CGroupScoperType, func(ctx *eval.Context) (eval.VariableScope, error) {
-		if ctx.Event.(*model.Event).CGroupContext == nil || ctx.Event.(*model.Event).CGroupContext.CGroupFile.IsNull() {
+		if ctx.Event.(*model.Event).ProcessContext == nil || ctx.Event.(*model.Event).ProcessContext.Process.CGroup.CGroupFile.IsNull() {
 			return nil, fmt.Errorf("failed to get cgroup scope")
 		}
-		return ctx.Event.(*model.Event).CGroupContext, nil
+		return &ctx.Event.(*model.Event).ProcessContext.Process.CGroup, nil
 	})
 	return variableScopers
 }

--- a/pkg/security/seclwin/model/accessors_win.go
+++ b/pkg/security/seclwin/model/accessors_win.go
@@ -107,39 +107,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "container.created_at":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext))
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "container.id":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
-			},
-			Field:  field,
-			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "container.tags":
-		return &eval.StringArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []string {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
-			},
-			Field:  field,
-			Weight: 9999 * eval.HandlerWeight,
-			Offset: offset,
-		}, nil
 	case "create.file.device_path":
 		return &eval.StringEvaluator{
 			OpOverrides: []*eval.OpOverrides{eval.WindowsPathCmp},
@@ -581,15 +548,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: 200 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "exec.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exec.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exec.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Exec.Process.ContainerID
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.Exec.Process.ContainerContext)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exec.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "exec.created_at":
@@ -763,15 +752,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exit.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exit.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exit.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Exit.Process.ContainerID
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.Exit.Process.ContainerContext)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exit.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "exit.created_at":
@@ -1031,6 +1042,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: 200 * eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "process.ancestors.container.created_at":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &element.ProcessContext.Process.ContainerContext))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &current.ProcessContext.Process.ContainerContext))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.ancestors.container.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -1042,20 +1080,47 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := element.ProcessContext.Process.ContainerID
+					result := ev.FieldHandlers.ResolveContainerID(ev, &element.ProcessContext.Process.ContainerContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
-					return current.ProcessContext.Process.ContainerID
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveContainerID(ev, &current.ProcessContext.Process.ContainerContext)
 				})
 				ctx.StringCache[field] = results
 				return results
 			},
 			Field:  field,
 			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveContainerTags(ev, &element.ProcessContext.Process.ContainerContext)
+					return result
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIteratorArray(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
+					return ev.FieldHandlers.ResolveContainerTags(ev, &current.ProcessContext.Process.ContainerContext)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: 9999 * eval.IteratorWeight,
 			Offset: offset,
 		}, nil
 	case "process.ancestors.created_at":
@@ -1410,15 +1475,37 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: 200 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "process.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.BaseEvent.ProcessContext.Process.ContainerID
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "process.created_at":
@@ -1529,6 +1616,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: 200 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "process.parent.container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.parent.container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -1537,10 +1638,24 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return ""
 				}
-				return ev.BaseEvent.ProcessContext.Parent.ContainerID
+				return ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
 			},
 			Field:  field,
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.container.tags":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return []string{}
+				}
+				return ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
+			},
+			Field:  field,
+			Weight: 9999 * eval.HandlerWeight,
 			Offset: offset,
 		}, nil
 	case "process.parent.created_at":
@@ -2175,9 +2290,6 @@ func (ev *Event) GetFields() []eval.Field {
 		"change_permission.type",
 		"change_permission.user_domain",
 		"change_permission.username",
-		"container.created_at",
-		"container.id",
-		"container.tags",
 		"create.file.device_path",
 		"create.file.device_path.length",
 		"create.file.extension",
@@ -2216,7 +2328,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"event.source",
 		"event.timestamp",
 		"exec.cmdline",
+		"exec.container.created_at",
 		"exec.container.id",
+		"exec.container.tags",
 		"exec.created_at",
 		"exec.envp",
 		"exec.envs",
@@ -2232,7 +2346,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.cause",
 		"exit.cmdline",
 		"exit.code",
+		"exit.container.created_at",
 		"exit.container.id",
+		"exit.container.tags",
 		"exit.created_at",
 		"exit.envp",
 		"exit.envs",
@@ -2254,7 +2370,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"open_key.registry.key_path",
 		"open_key.registry.key_path.length",
 		"process.ancestors.cmdline",
+		"process.ancestors.container.created_at",
 		"process.ancestors.container.id",
+		"process.ancestors.container.tags",
 		"process.ancestors.created_at",
 		"process.ancestors.envp",
 		"process.ancestors.envs",
@@ -2269,7 +2387,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.user",
 		"process.ancestors.user_sid",
 		"process.cmdline",
+		"process.container.created_at",
 		"process.container.id",
+		"process.container.tags",
 		"process.created_at",
 		"process.envp",
 		"process.envs",
@@ -2279,7 +2399,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.file.path",
 		"process.file.path.length",
 		"process.parent.cmdline",
+		"process.parent.container.created_at",
 		"process.parent.container.id",
+		"process.parent.container.tags",
 		"process.parent.created_at",
 		"process.parent.envp",
 		"process.parent.envs",
@@ -2347,12 +2469,6 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "change_permission", reflect.String, "string", nil
 	case "change_permission.username":
 		return "change_permission", reflect.String, "string", nil
-	case "container.created_at":
-		return "", reflect.Int, "int", nil
-	case "container.id":
-		return "", reflect.String, "string", nil
-	case "container.tags":
-		return "", reflect.String, "string", nil
 	case "create.file.device_path":
 		return "create", reflect.String, "string", nil
 	case "create.file.device_path.length":
@@ -2429,7 +2545,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", nil
 	case "exec.cmdline":
 		return "exec", reflect.String, "string", nil
+	case "exec.container.created_at":
+		return "exec", reflect.Int, "int", nil
 	case "exec.container.id":
+		return "exec", reflect.String, "string", nil
+	case "exec.container.tags":
 		return "exec", reflect.String, "string", nil
 	case "exec.created_at":
 		return "exec", reflect.Int, "int", nil
@@ -2461,7 +2581,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.String, "string", nil
 	case "exit.code":
 		return "exit", reflect.Int, "int", nil
+	case "exit.container.created_at":
+		return "exit", reflect.Int, "int", nil
 	case "exit.container.id":
+		return "exit", reflect.String, "string", nil
+	case "exit.container.tags":
 		return "exit", reflect.String, "string", nil
 	case "exit.created_at":
 		return "exit", reflect.Int, "int", nil
@@ -2505,7 +2629,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "open_key", reflect.Int, "int", nil
 	case "process.ancestors.cmdline":
 		return "", reflect.String, "string", nil
+	case "process.ancestors.container.created_at":
+		return "", reflect.Int, "int", nil
 	case "process.ancestors.container.id":
+		return "", reflect.String, "string", nil
+	case "process.ancestors.container.tags":
 		return "", reflect.String, "string", nil
 	case "process.ancestors.created_at":
 		return "", reflect.Int, "int", nil
@@ -2535,7 +2663,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.cmdline":
 		return "", reflect.String, "string", nil
+	case "process.container.created_at":
+		return "", reflect.Int, "int", nil
 	case "process.container.id":
+		return "", reflect.String, "string", nil
+	case "process.container.tags":
 		return "", reflect.String, "string", nil
 	case "process.created_at":
 		return "", reflect.Int, "int", nil
@@ -2555,7 +2687,11 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", nil
 	case "process.parent.cmdline":
 		return "", reflect.String, "string", nil
+	case "process.parent.container.created_at":
+		return "", reflect.Int, "int", nil
 	case "process.parent.container.id":
+		return "", reflect.String, "string", nil
+	case "process.parent.container.tags":
 		return "", reflect.String, "string", nil
 	case "process.parent.created_at":
 		return "", reflect.Int, "int", nil
@@ -2679,26 +2815,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("change_permission.user_domain", &ev.ChangePermission.UserDomain, value)
 	case "change_permission.username":
 		return ev.setStringFieldValue("change_permission.username", &ev.ChangePermission.UserName, value)
-	case "container.created_at":
-		if ev.BaseEvent.ContainerContext == nil {
-			ev.BaseEvent.ContainerContext = &ContainerContext{}
-		}
-		return ev.setUint64FieldValue("container.created_at", &ev.BaseEvent.ContainerContext.CreatedAt, value)
-	case "container.id":
-		if ev.BaseEvent.ContainerContext == nil {
-			ev.BaseEvent.ContainerContext = &ContainerContext{}
-		}
-		rv, ok := value.(string)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "container.id"}
-		}
-		ev.BaseEvent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
-		return nil
-	case "container.tags":
-		if ev.BaseEvent.ContainerContext == nil {
-			ev.BaseEvent.ContainerContext = &ContainerContext{}
-		}
-		return ev.setStringArrayFieldValue("container.tags", &ev.BaseEvent.ContainerContext.Tags, value)
 	case "create.file.device_path":
 		return ev.setStringFieldValue("create.file.device_path", &ev.CreateNewFile.File.PathnameStr, value)
 	case "create.file.device_path.length":
@@ -2775,8 +2891,17 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint64FieldValue("event.timestamp", &ev.BaseEvent.TimestampRaw, value)
 	case "exec.cmdline":
 		return ev.setStringFieldValue("exec.cmdline", &ev.Exec.Process.CmdLine, value)
+	case "exec.container.created_at":
+		return ev.setUint64FieldValue("exec.container.created_at", &ev.Exec.Process.ContainerContext.CreatedAt, value)
 	case "exec.container.id":
-		return ev.setStringFieldValue("exec.container.id", &ev.Exec.Process.ContainerID, value)
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "exec.container.id"}
+		}
+		ev.Exec.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
+		return nil
+	case "exec.container.tags":
+		return ev.setStringArrayFieldValue("exec.container.tags", &ev.Exec.Process.ContainerContext.Tags, value)
 	case "exec.created_at":
 		return ev.setUint64FieldValue("exec.created_at", &ev.Exec.Process.CreatedAt, value)
 	case "exec.envp":
@@ -2810,11 +2935,26 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("exit.cmdline", &ev.Exit.Process.CmdLine, value)
 	case "exit.code":
 		return ev.setUint32FieldValue("exit.code", &ev.Exit.Code, value)
+	case "exit.container.created_at":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setUint64FieldValue("exit.container.created_at", &ev.Exit.Process.ContainerContext.CreatedAt, value)
 	case "exit.container.id":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setStringFieldValue("exit.container.id", &ev.Exit.Process.ContainerID, value)
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "exit.container.id"}
+		}
+		ev.Exit.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
+		return nil
+	case "exit.container.tags":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setStringArrayFieldValue("exit.container.tags", &ev.Exit.Process.ContainerContext.Tags, value)
 	case "exit.created_at":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -2893,8 +3033,17 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return &eval.ErrFieldReadOnly{Field: "open_key.registry.key_path.length"}
 	case "process.ancestors.cmdline":
 		return ev.setStringFieldValue("process.ancestors.cmdline", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.CmdLine, value)
+	case "process.ancestors.container.created_at":
+		return ev.setUint64FieldValue("process.ancestors.container.created_at", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.CreatedAt, value)
 	case "process.ancestors.container.id":
-		return ev.setStringFieldValue("process.ancestors.container.id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerID, value)
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "process.ancestors.container.id"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
+		return nil
+	case "process.ancestors.container.tags":
+		return ev.setStringArrayFieldValue("process.ancestors.container.tags", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.Tags, value)
 	case "process.ancestors.created_at":
 		return ev.setUint64FieldValue("process.ancestors.created_at", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.CreatedAt, value)
 	case "process.ancestors.envp":
@@ -2923,8 +3072,17 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.ancestors.user_sid", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.OwnerSidString, value)
 	case "process.cmdline":
 		return ev.setStringFieldValue("process.cmdline", &ev.BaseEvent.ProcessContext.Process.CmdLine, value)
+	case "process.container.created_at":
+		return ev.setUint64FieldValue("process.container.created_at", &ev.BaseEvent.ProcessContext.Process.ContainerContext.CreatedAt, value)
 	case "process.container.id":
-		return ev.setStringFieldValue("process.container.id", &ev.BaseEvent.ProcessContext.Process.ContainerID, value)
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "process.container.id"}
+		}
+		ev.BaseEvent.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
+		return nil
+	case "process.container.tags":
+		return ev.setStringArrayFieldValue("process.container.tags", &ev.BaseEvent.ProcessContext.Process.ContainerContext.Tags, value)
 	case "process.created_at":
 		return ev.setUint64FieldValue("process.created_at", &ev.BaseEvent.ProcessContext.Process.CreatedAt, value)
 	case "process.envp":
@@ -2943,8 +3101,17 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return &eval.ErrFieldReadOnly{Field: "process.file.path.length"}
 	case "process.parent.cmdline":
 		return ev.setStringFieldValue("process.parent.cmdline", &ev.BaseEvent.ProcessContext.Parent.CmdLine, value)
+	case "process.parent.container.created_at":
+		return ev.setUint64FieldValue("process.parent.container.created_at", &ev.BaseEvent.ProcessContext.Parent.ContainerContext.CreatedAt, value)
 	case "process.parent.container.id":
-		return ev.setStringFieldValue("process.parent.container.id", &ev.BaseEvent.ProcessContext.Parent.ContainerID, value)
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "process.parent.container.id"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
+		return nil
+	case "process.parent.container.tags":
+		return ev.setStringArrayFieldValue("process.parent.container.tags", &ev.BaseEvent.ProcessContext.Parent.ContainerContext.Tags, value)
 	case "process.parent.created_at":
 		return ev.setUint64FieldValue("process.parent.created_at", &ev.BaseEvent.ProcessContext.Parent.CreatedAt, value)
 	case "process.parent.envp":

--- a/pkg/security/seclwin/model/field_handlers_win.go
+++ b/pkg/security/seclwin/model/field_handlers_win.go
@@ -22,11 +22,6 @@ func (ev *Event) ResolveFieldsForAD() {
 func (ev *Event) resolveFields(forADs bool) {
 	eventType := ev.GetEventType().String()
 	// resolve context fields that are not related to any event type
-	_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)
-	_ = ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
-	if !forADs {
-		_ = ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
-	}
 	_ = ev.FieldHandlers.ResolveHostname(ev, &ev.BaseEvent)
 	if !forADs {
 		_ = ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)
@@ -34,6 +29,11 @@ func (ev *Event) resolveFields(forADs bool) {
 	_ = ev.FieldHandlers.ResolveSource(ev, &ev.BaseEvent)
 	_ = ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
 	_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, &ev.BaseEvent.ProcessContext.Process)
+	_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	if !forADs {
+		_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Process.ContainerContext)
+	}
 	_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process)
@@ -42,6 +42,15 @@ func (ev *Event) resolveFields(forADs bool) {
 	_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
 	if ev.BaseEvent.ProcessContext.HasParent() {
 		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.BaseEvent.ProcessContext.Parent)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
+	}
+	if ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
+	}
+	if !forADs && ev.BaseEvent.ProcessContext.HasParent() {
+		_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.BaseEvent.ProcessContext.Parent.ContainerContext)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() {
 		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.BaseEvent.ProcessContext.Parent)
@@ -86,6 +95,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent)
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Exec.Process.FileEvent)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Exec.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exec.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exec.Process.ContainerContext)
+		}
 		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exec.Process)
 		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exec.Process)
 		_ = ev.FieldHandlers.ResolveUser(ev, ev.Exec.Process)
@@ -95,6 +109,11 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent)
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Exit.Process.FileEvent)
+		_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.Exit.Process.ContainerContext)
+		_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.Exit.Process.ContainerContext)
+		if !forADs {
+			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exit.Process.ContainerContext)
+		}
 		_ = ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exit.Process)
 		_ = ev.FieldHandlers.ResolveProcessCmdLine(ev, ev.Exit.Process)
 		_ = ev.FieldHandlers.ResolveUser(ev, ev.Exit.Process)

--- a/pkg/security/seclwin/model/legacy_secl.go
+++ b/pkg/security/seclwin/model/legacy_secl.go
@@ -11,7 +11,14 @@ import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 // SECLLegacyFields contains the list of the legacy attributes we need to support
 var SECLLegacyFields = map[eval.Field]eval.Field{
 	// event
-	"async": "event.async",
+	"async":                "event.async",
+	"container.id":         "process.container.id",
+	"container.created_at": "process.container.created_at",
+	"container.tags":       "process.container.tags",
+	"cgroup.id":            "process.cgroup.id",
+	"cgroup.version":       "process.cgroup.version",
+	"cgroup.file.inode":    "process.cgroup.file.inode",
+	"cgroup.file.mount_id": "process.cgroup.file.mount_id",
 
 	// chmod
 	"chmod.filename": "chmod.file.path",

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -24,8 +24,6 @@ type Model struct {
 	ExtraValidateFieldFnc func(field eval.Field, fieldValue eval.FieldValue) error
 }
 
-var containerContextZero ContainerContext
-
 // Releasable represents an object than can be released
 type Releasable struct {
 	onReleaseCallbacks []func() `field:"-"`
@@ -154,7 +152,6 @@ type BaseEvent struct {
 
 	// context shared with all event types
 	ProcessContext         *ProcessContext        `field:"process"`
-	ContainerContext       *ContainerContext      `field:"container"`
 	SecurityProfileContext SecurityProfileContext `field:"-"`
 
 	// internal usage
@@ -265,8 +262,8 @@ func (e *Event) GetTags() []string {
 	tags := []string{"type:" + e.GetType()}
 
 	// should already be resolved at this stage
-	if len(e.ContainerContext.Tags) > 0 {
-		tags = append(tags, e.ContainerContext.Tags...)
+	if e.ProcessContext != nil && len(e.ProcessContext.Process.ContainerContext.Tags) > 0 {
+		tags = append(tags, e.ProcessContext.Process.ContainerContext.Tags...)
 	}
 	return tags
 }
@@ -445,7 +442,7 @@ type ProcessCacheEntry struct {
 
 // IsContainerRoot returns whether this is a top level process in the container ID
 func (pc *ProcessCacheEntry) IsContainerRoot() bool {
-	return pc.ContainerID != "" && pc.Ancestor != nil && pc.Ancestor.ContainerID == ""
+	return pc.Process.ContainerContext.ContainerID != "" && pc.Ancestor != nil && pc.Ancestor.ContainerContext.ContainerID == ""
 }
 
 // Reset the entry

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -20,8 +20,7 @@ import (
 func (m *Model) NewEvent() eval.Event {
 	return &Event{
 		BaseEvent: BaseEvent{
-			ContainerContext: &ContainerContext{},
-			Os:               runtime.GOOS,
+			Os: runtime.GOOS,
 		},
 	}
 }
@@ -30,9 +29,8 @@ func (m *Model) NewEvent() eval.Event {
 func NewFakeEvent() *Event {
 	return &Event{
 		BaseEvent: BaseEvent{
-			FieldHandlers:    &FakeFieldHandlers{},
-			ContainerContext: &ContainerContext{},
-			Os:               runtime.GOOS,
+			FieldHandlers: &FakeFieldHandlers{},
+			Os:            runtime.GOOS,
 		},
 	}
 }
@@ -61,8 +59,6 @@ func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) erro
 
 // Event represents an event sent from the kernel
 // genaccessors
-// gengetter: GetContainerId
-// gengetter: GetContainerId
 // gengetter: GetEventService
 // gengetter: GetExecFilePath
 // gengetter: GetExitCode
@@ -96,12 +92,19 @@ type Event struct {
 
 // NewEventZeroer returns a function that can be used to zero an Event
 func NewEventZeroer() func(*Event) {
-	var eventZero = Event{BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}, Os: runtime.GOOS}}
+	var eventZero = Event{BaseEvent: BaseEvent{Os: runtime.GOOS}}
 
 	return func(e *Event) {
 		*e = eventZero
-		*e.BaseEvent.ContainerContext = containerContextZero
 	}
+}
+
+// GetContainerID returns event's process container ID if any
+func (e *Event) GetContainerID() string {
+	if e.ProcessContext == nil {
+		return ""
+	}
+	return string(e.ProcessContext.Process.ContainerContext.ContainerID)
 }
 
 // FileEvent is the common file event type
@@ -133,7 +136,7 @@ type Process struct {
 
 	FileEvent FileEvent `field:"file"`
 
-	ContainerID string `field:"container.id"` // SECLDoc[container.id] Definition:`Container ID`
+	ContainerContext ContainerContext `field:"container"` // SECLDoc[container] Definition:`Container`
 
 	ExitTime time.Time `field:"exit_time,opts:getters_only|gen_getters"`
 	ExecTime time.Time `field:"exec_time,opts:getters_only|gen_getters"`

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
@@ -15,7 +15,6 @@ import (
 	adproto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
@@ -136,14 +135,13 @@ func protoDecodeProcessNode(p *adproto.ProcessInfo) model.Process {
 			Pid: p.Pid,
 			Tid: p.Tid,
 		},
-		PPid:        p.Ppid,
-		Cookie:      p.Cookie64,
-		IsThread:    p.IsThread,
-		IsExecExec:  p.IsExecChild,
-		FileEvent:   *protoDecodeFileEvent(p.File),
-		ContainerID: containerutils.ContainerID(p.ContainerId),
-		TTYName:     p.Tty,
-		Comm:        p.Comm,
+		PPid:       p.Ppid,
+		Cookie:     p.Cookie64,
+		IsThread:   p.IsThread,
+		IsExecExec: p.IsExecChild,
+		FileEvent:  *protoDecodeFileEvent(p.File),
+		TTYName:    p.Tty,
+		Comm:       p.Comm,
 
 		ForkTime: ProtoDecodeTimestamp(p.ForkTime),
 		ExitTime: ProtoDecodeTimestamp(p.ExitTime),

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
@@ -169,7 +169,6 @@ func processNodeToProto(p *model.Process) *adproto.ProcessInfo {
 		IsThread:    p.IsThread,
 		IsExecChild: p.IsExecExec,
 		File:        fileEventToProto(&p.FileEvent),
-		ContainerId: string(p.ContainerID),
 		Tty:         escape(p.TTYName),
 		Comm:        escape(p.Comm),
 

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -96,7 +96,7 @@ func assertTreeEqual(t *testing.T, wanted *ActivityTree, tree *ActivityTree) {
 type activityTreeInsertTestValidator struct{}
 
 func (a activityTreeInsertTestValidator) MatchesSelector(entry *model.ProcessCacheEntry) bool {
-	return entry.ContainerID == "123"
+	return entry.ContainerContext.ContainerID == "123"
 }
 
 func (a activityTreeInsertTestValidator) IsEventTypeValid(_ model.EventType) bool {
@@ -157,10 +157,9 @@ func newExecTestEventWithAncestors(lineage []model.Process) *model.Event {
 
 	evt := &model.Event{
 		BaseEvent: model.BaseEvent{
-			Type:             uint32(model.ExecEventType),
-			FieldHandlers:    &model.FakeFieldHandlers{},
-			ContainerContext: &model.ContainerContext{},
-			ProcessContext:   &model.ProcessContext{},
+			Type:           uint32(model.ExecEventType),
+			FieldHandlers:  &model.FakeFieldHandlers{},
+			ProcessContext: &model.ProcessContext{},
 			ProcessCacheEntry: &model.ProcessCacheEntry{
 				ProcessContext: model.ProcessContext{
 					Process:  lineageDup[0],
@@ -169,7 +168,6 @@ func newExecTestEventWithAncestors(lineage []model.Process) *model.Event {
 				},
 			},
 		},
-		CGroupContext: &model.CGroupContext{},
 		Exec: model.ExecEvent{
 			Process: &model.Process{},
 		},
@@ -191,7 +189,7 @@ func TestActivityTree_Patterns(t *testing.T) {
 
 		event := newExecTestEventWithAncestors([]model.Process{
 			{
-				ContainerID: "123",
+				ContainerContext: model.ContainerContext{ContainerID: "123"},
 				FileEvent: model.FileEvent{
 					PathnameStr: "/tmp/123456789/script.sh",
 					FileFields: model.FileFields{
@@ -223,7 +221,7 @@ func TestActivityTree_Patterns(t *testing.T) {
 		// add an event that generates a pattern
 		event = newExecTestEventWithAncestors([]model.Process{
 			{
-				ContainerID: "123",
+				ContainerContext: model.ContainerContext{ContainerID: "123"},
 				FileEvent: model.FileEvent{
 					PathnameStr: "/tmp/987654321/script.sh",
 					FileFields: model.FileFields{
@@ -266,7 +264,7 @@ func TestActivityTree_Patterns(t *testing.T) {
 
 		event := newExecTestEventWithAncestors([]model.Process{
 			{
-				ContainerID: "123",
+				ContainerContext: model.ContainerContext{ContainerID: "123"},
 				FileEvent: model.FileEvent{
 					PathnameStr: "/tmp/123456789/script.sh",
 					FileFields: model.FileFields{
@@ -298,7 +296,7 @@ func TestActivityTree_Patterns(t *testing.T) {
 		// add an event that generates a pattern
 		event = newExecTestEventWithAncestors([]model.Process{
 			{
-				ContainerID: "123",
+				ContainerContext: model.ContainerContext{ContainerID: "123"},
 				FileEvent: model.FileEvent{
 					PathnameStr: "/var/123456789/script.sh",
 					FileFields: model.FileFields{

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -27,7 +27,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe/procfs"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -134,12 +133,7 @@ func (pn *ProcessNode) addFiles(files []string, stats *Stats, newEvent func() *m
 		if evt.ProcessContext == nil {
 			evt.ProcessContext = &model.ProcessContext{}
 		}
-		if evt.ContainerContext == nil {
-			evt.ContainerContext = &model.ContainerContext{}
-		}
 		evt.ProcessContext.Process = pn.Process
-		evt.CGroupContext.CGroupID = containerutils.CGroupID(pn.Process.CGroup.CGroupID)
-		evt.ContainerContext.ContainerID = containerutils.ContainerID(pn.Process.ContainerID)
 
 		var fileStats unix.Statx_t
 		if err := unix.Statx(unix.AT_FDCWD, fullPath, 0, unix.STATX_ALL, &fileStats); err != nil {

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -98,7 +98,7 @@ func (ad *ActivityDump) MatchesSelector(entry *model.ProcessCacheEntry) bool {
 	}
 
 	if len(ad.Profile.Metadata.ContainerID) > 0 {
-		if ad.Profile.Metadata.ContainerID != entry.ContainerID {
+		if ad.Profile.Metadata.ContainerID != entry.ContainerContext.ContainerID {
 			return false
 		}
 	}

--- a/pkg/security/security_profile/manager_test.go
+++ b/pkg/security/security_profile/manager_test.go
@@ -992,17 +992,17 @@ type testIteration struct {
 func craftFakeEvent(t0 time.Time, ti *testIteration, defaultContainerID string) *model.Event {
 	event := model.NewFakeEvent()
 	event.Type = uint32(ti.eventType)
-	event.ContainerContext.CreatedAt = uint64(t0.Add(ti.containerCreatedAt).UnixNano())
 	event.TimestampRaw = uint64(t0.Add(ti.eventTimestampRaw).UnixNano())
 	event.Timestamp = t0.Add(ti.eventTimestampRaw)
 
 	// setting process
 	event.ProcessCacheEntry = model.NewPlaceholderProcessCacheEntry(42, 42, false)
-	event.ProcessCacheEntry.ContainerID = containerutils.ContainerID(defaultContainerID)
+	event.ProcessCacheEntry.ContainerContext.ContainerID = containerutils.ContainerID(defaultContainerID)
 	event.ProcessCacheEntry.FileEvent.PathnameStr = ti.eventProcessPath
 	event.ProcessCacheEntry.FileEvent.Inode = 42
 	event.ProcessCacheEntry.Args = "foo"
 	event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
+	event.ProcessContext.Process.ContainerContext.CreatedAt = uint64(t0.Add(ti.containerCreatedAt).UnixNano())
 	switch ti.eventType {
 	case model.ExecEventType:
 		event.Exec.Process = &event.ProcessCacheEntry.ProcessContext.Process
@@ -1052,6 +1052,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 			eventType:           model.ExecEventType,
 			eventProcessPath:    "/bin/foo0",
 		},
+
 		// and for dns:
 		{
 			name:                "warmup-dns/insert-dns-process",

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -648,7 +648,7 @@ func (p *Profile) MatchesSelector(entry *model.ProcessCacheEntry) bool {
 	for _, workload := range p.Instances {
 		// Check if the workload IDs match
 		workloadID := workload.GetWorkloadID()
-		if workloadID != nil && (workloadID == entry.ContainerID || workloadID == entry.CGroup.CGroupID) {
+		if workloadID != nil && (workloadID == entry.ContainerContext.ContainerID || workloadID == entry.CGroup.CGroupID) {
 			return true
 		}
 	}

--- a/pkg/security/security_profile/testing.go
+++ b/pkg/security/security_profile/testing.go
@@ -137,7 +137,7 @@ func (m *Manager) ClearTracedCgroups() {
 
 	// Walk through all process cache entries and blacklist their cgroups
 	m.resolvers.ProcessResolver.Walk(func(entry *model.ProcessCacheEntry) {
-		if entry.ContainerID != "" && !entry.CGroup.CGroupFile.IsNull() {
+		if entry.ContainerContext.ContainerID != "" && !entry.CGroup.CGroupFile.IsNull() {
 			if err := m.tracedCgroupsDiscardedMap.Put(entry.CGroup.CGroupFile.Inode, uint8(1)); err != nil {
 				if !errors.Is(err, ebpf.ErrKeyNotExist) {
 					seclog.Warnf("couldn't add system container cgroup to discarded map: %v", err)

--- a/pkg/security/security_profile/tests/activity_tree_test.go
+++ b/pkg/security/security_profile/tests/activity_tree_test.go
@@ -91,7 +91,7 @@ func matchResultTree(at *activity_tree.ActivityTree, toMatch map[string][]string
 func craftFakeProcess(containerID string, test *testIteration) *model.ProcessCacheEntry {
 	// setting process
 	process := model.NewPlaceholderProcessCacheEntry(42, 42, false)
-	process.ContainerID = containerutils.ContainerID(containerID)
+	process.ContainerContext.ContainerID = containerutils.ContainerID(containerID)
 	process.FileEvent.PathnameStr = test.processPath
 	process.FileEvent.BasenameStr = filepath.Base(test.processPath)
 	process.Argv0 = filepath.Base(test.processPath)
@@ -106,7 +106,7 @@ func craftFakeProcess(containerID string, test *testIteration) *model.ProcessCac
 
 	// setting process ancestor
 	process.Ancestor = model.NewPlaceholderProcessCacheEntry(41, 41, false)
-	process.Ancestor.ContainerID = containerutils.ContainerID(containerID)
+	process.Ancestor.ContainerContext.ContainerID = containerutils.ContainerID(containerID)
 	process.Ancestor.FileEvent.PathnameStr = test.parentProcessPath
 	process.Ancestor.FileEvent.BasenameStr = filepath.Base(test.parentProcessPath)
 	process.Ancestor.Argv0 = filepath.Base(test.parentProcessPath)
@@ -133,7 +133,7 @@ func craftFakeProcess(containerID string, test *testIteration) *model.ProcessCac
 	process.Ancestor.Ancestor.FileEvent.PathnameStr = "/usr/bin/systemd"
 	process.Ancestor.Ancestor.FileEvent.BasenameStr = "systemd"
 	if test.granpaInsideContainer {
-		process.Ancestor.Ancestor.ContainerID = containerutils.ContainerID(containerID)
+		process.Ancestor.Ancestor.ContainerContext.ContainerID = containerutils.ContainerID(containerID)
 	}
 	process.Ancestor.Ancestor.FileEvent.Inode = 40
 	process.Ancestor.Ancestor.FileEvent.MountID = 40

--- a/pkg/security/serializers/deserializers.go
+++ b/pkg/security/serializers/deserializers.go
@@ -81,7 +81,7 @@ func newProcess(ps *ProcessSerializer) model.Process {
 		p.ExitTime = ps.ExitTime.GetInnerTime()
 	}
 	if ps.Container != nil {
-		p.ContainerID = containerutils.ContainerID(ps.Container.ID)
+		p.ContainerContext.ContainerID = containerutils.ContainerID(ps.Container.ID)
 	}
 
 	// TODO: credentials
@@ -103,9 +103,8 @@ func UnmarshalEvent(raw []byte) (*model.Event, error) {
 	process := newProcess(rawEvent.ProcessContextSerializer.ProcessSerializer)
 	event := model.Event{
 		BaseEvent: model.BaseEvent{
-			Type:             uint32(model.ExecEventType),
-			FieldHandlers:    &model.FakeFieldHandlers{},
-			ContainerContext: &model.ContainerContext{},
+			Type:          uint32(model.ExecEventType),
+			FieldHandlers: &model.FakeFieldHandlers{},
 			ProcessContext: &model.ProcessContext{
 				Process:  process,
 				Parent:   &parent,

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -948,10 +948,10 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 			}
 		}
 
-		if len(ps.ContainerID) != 0 {
+		if len(ps.ContainerContext.ContainerID) != 0 {
 			psSerializer.Container = &ContainerContextSerializer{
-				ID:        string(ps.ContainerID),
-				CreatedAt: utils.NewEasyjsonTimeIfNotZero(time.Unix(0, int64(e.GetContainerCreatedAt()))),
+				ID:        string(ps.ContainerContext.ContainerID),
+				CreatedAt: utils.NewEasyjsonTimeIfNotZero(time.Unix(0, int64(e.ProcessContext.ContainerContext.CreatedAt))),
 			}
 		}
 
@@ -1081,9 +1081,6 @@ func newPTraceEventSerializer(e *model.Event) *PTraceEventSerializer {
 		BaseEvent: model.BaseEvent{
 			FieldHandlers:  e.FieldHandlers,
 			ProcessContext: e.PTrace.Tracee,
-			ContainerContext: &model.ContainerContext{
-				ContainerID: e.PTrace.Tracee.ContainerID,
-			},
 		},
 	}
 
@@ -1486,9 +1483,9 @@ func NewEventSerializer(event *model.Event, rule *rules.Rule) *EventSerializer {
 		}
 	}
 
-	if cgroupID := event.FieldHandlers.ResolveCGroupID(event, event.CGroupContext); cgroupID != "" {
+	if cgroupID := event.FieldHandlers.ResolveCGroupID(event, &event.ProcessContext.CGroup); cgroupID != "" {
 		s.CGroupContextSerializer = &CGroupContextSerializer{
-			ID:        string(event.CGroupContext.CGroupID),
+			ID:        string(event.ProcessContext.CGroup.CGroupID),
 			Variables: newVariablesContext(event, rule, eval.CGroupScoperType),
 		}
 	}

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -163,9 +163,9 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 		User:       e.FieldHandlers.ResolveUser(e, ps),
 	}
 
-	if len(ps.ContainerID) != 0 {
+	if len(ps.ContainerContext.ContainerID) != 0 {
 		psSerializer.Container = &ContainerContextSerializer{
-			ID: ps.ContainerID,
+			ID: string(ps.ContainerContext.ContainerID),
 		}
 	}
 	return psSerializer

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -542,7 +542,7 @@ func TestActionKillDisarm(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "kill_action_disarm_executable",
-			Expression: `exec.envs in ["TARGETTOKILL"] && container.id == ""`,
+			Expression: `exec.envs in ["TARGETTOKILL"] && process.container.id == ""`,
 			Actions: []*rules.ActionDefinition{
 				{
 					Kill: &rules.KillDefinition{
@@ -553,7 +553,7 @@ func TestActionKillDisarm(t *testing.T) {
 		},
 		{
 			ID:         "kill_action_disarm_container",
-			Expression: `exec.envs in ["TARGETTOKILL"] && container.id != ""`,
+			Expression: `exec.envs in ["TARGETTOKILL"] && process.container.id != ""`,
 			Actions: []*rules.ActionDefinition{
 				{
 					Kill: &rules.KillDefinition{

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -641,7 +641,7 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
-			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
+			if event.ProcessContext.Process.ContainerContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
 				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
@@ -660,7 +660,7 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
-			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
+			if event.ProcessContext.Process.ContainerContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
 				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
@@ -750,7 +750,7 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 			_, err := cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
-			if event.ProcessContext.ContainerID == containerutils.ContainerID(dockerInstance2.containerID) {
+			if event.ProcessContext.Process.ContainerContext.ContainerID == containerutils.ContainerID(dockerInstance2.containerID) {
 				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
@@ -769,7 +769,7 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
-			if event.ProcessContext.ContainerID == containerutils.ContainerID(dockerInstance2.containerID) {
+			if event.ProcessContext.Process.ContainerContext.ContainerID == containerutils.ContainerID(dockerInstance2.containerID) {
 				t.Error("Got a signal that should have been suppressed")
 			}
 			return false

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -99,11 +99,11 @@ func TestCGroup(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_cgroup_id",
-			Expression: `open.file.path == "{{.Root}}/test-open" && cgroup.id =~ "*/cg1"`,
+			Expression: `open.file.path == "{{.Root}}/test-open" && process.cgroup.id =~ "*/cg1"`,
 		},
 		{
 			ID:         "test_cgroup_systemd",
-			Expression: `open.file.path == "{{.Root}}/test-open2" && cgroup.id == "/system.slice/cws-test.service"`,
+			Expression: `open.file.path == "{{.Root}}/test-open2" && process.cgroup.id == "/system.slice/cws-test.service"`,
 		},
 	}
 	test, err := newTestModule(t, nil, ruleDefs)
@@ -148,9 +148,9 @@ func TestCGroup(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_cgroup_id")
 			assertFieldEqual(t, event, "open.file.path", testFile)
-			assertFieldEqual(t, event, "container.id", "")
-			assertFieldIsOneOf(t, event, "cgroup.id", []string{"/cg1", "/systemd/cg1"})
-			assertFieldIsOneOf(t, event, "cgroup.version", []int{1, 2})
+			assertFieldEqual(t, event, "process.container.id", "")
+			assertFieldIsOneOf(t, event, "process.cgroup.id", []string{"/cg1", "/systemd/cg1"})
+			assertFieldIsOneOf(t, event, "process.cgroup.version", []int{1, 2})
 
 			test.validateOpenSchema(t, event)
 		})
@@ -189,7 +189,7 @@ ExecStart=/usr/bin/touch %s`, testFile2)
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_cgroup_systemd")
 			assertFieldEqual(t, event, "open.file.path", testFile2)
-			assertFieldNotEqual(t, event, "cgroup.id", "")
+			assertFieldNotEqual(t, event, "process.cgroup.id", "")
 
 			test.validateOpenSchema(t, event)
 		})
@@ -238,7 +238,7 @@ func TestCGroupSnapshot(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_cgroup_snapshot",
-			Expression: `open.file.path == "{{.Root}}/test-open" && cgroup.id != ""`,
+			Expression: `open.file.path == "{{.Root}}/test-open" && process.cgroup.id != ""`,
 		},
 	}
 
@@ -341,7 +341,7 @@ func TestCGroupVariables(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_cgroup_set_variable",
-			Expression: `cgroup.id != "" && open.file.path == "{{.Root}}/test-open"`,
+			Expression: `process.cgroup.id != "" && open.file.path == "{{.Root}}/test-open"`,
 			Actions: []*rules.ActionDefinition{
 				{
 					Set: &rules.SetDefinition{
@@ -354,7 +354,7 @@ func TestCGroupVariables(t *testing.T) {
 		},
 		{
 			ID:         "test_cgroup_check_variable",
-			Expression: `cgroup.id != "" && open.file.path == "{{.Root}}/test-open2" && ${cgroup.foo} == 1`,
+			Expression: `process.cgroup.id != "" && open.file.path == "{{.Root}}/test-open2" && ${cgroup.foo} == 1`,
 		},
 	}
 
@@ -386,7 +386,7 @@ func TestCGroupVariables(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_cgroup_set_variable")
 			assertFieldEqual(t, event, "open.file.path", testFile)
-			assertFieldNotEmpty(t, event, "cgroup.id", "cgroup id shouldn't be empty")
+			assertFieldNotEmpty(t, event, "process.cgroup.id", "cgroup id shouldn't be empty")
 
 			test.validateOpenSchema(t, event)
 		})
@@ -397,7 +397,7 @@ func TestCGroupVariables(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_cgroup_check_variable")
 			assertFieldEqual(t, event, "open.file.path", testFile2)
-			assertFieldNotEmpty(t, event, "cgroup.id", "cgroup id shouldn't be empty")
+			assertFieldNotEmpty(t, event, "process.cgroup.id", "cgroup id shouldn't be empty")
 
 			test.validateOpenSchema(t, event)
 		})

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -35,11 +35,11 @@ func TestContainerCreatedAt(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_container_created_at",
-			Expression: `container.id != "" && container.created_at < 3s && open.file.path == "{{.Root}}/test-open"`,
+			Expression: `process.container.id != "" && container.created_at < 3s && open.file.path == "{{.Root}}/test-open"`,
 		},
 		{
 			ID:         "test_container_created_at_delay",
-			Expression: `container.id != "" && container.created_at > 3s && open.file.path == "{{.Root}}/test-open-delay"`,
+			Expression: `process.container.id != "" && container.created_at > 3s && open.file.path == "{{.Root}}/test-open-delay"`,
 		},
 	}
 	test, err := newTestModule(t, nil, ruleDefs)
@@ -70,7 +70,7 @@ func TestContainerCreatedAt(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_container_created_at")
 			assertFieldEqual(t, event, "open.file.path", testFile)
-			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
+			assertFieldNotEmpty(t, event, "process.container.id", "container id shouldn't be empty")
 
 			test.validateOpenSchema(t, event)
 		})
@@ -88,8 +88,8 @@ func TestContainerCreatedAt(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_container_created_at_delay")
 			assertFieldEqual(t, event, "open.file.path", testFileDelay)
-			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
-			createdAtNano, _ := event.GetFieldValue("container.created_at")
+			assertFieldNotEmpty(t, event, "process.container.id", "container id shouldn't be empty")
+			createdAtNano, _ := event.GetFieldValue("process.container.created_at")
 			createdAt := time.Unix(0, int64(createdAtNano.(int)))
 			assert.True(t, time.Since(createdAt) > 3*time.Second)
 
@@ -108,7 +108,7 @@ func TestContainerVariables(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_container_set_variable",
-			Expression: `container.id != "" && open.file.path == "{{.Root}}/test-open"`,
+			Expression: `process.container.id != "" && open.file.path == "{{.Root}}/test-open"`,
 			Actions: []*rules.ActionDefinition{
 				{
 					Set: &rules.SetDefinition{
@@ -121,7 +121,7 @@ func TestContainerVariables(t *testing.T) {
 		},
 		{
 			ID:         "test_container_check_variable",
-			Expression: `container.id != "" && open.file.path == "{{.Root}}/test-open2" && ${container.foo} == 1`,
+			Expression: `process.container.id != "" && open.file.path == "{{.Root}}/test-open2" && ${container.foo} == 1`,
 		},
 	}
 	test, err := newTestModule(t, nil, ruleDefs)
@@ -152,7 +152,7 @@ func TestContainerVariables(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_container_set_variable")
 			assertFieldEqual(t, event, "open.file.path", testFile)
-			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
+			assertFieldNotEmpty(t, event, "process.container.id", "container id shouldn't be empty")
 
 			test.validateOpenSchema(t, event)
 		})
@@ -163,7 +163,7 @@ func TestContainerVariables(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_container_check_variable")
 			assertFieldEqual(t, event, "open.file.path", testFile2)
-			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
+			assertFieldNotEmpty(t, event, "process.container.id", "container id shouldn't be empty")
 
 			test.validateOpenSchema(t, event)
 		})

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -430,7 +430,7 @@ func TestMountEvent(t *testing.T) {
 		},
 		{
 			ID:         "test_mount_in_container_root",
-			Expression: `mount.mountpoint.path == "/host_root" && mount.source.path == "/" && mount.fs_type != "overlay" && container.id != ""`,
+			Expression: `mount.mountpoint.path == "/host_root" && mount.source.path == "/" && mount.fs_type != "overlay" && process.container.id != ""`,
 		},
 	}
 
@@ -542,7 +542,7 @@ func TestMountEvent(t *testing.T) {
 			assertFieldEqual(t, event, "mount.mountpoint.path", "/host_root")
 			assertFieldEqual(t, event, "mount.source.path", "/")
 			assertFieldNotEqual(t, event, "mount.fs_type", "overlay")
-			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
+			assertFieldNotEmpty(t, event, "process.container.id", "container id shouldn't be empty")
 
 			test.validateMountSchema(t, event)
 			validateSyscallContext(t, event, "$.syscall.mount.path")

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -666,7 +666,7 @@ func TestOverlayOpOverride(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_open")
 			assertFieldEqual(t, event, "open.file.path", "/tmp/target.txt")
-			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
+			assertFieldNotEmpty(t, event, "process.container.id", "container id shouldn't be empty")
 		})
 	})
 
@@ -680,7 +680,7 @@ func TestOverlayOpOverride(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_open")
 			assertFieldEqual(t, event, "open.file.path", openTargetFromOverlayMnt)
-			assertFieldEqual(t, event, "container.id", "", "container id should be empty")
+			assertFieldEqual(t, event, "process.container.id", "", "container id should be empty")
 		})
 	})
 
@@ -694,7 +694,7 @@ func TestOverlayOpOverride(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_mkdir")
 			assertFieldEqual(t, event, "mkdir.file.path", mkdirTargetFromOverlayMnt)
-			assertFieldEqual(t, event, "container.id", "", "container id should be empty")
+			assertFieldEqual(t, event, "process.container.id", "", "container id should be empty")
 		})
 	})
 }

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1024,9 +1024,9 @@ func TestProcessContext(t *testing.T) {
 			assert.Equal(t, "test_rule_container", rule.ID, "wrong rule triggered")
 
 			if kind == dockerWrapperType {
-				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessContext.ContainerID)
-				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessContext.Ancestor.ContainerID)
-				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessContext.Parent.ContainerID)
+				assert.Equal(t, event.Exec.Process.ContainerContext.ContainerID, event.ProcessContext.Process.ContainerContext.ContainerID)
+				assert.Equal(t, event.Exec.Process.ContainerContext.ContainerID, event.ProcessContext.Ancestor.ContainerContext.ContainerID)
+				assert.Equal(t, event.Exec.Process.ContainerContext.ContainerID, event.ProcessContext.Parent.ContainerContext.ContainerID)
 			}
 		}))
 	})
@@ -2318,7 +2318,7 @@ func TestProcessResolution(t *testing.T) {
 			assert.Equal(t, entry1.FileEvent.PathnameStr, entry2.FileEvent.PathnameStr)
 			assert.Equal(t, entry1.Pid, entry2.Pid)
 			assert.Equal(t, entry1.PPid, entry2.PPid)
-			assert.Equal(t, entry1.ContainerID, entry2.ContainerID)
+			assert.Equal(t, entry1.ProcessContext.Process.ContainerContext.ContainerID, entry2.ProcessContext.Process.ContainerContext.ContainerID)
 			if checkCookie {
 				assert.Equal(t, entry1.Cookie, entry2.Cookie)
 			}

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -43,12 +43,12 @@ func TestSBOM(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID: "test_file_package",
-			Expression: `open.file.path == "/usr/lib/os-release" && (open.flags & O_CREAT != 0) && (container.id != "") ` +
+			Expression: `open.file.path == "/usr/lib/os-release" && (open.flags & O_CREAT != 0) && (process.container.id != "") ` +
 				`&& open.file.package.name == "base-files" && process.file.path != "" && process.file.package.name == "coreutils"`,
 		},
 		{
 			ID: "test_host_file_package",
-			Expression: `open.file.path == "/usr/lib/os-release" && (open.flags & O_CREAT != 0) && (container.id == "") ` +
+			Expression: `open.file.path == "/usr/lib/os-release" && (open.flags & O_CREAT != 0) && (process.container.id == "") ` +
 				`&& process.file.path != "" && process.file.package.name == "coreutils"`,
 		},
 	}
@@ -86,7 +86,7 @@ func TestSBOM(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_file_package")
 			assertFieldEqual(t, event, "open.file.package.name", "base-files")
 			assertFieldEqual(t, event, "process.file.package.name", "coreutils")
-			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
+			assertFieldNotEmpty(t, event, "process.container.id", "container id shouldn't be empty")
 
 			test.validateOpenSchema(t, event)
 		})
@@ -103,7 +103,7 @@ func TestSBOM(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_host_file_package")
 			assertFieldEqual(t, event, "process.file.package.name", "coreutils")
-			assertFieldEqual(t, event, "container.id", "", "container id should be empty")
+			assertFieldEqual(t, event, "process.container.id", "", "container id should be empty")
 
 			if kv.IsUbuntuKernel() || kv.IsDebianKernel() {
 				checkVersionAgainstApt(t, event, "coreutils")

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -854,7 +854,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
-			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
+			if event.ProcessContext.Process.ContainerContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
 				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
@@ -873,7 +873,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
-			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
+			if event.ProcessContext.Process.ContainerContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
 				t.Error("Got a signal that should have been suppressed")
 			}
 			return false

--- a/pkg/security/tests/snapshot_test.go
+++ b/pkg/security/tests/snapshot_test.go
@@ -64,7 +64,7 @@ func TestSnapshot(t *testing.T) {
 		ruleDefs := []*rules.RuleDefinition{
 			{
 				ID:         "test_rule_snapshot_container",
-				Expression: `exec.comm in ["sleep"] && process.argv in ["123"] && container.id != ""`,
+				Expression: `exec.comm in ["sleep"] && process.argv in ["123"] && process.container.id != ""`,
 			},
 		}
 


### PR DESCRIPTION
### What does this PR do?

It removes container/cgroup context/ids at root of events (for both unix/windows).

It was misleading and error prone as it's copied from the process context ones, which is the only source of truth and is now used broadly.

Backward compatibility is preserved (but old fields are not longer documented)

### Motivation

Cleanup cgroup/container usage and prepare upcoming other reworks for them

### Describe how you validated your changes

Unitary/Functional tests

### Additional Notes
