### PR TITLE
[NCM] Add Cisco IOS profile + `default_profiles` directory for core check

### DIFF
--- a/cmd/agent/dist/conf.d/network_config_management.d/default_profiles/cisco-ios.json
+++ b/cmd/agent/dist/conf.d/network_config_management.d/default_profiles/cisco-ios.json
@@ -1,0 +1,264 @@
+{
+  "commands": [
+    {
+      "type": "running",
+      "values": [
+        "show running-config"
+      ],
+      "processing_rules": {
+        "metadata": [
+          {
+            "type": "timestamp",
+            "regex": "! Last configuration change at ([^\r\n]+)",
+            "format": "15:04:05 MST Mon Jan 2 2006"
+          },
+          {
+            "type": "config_size",
+            "regex": "Current configuration : (?P<Size>\\d+)"
+          }
+        ],
+        "validation": [
+          {
+            "type": "valid_output",
+            "pattern": "Building configuration..."
+          }
+        ],
+        "redaction": [
+          {
+            "regex": "(?m)^(snmp-server community).*",
+            "replacement": "$1 <configuration removed>"
+          },
+          {
+            "regex": "(?m)^(snmp-server host \\S+( vrf \\S+)?( informs?)?( version (1|2c))?) +\\S+( .*)?$",
+            "replacement": "$1 <secret hidden>$6"
+          },
+          {
+            "regex": "(?m)^(username .+ (password|secret) \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(enable (password|secret)( level \\d+)? \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +(?:password|secret)) (?:\\d )?\\S+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(.*wpa-psk ascii \\d) (\\S+)",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(.*key 7) (\\d.+)",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(tacacs-server (.+ )?key) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(crypto isakmp key) (\\S+) (.*)",
+            "replacement": "$1 <secret hidden> $3"
+          },
+          {
+            "regex": "(?m)^( +ip ospf message-digest-key \\d+ md5) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +ip ospf authentication-key) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +neighbor \\S+ password) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +vrrp \\d+ authentication text) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +standby \\d+ authentication) .{1,8}$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +standby \\d+ authentication md5 key-string) .+?( timeout \\d+)?$",
+            "replacement": "$1 <secret hidden> $2"
+          },
+          {
+            "regex": "(?m)^( +key-string) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^((tacacs|radius) server [^\\n]+\\n( +[^\\n]+\\n)* +key) [^\\n]+$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +ppp (chap|pap) password \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +security wpa psk set-key (?:ascii|hex) \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +dot1x username \\S+ password \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +mgmtuser username \\S+ password \\d) (.*) (secret \\d) (.*)$",
+            "replacement": "$1 <secret hidden> $3 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +client \\S+ server-key \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +domain-password) \\S+ ?(.*)",
+            "replacement": "$1 <secret hidden> $2"
+          },
+          {
+            "regex": "(?m)^( +pre-shared-key).*",
+            "replacement": "$1 <configuration removed>"
+          },
+          {
+            "regex": "(?m)^(.*server-key(?: \\d)?) \\S+",
+            "replacement": "$1 <secret hidden>"
+          }
+        ]
+      }
+    },
+    {
+      "type": "startup",
+      "values": [
+        "show startup-config"
+      ],
+      "processing_rules": {
+        "metadata": [
+          {
+            "type": "timestamp",
+            "regex": "! Last configuration change at ([^\r\n]+)",
+            "format": "15:04:05 MST Mon Jan 2 2006"
+          },
+          {
+            "type": "config_size",
+            "regex": "Current configuration : (?P<Size>\\d+)"
+          }
+        ],
+        "validation": [
+          {
+            "type": "valid_output",
+            "pattern": "Building configuration..."
+          }
+        ],
+        "redaction": [
+          {
+            "regex": "(?m)^(snmp-server community).*",
+            "replacement": "$1 <configuration removed>"
+          },
+          {
+            "regex": "(?m)^(snmp-server host \\S+( vrf \\S+)?( informs?)?( version (1|2c))?) +\\S+( .*)?$",
+            "replacement": "$1 <secret hidden>$6"
+          },
+          {
+            "regex": "(?m)^(username .+ (password|secret) \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(enable (password|secret)( level \\d+)? \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +(?:password|secret)) (?:\\d )?\\S+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(.*wpa-psk ascii \\d) (\\S+)",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(.*key 7) (\\d.+)",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(tacacs-server (.+ )?key) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^(crypto isakmp key) (\\S+) (.*)",
+            "replacement": "$1 <secret hidden> $3"
+          },
+          {
+            "regex": "(?m)^( +ip ospf message-digest-key \\d+ md5) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +ip ospf authentication-key) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +neighbor \\S+ password) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +vrrp \\d+ authentication text) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +standby \\d+ authentication) .{1,8}$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +standby \\d+ authentication md5 key-string) .+?( timeout \\d+)?$",
+            "replacement": "$1 <secret hidden> $2"
+          },
+          {
+            "regex": "(?m)^( +key-string) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^((tacacs|radius) server [^\\n]+\\n( +[^\\n]+\\n)* +key) [^\\n]+$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +ppp (chap|pap) password \\d) .+",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +security wpa psk set-key (?:ascii|hex) \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +dot1x username \\S+ password \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +mgmtuser username \\S+ password \\d) (.*) (secret \\d) (.*)$",
+            "replacement": "$1 <secret hidden> $3 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +client \\S+ server-key \\d) (.*)$",
+            "replacement": "$1 <secret hidden>"
+          },
+          {
+            "regex": "(?m)^( +domain-password) \\S+ ?(.*)",
+            "replacement": "$1 <secret hidden> $2"
+          },
+          {
+            "regex": "(?m)^( +pre-shared-key).*",
+            "replacement": "$1 <configuration removed>"
+          },
+          {
+            "regex": "(?m)^(.*server-key(?: \\d)?) \\S+",
+            "replacement": "$1 <secret hidden>"
+          }
+        ]
+      }
+    },
+    {
+      "type": "version",
+      "values": [
+        "show version"
+      ]
+    }
+  ]
+}

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -86,6 +86,7 @@ AGENT_CORECHECKS = [
     "wlan",
     "discovery",
     "versa",
+    "network_config_management",
 ]
 
 WINDOWS_CORECHECKS = [


### PR DESCRIPTION
### What does this PR do?
This PR is:
* Adding a directory for the `network_config_management` core check to store `default_profiles` representing commands to communicate w/ a network device + how to process the output
  * More detail and context can be seen [here](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5314904489/Sub-RFC+Ingestion+Generic+retrieval+of+configs#:Vending_Machine:-Multi-vendor/device-support) for device profiles, [here](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5182783901/RFC+s+Network+Configuration+Management?focusedCommentId=5187731849) for the NCM feature
* I believe for the directory to be copied to the build, it must be added as an `AGENT_CORECHECK`

### Motivation

### Describe how you validated your changes


Pull in the ndm-tools/cml-qa repo and follow instructions for setting up the CLI ([link](https://github.com/DataDog/ndm-tools/tree/main/cml-qa))
```
python cml_template_generator.py \
  --deb-url <INSERT THE DEB FROM CI/CD BUILD> \
  --api-key <INSERT YOUR KEY> \
  --site "datad0g.com" \
  --title "<YOUR NAME/TITLE> NCM Agent QA"
```
* Go the NDM hosted CML ([docs](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5061640281/Getting+Started+with+Cisco+Modeling+Labs+CML))
* Press Import
* Pull in the YAML that gets created, start the lab

```
sudo -u dd-agent -- datadog-agent check network_config_management
{"namespace":"cml-test","integration":"","configs":[{"device_id":"cml-test:10.10.1.1","device_ip":"10.10.1.1","config_type":"running","timestamp":0,"tags":["device_ip:10.10.1.1"],"content":"redacted"}],"collect_timestamp":1761246610}


  Running Checks
  ==============
    
    network_config_management
    -------------------------
      Instance ID: network_config_management:bd436a37500d07da [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/network_config_management.d/conf.yaml[0]
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      ndmconfig: Last Run: 1, Total: 1
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 1.855s
      Last Execution Date : 2025-10-23 19:10:11.035 UTC (1761246611035)
      Last Successful Execution Date : 2025-10-23 19:10:11 UTC (1761246611000)
      
  Check Worker Utilization
  ========================
    No worker utilization data available

  Metadata
  ========
    config.hash: network_config_management:bd436a37500d07da
    config.provider: file
    config.source: /etc/datadog-agent/conf.d/network_config_management.d/conf.yaml[0]
```



### Additional Notes
