### PR TITLE
[CWS] fix touch usage in TestActionHash for ubuntu 25.10

### DIFF
--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -605,7 +605,7 @@ func TestActionHash(t *testing.T) {
 		},
 		{
 			ID:         "hash_action_exec",
-			Expression: `exec.file.path == "{{.Root}}/test-hash-action-exec"`,
+			Expression: `exec.file.path == "{{.Root}}/test-hash-action-exec_touch"`,
 			Actions: []*rules.ActionDefinition{
 				{
 					Hash: &rules.HashDefinition{},
@@ -625,7 +625,10 @@ func TestActionHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testExecutable, _, err := test.Path("test-hash-action-exec")
+	// it's important that this ends with `touch` because for example ubuntu 25.10
+	// uses the suffix to know which "function/utility" is running
+	// https://github.com/uutils/coreutils/blob/909da503713f39f8e36b1ff077841c9cc13d920b/src/bin/coreutils.rs#L60
+	testExecutable, _, err := test.Path("test-hash-action-exec_touch")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -740,7 +740,12 @@ func TestActionHash(t *testing.T) {
 	t.Run("exec", func(t *testing.T) {
 		test.msgSender.flush()
 		test.WaitSignal(t, func() error {
-			return exec.Command(testExecutable, "/tmp/aaa").Run()
+			cmd := exec.Command(testExecutable, "/tmp/aaa")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Logf("output: %s", string(out))
+			}
+			return err
 		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "hash_action_exec")
 		})


### PR DESCRIPTION
### What does this PR do?

Copying the `touch` binary with a name that doesn't end with `touch` doesn't work anymore on ubuntu 25.10 because of the switch to uutils (coreutils written in rust, https://www.phoronix.com/news/Rust-Coreutils-Release-Pocket). This PR fixes this, and also improves the error reporting when the execution fails.

### Motivation

### Describe how you validated your changes

### Additional Notes
