### PR TITLE
kmt: add ubuntu 25 images

### DIFF
--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -273,6 +273,17 @@
       "os_version": "8.4",
       "image": "rocky-8.4-x86_64.qcow2.xz",
       "image_version": "20250320_7cf8bbf7"
+    },
+    "ubuntu_25.04": {
+      "image": "ubuntu-25.04-x86_64.qcow2.xz",
+      "image_version": "20251020_18933692",
+      "os_name": "Ubuntu",
+      "os_id": "ubuntu",
+      "kernel": "6.14.0-33-generic",
+      "os_version": "25.04",
+      "alt_version_names": [
+        "plucky"
+      ]
     }
   },
   "arm64": {
@@ -510,6 +521,17 @@
       "os_version": "9.4",
       "image": "rocky-9.4-arm64.qcow2.xz",
       "image_version": "20241209_f6a14db0"
+    },
+    "ubuntu_25.04": {
+      "image": "ubuntu-25.04-arm64.qcow2.xz",
+      "image_version": "20251020_18933692",
+      "os_name": "Ubuntu",
+      "os_id": "ubuntu",
+      "kernel": "6.14.0-33-generic",
+      "os_version": "25.04",
+      "alt_version_names": [
+        "plucky"
+      ]
     }
   }
 }

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -284,6 +284,17 @@
       "alt_version_names": [
         "plucky"
       ]
+    },
+    "ubuntu_25.10": {
+      "image": "ubuntu-25.10-x86_64.qcow2.xz",
+      "image_version": "20251024_ac38a07f",
+      "os_name": "Ubuntu",
+      "os_id": "ubuntu",
+      "kernel": "6.17.0-5-generic",
+      "os_version": "25.10",
+      "alt_version_names": [
+        "questing"
+      ]
     }
   },
   "arm64": {
@@ -531,6 +542,17 @@
       "os_version": "25.04",
       "alt_version_names": [
         "plucky"
+      ]
+    },
+    "ubuntu_25.10": {
+      "image": "ubuntu-25.10-arm64.qcow2.xz",
+      "image_version": "20251024_ac38a07f",
+      "os_name": "Ubuntu",
+      "os_id": "ubuntu",
+      "kernel": "6.17.0-5-generic",
+      "os_version": "25.10",
+      "alt_version_names": [
+        "questing"
       ]
     }
   }


### PR DESCRIPTION
### What does this PR do?

Adds Ubuntu 25.04 and 25.10 images to KMT. They are not used by default until failing tests are fixed by various teams.

### Motivation

Updated kernel version testing

### Describe how you validated your changes

### Additional Notes

Ubuntu 25.10 will be updated to the `master` version before merge, once the image PR is approved and merged.
