### PR TITLE
dyninst/ir: remove EventID

### DIFF
--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -17,10 +17,6 @@ type ProgramID uint32
 // TypeID is a ID corresponding to a type in a program.
 type TypeID uint32
 
-// EventID is a ID corresponding to an event output by the program.  It is used
-// to identify events as they are communicated over the ring buffer.
-type EventID uint32
-
 // SubprogramID is a ID corresponding to a subprogram in a program.
 type SubprogramID uint32
 
@@ -157,9 +153,6 @@ type Probe struct {
 
 // Event corresponds to an action that will occur when a PC is hit.
 type Event struct {
-	// ID of the event. This is used to identify data produced by the event over
-	// the ring buffer.
-	ID EventID
 	// Kind is the kind of event.
 	Kind EventKind
 	// SourceLine for line events, empty otherwise.

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -879,10 +879,9 @@ func createProbes(
 	skipReturnEvents bool,
 ) ([]*ir.Probe, []*ir.Subprogram, []ir.ProbeIssue, error) {
 	var (
-		probes       []*ir.Probe
-		subprograms  []*ir.Subprogram
-		issues       []ir.ProbeIssue
-		eventIDAlloc idAllocator[ir.EventID]
+		probes      []*ir.Probe
+		subprograms []*ir.Subprogram
+		issues      []ir.ProbeIssue
 	)
 
 	for _, p := range pending {
@@ -897,8 +896,7 @@ func createProbes(
 		var haveProbe bool
 		for _, cfg := range p.probesCfgs {
 			probe, iss, err := newProbe(
-				arch, cfg, sp, &eventIDAlloc, lineData, textSection,
-				skipReturnEvents,
+				arch, cfg, sp, lineData, textSection, skipReturnEvents,
 			)
 			if err != nil {
 				return nil, nil, nil, err
@@ -2279,7 +2277,6 @@ func newProbe(
 	arch object.Architecture,
 	probeCfg ir.ProbeDefinition,
 	subprogram *ir.Subprogram,
-	eventIDAlloc *idAllocator[ir.EventID],
 	lineData map[ir.PCRange]lineData,
 	textSection *section,
 	skipReturnEvents bool,
@@ -2304,7 +2301,6 @@ func newProbe(
 		var issue ir.Issue
 		var err error
 		injectionPoints, returnEvent, issue, err = pickInjectionPoint(
-			eventIDAlloc,
 			subprogram.Name,
 			subprogram.OutOfLinePCRanges,
 			subprogram.OutOfLinePCRanges,
@@ -2324,7 +2320,6 @@ func newProbe(
 		var issue ir.Issue
 		var err error
 		injectionPoints, _, issue, err = pickInjectionPoint(
-			eventIDAlloc,
 			subprogram.Name,
 			inlined.Ranges,
 			inlined.RootRanges,
@@ -2354,7 +2349,6 @@ func newProbe(
 	}
 	events := []*ir.Event{
 		{
-			ID:              eventIDAlloc.next(),
 			InjectionPoints: injectionPoints,
 			Condition:       nil,
 			Kind:            eventKind,
@@ -2379,7 +2373,6 @@ func newProbe(
 // Returns a list of injection points for a given probe, as well as optional
 // return event, if required.
 func pickInjectionPoint(
-	eventIDAlloc *idAllocator[ir.EventID],
 	subprogramName string,
 	ranges []ir.PCRange,
 	rootRanges []ir.PCRange,
@@ -2457,7 +2450,6 @@ func pickInjectionPoint(
 			})
 			if hasAssociatedReturn {
 				returnEvent = &ir.Event{
-					ID:              eventIDAlloc.next(),
 					InjectionPoints: returnLocations,
 					Kind:            ir.EventKindReturn,
 					Type:            nil,

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -9,8 +9,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 105 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4a5f60", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
@@ -9,8 +9,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 110 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4a7fe0", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
@@ -9,8 +9,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 115 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4ae5e0", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -9,8 +9,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 106 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb5290", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
@@ -9,8 +9,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 111 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb5170", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
@@ -9,8 +9,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 116 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb7d10", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 105 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4a804e", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 106 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4a80f2", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 110 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4aa26e", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 111 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4aa312", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 115 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4b094e", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 116 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4b09f2", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 106 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xb7508", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 107 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xb7588", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 111 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xb7538", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 112 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xb75b8", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 116 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xba068", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 117 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xba0dc", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 234 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 235 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd59a14"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 236 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 237 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd59bbd", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 268 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd315af"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 269 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 270 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3175d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 272 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 273 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd3658f"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 274 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 275 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3673d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 234 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff50", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 235 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8e0124"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 236 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e0268", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 237 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8e02dc", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0cb0", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 268 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8a0e80"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 269 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0fa8", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 270 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8a101c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 272 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859990", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 273 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x859b34"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 274 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c68", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 275 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x859cd0", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 199 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd28c4b"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 200 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 201 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd28dfd", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 211 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 212 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xcfc8ab"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 213 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 214 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xcfca5d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 216 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 217 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd050cb"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 218 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 219 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd0527d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad880", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 199 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8ada5c"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 200 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adba8", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 201 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8adc1c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 211 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c120", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 212 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x86c2f8"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 213 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c428", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 214 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x86c49c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 216 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b110", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 217 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x82b2d8"
@@ -34,13 +32,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 218 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b408", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 219 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x82b470", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
-          Kind: Entry
+        - Kind: Entry
           Type: 1312 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd0a46a", Frameless: false}]
           Condition: null
-        - ID: 189
-          Kind: Return
+        - Kind: Return
           Type: 1313 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd0a4a5", Frameless: false}]
           Condition: null
@@ -30,13 +28,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
-        - ID: 69
-          Kind: Entry
+        - Kind: Entry
           Type: 1191 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04dea", Frameless: false}]
           Condition: null
-        - ID: 68
-          Kind: Return
+        - Kind: Return
           Type: 1192 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xd04e25", Frameless: false}]
           Condition: null
@@ -50,13 +46,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
-        - ID: 72
-          Kind: Entry
+        - Kind: Entry
           Type: 1194 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04e8a", Frameless: false}]
           Condition: null
-        - ID: 71
-          Kind: Return
+        - Kind: Return
           Type: 1195 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xd04ebd", Frameless: false}]
           Condition: null
@@ -69,13 +63,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
-          Kind: Entry
+        - Kind: Entry
           Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xd08f2e", Frameless: false}]
           Condition: null
-        - ID: 161
-          Kind: Return
+        - Kind: Return
           Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08fe2", Frameless: false}]
           Condition: null
@@ -89,8 +81,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 1142 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
@@ -104,8 +95,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 1138 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
@@ -119,8 +109,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 1140 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd03000", Frameless: true}]
           Condition: null
@@ -134,8 +123,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
-        - ID: 80
-          Kind: Entry
+        - Kind: Entry
           Type: 1203 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd05600", Frameless: true}]
           Condition: null
@@ -149,8 +137,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
-        - ID: 16
-          Kind: Entry
+        - Kind: Entry
           Type: 1139 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
@@ -163,8 +150,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
-        - ID: 18
-          Kind: Entry
+        - Kind: Entry
           Type: 1141 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xd03020", Frameless: true}]
           Condition: null
@@ -178,13 +164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
-        - ID: 38
-          Kind: Entry
+        - Kind: Entry
           Type: 1160 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03740", Frameless: true}]
           Condition: null
-        - ID: 37
-          Kind: Return
+        - Kind: Return
           Type: 1161 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xd0375e", Frameless: true}]
           Condition: null
@@ -198,8 +182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 1127 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
@@ -213,8 +196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 1124 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
@@ -228,8 +210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
-        - ID: 100
-          Kind: Entry
+        - Kind: Entry
           Type: 1223 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd07320", Frameless: true}]
           Condition: null
@@ -243,8 +224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
-        - ID: 98
-          Kind: Entry
+        - Kind: Entry
           Type: 1221 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd06f40", Frameless: true}]
           Condition: null
@@ -258,8 +238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 108
-          Kind: Entry
+        - Kind: Entry
           Type: 1231 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
           Condition: null
@@ -273,8 +252,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
-        - ID: 43
-          Kind: Entry
+        - Kind: Entry
           Type: 1166 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
@@ -288,8 +266,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
-        - ID: 44
-          Kind: Entry
+        - Kind: Entry
           Type: 1167 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
@@ -303,8 +280,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
-        - ID: 39
-          Kind: Entry
+        - Kind: Entry
           Type: 1162 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd03800", Frameless: true}]
           Condition: null
@@ -318,8 +294,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
-        - ID: 40
-          Kind: Entry
+        - Kind: Entry
           Type: 1163 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd03820", Frameless: true}]
           Condition: null
@@ -333,8 +308,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
-        - ID: 41
-          Kind: Entry
+        - Kind: Entry
           Type: 1164 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd039a0", Frameless: true}]
           Condition: null
@@ -348,8 +322,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
-        - ID: 42
-          Kind: Entry
+        - Kind: Entry
           Type: 1165 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd039c0", Frameless: true}]
           Condition: null
@@ -363,8 +336,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
-          Kind: Entry
+        - Kind: Entry
           Type: 1301 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd0a000", Frameless: true}]
           Condition: null
@@ -378,8 +350,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
-          Kind: Entry
+        - Kind: Entry
           Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
@@ -394,8 +365,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
-          Kind: Entry
+        - Kind: Entry
           Type: 1323 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
@@ -409,8 +379,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
-          Kind: Entry
+        - Kind: Entry
           Type: 1329 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd0a9e0", Frameless: true}]
           Condition: null
@@ -423,8 +392,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
-          Kind: Entry
+        - Kind: Entry
           Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd0aa00", Frameless: true}]
           Condition: null
@@ -438,8 +406,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
-        - ID: 70
-          Kind: Entry
+        - Kind: Entry
           Type: 1193 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04e60", Frameless: true}]
           Condition: null
@@ -453,13 +420,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
-          Kind: Entry
+        - Kind: Entry
           Type: 1175 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd0436a", Frameless: false}]
           Condition: null
-        - ID: 52
-          Kind: Return
+        - Kind: Return
           Type: 1176 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xd043ac", Frameless: false}]
           Condition: null
@@ -473,13 +438,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
-          Kind: Entry
+        - Kind: Entry
           Type: 1173 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd0424e", Frameless: false}]
           Condition: null
-        - ID: 50
-          Kind: Return
+        - Kind: Return
           Type: 1174 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xd042db", Frameless: false}]
           Condition: null
@@ -493,13 +456,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 63
-          Kind: Entry
+        - Kind: Entry
           Type: 1185 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04ac0", Frameless: true}]
           Condition: null
-        - ID: 62
-          Kind: Return
+        - Kind: Return
           Type: 1186 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xd04ac5", Frameless: true}]
           Condition: null
@@ -513,13 +474,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 65
-          Kind: Entry
+        - Kind: Entry
           Type: 1187 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04ae4", Frameless: false}]
           Condition: null
-        - ID: 64
-          Kind: Return
+        - Kind: Return
           Type: 1188 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xd04b1d", Frameless: false}]
           Condition: null
@@ -536,8 +495,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 66
-          Kind: Line
+        - Kind: Line
           Type: 1189 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xd04ae8", Frameless: false}]
           Condition: null
@@ -551,13 +509,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
-          Kind: Entry
+        - Kind: Entry
           Type: 1177 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd047aa", Frameless: false}]
           Condition: null
-        - ID: 54
-          Kind: Return
+        - Kind: Return
           Type: 1178 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xd0480e", Frameless: false}]
           Condition: null
@@ -571,13 +527,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
-          Kind: Entry
+        - Kind: Entry
           Type: 1179 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd0484e", Frameless: false}]
           Condition: null
-        - ID: 56
-          Kind: Return
+        - Kind: Return
           Type: 1180 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xd048de", Frameless: false}]
           Condition: null
@@ -591,13 +545,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
-          Kind: Entry
+        - Kind: Entry
           Type: 1181 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd0492a", Frameless: false}]
           Condition: null
-        - ID: 58
-          Kind: Return
+        - Kind: Return
           Type: 1182 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xd0496b", Frameless: false}]
           Condition: null
@@ -611,8 +563,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
-          Kind: Entry
+        - Kind: Entry
           Type: 1334 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
@@ -626,13 +577,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
-        - ID: 61
-          Kind: Entry
+        - Kind: Entry
           Type: 1183 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd049ae", Frameless: false}]
           Condition: null
-        - ID: 60
-          Kind: Return
+        - Kind: Return
           Type: 1184 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xd04a9e", Frameless: false}]
           Condition: null
@@ -646,8 +595,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
-          Kind: Entry
+        - Kind: Entry
           Type: 1335 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
@@ -664,8 +612,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
-          Kind: Line
+        - Kind: Line
           Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
@@ -679,8 +626,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
-          Kind: Entry
+        - Kind: Entry
           Type: 1337 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
@@ -697,8 +643,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
-          Kind: Line
+        - Kind: Line
           Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
@@ -713,8 +658,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
-          Kind: Entry
+        - Kind: Entry
           Type: 1331 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0460a"
@@ -728,8 +672,7 @@ Probes:
             - PC: "0xd0492f"
               Frameless: false
           Condition: null
-        - ID: 208
-          Kind: Return
+        - Kind: Return
           Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
@@ -746,8 +689,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
-          Kind: Line
+        - Kind: Line
           Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
@@ -771,8 +713,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
-          Kind: Entry
+        - Kind: Entry
           Type: 1339 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
@@ -789,8 +730,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
-          Kind: Line
+        - Kind: Line
           Type: 1340 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
@@ -805,8 +745,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
-          Kind: Entry
+        - Kind: Entry
           Type: 1341 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04b05"
@@ -824,8 +763,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 7
-          Kind: Entry
+        - Kind: Entry
           Type: 1130 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
@@ -839,8 +777,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 1131 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
@@ -854,8 +791,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 9
-          Kind: Entry
+        - Kind: Entry
           Type: 1132 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
@@ -869,8 +805,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 1129 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
@@ -884,8 +819,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 5
-          Kind: Entry
+        - Kind: Entry
           Type: 1128 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
@@ -899,8 +833,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 67
-          Kind: Entry
+        - Kind: Entry
           Type: 1190 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04dc0", Frameless: true}]
           Condition: null
@@ -913,13 +846,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
-          Kind: Entry
+        - Kind: Entry
           Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xd08dae", Frameless: false}]
           Condition: null
-        - ID: 159
-          Kind: Return
+        - Kind: Return
           Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08ef3", Frameless: false}]
           Condition: null
@@ -933,8 +864,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
-        - ID: 102
-          Kind: Entry
+        - Kind: Entry
           Type: 1225 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd07500", Frameless: true}]
           Condition: null
@@ -951,8 +881,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 47
-          Kind: Line
+        - Kind: Line
           Type: 1170 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03bba", Frameless: false}]
           Condition: null
@@ -969,8 +898,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 48
-          Kind: Line
+        - Kind: Line
           Type: 1171 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03c6d", Frameless: false}]
           Condition: null
@@ -987,8 +915,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
-          Kind: Line
+        - Kind: Line
           Type: 1172 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03d34", Frameless: false}]
           Condition: null
@@ -1001,13 +928,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
-          Kind: Entry
+        - Kind: Entry
           Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xd09253", Frameless: false}]
           Condition: null
-        - ID: 165
-          Kind: Return
+        - Kind: Return
           Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xd09462", Frameless: false}]
           Condition: null
@@ -1021,8 +946,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
-        - ID: 78
-          Kind: Entry
+        - Kind: Entry
           Type: 1201 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd055c0", Frameless: true}]
           Condition: null
@@ -1036,8 +960,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
-        - ID: 85
-          Kind: Entry
+        - Kind: Entry
           Type: 1208 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd05680", Frameless: true}]
           Condition: null
@@ -1051,8 +974,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
-        - ID: 95
-          Kind: Entry
+        - Kind: Entry
           Type: 1218 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xd057c0", Frameless: true}]
           Condition: null
@@ -1066,8 +988,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
-        - ID: 97
-          Kind: Entry
+        - Kind: Entry
           Type: 1220 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xd05800", Frameless: true}]
           Condition: null
@@ -1081,8 +1002,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
-        - ID: 96
-          Kind: Entry
+        - Kind: Entry
           Type: 1219 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xd057e0", Frameless: true}]
           Condition: null
@@ -1096,8 +1016,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
-        - ID: 82
-          Kind: Entry
+        - Kind: Entry
           Type: 1205 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd05640", Frameless: true}]
           Condition: null
@@ -1111,8 +1030,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
-        - ID: 94
-          Kind: Entry
+        - Kind: Entry
           Type: 1217 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd057a0", Frameless: true}]
           Condition: null
@@ -1126,8 +1044,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
-        - ID: 93
-          Kind: Entry
+        - Kind: Entry
           Type: 1216 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd05780", Frameless: true}]
           Condition: null
@@ -1141,8 +1058,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 83
-          Kind: Entry
+        - Kind: Entry
           Type: 1206 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
@@ -1156,8 +1072,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 84
-          Kind: Entry
+        - Kind: Entry
           Type: 1207 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
@@ -1171,8 +1086,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
-        - ID: 92
-          Kind: Entry
+        - Kind: Entry
           Type: 1215 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd05760", Frameless: true}]
           Condition: null
@@ -1186,8 +1100,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
-        - ID: 91
-          Kind: Entry
+        - Kind: Entry
           Type: 1214 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd05740", Frameless: true}]
           Condition: null
@@ -1201,8 +1114,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
-        - ID: 76
-          Kind: Entry
+        - Kind: Entry
           Type: 1199 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd05580", Frameless: true}]
           Condition: null
@@ -1216,8 +1128,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
-        - ID: 77
-          Kind: Entry
+        - Kind: Entry
           Type: 1200 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd055a0", Frameless: true}]
           Condition: null
@@ -1231,8 +1142,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
-        - ID: 75
-          Kind: Entry
+        - Kind: Entry
           Type: 1198 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd05560", Frameless: true}]
           Condition: null
@@ -1246,8 +1156,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
-        - ID: 86
-          Kind: Entry
+        - Kind: Entry
           Type: 1209 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
           Condition: null
@@ -1261,8 +1170,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
-        - ID: 89
-          Kind: Entry
+        - Kind: Entry
           Type: 1212 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd05700", Frameless: true}]
           Condition: null
@@ -1276,8 +1184,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
-        - ID: 90
-          Kind: Entry
+        - Kind: Entry
           Type: 1213 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd05720", Frameless: true}]
           Condition: null
@@ -1291,8 +1198,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
-        - ID: 87
-          Kind: Entry
+        - Kind: Entry
           Type: 1210 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
           Condition: null
@@ -1306,8 +1212,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
-        - ID: 88
-          Kind: Entry
+        - Kind: Entry
           Type: 1211 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
           Condition: null
@@ -1321,8 +1226,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
-          Kind: Entry
+        - Kind: Entry
           Type: 1320 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
@@ -1337,8 +1241,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
-          Kind: Entry
+        - Kind: Entry
           Type: 1321 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
@@ -1351,13 +1254,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
-          Kind: Entry
+        - Kind: Entry
           Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xd094f3", Frameless: false}]
           Condition: null
-        - ID: 167
-          Kind: Return
+        - Kind: Return
           Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xd0972b", Frameless: false}]
           Condition: null
@@ -1370,13 +1271,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
-          Kind: Entry
+        - Kind: Entry
           Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xd0986e", Frameless: false}]
           Condition: null
-        - ID: 171
-          Kind: Return
+        - Kind: Return
           Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xd09936", Frameless: false}]
           Condition: null
@@ -1389,13 +1288,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
-          Kind: Entry
+        - Kind: Entry
           Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xd0900e", Frameless: false}]
           Condition: null
-        - ID: 163
-          Kind: Return
+        - Kind: Return
           Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xd0922a", Frameless: false}]
           Condition: null
@@ -1408,13 +1305,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
-          Kind: Entry
+        - Kind: Entry
           Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
           Condition: null
-        - ID: 125
-          Kind: Return
+        - Kind: Return
           Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
@@ -1428,8 +1323,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
-        - ID: 99
-          Kind: Entry
+        - Kind: Entry
           Type: 1222 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd07100", Frameless: true}]
           Condition: null
@@ -1442,13 +1336,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
-        - ID: 124
-          Kind: Entry
+        - Kind: Entry
           Type: 1246 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xd0832a", Frameless: false}]
           Condition: null
-        - ID: 123
-          Kind: Return
+        - Kind: Return
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd08395", Frameless: false}]
           Condition: null
@@ -1462,8 +1354,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 107
-          Kind: Entry
+        - Kind: Entry
           Type: 1230 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
           Condition: null
@@ -1477,8 +1368,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
-          Kind: Entry
+        - Kind: Entry
           Type: 1308 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
@@ -1492,8 +1382,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
-          Kind: Entry
+        - Kind: Entry
           Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
@@ -1507,8 +1396,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
-          Kind: Entry
+        - Kind: Entry
           Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
@@ -1522,8 +1410,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
-          Kind: Entry
+        - Kind: Entry
           Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd0a540", Frameless: true}]
           Condition: null
@@ -1537,8 +1424,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 103
-          Kind: Entry
+        - Kind: Entry
           Type: 1226 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07520", Frameless: true}]
           Condition: null
@@ -1552,8 +1438,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
-        - ID: 81
-          Kind: Entry
+        - Kind: Entry
           Type: 1204 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
@@ -1567,8 +1452,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
-        - ID: 101
-          Kind: Entry
+        - Kind: Entry
           Type: 1224 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd074e0", Frameless: true}]
           Condition: null
@@ -1582,13 +1466,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
-        - ID: 120
-          Kind: Entry
+        - Kind: Entry
           Type: 1242 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xd07fae", Frameless: false}]
           Condition: null
-        - ID: 119
-          Kind: Return
+        - Kind: Return
           Type: 1243 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xd08064"
@@ -1610,13 +1492,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
-        - ID: 118
-          Kind: Entry
+        - Kind: Entry
           Type: 1240 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xd07e4e", Frameless: false}]
           Condition: null
-        - ID: 117
-          Kind: Return
+        - Kind: Return
           Type: 1241 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xd07eb8"
@@ -1637,13 +1517,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
-          Kind: Entry
+        - Kind: Entry
           Type: 1260 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xd0884a", Frameless: false}]
           Condition: null
-        - ID: 137
-          Kind: Return
+        - Kind: Return
           Type: 1261 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xd088ad", Frameless: false}]
           Condition: null
@@ -1656,13 +1534,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
-          Kind: Entry
+        - Kind: Entry
           Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xd088ca", Frameless: false}]
           Condition: null
-        - ID: 139
-          Kind: Return
+        - Kind: Return
           Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xd0890b", Frameless: false}]
           Condition: null
@@ -1675,13 +1551,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
-          Kind: Entry
+        - Kind: Entry
           Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xd0892a", Frameless: false}]
           Condition: null
-        - ID: 141
-          Kind: Return
+        - Kind: Return
           Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xd08966", Frameless: false}]
           Condition: null
@@ -1694,13 +1568,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
-          Kind: Entry
+        - Kind: Entry
           Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xd08a0e", Frameless: false}]
           Condition: null
-        - ID: 145
-          Kind: Return
+        - Kind: Return
           Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xd08a8a", Frameless: false}]
           Condition: null
@@ -1713,13 +1585,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
-          Kind: Entry
+        - Kind: Entry
           Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xd08d4a", Frameless: false}]
           Condition: null
-        - ID: 157
-          Kind: Return
+        - Kind: Return
           Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xd08d90", Frameless: false}]
           Condition: null
@@ -1732,13 +1602,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
-          Kind: Entry
+        - Kind: Entry
           Type: 1256 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xd0870a", Frameless: false}]
           Condition: null
-        - ID: 133
-          Kind: Return
+        - Kind: Return
           Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xd08766", Frameless: false}]
           Condition: null
@@ -1752,13 +1620,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 116
-          Kind: Entry
+        - Kind: Entry
           Type: 1238 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xd07dea", Frameless: false}]
           Condition: null
-        - ID: 115
-          Kind: Return
+        - Kind: Return
           Type: 1239 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xd07e1a"
@@ -1775,13 +1641,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 110
-          Kind: Entry
+        - Kind: Entry
           Type: 1232 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xd07bea", Frameless: false}]
           Condition: null
-        - ID: 109
-          Kind: Return
+        - Kind: Return
           Type: 1233 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xd07c3b", Frameless: false}]
           Condition: null
@@ -1794,13 +1658,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 114
-          Kind: Entry
+        - Kind: Entry
           Type: 1236 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xd07d0e", Frameless: false}]
           Condition: null
-        - ID: 113
-          Kind: Return
+        - Kind: Return
           Type: 1237 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xd07dc4", Frameless: false}]
           Condition: null
@@ -1813,13 +1675,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 112
-          Kind: Entry
+        - Kind: Entry
           Type: 1234 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xd07c6a", Frameless: false}]
           Condition: null
-        - ID: 111
-          Kind: Return
+        - Kind: Return
           Type: 1235 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xd07cdb", Frameless: false}]
           Condition: null
@@ -1833,13 +1693,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
-        - ID: 122
-          Kind: Entry
+        - Kind: Entry
           Type: 1244 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xd081ae", Frameless: false}]
           Condition: null
-        - ID: 121
-          Kind: Return
+        - Kind: Return
           Type: 1245 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xd08291"
@@ -1856,13 +1714,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
-          Kind: Entry
+        - Kind: Entry
           Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xd0878e", Frameless: false}]
           Condition: null
-        - ID: 135
-          Kind: Return
+        - Kind: Return
           Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xd08813", Frameless: false}]
           Condition: null
@@ -1875,13 +1731,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
-          Kind: Entry
+        - Kind: Entry
           Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xd0860e", Frameless: false}]
           Condition: null
-        - ID: 131
-          Kind: Return
+        - Kind: Return
           Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xd086e5", Frameless: false}]
           Condition: null
@@ -1894,13 +1748,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
-          Kind: Entry
+        - Kind: Entry
           Type: 1272 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xd08b6a", Frameless: false}]
           Condition: null
-        - ID: 149
-          Kind: Return
+        - Kind: Return
           Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xd08bcc", Frameless: false}]
           Condition: null
@@ -1913,13 +1765,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
-          Kind: Entry
+        - Kind: Entry
           Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xd0898a", Frameless: false}]
           Condition: null
-        - ID: 143
-          Kind: Return
+        - Kind: Return
           Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xd089d8", Frameless: false}]
           Condition: null
@@ -1932,13 +1782,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
-          Kind: Entry
+        - Kind: Entry
           Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xd08cca", Frameless: false}]
           Condition: null
-        - ID: 155
-          Kind: Return
+        - Kind: Return
           Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xd08d16", Frameless: false}]
           Condition: null
@@ -1951,13 +1799,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
-          Kind: Entry
+        - Kind: Entry
           Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xd08c6a", Frameless: false}]
           Condition: null
-        - ID: 153
-          Kind: Return
+        - Kind: Return
           Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xd08cae", Frameless: false}]
           Condition: null
@@ -1970,13 +1816,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
-          Kind: Entry
+        - Kind: Entry
           Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xd0858a", Frameless: false}]
           Condition: null
-        - ID: 129
-          Kind: Return
+        - Kind: Return
           Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xd085f1", Frameless: false}]
           Condition: null
@@ -1989,13 +1833,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
-          Kind: Entry
+        - Kind: Entry
           Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xd08bea", Frameless: false}]
           Condition: null
-        - ID: 151
-          Kind: Return
+        - Kind: Return
           Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xd08c4d", Frameless: false}]
           Condition: null
@@ -2008,13 +1850,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
-          Kind: Entry
+        - Kind: Entry
           Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xd08aae", Frameless: false}]
           Condition: null
-        - ID: 147
-          Kind: Return
+        - Kind: Return
           Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xd08b34", Frameless: false}]
           Condition: null
@@ -2028,8 +1868,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 1125 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
@@ -2043,8 +1882,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 1146 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
@@ -2058,8 +1896,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 1144 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
@@ -2073,8 +1910,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
-        - ID: 34
-          Kind: Entry
+        - Kind: Entry
           Type: 1157 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
@@ -2088,8 +1924,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
-          Kind: Entry
+        - Kind: Entry
           Type: 1158 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd035c0", Frameless: true}]
           Condition: null
@@ -2103,8 +1938,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 1147 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
@@ -2118,8 +1952,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
-        - ID: 26
-          Kind: Entry
+        - Kind: Entry
           Type: 1149 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
@@ -2133,8 +1966,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
-        - ID: 27
-          Kind: Entry
+        - Kind: Entry
           Type: 1150 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
@@ -2148,8 +1980,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
-        - ID: 28
-          Kind: Entry
+        - Kind: Entry
           Type: 1151 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
@@ -2163,8 +1994,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 1148 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
@@ -2178,8 +2008,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
-        - ID: 22
-          Kind: Entry
+        - Kind: Entry
           Type: 1145 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
@@ -2193,8 +2022,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
-          Kind: Entry
+        - Kind: Entry
           Type: 1314 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd0a4c0", Frameless: true}]
           Condition: null
@@ -2208,8 +2036,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
-        - ID: 29
-          Kind: Entry
+        - Kind: Entry
           Type: 1152 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
@@ -2223,8 +2050,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
-        - ID: 31
-          Kind: Entry
+        - Kind: Entry
           Type: 1154 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
@@ -2238,8 +2064,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
-        - ID: 32
-          Kind: Entry
+        - Kind: Entry
           Type: 1155 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
@@ -2253,8 +2078,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
-        - ID: 33
-          Kind: Entry
+        - Kind: Entry
           Type: 1156 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
@@ -2268,8 +2092,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
-        - ID: 30
-          Kind: Entry
+        - Kind: Entry
           Type: 1153 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
@@ -2283,8 +2106,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
-          Kind: Entry
+        - Kind: Entry
           Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
@@ -2298,8 +2120,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
-          Kind: Entry
+        - Kind: Entry
           Type: 1302 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
@@ -2313,8 +2134,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
-        - ID: 79
-          Kind: Entry
+        - Kind: Entry
           Type: 1202 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
           Condition: null
@@ -2327,13 +2147,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
-          Kind: Entry
+        - Kind: Entry
           Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd084ae", Frameless: false}]
           Condition: null
-        - ID: 127
-          Kind: Return
+        - Kind: Return
           Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0854e", Frameless: false}]
           Condition: null
@@ -2346,13 +2164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
-          Kind: Entry
+        - Kind: Entry
           Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xd097ca", Frameless: false}]
           Condition: null
-        - ID: 169
-          Kind: Return
+        - Kind: Return
           Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xd0983c", Frameless: false}]
           Condition: null
@@ -2366,8 +2182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 3
-          Kind: Entry
+        - Kind: Entry
           Type: 1126 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
@@ -2381,8 +2196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
-          Kind: Entry
+        - Kind: Entry
           Type: 1229 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd07660", Frameless: true}]
           Condition: null
@@ -2396,8 +2210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
-          Kind: Entry
+        - Kind: Entry
           Type: 1306 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
@@ -2411,8 +2224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
-          Kind: Entry
+        - Kind: Entry
           Type: 1168 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b60", Frameless: true}]
           Condition: null
@@ -2426,8 +2238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 46
-          Kind: Entry
+        - Kind: Entry
           Type: 1169 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b80", Frameless: true}]
           Condition: null
@@ -2441,13 +2252,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
-          Kind: Entry
+        - Kind: Entry
           Type: 1327 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd0a860", Frameless: true}]
           Condition: null
-        - ID: 204
-          Kind: Return
+        - Kind: Return
           Type: 1328 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd0a882", Frameless: true}]
           Condition: null
@@ -2461,8 +2270,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
-          Kind: Entry
+        - Kind: Entry
           Type: 1303 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
@@ -2476,8 +2284,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
-        - ID: 73
-          Kind: Entry
+        - Kind: Entry
           Type: 1196 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xd04ee0", Frameless: true}]
           Condition: null
@@ -2490,13 +2297,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
-          Kind: Entry
+        - Kind: Entry
           Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xd0996e", Frameless: false}]
           Condition: null
-        - ID: 173
-          Kind: Return
+        - Kind: Return
           Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xd09a1a", Frameless: false}]
           Condition: null
@@ -2509,13 +2314,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
-          Kind: Entry
+        - Kind: Entry
           Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd0a720", Frameless: true}]
           Condition: null
-        - ID: 202
-          Kind: Return
+        - Kind: Return
           Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd0a73e", Frameless: true}]
           Condition: null
@@ -2528,8 +2331,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
-          Kind: Entry
+        - Kind: Entry
           Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd0a700", Frameless: true}]
           Condition: null
@@ -2543,8 +2345,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
-        - ID: 74
-          Kind: Entry
+        - Kind: Entry
           Type: 1197 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05540", Frameless: true}]
           Condition: null
@@ -2558,8 +2359,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
-          Kind: Entry
+        - Kind: Entry
           Type: 1315 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd0a4e0", Frameless: true}]
           Condition: null
@@ -2573,13 +2373,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
-          Kind: Entry
+        - Kind: Entry
           Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd0a500", Frameless: true}]
           Condition: null
-        - ID: 193
-          Kind: Return
+        - Kind: Return
           Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a51e", Frameless: true}]
           Condition: null
@@ -2593,8 +2391,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
-          Kind: Entry
+        - Kind: Entry
           Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a520", Frameless: true}]
           Condition: null
@@ -2608,8 +2405,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
-        - ID: 36
-          Kind: Entry
+        - Kind: Entry
           Type: 1159 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035e0", Frameless: true}]
           Condition: null
@@ -2623,8 +2419,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 1135 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
@@ -2638,8 +2433,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 1136 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
@@ -2653,8 +2447,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 14
-          Kind: Entry
+        - Kind: Entry
           Type: 1137 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
@@ -2668,8 +2461,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 11
-          Kind: Entry
+        - Kind: Entry
           Type: 1134 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
@@ -2683,8 +2475,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 1133 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
@@ -2698,8 +2489,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 105
-          Kind: Entry
+        - Kind: Entry
           Type: 1228 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd07580", Frameless: true}]
           Condition: null
@@ -2713,8 +2503,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
-          Kind: Entry
+        - Kind: Entry
           Type: 1300 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd09fe0", Frameless: true}]
           Condition: null
@@ -2728,8 +2517,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
-          Kind: Entry
+        - Kind: Entry
           Type: 1322 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
@@ -2743,8 +2531,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 104
-          Kind: Entry
+        - Kind: Entry
           Type: 1227 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd07540", Frameless: true}]
           Condition: null
@@ -2758,8 +2545,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
-        - ID: 20
-          Kind: Entry
+        - Kind: Entry
           Type: 1143 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03080", Frameless: true}]
           Condition: null
@@ -2773,8 +2559,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
-          Kind: Entry
+        - Kind: Entry
           Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
@@ -2788,8 +2573,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
-          Kind: Entry
+        - Kind: Entry
           Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
@@ -2802,13 +2586,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
-          Kind: Entry
+        - Kind: Entry
           Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xd09a4e", Frameless: false}]
           Condition: null
-        - ID: 175
-          Kind: Return
+        - Kind: Return
           Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09acc", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
-          Kind: Entry
+        - Kind: Entry
           Type: 1487 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcdb8aa", Frameless: false}]
           Condition: null
-        - ID: 189
-          Kind: Return
+        - Kind: Return
           Type: 1488 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcdb8e5", Frameless: false}]
           Condition: null
@@ -30,13 +28,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
-        - ID: 69
-          Kind: Entry
+        - Kind: Entry
           Type: 1366 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd610a", Frameless: false}]
           Condition: null
-        - ID: 68
-          Kind: Return
+        - Kind: Return
           Type: 1367 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcd6145", Frameless: false}]
           Condition: null
@@ -50,13 +46,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
-        - ID: 72
-          Kind: Entry
+        - Kind: Entry
           Type: 1369 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd61aa", Frameless: false}]
           Condition: null
-        - ID: 71
-          Kind: Return
+        - Kind: Return
           Type: 1370 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcd61dd", Frameless: false}]
           Condition: null
@@ -69,13 +63,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
-          Kind: Entry
+        - Kind: Entry
           Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcda36e", Frameless: false}]
           Condition: null
-        - ID: 161
-          Kind: Return
+        - Kind: Return
           Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda422", Frameless: false}]
           Condition: null
@@ -89,8 +81,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 1317 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
@@ -104,8 +95,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 1313 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
@@ -119,8 +109,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 1315 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
           Condition: null
@@ -134,8 +123,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
-        - ID: 80
-          Kind: Entry
+        - Kind: Entry
           Type: 1378 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd6920", Frameless: true}]
           Condition: null
@@ -149,8 +137,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
-        - ID: 16
-          Kind: Entry
+        - Kind: Entry
           Type: 1314 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
@@ -163,8 +150,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
-        - ID: 18
-          Kind: Entry
+        - Kind: Entry
           Type: 1316 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
           Condition: null
@@ -178,13 +164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
-        - ID: 38
-          Kind: Entry
+        - Kind: Entry
           Type: 1335 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a60", Frameless: true}]
           Condition: null
-        - ID: 37
-          Kind: Return
+        - Kind: Return
           Type: 1336 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd4a7e", Frameless: true}]
           Condition: null
@@ -198,8 +182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 1302 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
@@ -213,8 +196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 1299 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
@@ -228,8 +210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
-        - ID: 100
-          Kind: Entry
+        - Kind: Entry
           Type: 1398 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
           Condition: null
@@ -243,8 +224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
-        - ID: 98
-          Kind: Entry
+        - Kind: Entry
           Type: 1396 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
           Condition: null
@@ -258,8 +238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 108
-          Kind: Entry
+        - Kind: Entry
           Type: 1406 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
@@ -273,8 +252,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
-        - ID: 43
-          Kind: Entry
+        - Kind: Entry
           Type: 1341 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
@@ -288,8 +266,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
-        - ID: 44
-          Kind: Entry
+        - Kind: Entry
           Type: 1342 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
@@ -303,8 +280,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
-        - ID: 39
-          Kind: Entry
+        - Kind: Entry
           Type: 1337 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4b20", Frameless: true}]
           Condition: null
@@ -318,8 +294,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
-        - ID: 40
-          Kind: Entry
+        - Kind: Entry
           Type: 1338 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b40", Frameless: true}]
           Condition: null
@@ -333,8 +308,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
-        - ID: 41
-          Kind: Entry
+        - Kind: Entry
           Type: 1339 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4cc0", Frameless: true}]
           Condition: null
@@ -348,8 +322,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
-        - ID: 42
-          Kind: Entry
+        - Kind: Entry
           Type: 1340 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ce0", Frameless: true}]
           Condition: null
@@ -363,8 +336,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
-          Kind: Entry
+        - Kind: Entry
           Type: 1476 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdb440", Frameless: true}]
           Condition: null
@@ -378,8 +350,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
-          Kind: Entry
+        - Kind: Entry
           Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
@@ -394,8 +365,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
-          Kind: Entry
+        - Kind: Entry
           Type: 1498 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
@@ -409,8 +379,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
-          Kind: Entry
+        - Kind: Entry
           Type: 1504 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcdbe20", Frameless: true}]
           Condition: null
@@ -423,8 +392,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
-          Kind: Entry
+        - Kind: Entry
           Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcdbe40", Frameless: true}]
           Condition: null
@@ -438,8 +406,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
-        - ID: 70
-          Kind: Entry
+        - Kind: Entry
           Type: 1368 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd6180", Frameless: true}]
           Condition: null
@@ -453,13 +420,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
-          Kind: Entry
+        - Kind: Entry
           Type: 1350 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd568a", Frameless: false}]
           Condition: null
-        - ID: 52
-          Kind: Return
+        - Kind: Return
           Type: 1351 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd56cc", Frameless: false}]
           Condition: null
@@ -473,13 +438,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
-          Kind: Entry
+        - Kind: Entry
           Type: 1348 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd556e", Frameless: false}]
           Condition: null
-        - ID: 50
-          Kind: Return
+        - Kind: Return
           Type: 1349 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd55fb", Frameless: false}]
           Condition: null
@@ -493,13 +456,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 63
-          Kind: Entry
+        - Kind: Entry
           Type: 1360 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5de0", Frameless: true}]
           Condition: null
-        - ID: 62
-          Kind: Return
+        - Kind: Return
           Type: 1361 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcd5de5", Frameless: true}]
           Condition: null
@@ -513,13 +474,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 65
-          Kind: Entry
+        - Kind: Entry
           Type: 1362 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5e04", Frameless: false}]
           Condition: null
-        - ID: 64
-          Kind: Return
+        - Kind: Return
           Type: 1363 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcd5e3d", Frameless: false}]
           Condition: null
@@ -536,8 +495,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 66
-          Kind: Line
+        - Kind: Line
           Type: 1364 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcd5e08", Frameless: false}]
           Condition: null
@@ -551,13 +509,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
-          Kind: Entry
+        - Kind: Entry
           Type: 1352 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd5aca", Frameless: false}]
           Condition: null
-        - ID: 54
-          Kind: Return
+        - Kind: Return
           Type: 1353 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcd5b2e", Frameless: false}]
           Condition: null
@@ -571,13 +527,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
-          Kind: Entry
+        - Kind: Entry
           Type: 1354 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd5b6e", Frameless: false}]
           Condition: null
-        - ID: 56
-          Kind: Return
+        - Kind: Return
           Type: 1355 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcd5bfe", Frameless: false}]
           Condition: null
@@ -591,13 +545,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
-          Kind: Entry
+        - Kind: Entry
           Type: 1356 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd5c4a", Frameless: false}]
           Condition: null
-        - ID: 58
-          Kind: Return
+        - Kind: Return
           Type: 1357 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcd5c8b", Frameless: false}]
           Condition: null
@@ -611,8 +563,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
-          Kind: Entry
+        - Kind: Entry
           Type: 1509 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
@@ -626,13 +577,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
-        - ID: 61
-          Kind: Entry
+        - Kind: Entry
           Type: 1358 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5cce", Frameless: false}]
           Condition: null
-        - ID: 60
-          Kind: Return
+        - Kind: Return
           Type: 1359 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcd5dbe", Frameless: false}]
           Condition: null
@@ -646,8 +595,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
-          Kind: Entry
+        - Kind: Entry
           Type: 1510 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
@@ -664,8 +612,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
-          Kind: Line
+        - Kind: Line
           Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
@@ -679,8 +626,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
-          Kind: Entry
+        - Kind: Entry
           Type: 1512 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
@@ -697,8 +643,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
-          Kind: Line
+        - Kind: Line
           Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
@@ -713,8 +658,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
-          Kind: Entry
+        - Kind: Entry
           Type: 1506 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd592a"
@@ -728,8 +672,7 @@ Probes:
             - PC: "0xcd5c4f"
               Frameless: false
           Condition: null
-        - ID: 208
-          Kind: Return
+        - Kind: Return
           Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
@@ -746,8 +689,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
-          Kind: Line
+        - Kind: Line
           Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
@@ -771,8 +713,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
-          Kind: Entry
+        - Kind: Entry
           Type: 1514 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
@@ -789,8 +730,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
-          Kind: Line
+        - Kind: Line
           Type: 1515 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
@@ -805,8 +745,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
-          Kind: Entry
+        - Kind: Entry
           Type: 1516 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5e25"
@@ -824,8 +763,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 7
-          Kind: Entry
+        - Kind: Entry
           Type: 1305 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
@@ -839,8 +777,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 1306 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
@@ -854,8 +791,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 9
-          Kind: Entry
+        - Kind: Entry
           Type: 1307 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
@@ -869,8 +805,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 1304 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
@@ -884,8 +819,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 5
-          Kind: Entry
+        - Kind: Entry
           Type: 1303 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
@@ -899,8 +833,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 67
-          Kind: Entry
+        - Kind: Entry
           Type: 1365 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd60e0", Frameless: true}]
           Condition: null
@@ -913,13 +846,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
-          Kind: Entry
+        - Kind: Entry
           Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcda1ce", Frameless: false}]
           Condition: null
-        - ID: 159
-          Kind: Return
+        - Kind: Return
           Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda333", Frameless: false}]
           Condition: null
@@ -933,8 +864,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
-        - ID: 102
-          Kind: Entry
+        - Kind: Entry
           Type: 1400 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
           Condition: null
@@ -951,8 +881,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 47
-          Kind: Line
+        - Kind: Line
           Type: 1345 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4eda", Frameless: false}]
           Condition: null
@@ -969,8 +898,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 48
-          Kind: Line
+        - Kind: Line
           Type: 1346 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4f8d", Frameless: false}]
           Condition: null
@@ -987,8 +915,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
-          Kind: Line
+        - Kind: Line
           Type: 1347 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd5054", Frameless: false}]
           Condition: null
@@ -1001,13 +928,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
-          Kind: Entry
+        - Kind: Entry
           Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcda693", Frameless: false}]
           Condition: null
-        - ID: 165
-          Kind: Return
+        - Kind: Return
           Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcda8a2", Frameless: false}]
           Condition: null
@@ -1021,8 +946,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
-        - ID: 78
-          Kind: Entry
+        - Kind: Entry
           Type: 1376 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
           Condition: null
@@ -1036,8 +960,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
-        - ID: 85
-          Kind: Entry
+        - Kind: Entry
           Type: 1383 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
           Condition: null
@@ -1051,8 +974,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
-        - ID: 95
-          Kind: Entry
+        - Kind: Entry
           Type: 1393 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xcd6ae0", Frameless: true}]
           Condition: null
@@ -1066,8 +988,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
-        - ID: 97
-          Kind: Entry
+        - Kind: Entry
           Type: 1395 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xcd6b20", Frameless: true}]
           Condition: null
@@ -1081,8 +1002,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
-        - ID: 96
-          Kind: Entry
+        - Kind: Entry
           Type: 1394 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xcd6b00", Frameless: true}]
           Condition: null
@@ -1096,8 +1016,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
-        - ID: 82
-          Kind: Entry
+        - Kind: Entry
           Type: 1380 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd6960", Frameless: true}]
           Condition: null
@@ -1111,8 +1030,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
-        - ID: 94
-          Kind: Entry
+        - Kind: Entry
           Type: 1392 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6ac0", Frameless: true}]
           Condition: null
@@ -1126,8 +1044,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
-        - ID: 93
-          Kind: Entry
+        - Kind: Entry
           Type: 1391 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd6aa0", Frameless: true}]
           Condition: null
@@ -1141,8 +1058,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 83
-          Kind: Entry
+        - Kind: Entry
           Type: 1381 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
@@ -1156,8 +1072,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 84
-          Kind: Entry
+        - Kind: Entry
           Type: 1382 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
@@ -1171,8 +1086,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
-        - ID: 92
-          Kind: Entry
+        - Kind: Entry
           Type: 1390 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
           Condition: null
@@ -1186,8 +1100,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
-        - ID: 91
-          Kind: Entry
+        - Kind: Entry
           Type: 1389 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
           Condition: null
@@ -1201,8 +1114,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
-        - ID: 76
-          Kind: Entry
+        - Kind: Entry
           Type: 1374 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd68a0", Frameless: true}]
           Condition: null
@@ -1216,8 +1128,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
-        - ID: 77
-          Kind: Entry
+        - Kind: Entry
           Type: 1375 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
           Condition: null
@@ -1231,8 +1142,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
-        - ID: 75
-          Kind: Entry
+        - Kind: Entry
           Type: 1373 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd6880", Frameless: true}]
           Condition: null
@@ -1246,8 +1156,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
-        - ID: 86
-          Kind: Entry
+        - Kind: Entry
           Type: 1384 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
           Condition: null
@@ -1261,8 +1170,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
-        - ID: 89
-          Kind: Entry
+        - Kind: Entry
           Type: 1387 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
           Condition: null
@@ -1276,8 +1184,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
-        - ID: 90
-          Kind: Entry
+        - Kind: Entry
           Type: 1388 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
           Condition: null
@@ -1291,8 +1198,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
-        - ID: 87
-          Kind: Entry
+        - Kind: Entry
           Type: 1385 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
           Condition: null
@@ -1306,8 +1212,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
-        - ID: 88
-          Kind: Entry
+        - Kind: Entry
           Type: 1386 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
           Condition: null
@@ -1321,8 +1226,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
-          Kind: Entry
+        - Kind: Entry
           Type: 1495 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
@@ -1337,8 +1241,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
-          Kind: Entry
+        - Kind: Entry
           Type: 1496 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
@@ -1351,13 +1254,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
-          Kind: Entry
+        - Kind: Entry
           Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcda933", Frameless: false}]
           Condition: null
-        - ID: 167
-          Kind: Return
+        - Kind: Return
           Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdab6b", Frameless: false}]
           Condition: null
@@ -1370,13 +1271,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
-          Kind: Entry
+        - Kind: Entry
           Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdacae", Frameless: false}]
           Condition: null
-        - ID: 171
-          Kind: Return
+        - Kind: Return
           Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdad7e", Frameless: false}]
           Condition: null
@@ -1389,13 +1288,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
-          Kind: Entry
+        - Kind: Entry
           Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
           Condition: null
-        - ID: 163
-          Kind: Return
+        - Kind: Return
           Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcda66a", Frameless: false}]
           Condition: null
@@ -1408,13 +1305,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
-          Kind: Entry
+        - Kind: Entry
           Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
           Condition: null
-        - ID: 125
-          Kind: Return
+        - Kind: Return
           Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
@@ -1428,8 +1323,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
-        - ID: 99
-          Kind: Entry
+        - Kind: Entry
           Type: 1397 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd85e0", Frameless: true}]
           Condition: null
@@ -1442,13 +1336,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
-        - ID: 124
-          Kind: Entry
+        - Kind: Entry
           Type: 1421 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcd974a", Frameless: false}]
           Condition: null
-        - ID: 123
-          Kind: Return
+        - Kind: Return
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
           Condition: null
@@ -1462,8 +1354,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 107
-          Kind: Entry
+        - Kind: Entry
           Type: 1405 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
@@ -1477,8 +1368,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
-          Kind: Entry
+        - Kind: Entry
           Type: 1483 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
@@ -1492,8 +1382,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
-          Kind: Entry
+        - Kind: Entry
           Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
@@ -1507,8 +1396,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
-          Kind: Entry
+        - Kind: Entry
           Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
@@ -1522,8 +1410,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
-          Kind: Entry
+        - Kind: Entry
           Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdb980", Frameless: true}]
           Condition: null
@@ -1537,8 +1424,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 103
-          Kind: Entry
+        - Kind: Entry
           Type: 1401 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
@@ -1552,8 +1438,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
-        - ID: 81
-          Kind: Entry
+        - Kind: Entry
           Type: 1379 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
@@ -1567,8 +1452,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
-        - ID: 101
-          Kind: Entry
+        - Kind: Entry
           Type: 1399 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd89c0", Frameless: true}]
           Condition: null
@@ -1582,13 +1466,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
-        - ID: 120
-          Kind: Entry
+        - Kind: Entry
           Type: 1417 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcd93ee", Frameless: false}]
           Condition: null
-        - ID: 119
-          Kind: Return
+        - Kind: Return
           Type: 1418 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xcd94a4"
@@ -1610,13 +1492,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
-        - ID: 118
-          Kind: Entry
+        - Kind: Entry
           Type: 1415 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcd928e", Frameless: false}]
           Condition: null
-        - ID: 117
-          Kind: Return
+        - Kind: Return
           Type: 1416 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcd92e4"
@@ -1637,13 +1517,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
-          Kind: Entry
+        - Kind: Entry
           Type: 1435 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcd9c6a", Frameless: false}]
           Condition: null
-        - ID: 137
-          Kind: Return
+        - Kind: Return
           Type: 1436 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcd9ccd", Frameless: false}]
           Condition: null
@@ -1656,13 +1534,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
-          Kind: Entry
+        - Kind: Entry
           Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcd9cea", Frameless: false}]
           Condition: null
-        - ID: 139
-          Kind: Return
+        - Kind: Return
           Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcd9d2b", Frameless: false}]
           Condition: null
@@ -1675,13 +1551,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
-          Kind: Entry
+        - Kind: Entry
           Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcd9d4a", Frameless: false}]
           Condition: null
-        - ID: 141
-          Kind: Return
+        - Kind: Return
           Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcd9d86", Frameless: false}]
           Condition: null
@@ -1694,13 +1568,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
-          Kind: Entry
+        - Kind: Entry
           Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcd9e2e", Frameless: false}]
           Condition: null
-        - ID: 145
-          Kind: Return
+        - Kind: Return
           Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcd9eaa", Frameless: false}]
           Condition: null
@@ -1713,13 +1585,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
-          Kind: Entry
+        - Kind: Entry
           Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcda16a", Frameless: false}]
           Condition: null
-        - ID: 157
-          Kind: Return
+        - Kind: Return
           Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcda1b0", Frameless: false}]
           Condition: null
@@ -1732,13 +1602,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
-          Kind: Entry
+        - Kind: Entry
           Type: 1431 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcd9b2a", Frameless: false}]
           Condition: null
-        - ID: 133
-          Kind: Return
+        - Kind: Return
           Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
           Condition: null
@@ -1752,13 +1620,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 116
-          Kind: Entry
+        - Kind: Entry
           Type: 1413 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcd922a", Frameless: false}]
           Condition: null
-        - ID: 115
-          Kind: Return
+        - Kind: Return
           Type: 1414 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcd925a"
@@ -1775,13 +1641,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 110
-          Kind: Entry
+        - Kind: Entry
           Type: 1407 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcd902a", Frameless: false}]
           Condition: null
-        - ID: 109
-          Kind: Return
+        - Kind: Return
           Type: 1408 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcd907b", Frameless: false}]
           Condition: null
@@ -1794,13 +1658,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 114
-          Kind: Entry
+        - Kind: Entry
           Type: 1411 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcd914e", Frameless: false}]
           Condition: null
-        - ID: 113
-          Kind: Return
+        - Kind: Return
           Type: 1412 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcd9204", Frameless: false}]
           Condition: null
@@ -1813,13 +1675,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 112
-          Kind: Entry
+        - Kind: Entry
           Type: 1409 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcd90aa", Frameless: false}]
           Condition: null
-        - ID: 111
-          Kind: Return
+        - Kind: Return
           Type: 1410 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcd9114", Frameless: false}]
           Condition: null
@@ -1833,13 +1693,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
-        - ID: 122
-          Kind: Entry
+        - Kind: Entry
           Type: 1419 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcd95ee", Frameless: false}]
           Condition: null
-        - ID: 121
-          Kind: Return
+        - Kind: Return
           Type: 1420 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcd96cf"
@@ -1856,13 +1714,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
-          Kind: Entry
+        - Kind: Entry
           Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
-        - ID: 135
-          Kind: Return
+        - Kind: Return
           Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcd9c33", Frameless: false}]
           Condition: null
@@ -1875,13 +1731,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
-          Kind: Entry
+        - Kind: Entry
           Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcd9a2e", Frameless: false}]
           Condition: null
-        - ID: 131
-          Kind: Return
+        - Kind: Return
           Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcd9b07", Frameless: false}]
           Condition: null
@@ -1894,13 +1748,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
-          Kind: Entry
+        - Kind: Entry
           Type: 1447 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcd9f8a", Frameless: false}]
           Condition: null
-        - ID: 149
-          Kind: Return
+        - Kind: Return
           Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcd9fec", Frameless: false}]
           Condition: null
@@ -1913,13 +1765,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
-          Kind: Entry
+        - Kind: Entry
           Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcd9daa", Frameless: false}]
           Condition: null
-        - ID: 143
-          Kind: Return
+        - Kind: Return
           Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcd9df8", Frameless: false}]
           Condition: null
@@ -1932,13 +1782,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
-          Kind: Entry
+        - Kind: Entry
           Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcda0ea", Frameless: false}]
           Condition: null
-        - ID: 155
-          Kind: Return
+        - Kind: Return
           Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcda136", Frameless: false}]
           Condition: null
@@ -1951,13 +1799,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
-          Kind: Entry
+        - Kind: Entry
           Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcda08a", Frameless: false}]
           Condition: null
-        - ID: 153
-          Kind: Return
+        - Kind: Return
           Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcda0ce", Frameless: false}]
           Condition: null
@@ -1970,13 +1816,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
-          Kind: Entry
+        - Kind: Entry
           Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcd99aa", Frameless: false}]
           Condition: null
-        - ID: 129
-          Kind: Return
+        - Kind: Return
           Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcd9a11", Frameless: false}]
           Condition: null
@@ -1989,13 +1833,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
-          Kind: Entry
+        - Kind: Entry
           Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcda00a", Frameless: false}]
           Condition: null
-        - ID: 151
-          Kind: Return
+        - Kind: Return
           Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcda06d", Frameless: false}]
           Condition: null
@@ -2008,13 +1850,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
-          Kind: Entry
+        - Kind: Entry
           Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcd9ece", Frameless: false}]
           Condition: null
-        - ID: 147
-          Kind: Return
+        - Kind: Return
           Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcd9f54", Frameless: false}]
           Condition: null
@@ -2028,8 +1868,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 1300 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
@@ -2043,8 +1882,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 1321 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
@@ -2058,8 +1896,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 1319 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
@@ -2073,8 +1910,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
-        - ID: 34
-          Kind: Entry
+        - Kind: Entry
           Type: 1332 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
@@ -2088,8 +1924,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
-          Kind: Entry
+        - Kind: Entry
           Type: 1333 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48e0", Frameless: true}]
           Condition: null
@@ -2103,8 +1938,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 1322 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
@@ -2118,8 +1952,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
-        - ID: 26
-          Kind: Entry
+        - Kind: Entry
           Type: 1324 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
@@ -2133,8 +1966,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
-        - ID: 27
-          Kind: Entry
+        - Kind: Entry
           Type: 1325 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
@@ -2148,8 +1980,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
-        - ID: 28
-          Kind: Entry
+        - Kind: Entry
           Type: 1326 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
@@ -2163,8 +1994,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 1323 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
@@ -2178,8 +2008,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
-        - ID: 22
-          Kind: Entry
+        - Kind: Entry
           Type: 1320 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
@@ -2193,8 +2022,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
-          Kind: Entry
+        - Kind: Entry
           Type: 1489 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdb900", Frameless: true}]
           Condition: null
@@ -2208,8 +2036,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
-        - ID: 29
-          Kind: Entry
+        - Kind: Entry
           Type: 1327 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
@@ -2223,8 +2050,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
-        - ID: 31
-          Kind: Entry
+        - Kind: Entry
           Type: 1329 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
@@ -2238,8 +2064,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
-        - ID: 32
-          Kind: Entry
+        - Kind: Entry
           Type: 1330 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
@@ -2253,8 +2078,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
-        - ID: 33
-          Kind: Entry
+        - Kind: Entry
           Type: 1331 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
@@ -2268,8 +2092,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
-        - ID: 30
-          Kind: Entry
+        - Kind: Entry
           Type: 1328 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
@@ -2283,8 +2106,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
-          Kind: Entry
+        - Kind: Entry
           Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
@@ -2298,8 +2120,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
-          Kind: Entry
+        - Kind: Entry
           Type: 1477 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
@@ -2313,8 +2134,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
-        - ID: 79
-          Kind: Entry
+        - Kind: Entry
           Type: 1377 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd6900", Frameless: true}]
           Condition: null
@@ -2327,13 +2147,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
-          Kind: Entry
+        - Kind: Entry
           Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd98ce", Frameless: false}]
           Condition: null
-        - ID: 127
-          Kind: Return
+        - Kind: Return
           Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd996b", Frameless: false}]
           Condition: null
@@ -2346,13 +2164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
-          Kind: Entry
+        - Kind: Entry
           Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdac0a", Frameless: false}]
           Condition: null
-        - ID: 169
-          Kind: Return
+        - Kind: Return
           Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdac7c", Frameless: false}]
           Condition: null
@@ -2366,8 +2182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 3
-          Kind: Entry
+        - Kind: Entry
           Type: 1301 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
@@ -2381,8 +2196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
-          Kind: Entry
+        - Kind: Entry
           Type: 1404 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
@@ -2396,8 +2210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
-          Kind: Entry
+        - Kind: Entry
           Type: 1481 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
@@ -2411,8 +2224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
-          Kind: Entry
+        - Kind: Entry
           Type: 1343 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e80", Frameless: true}]
           Condition: null
@@ -2426,8 +2238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 46
-          Kind: Entry
+        - Kind: Entry
           Type: 1344 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4ea0", Frameless: true}]
           Condition: null
@@ -2441,13 +2252,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
-          Kind: Entry
+        - Kind: Entry
           Type: 1502 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcdbca0", Frameless: true}]
           Condition: null
-        - ID: 204
-          Kind: Return
+        - Kind: Return
           Type: 1503 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcdbcc2", Frameless: true}]
           Condition: null
@@ -2461,8 +2270,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
-          Kind: Entry
+        - Kind: Entry
           Type: 1478 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
@@ -2476,8 +2284,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
-        - ID: 73
-          Kind: Entry
+        - Kind: Entry
           Type: 1371 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcd6200", Frameless: true}]
           Condition: null
@@ -2490,13 +2297,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
-          Kind: Entry
+        - Kind: Entry
           Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdadae", Frameless: false}]
           Condition: null
-        - ID: 173
-          Kind: Return
+        - Kind: Return
           Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdae5a", Frameless: false}]
           Condition: null
@@ -2509,13 +2314,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
-          Kind: Entry
+        - Kind: Entry
           Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcdbb60", Frameless: true}]
           Condition: null
-        - ID: 202
-          Kind: Return
+        - Kind: Return
           Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcdbb7e", Frameless: true}]
           Condition: null
@@ -2528,8 +2331,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
-          Kind: Entry
+        - Kind: Entry
           Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcdbb40", Frameless: true}]
           Condition: null
@@ -2543,8 +2345,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
-        - ID: 74
-          Kind: Entry
+        - Kind: Entry
           Type: 1372 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
           Condition: null
@@ -2558,8 +2359,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
-          Kind: Entry
+        - Kind: Entry
           Type: 1490 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdb920", Frameless: true}]
           Condition: null
@@ -2573,13 +2373,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
-          Kind: Entry
+        - Kind: Entry
           Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdb940", Frameless: true}]
           Condition: null
-        - ID: 193
-          Kind: Return
+        - Kind: Return
           Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdb95e", Frameless: true}]
           Condition: null
@@ -2593,8 +2391,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
-          Kind: Entry
+        - Kind: Entry
           Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdb960", Frameless: true}]
           Condition: null
@@ -2608,8 +2405,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
-        - ID: 36
-          Kind: Entry
+        - Kind: Entry
           Type: 1334 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd4900", Frameless: true}]
           Condition: null
@@ -2623,8 +2419,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 1310 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
@@ -2638,8 +2433,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 1311 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
@@ -2653,8 +2447,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 14
-          Kind: Entry
+        - Kind: Entry
           Type: 1312 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
@@ -2668,8 +2461,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 11
-          Kind: Entry
+        - Kind: Entry
           Type: 1309 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
@@ -2683,8 +2475,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 1308 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
@@ -2698,8 +2489,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 105
-          Kind: Entry
+        - Kind: Entry
           Type: 1403 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
@@ -2713,8 +2503,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
-          Kind: Entry
+        - Kind: Entry
           Type: 1475 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdb420", Frameless: true}]
           Condition: null
@@ -2728,8 +2517,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
-          Kind: Entry
+        - Kind: Entry
           Type: 1497 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
@@ -2743,8 +2531,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 104
-          Kind: Entry
+        - Kind: Entry
           Type: 1402 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
@@ -2758,8 +2545,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
-        - ID: 20
-          Kind: Entry
+        - Kind: Entry
           Type: 1318 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
           Condition: null
@@ -2773,8 +2559,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
-          Kind: Entry
+        - Kind: Entry
           Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
@@ -2788,8 +2573,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
-          Kind: Entry
+        - Kind: Entry
           Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
@@ -2802,13 +2586,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
-          Kind: Entry
+        - Kind: Entry
           Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdae8e", Frameless: false}]
           Condition: null
-        - ID: 175
-          Kind: Return
+        - Kind: Return
           Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdaf0c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
-          Kind: Entry
+        - Kind: Entry
           Type: 1506 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xce00ca", Frameless: false}]
           Condition: null
-        - ID: 189
-          Kind: Return
+        - Kind: Return
           Type: 1507 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xce0105", Frameless: false}]
           Condition: null
@@ -30,13 +28,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
-        - ID: 69
-          Kind: Entry
+        - Kind: Entry
           Type: 1385 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda9ea", Frameless: false}]
           Condition: null
-        - ID: 68
-          Kind: Return
+        - Kind: Return
           Type: 1386 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcdaa25", Frameless: false}]
           Condition: null
@@ -50,13 +46,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
-        - ID: 72
-          Kind: Entry
+        - Kind: Entry
           Type: 1388 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcdaa8a", Frameless: false}]
           Condition: null
-        - ID: 71
-          Kind: Return
+        - Kind: Return
           Type: 1389 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcdaabd", Frameless: false}]
           Condition: null
@@ -69,13 +63,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
-          Kind: Entry
+        - Kind: Entry
           Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcdebae", Frameless: false}]
           Condition: null
-        - ID: 161
-          Kind: Return
+        - Kind: Return
           Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdec62", Frameless: false}]
           Condition: null
@@ -89,8 +81,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 1336 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
@@ -104,8 +95,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 1332 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
@@ -119,8 +109,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 1334 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
           Condition: null
@@ -134,8 +123,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
-        - ID: 80
-          Kind: Entry
+        - Kind: Entry
           Type: 1397 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcdb1a0", Frameless: true}]
           Condition: null
@@ -149,8 +137,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
-        - ID: 16
-          Kind: Entry
+        - Kind: Entry
           Type: 1333 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
@@ -163,8 +150,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
-        - ID: 18
-          Kind: Entry
+        - Kind: Entry
           Type: 1335 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
           Condition: null
@@ -178,13 +164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
-        - ID: 38
-          Kind: Entry
+        - Kind: Entry
           Type: 1354 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9360", Frameless: true}]
           Condition: null
-        - ID: 37
-          Kind: Return
+        - Kind: Return
           Type: 1355 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd937e", Frameless: true}]
           Condition: null
@@ -198,8 +182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 1321 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
@@ -213,8 +196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 1318 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
@@ -228,8 +210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
-        - ID: 100
-          Kind: Entry
+        - Kind: Entry
           Type: 1417 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
           Condition: null
@@ -243,8 +224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
-        - ID: 98
-          Kind: Entry
+        - Kind: Entry
           Type: 1415 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
           Condition: null
@@ -258,8 +238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 108
-          Kind: Entry
+        - Kind: Entry
           Type: 1425 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
           Condition: null
@@ -273,8 +252,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
-        - ID: 43
-          Kind: Entry
+        - Kind: Entry
           Type: 1360 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
@@ -288,8 +266,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
-        - ID: 44
-          Kind: Entry
+        - Kind: Entry
           Type: 1361 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
@@ -303,8 +280,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
-        - ID: 39
-          Kind: Entry
+        - Kind: Entry
           Type: 1356 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd9420", Frameless: true}]
           Condition: null
@@ -318,8 +294,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
-        - ID: 40
-          Kind: Entry
+        - Kind: Entry
           Type: 1357 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9440", Frameless: true}]
           Condition: null
@@ -333,8 +308,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
-        - ID: 41
-          Kind: Entry
+        - Kind: Entry
           Type: 1358 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
           Condition: null
@@ -348,8 +322,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
-        - ID: 42
-          Kind: Entry
+        - Kind: Entry
           Type: 1359 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95e0", Frameless: true}]
           Condition: null
@@ -363,8 +336,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
-          Kind: Entry
+        - Kind: Entry
           Type: 1495 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
           Condition: null
@@ -378,8 +350,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
-          Kind: Entry
+        - Kind: Entry
           Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
@@ -394,8 +365,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
-          Kind: Entry
+        - Kind: Entry
           Type: 1517 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
@@ -409,8 +379,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
-          Kind: Entry
+        - Kind: Entry
           Type: 1523 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xce0640", Frameless: true}]
           Condition: null
@@ -423,8 +392,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
-          Kind: Entry
+        - Kind: Entry
           Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xce0660", Frameless: true}]
           Condition: null
@@ -438,8 +406,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
-        - ID: 70
-          Kind: Entry
+        - Kind: Entry
           Type: 1387 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
           Condition: null
@@ -453,13 +420,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
-          Kind: Entry
+        - Kind: Entry
           Type: 1369 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9f6a", Frameless: false}]
           Condition: null
-        - ID: 52
-          Kind: Return
+        - Kind: Return
           Type: 1370 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd9fac", Frameless: false}]
           Condition: null
@@ -473,13 +438,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
-          Kind: Entry
+        - Kind: Entry
           Type: 1367 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9e4e", Frameless: false}]
           Condition: null
-        - ID: 50
-          Kind: Return
+        - Kind: Return
           Type: 1368 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd9edb", Frameless: false}]
           Condition: null
@@ -493,13 +456,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 63
-          Kind: Entry
+        - Kind: Entry
           Type: 1379 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda6c0", Frameless: true}]
           Condition: null
-        - ID: 62
-          Kind: Return
+        - Kind: Return
           Type: 1380 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcda6c5", Frameless: true}]
           Condition: null
@@ -513,13 +474,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 65
-          Kind: Entry
+        - Kind: Entry
           Type: 1381 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda6e4", Frameless: false}]
           Condition: null
-        - ID: 64
-          Kind: Return
+        - Kind: Return
           Type: 1382 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcda71d", Frameless: false}]
           Condition: null
@@ -536,8 +495,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 66
-          Kind: Line
+        - Kind: Line
           Type: 1383 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcda6e8", Frameless: false}]
           Condition: null
@@ -551,13 +509,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
-          Kind: Entry
+        - Kind: Entry
           Type: 1371 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda3aa", Frameless: false}]
           Condition: null
-        - ID: 54
-          Kind: Return
+        - Kind: Return
           Type: 1372 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcda40e", Frameless: false}]
           Condition: null
@@ -571,13 +527,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
-          Kind: Entry
+        - Kind: Entry
           Type: 1373 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
           Condition: null
-        - ID: 56
-          Kind: Return
+        - Kind: Return
           Type: 1374 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcda4de", Frameless: false}]
           Condition: null
@@ -591,13 +545,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
-          Kind: Entry
+        - Kind: Entry
           Type: 1375 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda52a", Frameless: false}]
           Condition: null
-        - ID: 58
-          Kind: Return
+        - Kind: Return
           Type: 1376 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcda56b", Frameless: false}]
           Condition: null
@@ -611,8 +563,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
-          Kind: Entry
+        - Kind: Entry
           Type: 1528 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
@@ -626,13 +577,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
-        - ID: 61
-          Kind: Entry
+        - Kind: Entry
           Type: 1377 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda5ae", Frameless: false}]
           Condition: null
-        - ID: 60
-          Kind: Return
+        - Kind: Return
           Type: 1378 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcda693", Frameless: false}]
           Condition: null
@@ -646,8 +595,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
-          Kind: Entry
+        - Kind: Entry
           Type: 1529 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
@@ -664,8 +612,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
-          Kind: Line
+        - Kind: Line
           Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
@@ -679,8 +626,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
-          Kind: Entry
+        - Kind: Entry
           Type: 1531 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
@@ -697,8 +643,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
-          Kind: Line
+        - Kind: Line
           Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
@@ -713,8 +658,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
-          Kind: Entry
+        - Kind: Entry
           Type: 1525 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda20a"
@@ -728,8 +672,7 @@ Probes:
             - PC: "0xcda52f"
               Frameless: false
           Condition: null
-        - ID: 208
-          Kind: Return
+        - Kind: Return
           Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
@@ -746,8 +689,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
-          Kind: Line
+        - Kind: Line
           Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
@@ -771,8 +713,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
-          Kind: Entry
+        - Kind: Entry
           Type: 1533 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
@@ -789,8 +730,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
-          Kind: Line
+        - Kind: Line
           Type: 1534 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
@@ -805,8 +745,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
-          Kind: Entry
+        - Kind: Entry
           Type: 1535 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda705"
@@ -824,8 +763,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 7
-          Kind: Entry
+        - Kind: Entry
           Type: 1324 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
@@ -839,8 +777,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 1325 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
@@ -854,8 +791,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 9
-          Kind: Entry
+        - Kind: Entry
           Type: 1326 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
@@ -869,8 +805,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 1323 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
@@ -884,8 +819,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 5
-          Kind: Entry
+        - Kind: Entry
           Type: 1322 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
@@ -899,8 +833,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 67
-          Kind: Entry
+        - Kind: Entry
           Type: 1384 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda9c0", Frameless: true}]
           Condition: null
@@ -913,13 +846,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
-          Kind: Entry
+        - Kind: Entry
           Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcdea0e", Frameless: false}]
           Condition: null
-        - ID: 159
-          Kind: Return
+        - Kind: Return
           Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdeb73", Frameless: false}]
           Condition: null
@@ -933,8 +864,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
-        - ID: 102
-          Kind: Entry
+        - Kind: Entry
           Type: 1419 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
           Condition: null
@@ -951,8 +881,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 47
-          Kind: Line
+        - Kind: Line
           Type: 1364 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd97da", Frameless: false}]
           Condition: null
@@ -969,8 +898,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 48
-          Kind: Line
+        - Kind: Line
           Type: 1365 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd988d", Frameless: false}]
           Condition: null
@@ -987,8 +915,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
-          Kind: Line
+        - Kind: Line
           Type: 1366 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd9954", Frameless: false}]
           Condition: null
@@ -1001,13 +928,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
-          Kind: Entry
+        - Kind: Entry
           Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcdeed3", Frameless: false}]
           Condition: null
-        - ID: 165
-          Kind: Return
+        - Kind: Return
           Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcdf0e2", Frameless: false}]
           Condition: null
@@ -1021,8 +946,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
-        - ID: 78
-          Kind: Entry
+        - Kind: Entry
           Type: 1395 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
           Condition: null
@@ -1036,8 +960,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
-        - ID: 85
-          Kind: Entry
+        - Kind: Entry
           Type: 1402 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
           Condition: null
@@ -1051,8 +974,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
-        - ID: 95
-          Kind: Entry
+        - Kind: Entry
           Type: 1412 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xcdb360", Frameless: true}]
           Condition: null
@@ -1066,8 +988,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
-        - ID: 97
-          Kind: Entry
+        - Kind: Entry
           Type: 1414 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xcdb3a0", Frameless: true}]
           Condition: null
@@ -1081,8 +1002,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
-        - ID: 96
-          Kind: Entry
+        - Kind: Entry
           Type: 1413 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xcdb380", Frameless: true}]
           Condition: null
@@ -1096,8 +1016,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
-        - ID: 82
-          Kind: Entry
+        - Kind: Entry
           Type: 1399 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcdb1e0", Frameless: true}]
           Condition: null
@@ -1111,8 +1030,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
-        - ID: 94
-          Kind: Entry
+        - Kind: Entry
           Type: 1411 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb340", Frameless: true}]
           Condition: null
@@ -1126,8 +1044,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
-        - ID: 93
-          Kind: Entry
+        - Kind: Entry
           Type: 1410 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcdb320", Frameless: true}]
           Condition: null
@@ -1141,8 +1058,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 83
-          Kind: Entry
+        - Kind: Entry
           Type: 1400 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
@@ -1156,8 +1072,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 84
-          Kind: Entry
+        - Kind: Entry
           Type: 1401 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
@@ -1171,8 +1086,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
-        - ID: 92
-          Kind: Entry
+        - Kind: Entry
           Type: 1409 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
           Condition: null
@@ -1186,8 +1100,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
-        - ID: 91
-          Kind: Entry
+        - Kind: Entry
           Type: 1408 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
           Condition: null
@@ -1201,8 +1114,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
-        - ID: 76
-          Kind: Entry
+        - Kind: Entry
           Type: 1393 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcdb120", Frameless: true}]
           Condition: null
@@ -1216,8 +1128,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
-        - ID: 77
-          Kind: Entry
+        - Kind: Entry
           Type: 1394 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcdb140", Frameless: true}]
           Condition: null
@@ -1231,8 +1142,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
-        - ID: 75
-          Kind: Entry
+        - Kind: Entry
           Type: 1392 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcdb100", Frameless: true}]
           Condition: null
@@ -1246,8 +1156,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
-        - ID: 86
-          Kind: Entry
+        - Kind: Entry
           Type: 1403 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
           Condition: null
@@ -1261,8 +1170,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
-        - ID: 89
-          Kind: Entry
+        - Kind: Entry
           Type: 1406 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
           Condition: null
@@ -1276,8 +1184,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
-        - ID: 90
-          Kind: Entry
+        - Kind: Entry
           Type: 1407 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
           Condition: null
@@ -1291,8 +1198,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
-        - ID: 87
-          Kind: Entry
+        - Kind: Entry
           Type: 1404 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
           Condition: null
@@ -1306,8 +1212,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
-        - ID: 88
-          Kind: Entry
+        - Kind: Entry
           Type: 1405 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
           Condition: null
@@ -1321,8 +1226,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
-          Kind: Entry
+        - Kind: Entry
           Type: 1514 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
@@ -1337,8 +1241,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
-          Kind: Entry
+        - Kind: Entry
           Type: 1515 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
@@ -1351,13 +1254,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
-          Kind: Entry
+        - Kind: Entry
           Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcdf173", Frameless: false}]
           Condition: null
-        - ID: 167
-          Kind: Return
+        - Kind: Return
           Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdf3ab", Frameless: false}]
           Condition: null
@@ -1370,13 +1271,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
-          Kind: Entry
+        - Kind: Entry
           Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdf4ee", Frameless: false}]
           Condition: null
-        - ID: 171
-          Kind: Return
+        - Kind: Return
           Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdf5bf", Frameless: false}]
           Condition: null
@@ -1389,13 +1288,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
-          Kind: Entry
+        - Kind: Entry
           Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcdec8e", Frameless: false}]
           Condition: null
-        - ID: 163
-          Kind: Return
+        - Kind: Return
           Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcdeeaa", Frameless: false}]
           Condition: null
@@ -1408,13 +1305,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
-          Kind: Entry
+        - Kind: Entry
           Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
           Condition: null
-        - ID: 125
-          Kind: Return
+        - Kind: Return
           Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
@@ -1428,8 +1323,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
-        - ID: 99
-          Kind: Entry
+        - Kind: Entry
           Type: 1416 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdce60", Frameless: true}]
           Condition: null
@@ -1442,13 +1336,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
-        - ID: 124
-          Kind: Entry
+        - Kind: Entry
           Type: 1440 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcddf8a", Frameless: false}]
           Condition: null
-        - ID: 123
-          Kind: Return
+        - Kind: Return
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
           Condition: null
@@ -1462,8 +1354,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 107
-          Kind: Entry
+        - Kind: Entry
           Type: 1424 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
           Condition: null
@@ -1477,8 +1368,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
-          Kind: Entry
+        - Kind: Entry
           Type: 1502 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
@@ -1492,8 +1382,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
-          Kind: Entry
+        - Kind: Entry
           Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
@@ -1507,8 +1396,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
-          Kind: Entry
+        - Kind: Entry
           Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
@@ -1522,8 +1410,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
-          Kind: Entry
+        - Kind: Entry
           Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xce01a0", Frameless: true}]
           Condition: null
@@ -1537,8 +1424,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 103
-          Kind: Entry
+        - Kind: Entry
           Type: 1420 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
           Condition: null
@@ -1552,8 +1438,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
-        - ID: 81
-          Kind: Entry
+        - Kind: Entry
           Type: 1398 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
@@ -1567,8 +1452,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
-        - ID: 101
-          Kind: Entry
+        - Kind: Entry
           Type: 1418 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdd220", Frameless: true}]
           Condition: null
@@ -1582,13 +1466,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
-        - ID: 120
-          Kind: Entry
+        - Kind: Entry
           Type: 1436 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcddc2e", Frameless: false}]
           Condition: null
-        - ID: 119
-          Kind: Return
+        - Kind: Return
           Type: 1437 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xcddcd5"
@@ -1610,13 +1492,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
-        - ID: 118
-          Kind: Entry
+        - Kind: Entry
           Type: 1434 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcddace", Frameless: false}]
           Condition: null
-        - ID: 117
-          Kind: Return
+        - Kind: Return
           Type: 1435 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcddb24"
@@ -1637,13 +1517,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
-          Kind: Entry
+        - Kind: Entry
           Type: 1454 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcde4aa", Frameless: false}]
           Condition: null
-        - ID: 137
-          Kind: Return
+        - Kind: Return
           Type: 1455 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcde50d", Frameless: false}]
           Condition: null
@@ -1656,13 +1534,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
-          Kind: Entry
+        - Kind: Entry
           Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcde52a", Frameless: false}]
           Condition: null
-        - ID: 139
-          Kind: Return
+        - Kind: Return
           Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcde56b", Frameless: false}]
           Condition: null
@@ -1675,13 +1551,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
-          Kind: Entry
+        - Kind: Entry
           Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcde58a", Frameless: false}]
           Condition: null
-        - ID: 141
-          Kind: Return
+        - Kind: Return
           Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcde5c6", Frameless: false}]
           Condition: null
@@ -1694,13 +1568,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
-          Kind: Entry
+        - Kind: Entry
           Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcde66e", Frameless: false}]
           Condition: null
-        - ID: 145
-          Kind: Return
+        - Kind: Return
           Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcde6ea", Frameless: false}]
           Condition: null
@@ -1713,13 +1585,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
-          Kind: Entry
+        - Kind: Entry
           Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcde9aa", Frameless: false}]
           Condition: null
-        - ID: 157
-          Kind: Return
+        - Kind: Return
           Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcde9f0", Frameless: false}]
           Condition: null
@@ -1732,13 +1602,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
-          Kind: Entry
+        - Kind: Entry
           Type: 1450 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcde36a", Frameless: false}]
           Condition: null
-        - ID: 133
-          Kind: Return
+        - Kind: Return
           Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcde3c6", Frameless: false}]
           Condition: null
@@ -1752,13 +1620,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 116
-          Kind: Entry
+        - Kind: Entry
           Type: 1432 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcdda6a", Frameless: false}]
           Condition: null
-        - ID: 115
-          Kind: Return
+        - Kind: Return
           Type: 1433 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcdda9a"
@@ -1775,13 +1641,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 110
-          Kind: Entry
+        - Kind: Entry
           Type: 1426 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcdd86a", Frameless: false}]
           Condition: null
-        - ID: 109
-          Kind: Return
+        - Kind: Return
           Type: 1427 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcdd8bb", Frameless: false}]
           Condition: null
@@ -1794,13 +1658,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 114
-          Kind: Entry
+        - Kind: Entry
           Type: 1430 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcdd98e", Frameless: false}]
           Condition: null
-        - ID: 113
-          Kind: Return
+        - Kind: Return
           Type: 1431 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcdda44", Frameless: false}]
           Condition: null
@@ -1813,13 +1675,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 112
-          Kind: Entry
+        - Kind: Entry
           Type: 1428 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcdd8ea", Frameless: false}]
           Condition: null
-        - ID: 111
-          Kind: Return
+        - Kind: Return
           Type: 1429 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcdd954", Frameless: false}]
           Condition: null
@@ -1833,13 +1693,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
-        - ID: 122
-          Kind: Entry
+        - Kind: Entry
           Type: 1438 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcdde2e", Frameless: false}]
           Condition: null
-        - ID: 121
-          Kind: Return
+        - Kind: Return
           Type: 1439 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcddeff"
@@ -1856,13 +1714,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
-          Kind: Entry
+        - Kind: Entry
           Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcde3ee", Frameless: false}]
           Condition: null
-        - ID: 135
-          Kind: Return
+        - Kind: Return
           Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcde473", Frameless: false}]
           Condition: null
@@ -1875,13 +1731,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
-          Kind: Entry
+        - Kind: Entry
           Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcde26e", Frameless: false}]
           Condition: null
-        - ID: 131
-          Kind: Return
+        - Kind: Return
           Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcde347", Frameless: false}]
           Condition: null
@@ -1894,13 +1748,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
-          Kind: Entry
+        - Kind: Entry
           Type: 1466 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcde7ca", Frameless: false}]
           Condition: null
-        - ID: 149
-          Kind: Return
+        - Kind: Return
           Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcde82c", Frameless: false}]
           Condition: null
@@ -1913,13 +1765,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
-          Kind: Entry
+        - Kind: Entry
           Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcde5ea", Frameless: false}]
           Condition: null
-        - ID: 143
-          Kind: Return
+        - Kind: Return
           Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcde638", Frameless: false}]
           Condition: null
@@ -1932,13 +1782,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
-          Kind: Entry
+        - Kind: Entry
           Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcde92a", Frameless: false}]
           Condition: null
-        - ID: 155
-          Kind: Return
+        - Kind: Return
           Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcde976", Frameless: false}]
           Condition: null
@@ -1951,13 +1799,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
-          Kind: Entry
+        - Kind: Entry
           Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcde8ca", Frameless: false}]
           Condition: null
-        - ID: 153
-          Kind: Return
+        - Kind: Return
           Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcde90e", Frameless: false}]
           Condition: null
@@ -1970,13 +1816,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
-          Kind: Entry
+        - Kind: Entry
           Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcde1ea", Frameless: false}]
           Condition: null
-        - ID: 129
-          Kind: Return
+        - Kind: Return
           Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcde251", Frameless: false}]
           Condition: null
@@ -1989,13 +1833,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
-          Kind: Entry
+        - Kind: Entry
           Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcde84a", Frameless: false}]
           Condition: null
-        - ID: 151
-          Kind: Return
+        - Kind: Return
           Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcde8ad", Frameless: false}]
           Condition: null
@@ -2008,13 +1850,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
-          Kind: Entry
+        - Kind: Entry
           Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcde70e", Frameless: false}]
           Condition: null
-        - ID: 147
-          Kind: Return
+        - Kind: Return
           Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcde794", Frameless: false}]
           Condition: null
@@ -2028,8 +1868,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 1319 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
@@ -2043,8 +1882,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 1340 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
@@ -2058,8 +1896,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 1338 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
@@ -2073,8 +1910,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
-        - ID: 34
-          Kind: Entry
+        - Kind: Entry
           Type: 1351 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
@@ -2088,8 +1924,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
-          Kind: Entry
+        - Kind: Entry
           Type: 1352 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91e0", Frameless: true}]
           Condition: null
@@ -2103,8 +1938,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 1341 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
@@ -2118,8 +1952,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
-        - ID: 26
-          Kind: Entry
+        - Kind: Entry
           Type: 1343 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
@@ -2133,8 +1966,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
-        - ID: 27
-          Kind: Entry
+        - Kind: Entry
           Type: 1344 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
@@ -2148,8 +1980,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
-        - ID: 28
-          Kind: Entry
+        - Kind: Entry
           Type: 1345 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
@@ -2163,8 +1994,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 1342 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
@@ -2178,8 +2008,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
-        - ID: 22
-          Kind: Entry
+        - Kind: Entry
           Type: 1339 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
@@ -2193,8 +2022,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
-          Kind: Entry
+        - Kind: Entry
           Type: 1508 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xce0120", Frameless: true}]
           Condition: null
@@ -2208,8 +2036,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
-        - ID: 29
-          Kind: Entry
+        - Kind: Entry
           Type: 1346 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
@@ -2223,8 +2050,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
-        - ID: 31
-          Kind: Entry
+        - Kind: Entry
           Type: 1348 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
@@ -2238,8 +2064,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
-        - ID: 32
-          Kind: Entry
+        - Kind: Entry
           Type: 1349 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
@@ -2253,8 +2078,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
-        - ID: 33
-          Kind: Entry
+        - Kind: Entry
           Type: 1350 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
@@ -2268,8 +2092,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
-        - ID: 30
-          Kind: Entry
+        - Kind: Entry
           Type: 1347 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
@@ -2283,8 +2106,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
-          Kind: Entry
+        - Kind: Entry
           Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
@@ -2298,8 +2120,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
-          Kind: Entry
+        - Kind: Entry
           Type: 1496 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
@@ -2313,8 +2134,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
-        - ID: 79
-          Kind: Entry
+        - Kind: Entry
           Type: 1396 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
           Condition: null
@@ -2327,13 +2147,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
-          Kind: Entry
+        - Kind: Entry
           Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcde10e", Frameless: false}]
           Condition: null
-        - ID: 127
-          Kind: Return
+        - Kind: Return
           Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcde1ad", Frameless: false}]
           Condition: null
@@ -2346,13 +2164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
-          Kind: Entry
+        - Kind: Entry
           Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdf44a", Frameless: false}]
           Condition: null
-        - ID: 169
-          Kind: Return
+        - Kind: Return
           Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdf4bc", Frameless: false}]
           Condition: null
@@ -2366,8 +2182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 3
-          Kind: Entry
+        - Kind: Entry
           Type: 1320 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
@@ -2381,8 +2196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
-          Kind: Entry
+        - Kind: Entry
           Type: 1423 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
           Condition: null
@@ -2396,8 +2210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
-          Kind: Entry
+        - Kind: Entry
           Type: 1500 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
@@ -2411,8 +2224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
-          Kind: Entry
+        - Kind: Entry
           Type: 1362 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
           Condition: null
@@ -2426,8 +2238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 46
-          Kind: Entry
+        - Kind: Entry
           Type: 1363 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
           Condition: null
@@ -2441,13 +2252,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
-          Kind: Entry
+        - Kind: Entry
           Type: 1521 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xce04c0", Frameless: true}]
           Condition: null
-        - ID: 204
-          Kind: Return
+        - Kind: Return
           Type: 1522 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xce04e2", Frameless: true}]
           Condition: null
@@ -2461,8 +2270,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
-          Kind: Entry
+        - Kind: Entry
           Type: 1497 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
@@ -2476,8 +2284,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
-        - ID: 73
-          Kind: Entry
+        - Kind: Entry
           Type: 1390 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
           Condition: null
@@ -2490,13 +2297,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
-          Kind: Entry
+        - Kind: Entry
           Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdf5ee", Frameless: false}]
           Condition: null
-        - ID: 173
-          Kind: Return
+        - Kind: Return
           Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdf69c", Frameless: false}]
           Condition: null
@@ -2509,13 +2314,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
-          Kind: Entry
+        - Kind: Entry
           Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xce0380", Frameless: true}]
           Condition: null
-        - ID: 202
-          Kind: Return
+        - Kind: Return
           Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xce039e", Frameless: true}]
           Condition: null
@@ -2528,8 +2331,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
-          Kind: Entry
+        - Kind: Entry
           Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xce0360", Frameless: true}]
           Condition: null
@@ -2543,8 +2345,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
-        - ID: 74
-          Kind: Entry
+        - Kind: Entry
           Type: 1391 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
           Condition: null
@@ -2558,8 +2359,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
-          Kind: Entry
+        - Kind: Entry
           Type: 1509 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xce0140", Frameless: true}]
           Condition: null
@@ -2573,13 +2373,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
-          Kind: Entry
+        - Kind: Entry
           Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xce0160", Frameless: true}]
           Condition: null
-        - ID: 193
-          Kind: Return
+        - Kind: Return
           Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce017e", Frameless: true}]
           Condition: null
@@ -2593,8 +2391,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
-          Kind: Entry
+        - Kind: Entry
           Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0180", Frameless: true}]
           Condition: null
@@ -2608,8 +2405,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
-        - ID: 36
-          Kind: Entry
+        - Kind: Entry
           Type: 1353 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd9200", Frameless: true}]
           Condition: null
@@ -2623,8 +2419,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 1329 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
@@ -2638,8 +2433,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 1330 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
@@ -2653,8 +2447,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 14
-          Kind: Entry
+        - Kind: Entry
           Type: 1331 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
@@ -2668,8 +2461,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 11
-          Kind: Entry
+        - Kind: Entry
           Type: 1328 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
@@ -2683,8 +2475,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 1327 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
@@ -2698,8 +2489,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 105
-          Kind: Entry
+        - Kind: Entry
           Type: 1422 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
           Condition: null
@@ -2713,8 +2503,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
-          Kind: Entry
+        - Kind: Entry
           Type: 1494 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
           Condition: null
@@ -2728,8 +2517,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
-          Kind: Entry
+        - Kind: Entry
           Type: 1516 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
@@ -2743,8 +2531,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 104
-          Kind: Entry
+        - Kind: Entry
           Type: 1421 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
           Condition: null
@@ -2758,8 +2545,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
-        - ID: 20
-          Kind: Entry
+        - Kind: Entry
           Type: 1337 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
           Condition: null
@@ -2773,8 +2559,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
-          Kind: Entry
+        - Kind: Entry
           Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
@@ -2788,8 +2573,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
-          Kind: Entry
+        - Kind: Entry
           Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
@@ -2802,13 +2586,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
-          Kind: Entry
+        - Kind: Entry
           Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdf6ce", Frameless: false}]
           Condition: null
-        - ID: 175
-          Kind: Return
+        - Kind: Return
           Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdf74c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
-          Kind: Entry
+        - Kind: Entry
           Type: 1312 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x892858", Frameless: false}]
           Condition: null
-        - ID: 189
-          Kind: Return
+        - Kind: Return
           Type: 1313 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x89288c", Frameless: false}]
           Condition: null
@@ -30,13 +28,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
-        - ID: 69
-          Kind: Entry
+        - Kind: Entry
           Type: 1191 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88dd58", Frameless: false}]
           Condition: null
-        - ID: 68
-          Kind: Return
+        - Kind: Return
           Type: 1192 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x88dd84", Frameless: false}]
           Condition: null
@@ -50,13 +46,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
-        - ID: 72
-          Kind: Entry
+        - Kind: Entry
           Type: 1194 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88ddd8", Frameless: false}]
           Condition: null
-        - ID: 71
-          Kind: Return
+        - Kind: Return
           Type: 1195 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x88de04", Frameless: false}]
           Condition: null
@@ -69,13 +63,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
-          Kind: Entry
+        - Kind: Entry
           Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x89160c", Frameless: false}]
           Condition: null
-        - ID: 161
-          Kind: Return
+        - Kind: Return
           Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x8916a4", Frameless: false}]
           Condition: null
@@ -89,8 +81,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 1142 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
@@ -104,8 +95,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 1138 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
@@ -119,8 +109,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 1140 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
@@ -134,8 +123,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
-        - ID: 80
-          Kind: Entry
+        - Kind: Entry
           Type: 1203 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88e440", Frameless: true}]
           Condition: null
@@ -149,8 +137,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
-        - ID: 16
-          Kind: Entry
+        - Kind: Entry
           Type: 1139 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
@@ -163,8 +150,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
-        - ID: 18
-          Kind: Entry
+        - Kind: Entry
           Type: 1141 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
@@ -178,13 +164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
-        - ID: 38
-          Kind: Entry
+        - Kind: Entry
           Type: 1160 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c8b0", Frameless: true}]
           Condition: null
-        - ID: 37
-          Kind: Return
+        - Kind: Return
           Type: 1161 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x88c8c8", Frameless: true}]
           Condition: null
@@ -198,8 +182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 1127 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
@@ -213,8 +196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 1124 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
@@ -228,8 +210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
-        - ID: 100
-          Kind: Entry
+        - Kind: Entry
           Type: 1223 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88fb30", Frameless: true}]
           Condition: null
@@ -243,8 +224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
-        - ID: 98
-          Kind: Entry
+        - Kind: Entry
           Type: 1221 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88f8b0", Frameless: true}]
           Condition: null
@@ -258,8 +238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 108
-          Kind: Entry
+        - Kind: Entry
           Type: 1231 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fdd0", Frameless: true}]
           Condition: null
@@ -273,8 +252,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
-        - ID: 43
-          Kind: Entry
+        - Kind: Entry
           Type: 1166 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
           Condition: null
@@ -288,8 +266,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
-        - ID: 44
-          Kind: Entry
+        - Kind: Entry
           Type: 1167 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
@@ -303,8 +280,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
-        - ID: 39
-          Kind: Entry
+        - Kind: Entry
           Type: 1162 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c980", Frameless: true}]
           Condition: null
@@ -318,8 +294,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
-        - ID: 40
-          Kind: Entry
+        - Kind: Entry
           Type: 1163 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c990", Frameless: true}]
           Condition: null
@@ -333,8 +308,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
-        - ID: 41
-          Kind: Entry
+        - Kind: Entry
           Type: 1164 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb30", Frameless: true}]
           Condition: null
@@ -348,8 +322,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
-        - ID: 42
-          Kind: Entry
+        - Kind: Entry
           Type: 1165 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb40", Frameless: true}]
           Condition: null
@@ -363,8 +336,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
-          Kind: Entry
+        - Kind: Entry
           Type: 1301 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x8924d0", Frameless: true}]
           Condition: null
@@ -378,8 +350,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
-          Kind: Entry
+        - Kind: Entry
           Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x892500", Frameless: true}]
           Condition: null
@@ -394,8 +365,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
-          Kind: Entry
+        - Kind: Entry
           Type: 1323 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x892930", Frameless: true}]
           Condition: null
@@ -409,8 +379,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
-          Kind: Entry
+        - Kind: Entry
           Type: 1329 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x892c80", Frameless: true}]
           Condition: null
@@ -423,8 +392,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
-          Kind: Entry
+        - Kind: Entry
           Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x892c90", Frameless: true}]
           Condition: null
@@ -438,8 +406,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
-        - ID: 70
-          Kind: Entry
+        - Kind: Entry
           Type: 1193 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88ddb0", Frameless: true}]
           Condition: null
@@ -453,13 +420,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
-          Kind: Entry
+        - Kind: Entry
           Type: 1175 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d358", Frameless: false}]
           Condition: null
-        - ID: 52
-          Kind: Return
+        - Kind: Return
           Type: 1176 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x88d394", Frameless: false}]
           Condition: null
@@ -473,13 +438,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
-          Kind: Entry
+        - Kind: Entry
           Type: 1173 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d26c", Frameless: false}]
           Condition: null
-        - ID: 50
-          Kind: Return
+        - Kind: Return
           Type: 1174 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x88d2dc", Frameless: false}]
           Condition: null
@@ -493,13 +456,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 63
-          Kind: Entry
+        - Kind: Entry
           Type: 1185 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88da80", Frameless: true}]
           Condition: null
-        - ID: 62
-          Kind: Return
+        - Kind: Return
           Type: 1186 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x88da88", Frameless: true}]
           Condition: null
@@ -513,13 +474,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 65
-          Kind: Entry
+        - Kind: Entry
           Type: 1187 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88da9c", Frameless: false}]
           Condition: null
-        - ID: 64
-          Kind: Return
+        - Kind: Return
           Type: 1188 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x88dad8", Frameless: false}]
           Condition: null
@@ -536,8 +495,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 66
-          Kind: Line
+        - Kind: Line
           Type: 1189 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x88da9c", Frameless: false}]
           Condition: null
@@ -551,13 +509,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
-          Kind: Entry
+        - Kind: Entry
           Type: 1177 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d798", Frameless: false}]
           Condition: null
-        - ID: 54
-          Kind: Return
+        - Kind: Return
           Type: 1178 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x88d7f0", Frameless: false}]
           Condition: null
@@ -571,13 +527,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
-          Kind: Entry
+        - Kind: Entry
           Type: 1179 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d828", Frameless: false}]
           Condition: null
-        - ID: 56
-          Kind: Return
+        - Kind: Return
           Type: 1180 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x88d8b0", Frameless: false}]
           Condition: null
@@ -591,13 +545,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
-          Kind: Entry
+        - Kind: Entry
           Type: 1181 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d8f8", Frameless: false}]
           Condition: null
-        - ID: 58
-          Kind: Return
+        - Kind: Return
           Type: 1182 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x88d934", Frameless: false}]
           Condition: null
@@ -611,8 +563,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
-          Kind: Entry
+        - Kind: Entry
           Type: 1334 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d878", Frameless: false}]
           Condition: null
@@ -626,13 +577,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
-        - ID: 61
-          Kind: Entry
+        - Kind: Entry
           Type: 1183 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d978", Frameless: false}]
           Condition: null
-        - ID: 60
-          Kind: Return
+        - Kind: Return
           Type: 1184 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x88da68", Frameless: false}]
           Condition: null
@@ -646,8 +595,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
-          Kind: Entry
+        - Kind: Entry
           Type: 1335 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
@@ -664,8 +612,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
-          Kind: Line
+        - Kind: Line
           Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
@@ -679,8 +626,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
-          Kind: Entry
+        - Kind: Entry
           Type: 1337 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
@@ -697,8 +643,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
-          Kind: Line
+        - Kind: Line
           Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
@@ -713,8 +658,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
-          Kind: Entry
+        - Kind: Entry
           Type: 1331 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d5f8"
@@ -728,8 +672,7 @@ Probes:
             - PC: "0x88d8fc"
               Frameless: false
           Condition: null
-        - ID: 208
-          Kind: Return
+        - Kind: Return
           Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d630", Frameless: false}]
           Condition: null
@@ -746,8 +689,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
-          Kind: Line
+        - Kind: Line
           Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d5f8"
@@ -771,8 +713,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
-          Kind: Entry
+        - Kind: Entry
           Type: 1339 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
@@ -789,8 +730,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
-          Kind: Line
+        - Kind: Line
           Type: 1340 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
@@ -805,8 +745,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
-          Kind: Entry
+        - Kind: Entry
           Type: 1341 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88dab4"
@@ -824,8 +763,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 7
-          Kind: Entry
+        - Kind: Entry
           Type: 1130 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
@@ -839,8 +777,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 1131 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
@@ -854,8 +791,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 9
-          Kind: Entry
+        - Kind: Entry
           Type: 1132 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
@@ -869,8 +805,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 1129 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
@@ -884,8 +819,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 5
-          Kind: Entry
+        - Kind: Entry
           Type: 1128 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
@@ -899,8 +833,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 67
-          Kind: Entry
+        - Kind: Entry
           Type: 1190 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88dd30", Frameless: true}]
           Condition: null
@@ -913,13 +846,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
-          Kind: Entry
+        - Kind: Entry
           Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x891430", Frameless: false}]
           Condition: null
-        - ID: 159
-          Kind: Return
+        - Kind: Return
           Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x891588", Frameless: false}]
           Condition: null
@@ -933,8 +864,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
-        - ID: 102
-          Kind: Entry
+        - Kind: Entry
           Type: 1225 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88fce0", Frameless: true}]
           Condition: null
@@ -951,8 +881,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 47
-          Kind: Line
+        - Kind: Line
           Type: 1170 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ccec", Frameless: false}]
           Condition: null
@@ -969,8 +898,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 48
-          Kind: Line
+        - Kind: Line
           Type: 1171 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88cd80", Frameless: false}]
           Condition: null
@@ -987,8 +915,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
-          Kind: Line
+        - Kind: Line
           Type: 1172 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ce2c", Frameless: false}]
           Condition: null
@@ -1001,13 +928,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
-          Kind: Entry
+        - Kind: Entry
           Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x89193c", Frameless: false}]
           Condition: null
-        - ID: 165
-          Kind: Return
+        - Kind: Return
           Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x891aac", Frameless: false}]
           Condition: null
@@ -1021,8 +946,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
-        - ID: 78
-          Kind: Entry
+        - Kind: Entry
           Type: 1201 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88e420", Frameless: true}]
           Condition: null
@@ -1036,8 +960,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
-        - ID: 85
-          Kind: Entry
+        - Kind: Entry
           Type: 1208 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
@@ -1051,8 +974,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
-        - ID: 95
-          Kind: Entry
+        - Kind: Entry
           Type: 1218 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x88e520", Frameless: true}]
           Condition: null
@@ -1066,8 +988,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
-        - ID: 97
-          Kind: Entry
+        - Kind: Entry
           Type: 1220 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x88e540", Frameless: true}]
           Condition: null
@@ -1081,8 +1002,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
-        - ID: 96
-          Kind: Entry
+        - Kind: Entry
           Type: 1219 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x88e530", Frameless: true}]
           Condition: null
@@ -1096,8 +1016,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
-        - ID: 82
-          Kind: Entry
+        - Kind: Entry
           Type: 1205 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88e460", Frameless: true}]
           Condition: null
@@ -1111,8 +1030,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
-        - ID: 94
-          Kind: Entry
+        - Kind: Entry
           Type: 1217 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88e510", Frameless: true}]
           Condition: null
@@ -1126,8 +1044,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
-        - ID: 93
-          Kind: Entry
+        - Kind: Entry
           Type: 1216 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88e500", Frameless: true}]
           Condition: null
@@ -1141,8 +1058,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 83
-          Kind: Entry
+        - Kind: Entry
           Type: 1206 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
@@ -1156,8 +1072,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 84
-          Kind: Entry
+        - Kind: Entry
           Type: 1207 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
@@ -1171,8 +1086,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
-        - ID: 92
-          Kind: Entry
+        - Kind: Entry
           Type: 1215 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
           Condition: null
@@ -1186,8 +1100,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
-        - ID: 91
-          Kind: Entry
+        - Kind: Entry
           Type: 1214 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
           Condition: null
@@ -1201,8 +1114,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
-        - ID: 76
-          Kind: Entry
+        - Kind: Entry
           Type: 1199 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88e400", Frameless: true}]
           Condition: null
@@ -1216,8 +1128,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
-        - ID: 77
-          Kind: Entry
+        - Kind: Entry
           Type: 1200 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88e410", Frameless: true}]
           Condition: null
@@ -1231,8 +1142,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
-        - ID: 75
-          Kind: Entry
+        - Kind: Entry
           Type: 1198 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
           Condition: null
@@ -1246,8 +1156,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
-        - ID: 86
-          Kind: Entry
+        - Kind: Entry
           Type: 1209 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88e490", Frameless: true}]
           Condition: null
@@ -1261,8 +1170,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
-        - ID: 89
-          Kind: Entry
+        - Kind: Entry
           Type: 1212 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
           Condition: null
@@ -1276,8 +1184,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
-        - ID: 90
-          Kind: Entry
+        - Kind: Entry
           Type: 1213 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
           Condition: null
@@ -1291,8 +1198,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
-        - ID: 87
-          Kind: Entry
+        - Kind: Entry
           Type: 1210 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
           Condition: null
@@ -1306,8 +1212,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
-        - ID: 88
-          Kind: Entry
+        - Kind: Entry
           Type: 1211 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
           Condition: null
@@ -1321,8 +1226,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
-          Kind: Entry
+        - Kind: Entry
           Type: 1320 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
@@ -1337,8 +1241,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
-          Kind: Entry
+        - Kind: Entry
           Type: 1321 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
@@ -1351,13 +1254,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
-          Kind: Entry
+        - Kind: Entry
           Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x891b30", Frameless: false}]
           Condition: null
-        - ID: 167
-          Kind: Return
+        - Kind: Return
           Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x891ce0", Frameless: false}]
           Condition: null
@@ -1370,13 +1271,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
-          Kind: Entry
+        - Kind: Entry
           Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x891e0c", Frameless: false}]
           Condition: null
-        - ID: 171
-          Kind: Return
+        - Kind: Return
           Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x891eb0", Frameless: false}]
           Condition: null
@@ -1389,13 +1288,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
-          Kind: Entry
+        - Kind: Entry
           Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x8916e0", Frameless: false}]
           Condition: null
-        - ID: 163
-          Kind: Return
+        - Kind: Return
           Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x8918b0", Frameless: false}]
           Condition: null
@@ -1408,13 +1305,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
-          Kind: Entry
+        - Kind: Entry
           Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
           Condition: null
-        - ID: 125
-          Kind: Return
+        - Kind: Return
           Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
@@ -1428,8 +1323,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
-        - ID: 99
-          Kind: Entry
+        - Kind: Entry
           Type: 1222 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f990", Frameless: true}]
           Condition: null
@@ -1442,13 +1336,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
-        - ID: 124
-          Kind: Entry
+        - Kind: Entry
           Type: 1246 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x890958", Frameless: false}]
           Condition: null
-        - ID: 123
-          Kind: Return
+        - Kind: Return
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
@@ -1462,8 +1354,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 107
-          Kind: Entry
+        - Kind: Entry
           Type: 1230 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fdb0", Frameless: true}]
           Condition: null
@@ -1477,8 +1368,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
-          Kind: Entry
+        - Kind: Entry
           Type: 1308 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
@@ -1492,8 +1382,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
-          Kind: Entry
+        - Kind: Entry
           Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x892510", Frameless: true}]
           Condition: null
@@ -1507,8 +1396,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
-          Kind: Entry
+        - Kind: Entry
           Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
@@ -1522,8 +1410,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
-          Kind: Entry
+        - Kind: Entry
           Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x892900", Frameless: true}]
           Condition: null
@@ -1537,8 +1424,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 103
-          Kind: Entry
+        - Kind: Entry
           Type: 1226 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88fcf0", Frameless: true}]
           Condition: null
@@ -1552,8 +1438,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
-        - ID: 81
-          Kind: Entry
+        - Kind: Entry
           Type: 1204 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
@@ -1567,8 +1452,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
-        - ID: 101
-          Kind: Entry
+        - Kind: Entry
           Type: 1224 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88fcd0", Frameless: true}]
           Condition: null
@@ -1582,13 +1466,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
-        - ID: 120
-          Kind: Entry
+        - Kind: Entry
           Type: 1242 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x8905e8", Frameless: false}]
           Condition: null
-        - ID: 119
-          Kind: Return
+        - Kind: Return
           Type: 1243 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x890688"
@@ -1610,13 +1492,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
-        - ID: 118
-          Kind: Entry
+        - Kind: Entry
           Type: 1240 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x890468", Frameless: false}]
           Condition: null
-        - ID: 117
-          Kind: Return
+        - Kind: Return
           Type: 1241 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x8904d4"
@@ -1637,13 +1517,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
-          Kind: Entry
+        - Kind: Entry
           Type: 1260 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x890e3c", Frameless: false}]
           Condition: null
-        - ID: 137
-          Kind: Return
+        - Kind: Return
           Type: 1261 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x890e90", Frameless: false}]
           Condition: null
@@ -1656,13 +1534,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
-          Kind: Entry
+        - Kind: Entry
           Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x890ec8", Frameless: false}]
           Condition: null
-        - ID: 139
-          Kind: Return
+        - Kind: Return
           Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x890f04", Frameless: false}]
           Condition: null
@@ -1675,13 +1551,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
-          Kind: Entry
+        - Kind: Entry
           Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x890f38", Frameless: false}]
           Condition: null
-        - ID: 141
-          Kind: Return
+        - Kind: Return
           Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x890f70", Frameless: false}]
           Condition: null
@@ -1694,13 +1568,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
-          Kind: Entry
+        - Kind: Entry
           Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x891028", Frameless: false}]
           Condition: null
-        - ID: 145
-          Kind: Return
+        - Kind: Return
           Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x89108c", Frameless: false}]
           Condition: null
@@ -1713,13 +1585,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
-          Kind: Entry
+        - Kind: Entry
           Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x8913b8", Frameless: false}]
           Condition: null
-        - ID: 157
-          Kind: Return
+        - Kind: Return
           Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x8913f8", Frameless: false}]
           Condition: null
@@ -1732,13 +1602,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
-          Kind: Entry
+        - Kind: Entry
           Type: 1256 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x890ce8", Frameless: false}]
           Condition: null
-        - ID: 133
-          Kind: Return
+        - Kind: Return
           Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x890d34", Frameless: false}]
           Condition: null
@@ -1752,13 +1620,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 116
-          Kind: Entry
+        - Kind: Entry
           Type: 1238 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x8903e8", Frameless: false}]
           Condition: null
-        - ID: 115
-          Kind: Return
+        - Kind: Return
           Type: 1239 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x890418"
@@ -1775,13 +1641,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 110
-          Kind: Entry
+        - Kind: Entry
           Type: 1232 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x8901f8", Frameless: false}]
           Condition: null
-        - ID: 109
-          Kind: Return
+        - Kind: Return
           Type: 1233 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x89023c", Frameless: false}]
           Condition: null
@@ -1794,13 +1658,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 114
-          Kind: Entry
+        - Kind: Entry
           Type: 1236 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x890318", Frameless: false}]
           Condition: null
-        - ID: 113
-          Kind: Return
+        - Kind: Return
           Type: 1237 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x8903b0", Frameless: false}]
           Condition: null
@@ -1813,13 +1675,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 112
-          Kind: Entry
+        - Kind: Entry
           Type: 1234 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x890278", Frameless: false}]
           Condition: null
-        - ID: 111
-          Kind: Return
+        - Kind: Return
           Type: 1235 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x8902dc", Frameless: false}]
           Condition: null
@@ -1833,13 +1693,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
-        - ID: 122
-          Kind: Entry
+        - Kind: Entry
           Type: 1244 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x8907e8", Frameless: false}]
           Condition: null
-        - ID: 121
-          Kind: Return
+        - Kind: Return
           Type: 1245 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x8908b8"
@@ -1856,13 +1714,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
-          Kind: Entry
+        - Kind: Entry
           Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x890d70", Frameless: false}]
           Condition: null
-        - ID: 135
-          Kind: Return
+        - Kind: Return
           Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x890e04", Frameless: false}]
           Condition: null
@@ -1875,13 +1731,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
-          Kind: Entry
+        - Kind: Entry
           Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x890c28", Frameless: false}]
           Condition: null
-        - ID: 131
-          Kind: Return
+        - Kind: Return
           Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x890cac", Frameless: false}]
           Condition: null
@@ -1894,13 +1748,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
-          Kind: Entry
+        - Kind: Entry
           Type: 1272 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x8911a8", Frameless: false}]
           Condition: null
-        - ID: 149
-          Kind: Return
+        - Kind: Return
           Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x891200", Frameless: false}]
           Condition: null
@@ -1913,13 +1765,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
-          Kind: Entry
+        - Kind: Entry
           Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x890fa8", Frameless: false}]
           Condition: null
-        - ID: 143
-          Kind: Return
+        - Kind: Return
           Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x890ff0", Frameless: false}]
           Condition: null
@@ -1932,13 +1782,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
-          Kind: Entry
+        - Kind: Entry
           Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x891338", Frameless: false}]
           Condition: null
-        - ID: 155
-          Kind: Return
+        - Kind: Return
           Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x89137c", Frameless: false}]
           Condition: null
@@ -1951,13 +1799,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
-          Kind: Entry
+        - Kind: Entry
           Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x8912c8", Frameless: false}]
           Condition: null
-        - ID: 153
-          Kind: Return
+        - Kind: Return
           Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x891308", Frameless: false}]
           Condition: null
@@ -1970,13 +1816,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
-          Kind: Entry
+        - Kind: Entry
           Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x890b98", Frameless: false}]
           Condition: null
-        - ID: 129
-          Kind: Return
+        - Kind: Return
           Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x890bf0", Frameless: false}]
           Condition: null
@@ -1989,13 +1833,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
-          Kind: Entry
+        - Kind: Entry
           Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x89123c", Frameless: false}]
           Condition: null
-        - ID: 151
-          Kind: Return
+        - Kind: Return
           Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x891290", Frameless: false}]
           Condition: null
@@ -2008,13 +1850,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
-          Kind: Entry
+        - Kind: Entry
           Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x8910d0", Frameless: false}]
           Condition: null
-        - ID: 147
-          Kind: Return
+        - Kind: Return
           Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x891174", Frameless: false}]
           Condition: null
@@ -2028,8 +1868,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 1125 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
@@ -2043,8 +1882,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 1146 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
@@ -2058,8 +1896,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 1144 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
@@ -2073,8 +1910,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
-        - ID: 34
-          Kind: Entry
+        - Kind: Entry
           Type: 1157 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
@@ -2088,8 +1924,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
-          Kind: Entry
+        - Kind: Entry
           Type: 1158 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c790", Frameless: true}]
           Condition: null
@@ -2103,8 +1938,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 1147 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
@@ -2118,8 +1952,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
-        - ID: 26
-          Kind: Entry
+        - Kind: Entry
           Type: 1149 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
@@ -2133,8 +1966,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
-        - ID: 27
-          Kind: Entry
+        - Kind: Entry
           Type: 1150 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
@@ -2148,8 +1980,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
-        - ID: 28
-          Kind: Entry
+        - Kind: Entry
           Type: 1151 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
@@ -2163,8 +1994,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 1148 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
@@ -2178,8 +2008,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
-        - ID: 22
-          Kind: Entry
+        - Kind: Entry
           Type: 1145 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
@@ -2193,8 +2022,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
-          Kind: Entry
+        - Kind: Entry
           Type: 1314 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x8928b0", Frameless: true}]
           Condition: null
@@ -2208,8 +2036,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
-        - ID: 29
-          Kind: Entry
+        - Kind: Entry
           Type: 1152 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
@@ -2223,8 +2050,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
-        - ID: 31
-          Kind: Entry
+        - Kind: Entry
           Type: 1154 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
@@ -2238,8 +2064,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
-        - ID: 32
-          Kind: Entry
+        - Kind: Entry
           Type: 1155 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
@@ -2253,8 +2078,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
-        - ID: 33
-          Kind: Entry
+        - Kind: Entry
           Type: 1156 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
@@ -2268,8 +2092,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
-        - ID: 30
-          Kind: Entry
+        - Kind: Entry
           Type: 1153 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
@@ -2283,8 +2106,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
-          Kind: Entry
+        - Kind: Entry
           Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
@@ -2298,8 +2120,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
-          Kind: Entry
+        - Kind: Entry
           Type: 1302 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x8924e0", Frameless: true}]
           Condition: null
@@ -2313,8 +2134,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
-        - ID: 79
-          Kind: Entry
+        - Kind: Entry
           Type: 1202 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88e430", Frameless: true}]
           Condition: null
@@ -2327,13 +2147,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
-          Kind: Entry
+        - Kind: Entry
           Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x890ac8", Frameless: false}]
           Condition: null
-        - ID: 127
-          Kind: Return
+        - Kind: Return
           Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890b54", Frameless: false}]
           Condition: null
@@ -2346,13 +2164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
-          Kind: Entry
+        - Kind: Entry
           Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x891d68", Frameless: false}]
           Condition: null
-        - ID: 169
-          Kind: Return
+        - Kind: Return
           Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
           Condition: null
@@ -2366,8 +2182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 3
-          Kind: Entry
+        - Kind: Entry
           Type: 1126 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
@@ -2381,8 +2196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
-          Kind: Entry
+        - Kind: Entry
           Type: 1229 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fd90", Frameless: true}]
           Condition: null
@@ -2396,8 +2210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
-          Kind: Entry
+        - Kind: Entry
           Type: 1306 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
@@ -2411,8 +2224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
-          Kind: Entry
+        - Kind: Entry
           Type: 1168 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88ccb0", Frameless: true}]
           Condition: null
@@ -2426,8 +2238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 46
-          Kind: Entry
+        - Kind: Entry
           Type: 1169 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88ccc0", Frameless: true}]
           Condition: null
@@ -2441,13 +2252,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
-          Kind: Entry
+        - Kind: Entry
           Type: 1327 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x892b80", Frameless: true}]
           Condition: null
-        - ID: 204
-          Kind: Return
+        - Kind: Return
           Type: 1328 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x892b9c", Frameless: true}]
           Condition: null
@@ -2461,8 +2270,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
-          Kind: Entry
+        - Kind: Entry
           Type: 1303 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x8924f0", Frameless: true}]
           Condition: null
@@ -2476,8 +2284,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
-        - ID: 73
-          Kind: Entry
+        - Kind: Entry
           Type: 1196 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x88de30", Frameless: true}]
           Condition: null
@@ -2490,13 +2297,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
-          Kind: Entry
+        - Kind: Entry
           Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x891eec", Frameless: false}]
           Condition: null
-        - ID: 173
-          Kind: Return
+        - Kind: Return
           Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x891f7c", Frameless: false}]
           Condition: null
@@ -2509,13 +2314,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
-          Kind: Entry
+        - Kind: Entry
           Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x892a90", Frameless: true}]
           Condition: null
-        - ID: 202
-          Kind: Return
+        - Kind: Return
           Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x892aa8", Frameless: true}]
           Condition: null
@@ -2528,8 +2331,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
-          Kind: Entry
+        - Kind: Entry
           Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x892a80", Frameless: true}]
           Condition: null
@@ -2543,8 +2345,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
-        - ID: 74
-          Kind: Entry
+        - Kind: Entry
           Type: 1197 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e3e0", Frameless: true}]
           Condition: null
@@ -2558,8 +2359,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
-          Kind: Entry
+        - Kind: Entry
           Type: 1315 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x8928c0", Frameless: true}]
           Condition: null
@@ -2573,13 +2373,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
-          Kind: Entry
+        - Kind: Entry
           Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x8928d0", Frameless: true}]
           Condition: null
-        - ID: 193
-          Kind: Return
+        - Kind: Return
           Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x8928e8", Frameless: true}]
           Condition: null
@@ -2593,8 +2391,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
-          Kind: Entry
+        - Kind: Entry
           Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8928f0", Frameless: true}]
           Condition: null
@@ -2608,8 +2405,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
-        - ID: 36
-          Kind: Entry
+        - Kind: Entry
           Type: 1159 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c7a0", Frameless: true}]
           Condition: null
@@ -2623,8 +2419,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 1135 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
@@ -2638,8 +2433,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 1136 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
@@ -2653,8 +2447,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 14
-          Kind: Entry
+        - Kind: Entry
           Type: 1137 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
@@ -2668,8 +2461,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 11
-          Kind: Entry
+        - Kind: Entry
           Type: 1134 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
@@ -2683,8 +2475,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 1133 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
@@ -2698,8 +2489,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 105
-          Kind: Entry
+        - Kind: Entry
           Type: 1228 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
           Condition: null
@@ -2713,8 +2503,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
-          Kind: Entry
+        - Kind: Entry
           Type: 1300 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x8924c0", Frameless: true}]
           Condition: null
@@ -2728,8 +2517,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
-          Kind: Entry
+        - Kind: Entry
           Type: 1322 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x892920", Frameless: true}]
           Condition: null
@@ -2743,8 +2531,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 104
-          Kind: Entry
+        - Kind: Entry
           Type: 1227 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88fd00", Frameless: true}]
           Condition: null
@@ -2758,8 +2545,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
-        - ID: 20
-          Kind: Entry
+        - Kind: Entry
           Type: 1143 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c380", Frameless: true}]
           Condition: null
@@ -2773,8 +2559,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
-          Kind: Entry
+        - Kind: Entry
           Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
@@ -2788,8 +2573,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
-          Kind: Entry
+        - Kind: Entry
           Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
@@ -2802,13 +2586,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
-          Kind: Entry
+        - Kind: Entry
           Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x891fb8", Frameless: false}]
           Condition: null
-        - ID: 175
-          Kind: Return
+        - Kind: Return
           Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x892024", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
-          Kind: Entry
+        - Kind: Entry
           Type: 1487 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84fe58", Frameless: false}]
           Condition: null
-        - ID: 189
-          Kind: Return
+        - Kind: Return
           Type: 1488 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84fe8c", Frameless: false}]
           Condition: null
@@ -30,13 +28,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
-        - ID: 69
-          Kind: Entry
+        - Kind: Entry
           Type: 1366 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b458", Frameless: false}]
           Condition: null
-        - ID: 68
-          Kind: Return
+        - Kind: Return
           Type: 1367 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x84b484", Frameless: false}]
           Condition: null
@@ -50,13 +46,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
-        - ID: 72
-          Kind: Entry
+        - Kind: Entry
           Type: 1369 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b4d8", Frameless: false}]
           Condition: null
-        - ID: 71
-          Kind: Return
+        - Kind: Return
           Type: 1370 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x84b504", Frameless: false}]
           Condition: null
@@ -69,13 +63,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
-          Kind: Entry
+        - Kind: Entry
           Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x84ecac", Frameless: false}]
           Condition: null
-        - ID: 161
-          Kind: Return
+        - Kind: Return
           Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ed44", Frameless: false}]
           Condition: null
@@ -89,8 +81,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 1317 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
@@ -104,8 +95,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 1313 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
@@ -119,8 +109,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 1315 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a80", Frameless: true}]
           Condition: null
@@ -134,8 +123,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
-        - ID: 80
-          Kind: Entry
+        - Kind: Entry
           Type: 1378 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
           Condition: null
@@ -149,8 +137,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
-        - ID: 16
-          Kind: Entry
+        - Kind: Entry
           Type: 1314 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
@@ -163,8 +150,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
-        - ID: 18
-          Kind: Entry
+        - Kind: Entry
           Type: 1316 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x849a90", Frameless: true}]
           Condition: null
@@ -178,13 +164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
-        - ID: 38
-          Kind: Entry
+        - Kind: Entry
           Type: 1335 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849ff0", Frameless: true}]
           Condition: null
-        - ID: 37
-          Kind: Return
+        - Kind: Return
           Type: 1336 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x84a008", Frameless: true}]
           Condition: null
@@ -198,8 +182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 1302 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
@@ -213,8 +196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 1299 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
@@ -228,8 +210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
-        - ID: 100
-          Kind: Entry
+        - Kind: Entry
           Type: 1398 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84d2e0", Frameless: true}]
           Condition: null
@@ -243,8 +224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
-        - ID: 98
-          Kind: Entry
+        - Kind: Entry
           Type: 1396 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84d060", Frameless: true}]
           Condition: null
@@ -258,8 +238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 108
-          Kind: Entry
+        - Kind: Entry
           Type: 1406 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d580", Frameless: true}]
           Condition: null
@@ -273,8 +252,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
-        - ID: 43
-          Kind: Entry
+        - Kind: Entry
           Type: 1341 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
@@ -288,8 +266,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
-        - ID: 44
-          Kind: Entry
+        - Kind: Entry
           Type: 1342 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
@@ -303,8 +280,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
-        - ID: 39
-          Kind: Entry
+        - Kind: Entry
           Type: 1337 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0c0", Frameless: true}]
           Condition: null
@@ -318,8 +294,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
-        - ID: 40
-          Kind: Entry
+        - Kind: Entry
           Type: 1338 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0d0", Frameless: true}]
           Condition: null
@@ -333,8 +308,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
-        - ID: 41
-          Kind: Entry
+        - Kind: Entry
           Type: 1339 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a270", Frameless: true}]
           Condition: null
@@ -348,8 +322,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
-        - ID: 42
-          Kind: Entry
+        - Kind: Entry
           Type: 1340 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a280", Frameless: true}]
           Condition: null
@@ -363,8 +336,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
-          Kind: Entry
+        - Kind: Entry
           Type: 1476 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84fad0", Frameless: true}]
           Condition: null
@@ -378,8 +350,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
-          Kind: Entry
+        - Kind: Entry
           Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84fb00", Frameless: true}]
           Condition: null
@@ -394,8 +365,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
-          Kind: Entry
+        - Kind: Entry
           Type: 1498 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ff30", Frameless: true}]
           Condition: null
@@ -409,8 +379,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
-          Kind: Entry
+        - Kind: Entry
           Type: 1504 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x850280", Frameless: true}]
           Condition: null
@@ -423,8 +392,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
-          Kind: Entry
+        - Kind: Entry
           Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x850290", Frameless: true}]
           Condition: null
@@ -438,8 +406,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
-        - ID: 70
-          Kind: Entry
+        - Kind: Entry
           Type: 1368 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b4b0", Frameless: true}]
           Condition: null
@@ -453,13 +420,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
-          Kind: Entry
+        - Kind: Entry
           Type: 1350 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84aa78", Frameless: false}]
           Condition: null
-        - ID: 52
-          Kind: Return
+        - Kind: Return
           Type: 1351 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x84aab4", Frameless: false}]
           Condition: null
@@ -473,13 +438,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
-          Kind: Entry
+        - Kind: Entry
           Type: 1348 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a9ac", Frameless: false}]
           Condition: null
-        - ID: 50
-          Kind: Return
+        - Kind: Return
           Type: 1349 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x84aa1c", Frameless: false}]
           Condition: null
@@ -493,13 +456,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 63
-          Kind: Entry
+        - Kind: Entry
           Type: 1360 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84b190", Frameless: true}]
           Condition: null
-        - ID: 62
-          Kind: Return
+        - Kind: Return
           Type: 1361 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x84b198", Frameless: true}]
           Condition: null
@@ -513,13 +474,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 65
-          Kind: Entry
+        - Kind: Entry
           Type: 1362 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
           Condition: null
-        - ID: 64
-          Kind: Return
+        - Kind: Return
           Type: 1363 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x84b1e8", Frameless: false}]
           Condition: null
@@ -536,8 +495,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 66
-          Kind: Line
+        - Kind: Line
           Type: 1364 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
           Condition: null
@@ -551,13 +509,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
-          Kind: Entry
+        - Kind: Entry
           Type: 1352 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84aeb8", Frameless: false}]
           Condition: null
-        - ID: 54
-          Kind: Return
+        - Kind: Return
           Type: 1353 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x84af10", Frameless: false}]
           Condition: null
@@ -571,13 +527,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
-          Kind: Entry
+        - Kind: Entry
           Type: 1354 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84af48", Frameless: false}]
           Condition: null
-        - ID: 56
-          Kind: Return
+        - Kind: Return
           Type: 1355 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x84afd0", Frameless: false}]
           Condition: null
@@ -591,13 +545,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
-          Kind: Entry
+        - Kind: Entry
           Type: 1356 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84b008", Frameless: false}]
           Condition: null
-        - ID: 58
-          Kind: Return
+        - Kind: Return
           Type: 1357 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x84b044", Frameless: false}]
           Condition: null
@@ -611,8 +563,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
-          Kind: Entry
+        - Kind: Entry
           Type: 1509 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
@@ -626,13 +577,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
-        - ID: 61
-          Kind: Entry
+        - Kind: Entry
           Type: 1358 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84b088", Frameless: false}]
           Condition: null
-        - ID: 60
-          Kind: Return
+        - Kind: Return
           Type: 1359 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x84b178", Frameless: false}]
           Condition: null
@@ -646,8 +595,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
-          Kind: Entry
+        - Kind: Entry
           Type: 1510 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
@@ -664,8 +612,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
-          Kind: Line
+        - Kind: Line
           Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
@@ -679,8 +626,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
-          Kind: Entry
+        - Kind: Entry
           Type: 1512 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
@@ -697,8 +643,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
-          Kind: Line
+        - Kind: Line
           Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
@@ -713,8 +658,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
-          Kind: Entry
+        - Kind: Entry
           Type: 1506 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84ad18"
@@ -728,8 +672,7 @@ Probes:
             - PC: "0x84b00c"
               Frameless: false
           Condition: null
-        - ID: 208
-          Kind: Return
+        - Kind: Return
           Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
@@ -746,8 +689,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
-          Kind: Line
+        - Kind: Line
           Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
@@ -771,8 +713,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
-          Kind: Entry
+        - Kind: Entry
           Type: 1514 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
@@ -789,8 +730,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
-          Kind: Line
+        - Kind: Line
           Type: 1515 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
@@ -805,8 +745,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
-          Kind: Entry
+        - Kind: Entry
           Type: 1516 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1c4"
@@ -824,8 +763,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 7
-          Kind: Entry
+        - Kind: Entry
           Type: 1305 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
@@ -839,8 +777,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 1306 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
@@ -854,8 +791,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 9
-          Kind: Entry
+        - Kind: Entry
           Type: 1307 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
@@ -869,8 +805,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 1304 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
@@ -884,8 +819,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 5
-          Kind: Entry
+        - Kind: Entry
           Type: 1303 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
@@ -899,8 +833,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 67
-          Kind: Entry
+        - Kind: Entry
           Type: 1365 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b430", Frameless: true}]
           Condition: null
@@ -913,13 +846,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
-          Kind: Entry
+        - Kind: Entry
           Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x84eaf0", Frameless: false}]
           Condition: null
-        - ID: 159
-          Kind: Return
+        - Kind: Return
           Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ec48", Frameless: false}]
           Condition: null
@@ -933,8 +864,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
-        - ID: 102
-          Kind: Entry
+        - Kind: Entry
           Type: 1400 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d490", Frameless: true}]
           Condition: null
@@ -951,8 +881,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 47
-          Kind: Line
+        - Kind: Line
           Type: 1345 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a42c", Frameless: false}]
           Condition: null
@@ -969,8 +898,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 48
-          Kind: Line
+        - Kind: Line
           Type: 1346 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a4bc", Frameless: false}]
           Condition: null
@@ -987,8 +915,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
-          Kind: Line
+        - Kind: Line
           Type: 1347 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a564", Frameless: false}]
           Condition: null
@@ -1001,13 +928,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
-          Kind: Entry
+        - Kind: Entry
           Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x84efac", Frameless: false}]
           Condition: null
-        - ID: 165
-          Kind: Return
+        - Kind: Return
           Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x84f118", Frameless: false}]
           Condition: null
@@ -1021,8 +946,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
-        - ID: 78
-          Kind: Entry
+        - Kind: Entry
           Type: 1376 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84bb20", Frameless: true}]
           Condition: null
@@ -1036,8 +960,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
-        - ID: 85
-          Kind: Entry
+        - Kind: Entry
           Type: 1383 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84bb80", Frameless: true}]
           Condition: null
@@ -1051,8 +974,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
-        - ID: 95
-          Kind: Entry
+        - Kind: Entry
           Type: 1393 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x84bc20", Frameless: true}]
           Condition: null
@@ -1066,8 +988,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
-        - ID: 97
-          Kind: Entry
+        - Kind: Entry
           Type: 1395 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x84bc40", Frameless: true}]
           Condition: null
@@ -1081,8 +1002,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
-        - ID: 96
-          Kind: Entry
+        - Kind: Entry
           Type: 1394 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x84bc30", Frameless: true}]
           Condition: null
@@ -1096,8 +1016,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
-        - ID: 82
-          Kind: Entry
+        - Kind: Entry
           Type: 1380 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84bb60", Frameless: true}]
           Condition: null
@@ -1111,8 +1030,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
-        - ID: 94
-          Kind: Entry
+        - Kind: Entry
           Type: 1392 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84bc10", Frameless: true}]
           Condition: null
@@ -1126,8 +1044,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
-        - ID: 93
-          Kind: Entry
+        - Kind: Entry
           Type: 1391 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84bc00", Frameless: true}]
           Condition: null
@@ -1141,8 +1058,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 83
-          Kind: Entry
+        - Kind: Entry
           Type: 1381 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
@@ -1156,8 +1072,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 84
-          Kind: Entry
+        - Kind: Entry
           Type: 1382 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
@@ -1171,8 +1086,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
-        - ID: 92
-          Kind: Entry
+        - Kind: Entry
           Type: 1390 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84bbf0", Frameless: true}]
           Condition: null
@@ -1186,8 +1100,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
-        - ID: 91
-          Kind: Entry
+        - Kind: Entry
           Type: 1389 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84bbe0", Frameless: true}]
           Condition: null
@@ -1201,8 +1114,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
-        - ID: 76
-          Kind: Entry
+        - Kind: Entry
           Type: 1374 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84bb00", Frameless: true}]
           Condition: null
@@ -1216,8 +1128,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
-        - ID: 77
-          Kind: Entry
+        - Kind: Entry
           Type: 1375 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84bb10", Frameless: true}]
           Condition: null
@@ -1231,8 +1142,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
-        - ID: 75
-          Kind: Entry
+        - Kind: Entry
           Type: 1373 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84baf0", Frameless: true}]
           Condition: null
@@ -1246,8 +1156,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
-        - ID: 86
-          Kind: Entry
+        - Kind: Entry
           Type: 1384 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84bb90", Frameless: true}]
           Condition: null
@@ -1261,8 +1170,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
-        - ID: 89
-          Kind: Entry
+        - Kind: Entry
           Type: 1387 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
           Condition: null
@@ -1276,8 +1184,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
-        - ID: 90
-          Kind: Entry
+        - Kind: Entry
           Type: 1388 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84bbd0", Frameless: true}]
           Condition: null
@@ -1291,8 +1198,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
-        - ID: 87
-          Kind: Entry
+        - Kind: Entry
           Type: 1385 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84bba0", Frameless: true}]
           Condition: null
@@ -1306,8 +1212,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
-        - ID: 88
-          Kind: Entry
+        - Kind: Entry
           Type: 1386 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
           Condition: null
@@ -1321,8 +1226,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
-          Kind: Entry
+        - Kind: Entry
           Type: 1495 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
@@ -1337,8 +1241,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
-          Kind: Entry
+        - Kind: Entry
           Type: 1496 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
@@ -1351,13 +1254,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
-          Kind: Entry
+        - Kind: Entry
           Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x84f180", Frameless: false}]
           Condition: null
-        - ID: 167
-          Kind: Return
+        - Kind: Return
           Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x84f32c", Frameless: false}]
           Condition: null
@@ -1370,13 +1271,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
-          Kind: Entry
+        - Kind: Entry
           Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
           Condition: null
-        - ID: 171
-          Kind: Return
+        - Kind: Return
           Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x84f4d4", Frameless: false}]
           Condition: null
@@ -1389,13 +1288,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
-          Kind: Entry
+        - Kind: Entry
           Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x84ed80", Frameless: false}]
           Condition: null
-        - ID: 163
-          Kind: Return
+        - Kind: Return
           Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x84ef50", Frameless: false}]
           Condition: null
@@ -1408,13 +1305,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
-          Kind: Entry
+        - Kind: Entry
           Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
           Condition: null
-        - ID: 125
-          Kind: Return
+        - Kind: Return
           Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
@@ -1428,8 +1323,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
-        - ID: 99
-          Kind: Entry
+        - Kind: Entry
           Type: 1397 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84d140", Frameless: true}]
           Condition: null
@@ -1442,13 +1336,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
-        - ID: 124
-          Kind: Entry
+        - Kind: Entry
           Type: 1421 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x84e028", Frameless: false}]
           Condition: null
-        - ID: 123
-          Kind: Return
+        - Kind: Return
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e088", Frameless: false}]
           Condition: null
@@ -1462,8 +1354,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 107
-          Kind: Entry
+        - Kind: Entry
           Type: 1405 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d560", Frameless: true}]
           Condition: null
@@ -1477,8 +1368,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
-          Kind: Entry
+        - Kind: Entry
           Type: 1483 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
@@ -1492,8 +1382,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
-          Kind: Entry
+        - Kind: Entry
           Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
@@ -1507,8 +1396,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
-          Kind: Entry
+        - Kind: Entry
           Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
@@ -1522,8 +1410,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
-          Kind: Entry
+        - Kind: Entry
           Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ff00", Frameless: true}]
           Condition: null
@@ -1537,8 +1424,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 103
-          Kind: Entry
+        - Kind: Entry
           Type: 1401 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d4a0", Frameless: true}]
           Condition: null
@@ -1552,8 +1438,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
-        - ID: 81
-          Kind: Entry
+        - Kind: Entry
           Type: 1379 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
@@ -1567,8 +1452,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
-        - ID: 101
-          Kind: Entry
+        - Kind: Entry
           Type: 1399 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d480", Frameless: true}]
           Condition: null
@@ -1582,13 +1466,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
-        - ID: 120
-          Kind: Entry
+        - Kind: Entry
           Type: 1417 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x84dcc8", Frameless: false}]
           Condition: null
-        - ID: 119
-          Kind: Return
+        - Kind: Return
           Type: 1418 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x84dd64"
@@ -1610,13 +1492,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
-        - ID: 118
-          Kind: Entry
+        - Kind: Entry
           Type: 1415 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x84db48", Frameless: false}]
           Condition: null
-        - ID: 117
-          Kind: Return
+        - Kind: Return
           Type: 1416 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x84db9c"
@@ -1637,13 +1517,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
-          Kind: Entry
+        - Kind: Entry
           Type: 1435 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x84e4fc", Frameless: false}]
           Condition: null
-        - ID: 137
-          Kind: Return
+        - Kind: Return
           Type: 1436 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x84e550", Frameless: false}]
           Condition: null
@@ -1656,13 +1534,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
-          Kind: Entry
+        - Kind: Entry
           Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x84e588", Frameless: false}]
           Condition: null
-        - ID: 139
-          Kind: Return
+        - Kind: Return
           Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x84e5c4", Frameless: false}]
           Condition: null
@@ -1675,13 +1551,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
-          Kind: Entry
+        - Kind: Entry
           Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x84e5f8", Frameless: false}]
           Condition: null
-        - ID: 141
-          Kind: Return
+        - Kind: Return
           Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x84e630", Frameless: false}]
           Condition: null
@@ -1694,13 +1568,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
-          Kind: Entry
+        - Kind: Entry
           Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x84e6e8", Frameless: false}]
           Condition: null
-        - ID: 145
-          Kind: Return
+        - Kind: Return
           Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x84e74c", Frameless: false}]
           Condition: null
@@ -1713,13 +1585,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
-          Kind: Entry
+        - Kind: Entry
           Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x84ea78", Frameless: false}]
           Condition: null
-        - ID: 157
-          Kind: Return
+        - Kind: Return
           Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x84eab8", Frameless: false}]
           Condition: null
@@ -1732,13 +1602,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
-          Kind: Entry
+        - Kind: Entry
           Type: 1431 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x84e3a8", Frameless: false}]
           Condition: null
-        - ID: 133
-          Kind: Return
+        - Kind: Return
           Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x84e3f4", Frameless: false}]
           Condition: null
@@ -1752,13 +1620,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 116
-          Kind: Entry
+        - Kind: Entry
           Type: 1413 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x84dac8", Frameless: false}]
           Condition: null
-        - ID: 115
-          Kind: Return
+        - Kind: Return
           Type: 1414 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x84daf8"
@@ -1775,13 +1641,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 110
-          Kind: Entry
+        - Kind: Entry
           Type: 1407 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x84d8d8", Frameless: false}]
           Condition: null
-        - ID: 109
-          Kind: Return
+        - Kind: Return
           Type: 1408 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x84d91c", Frameless: false}]
           Condition: null
@@ -1794,13 +1658,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 114
-          Kind: Entry
+        - Kind: Entry
           Type: 1411 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x84d9f8", Frameless: false}]
           Condition: null
-        - ID: 113
-          Kind: Return
+        - Kind: Return
           Type: 1412 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x84da90", Frameless: false}]
           Condition: null
@@ -1813,13 +1675,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 112
-          Kind: Entry
+        - Kind: Entry
           Type: 1409 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x84d958", Frameless: false}]
           Condition: null
-        - ID: 111
-          Kind: Return
+        - Kind: Return
           Type: 1410 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x84d9b8", Frameless: false}]
           Condition: null
@@ -1833,13 +1693,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
-        - ID: 122
-          Kind: Entry
+        - Kind: Entry
           Type: 1419 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x84dec8", Frameless: false}]
           Condition: null
-        - ID: 121
-          Kind: Return
+        - Kind: Return
           Type: 1420 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x84df94"
@@ -1856,13 +1714,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
-          Kind: Entry
+        - Kind: Entry
           Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x84e430", Frameless: false}]
           Condition: null
-        - ID: 135
-          Kind: Return
+        - Kind: Return
           Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x84e4c4", Frameless: false}]
           Condition: null
@@ -1875,13 +1731,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
-          Kind: Entry
+        - Kind: Entry
           Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x84e2e8", Frameless: false}]
           Condition: null
-        - ID: 131
-          Kind: Return
+        - Kind: Return
           Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x84e36c", Frameless: false}]
           Condition: null
@@ -1894,13 +1748,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
-          Kind: Entry
+        - Kind: Entry
           Type: 1447 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x84e868", Frameless: false}]
           Condition: null
-        - ID: 149
-          Kind: Return
+        - Kind: Return
           Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x84e8c0", Frameless: false}]
           Condition: null
@@ -1913,13 +1765,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
-          Kind: Entry
+        - Kind: Entry
           Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x84e668", Frameless: false}]
           Condition: null
-        - ID: 143
-          Kind: Return
+        - Kind: Return
           Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x84e6b0", Frameless: false}]
           Condition: null
@@ -1932,13 +1782,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
-          Kind: Entry
+        - Kind: Entry
           Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x84e9f8", Frameless: false}]
           Condition: null
-        - ID: 155
-          Kind: Return
+        - Kind: Return
           Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x84ea3c", Frameless: false}]
           Condition: null
@@ -1951,13 +1799,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
-          Kind: Entry
+        - Kind: Entry
           Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x84e988", Frameless: false}]
           Condition: null
-        - ID: 153
-          Kind: Return
+        - Kind: Return
           Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x84e9c8", Frameless: false}]
           Condition: null
@@ -1970,13 +1816,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
-          Kind: Entry
+        - Kind: Entry
           Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x84e258", Frameless: false}]
           Condition: null
-        - ID: 129
-          Kind: Return
+        - Kind: Return
           Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x84e2b0", Frameless: false}]
           Condition: null
@@ -1989,13 +1833,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
-          Kind: Entry
+        - Kind: Entry
           Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x84e8fc", Frameless: false}]
           Condition: null
-        - ID: 151
-          Kind: Return
+        - Kind: Return
           Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x84e950", Frameless: false}]
           Condition: null
@@ -2008,13 +1850,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
-          Kind: Entry
+        - Kind: Entry
           Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x84e790", Frameless: false}]
           Condition: null
-        - ID: 147
-          Kind: Return
+        - Kind: Return
           Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x84e834", Frameless: false}]
           Condition: null
@@ -2028,8 +1868,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 1300 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
@@ -2043,8 +1882,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 1321 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
@@ -2058,8 +1896,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 1319 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
@@ -2073,8 +1910,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
-        - ID: 34
-          Kind: Entry
+        - Kind: Entry
           Type: 1332 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
@@ -2088,8 +1924,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
-          Kind: Entry
+        - Kind: Entry
           Type: 1333 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849ed0", Frameless: true}]
           Condition: null
@@ -2103,8 +1938,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 1322 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
@@ -2118,8 +1952,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
-        - ID: 26
-          Kind: Entry
+        - Kind: Entry
           Type: 1324 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
@@ -2133,8 +1966,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
-        - ID: 27
-          Kind: Entry
+        - Kind: Entry
           Type: 1325 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
@@ -2148,8 +1980,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
-        - ID: 28
-          Kind: Entry
+        - Kind: Entry
           Type: 1326 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
@@ -2163,8 +1994,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 1323 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
@@ -2178,8 +2008,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
-        - ID: 22
-          Kind: Entry
+        - Kind: Entry
           Type: 1320 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
@@ -2193,8 +2022,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
-          Kind: Entry
+        - Kind: Entry
           Type: 1489 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84feb0", Frameless: true}]
           Condition: null
@@ -2208,8 +2036,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
-        - ID: 29
-          Kind: Entry
+        - Kind: Entry
           Type: 1327 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
@@ -2223,8 +2050,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
-        - ID: 31
-          Kind: Entry
+        - Kind: Entry
           Type: 1329 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
@@ -2238,8 +2064,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
-        - ID: 32
-          Kind: Entry
+        - Kind: Entry
           Type: 1330 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
@@ -2253,8 +2078,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
-        - ID: 33
-          Kind: Entry
+        - Kind: Entry
           Type: 1331 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
@@ -2268,8 +2092,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
-        - ID: 30
-          Kind: Entry
+        - Kind: Entry
           Type: 1328 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
@@ -2283,8 +2106,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
-          Kind: Entry
+        - Kind: Entry
           Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
@@ -2298,8 +2120,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
-          Kind: Entry
+        - Kind: Entry
           Type: 1477 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84fae0", Frameless: true}]
           Condition: null
@@ -2313,8 +2134,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
-        - ID: 79
-          Kind: Entry
+        - Kind: Entry
           Type: 1377 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84bb30", Frameless: true}]
           Condition: null
@@ -2327,13 +2147,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
-          Kind: Entry
+        - Kind: Entry
           Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84e198", Frameless: false}]
           Condition: null
-        - ID: 127
-          Kind: Return
+        - Kind: Return
           Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84e220", Frameless: false}]
           Condition: null
@@ -2346,13 +2164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
-          Kind: Entry
+        - Kind: Entry
           Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x84f388", Frameless: false}]
           Condition: null
-        - ID: 169
-          Kind: Return
+        - Kind: Return
           Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x84f3ec", Frameless: false}]
           Condition: null
@@ -2366,8 +2182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 3
-          Kind: Entry
+        - Kind: Entry
           Type: 1301 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
@@ -2381,8 +2196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
-          Kind: Entry
+        - Kind: Entry
           Type: 1404 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d540", Frameless: true}]
           Condition: null
@@ -2396,8 +2210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
-          Kind: Entry
+        - Kind: Entry
           Type: 1481 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
@@ -2411,8 +2224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
-          Kind: Entry
+        - Kind: Entry
           Type: 1343 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3f0", Frameless: true}]
           Condition: null
@@ -2426,8 +2238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 46
-          Kind: Entry
+        - Kind: Entry
           Type: 1344 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a400", Frameless: true}]
           Condition: null
@@ -2441,13 +2252,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
-          Kind: Entry
+        - Kind: Entry
           Type: 1502 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x850180", Frameless: true}]
           Condition: null
-        - ID: 204
-          Kind: Return
+        - Kind: Return
           Type: 1503 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x85019c", Frameless: true}]
           Condition: null
@@ -2461,8 +2270,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
-          Kind: Entry
+        - Kind: Entry
           Type: 1478 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84faf0", Frameless: true}]
           Condition: null
@@ -2476,8 +2284,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
-        - ID: 73
-          Kind: Entry
+        - Kind: Entry
           Type: 1371 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x84b530", Frameless: true}]
           Condition: null
@@ -2490,13 +2297,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
-          Kind: Entry
+        - Kind: Entry
           Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x84f50c", Frameless: false}]
           Condition: null
-        - ID: 173
-          Kind: Return
+        - Kind: Return
           Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x84f59c", Frameless: false}]
           Condition: null
@@ -2509,13 +2314,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
-          Kind: Entry
+        - Kind: Entry
           Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x850090", Frameless: true}]
           Condition: null
-        - ID: 202
-          Kind: Return
+        - Kind: Return
           Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x8500a8", Frameless: true}]
           Condition: null
@@ -2528,8 +2331,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
-          Kind: Entry
+        - Kind: Entry
           Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x850080", Frameless: true}]
           Condition: null
@@ -2543,8 +2345,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
-        - ID: 74
-          Kind: Entry
+        - Kind: Entry
           Type: 1372 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
           Condition: null
@@ -2558,8 +2359,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
-          Kind: Entry
+        - Kind: Entry
           Type: 1490 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84fec0", Frameless: true}]
           Condition: null
@@ -2573,13 +2373,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
-          Kind: Entry
+        - Kind: Entry
           Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84fed0", Frameless: true}]
           Condition: null
-        - ID: 193
-          Kind: Return
+        - Kind: Return
           Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84fee8", Frameless: true}]
           Condition: null
@@ -2593,8 +2391,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
-          Kind: Entry
+        - Kind: Entry
           Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84fef0", Frameless: true}]
           Condition: null
@@ -2608,8 +2405,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
-        - ID: 36
-          Kind: Entry
+        - Kind: Entry
           Type: 1334 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ee0", Frameless: true}]
           Condition: null
@@ -2623,8 +2419,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 1310 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
@@ -2638,8 +2433,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 1311 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
@@ -2653,8 +2447,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 14
-          Kind: Entry
+        - Kind: Entry
           Type: 1312 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
@@ -2668,8 +2461,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 11
-          Kind: Entry
+        - Kind: Entry
           Type: 1309 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
@@ -2683,8 +2475,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 1308 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
@@ -2698,8 +2489,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 105
-          Kind: Entry
+        - Kind: Entry
           Type: 1403 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
           Condition: null
@@ -2713,8 +2503,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
-          Kind: Entry
+        - Kind: Entry
           Type: 1475 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84fac0", Frameless: true}]
           Condition: null
@@ -2728,8 +2517,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
-          Kind: Entry
+        - Kind: Entry
           Type: 1497 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ff20", Frameless: true}]
           Condition: null
@@ -2743,8 +2531,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 104
-          Kind: Entry
+        - Kind: Entry
           Type: 1402 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d4b0", Frameless: true}]
           Condition: null
@@ -2758,8 +2545,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
-        - ID: 20
-          Kind: Entry
+        - Kind: Entry
           Type: 1318 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849ac0", Frameless: true}]
           Condition: null
@@ -2773,8 +2559,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
-          Kind: Entry
+        - Kind: Entry
           Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
@@ -2788,8 +2573,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
-          Kind: Entry
+        - Kind: Entry
           Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
@@ -2802,13 +2586,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
-          Kind: Entry
+        - Kind: Entry
           Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
           Condition: null
-        - ID: 175
-          Kind: Return
+        - Kind: Return
           Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84f640", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,13 +10,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
-        - ID: 190
-          Kind: Entry
+        - Kind: Entry
           Type: 1506 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80c2e8", Frameless: false}]
           Condition: null
-        - ID: 189
-          Kind: Return
+        - Kind: Return
           Type: 1507 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80c318", Frameless: false}]
           Condition: null
@@ -30,13 +28,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
-        - ID: 69
-          Kind: Entry
+        - Kind: Entry
           Type: 1385 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807c18", Frameless: false}]
           Condition: null
-        - ID: 68
-          Kind: Return
+        - Kind: Return
           Type: 1386 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x807c40", Frameless: false}]
           Condition: null
@@ -50,13 +46,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
-        - ID: 72
-          Kind: Entry
+        - Kind: Entry
           Type: 1388 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807c88", Frameless: false}]
           Condition: null
-        - ID: 71
-          Kind: Return
+        - Kind: Return
           Type: 1389 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x807cb0", Frameless: false}]
           Condition: null
@@ -69,13 +63,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
-        - ID: 162
-          Kind: Entry
+        - Kind: Entry
           Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x80b24c", Frameless: false}]
           Condition: null
-        - ID: 161
-          Kind: Return
+        - Kind: Return
           Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b2d8", Frameless: false}]
           Condition: null
@@ -89,8 +81,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 1336 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
@@ -104,8 +95,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 1332 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
@@ -119,8 +109,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 1334 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806390", Frameless: true}]
           Condition: null
@@ -134,8 +123,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
-        - ID: 80
-          Kind: Entry
+        - Kind: Entry
           Type: 1397 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x808280", Frameless: true}]
           Condition: null
@@ -149,8 +137,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
-        - ID: 16
-          Kind: Entry
+        - Kind: Entry
           Type: 1333 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
@@ -163,8 +150,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
-        - ID: 18
-          Kind: Entry
+        - Kind: Entry
           Type: 1335 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
           Condition: null
@@ -178,13 +164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
-        - ID: 38
-          Kind: Entry
+        - Kind: Entry
           Type: 1354 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068f0", Frameless: true}]
           Condition: null
-        - ID: 37
-          Kind: Return
+        - Kind: Return
           Type: 1355 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x8068fc", Frameless: true}]
           Condition: null
@@ -198,8 +182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 1321 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
@@ -213,8 +196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
-          Kind: Entry
+        - Kind: Entry
           Type: 1318 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
@@ -228,8 +210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
-        - ID: 100
-          Kind: Entry
+        - Kind: Entry
           Type: 1417 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
           Condition: null
@@ -243,8 +224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
-        - ID: 98
-          Kind: Entry
+        - Kind: Entry
           Type: 1415 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x809750", Frameless: true}]
           Condition: null
@@ -258,8 +238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 108
-          Kind: Entry
+        - Kind: Entry
           Type: 1425 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x809c50", Frameless: true}]
           Condition: null
@@ -273,8 +252,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
-        - ID: 43
-          Kind: Entry
+        - Kind: Entry
           Type: 1360 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
@@ -288,8 +266,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
-        - ID: 44
-          Kind: Entry
+        - Kind: Entry
           Type: 1361 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
@@ -303,8 +280,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
-        - ID: 39
-          Kind: Entry
+        - Kind: Entry
           Type: 1356 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x8069b0", Frameless: true}]
           Condition: null
@@ -318,8 +294,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
-        - ID: 40
-          Kind: Entry
+        - Kind: Entry
           Type: 1357 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069c0", Frameless: true}]
           Condition: null
@@ -333,8 +308,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
-        - ID: 41
-          Kind: Entry
+        - Kind: Entry
           Type: 1358 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b30", Frameless: true}]
           Condition: null
@@ -348,8 +322,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
-        - ID: 42
-          Kind: Entry
+        - Kind: Entry
           Type: 1359 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b40", Frameless: true}]
           Condition: null
@@ -363,8 +336,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
-        - ID: 178
-          Kind: Entry
+        - Kind: Entry
           Type: 1495 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80bf90", Frameless: true}]
           Condition: null
@@ -378,8 +350,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
-        - ID: 181
-          Kind: Entry
+        - Kind: Entry
           Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80bfc0", Frameless: true}]
           Condition: null
@@ -394,8 +365,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
-        - ID: 200
-          Kind: Entry
+        - Kind: Entry
           Type: 1517 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
           Condition: null
@@ -409,8 +379,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
-        - ID: 206
-          Kind: Entry
+        - Kind: Entry
           Type: 1523 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
@@ -423,8 +392,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
-        - ID: 207
-          Kind: Entry
+        - Kind: Entry
           Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
@@ -438,8 +406,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
-        - ID: 70
-          Kind: Entry
+        - Kind: Entry
           Type: 1387 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807c60", Frameless: true}]
           Condition: null
@@ -453,13 +420,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
-          Kind: Entry
+        - Kind: Entry
           Type: 1369 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8072b8", Frameless: false}]
           Condition: null
-        - ID: 52
-          Kind: Return
+        - Kind: Return
           Type: 1370 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x8072f0", Frameless: false}]
           Condition: null
@@ -473,13 +438,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
-          Kind: Entry
+        - Kind: Entry
           Type: 1367 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x8071fc", Frameless: false}]
           Condition: null
-        - ID: 50
-          Kind: Return
+        - Kind: Return
           Type: 1368 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x807258", Frameless: false}]
           Condition: null
@@ -493,13 +456,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 63
-          Kind: Entry
+        - Kind: Entry
           Type: 1379 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807980", Frameless: true}]
           Condition: null
-        - ID: 62
-          Kind: Return
+        - Kind: Return
           Type: 1380 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x807988", Frameless: true}]
           Condition: null
@@ -513,13 +474,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 65
-          Kind: Entry
+        - Kind: Entry
           Type: 1381 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x80799c", Frameless: false}]
           Condition: null
-        - ID: 64
-          Kind: Return
+        - Kind: Return
           Type: 1382 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x8079d0", Frameless: false}]
           Condition: null
@@ -536,8 +495,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
-        - ID: 66
-          Kind: Line
+        - Kind: Line
           Type: 1383 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x80799c", Frameless: false}]
           Condition: null
@@ -551,13 +509,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
-          Kind: Entry
+        - Kind: Entry
           Type: 1371 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8076c8", Frameless: false}]
           Condition: null
-        - ID: 54
-          Kind: Return
+        - Kind: Return
           Type: 1372 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x80771c", Frameless: false}]
           Condition: null
@@ -571,13 +527,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
-          Kind: Entry
+        - Kind: Entry
           Type: 1373 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x807758", Frameless: false}]
           Condition: null
-        - ID: 56
-          Kind: Return
+        - Kind: Return
           Type: 1374 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
           Condition: null
@@ -591,13 +545,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
-          Kind: Entry
+        - Kind: Entry
           Type: 1375 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x807818", Frameless: false}]
           Condition: null
-        - ID: 58
-          Kind: Return
+        - Kind: Return
           Type: 1376 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x807850", Frameless: false}]
           Condition: null
@@ -611,8 +563,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
-        - ID: 211
-          Kind: Entry
+        - Kind: Entry
           Type: 1528 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
@@ -626,13 +577,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
-        - ID: 61
-          Kind: Entry
+        - Kind: Entry
           Type: 1377 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x807888", Frameless: false}]
           Condition: null
-        - ID: 60
-          Kind: Return
+        - Kind: Return
           Type: 1378 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x807964", Frameless: false}]
           Condition: null
@@ -646,8 +595,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 212
-          Kind: Entry
+        - Kind: Entry
           Type: 1529 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
@@ -664,8 +612,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
-        - ID: 213
-          Kind: Line
+        - Kind: Line
           Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
@@ -679,8 +626,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 214
-          Kind: Entry
+        - Kind: Entry
           Type: 1531 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
@@ -697,8 +643,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
-        - ID: 215
-          Kind: Line
+        - Kind: Line
           Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
@@ -713,8 +658,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 209
-          Kind: Entry
+        - Kind: Entry
           Type: 1525 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807538"
@@ -728,8 +672,7 @@ Probes:
             - PC: "0x80781c"
               Frameless: false
           Condition: null
-        - ID: 208
-          Kind: Return
+        - Kind: Return
           Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
@@ -746,8 +689,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
-        - ID: 210
-          Kind: Line
+        - Kind: Line
           Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
@@ -771,8 +713,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 216
-          Kind: Entry
+        - Kind: Entry
           Type: 1533 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
@@ -789,8 +730,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
-        - ID: 217
-          Kind: Line
+        - Kind: Line
           Type: 1534 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
@@ -805,8 +745,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
-        - ID: 218
-          Kind: Entry
+        - Kind: Entry
           Type: 1535 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8079b4"
@@ -824,8 +763,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 7
-          Kind: Entry
+        - Kind: Entry
           Type: 1324 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
@@ -839,8 +777,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 1325 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
@@ -854,8 +791,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 9
-          Kind: Entry
+        - Kind: Entry
           Type: 1326 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
@@ -869,8 +805,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 1323 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
@@ -884,8 +819,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 5
-          Kind: Entry
+        - Kind: Entry
           Type: 1322 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
@@ -899,8 +833,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 67
-          Kind: Entry
+        - Kind: Entry
           Type: 1384 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x807bf0", Frameless: true}]
           Condition: null
@@ -913,13 +846,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 160
-          Kind: Entry
+        - Kind: Entry
           Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x80b0c0", Frameless: false}]
           Condition: null
-        - ID: 159
-          Kind: Return
+        - Kind: Return
           Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b1e8", Frameless: false}]
           Condition: null
@@ -933,8 +864,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
-        - ID: 102
-          Kind: Entry
+        - Kind: Entry
           Type: 1419 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x809b60", Frameless: true}]
           Condition: null
@@ -951,8 +881,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 47
-          Kind: Line
+        - Kind: Line
           Type: 1364 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806cec", Frameless: false}]
           Condition: null
@@ -969,8 +898,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 48
-          Kind: Line
+        - Kind: Line
           Type: 1365 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806d70", Frameless: false}]
           Condition: null
@@ -987,8 +915,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
-          Kind: Line
+        - Kind: Line
           Type: 1366 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806e0c", Frameless: false}]
           Condition: null
@@ -1001,13 +928,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 166
-          Kind: Entry
+        - Kind: Entry
           Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x80b51c", Frameless: false}]
           Condition: null
-        - ID: 165
-          Kind: Return
+        - Kind: Return
           Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x80b65c", Frameless: false}]
           Condition: null
@@ -1021,8 +946,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
-        - ID: 78
-          Kind: Entry
+        - Kind: Entry
           Type: 1395 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x808260", Frameless: true}]
           Condition: null
@@ -1036,8 +960,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
-        - ID: 85
-          Kind: Entry
+        - Kind: Entry
           Type: 1402 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
           Condition: null
@@ -1051,8 +974,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
-        - ID: 95
-          Kind: Entry
+        - Kind: Entry
           Type: 1412 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x808360", Frameless: true}]
           Condition: null
@@ -1066,8 +988,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
-        - ID: 97
-          Kind: Entry
+        - Kind: Entry
           Type: 1414 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x808380", Frameless: true}]
           Condition: null
@@ -1081,8 +1002,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
-        - ID: 96
-          Kind: Entry
+        - Kind: Entry
           Type: 1413 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x808370", Frameless: true}]
           Condition: null
@@ -1096,8 +1016,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
-        - ID: 82
-          Kind: Entry
+        - Kind: Entry
           Type: 1399 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
           Condition: null
@@ -1111,8 +1030,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
-        - ID: 94
-          Kind: Entry
+        - Kind: Entry
           Type: 1411 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x808350", Frameless: true}]
           Condition: null
@@ -1126,8 +1044,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
-        - ID: 93
-          Kind: Entry
+        - Kind: Entry
           Type: 1410 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x808340", Frameless: true}]
           Condition: null
@@ -1141,8 +1058,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 83
-          Kind: Entry
+        - Kind: Entry
           Type: 1400 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
@@ -1156,8 +1072,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
-        - ID: 84
-          Kind: Entry
+        - Kind: Entry
           Type: 1401 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
@@ -1171,8 +1086,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
-        - ID: 92
-          Kind: Entry
+        - Kind: Entry
           Type: 1409 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x808330", Frameless: true}]
           Condition: null
@@ -1186,8 +1100,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
-        - ID: 91
-          Kind: Entry
+        - Kind: Entry
           Type: 1408 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x808320", Frameless: true}]
           Condition: null
@@ -1201,8 +1114,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
-        - ID: 76
-          Kind: Entry
+        - Kind: Entry
           Type: 1393 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x808240", Frameless: true}]
           Condition: null
@@ -1216,8 +1128,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
-        - ID: 77
-          Kind: Entry
+        - Kind: Entry
           Type: 1394 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x808250", Frameless: true}]
           Condition: null
@@ -1231,8 +1142,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
-        - ID: 75
-          Kind: Entry
+        - Kind: Entry
           Type: 1392 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x808230", Frameless: true}]
           Condition: null
@@ -1246,8 +1156,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
-        - ID: 86
-          Kind: Entry
+        - Kind: Entry
           Type: 1403 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
           Condition: null
@@ -1261,8 +1170,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
-        - ID: 89
-          Kind: Entry
+        - Kind: Entry
           Type: 1406 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x808300", Frameless: true}]
           Condition: null
@@ -1276,8 +1184,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
-        - ID: 90
-          Kind: Entry
+        - Kind: Entry
           Type: 1407 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x808310", Frameless: true}]
           Condition: null
@@ -1291,8 +1198,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
-        - ID: 87
-          Kind: Entry
+        - Kind: Entry
           Type: 1404 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
           Condition: null
@@ -1306,8 +1212,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
-        - ID: 88
-          Kind: Entry
+        - Kind: Entry
           Type: 1405 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
           Condition: null
@@ -1321,8 +1226,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 197
-          Kind: Entry
+        - Kind: Entry
           Type: 1514 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
@@ -1337,8 +1241,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
-        - ID: 198
-          Kind: Entry
+        - Kind: Entry
           Type: 1515 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
@@ -1351,13 +1254,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
-        - ID: 168
-          Kind: Entry
+        - Kind: Entry
           Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x80b6c0", Frameless: false}]
           Condition: null
-        - ID: 167
-          Kind: Return
+        - Kind: Return
           Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x80b848", Frameless: false}]
           Condition: null
@@ -1370,13 +1271,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
-        - ID: 172
-          Kind: Entry
+        - Kind: Entry
           Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x80b93c", Frameless: false}]
           Condition: null
-        - ID: 171
-          Kind: Return
+        - Kind: Return
           Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x80b9d4", Frameless: false}]
           Condition: null
@@ -1389,13 +1288,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 164
-          Kind: Entry
+        - Kind: Entry
           Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x80b310", Frameless: false}]
           Condition: null
-        - ID: 163
-          Kind: Return
+        - Kind: Return
           Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x80b4b4", Frameless: false}]
           Condition: null
@@ -1408,13 +1305,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
-        - ID: 126
-          Kind: Entry
+        - Kind: Entry
           Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a718", Frameless: false}]
           Condition: null
-        - ID: 125
-          Kind: Return
+        - Kind: Return
           Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
@@ -1428,8 +1323,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
-        - ID: 99
-          Kind: Entry
+        - Kind: Entry
           Type: 1416 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x809830", Frameless: true}]
           Condition: null
@@ -1442,13 +1336,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
-        - ID: 124
-          Kind: Entry
+        - Kind: Entry
           Type: 1440 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x80a688", Frameless: false}]
           Condition: null
-        - ID: 123
-          Kind: Return
+        - Kind: Return
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
           Condition: null
@@ -1462,8 +1354,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 107
-          Kind: Entry
+        - Kind: Entry
           Type: 1424 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x809c30", Frameless: true}]
           Condition: null
@@ -1477,8 +1368,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
-        - ID: 185
-          Kind: Entry
+        - Kind: Entry
           Type: 1502 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
@@ -1492,8 +1382,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
-        - ID: 182
-          Kind: Entry
+        - Kind: Entry
           Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
@@ -1507,8 +1396,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
-        - ID: 184
-          Kind: Entry
+        - Kind: Entry
           Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
@@ -1522,8 +1410,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
-        - ID: 196
-          Kind: Entry
+        - Kind: Entry
           Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80c370", Frameless: true}]
           Condition: null
@@ -1537,8 +1424,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 103
-          Kind: Entry
+        - Kind: Entry
           Type: 1420 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x809b70", Frameless: true}]
           Condition: null
@@ -1552,8 +1438,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
-        - ID: 81
-          Kind: Entry
+        - Kind: Entry
           Type: 1398 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
@@ -1567,8 +1452,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
-        - ID: 101
-          Kind: Entry
+        - Kind: Entry
           Type: 1418 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x809b50", Frameless: true}]
           Condition: null
@@ -1582,13 +1466,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
-        - ID: 120
-          Kind: Entry
+        - Kind: Entry
           Type: 1436 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x80a358", Frameless: false}]
           Condition: null
-        - ID: 119
-          Kind: Return
+        - Kind: Return
           Type: 1437 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x80a3e0"
@@ -1610,13 +1492,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
-        - ID: 118
-          Kind: Entry
+        - Kind: Entry
           Type: 1434 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x80a1e8", Frameless: false}]
           Condition: null
-        - ID: 117
-          Kind: Return
+        - Kind: Return
           Type: 1435 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x80a23c"
@@ -1637,13 +1517,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 138
-          Kind: Entry
+        - Kind: Entry
           Type: 1454 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x80ab1c", Frameless: false}]
           Condition: null
-        - ID: 137
-          Kind: Return
+        - Kind: Return
           Type: 1455 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x80ab68", Frameless: false}]
           Condition: null
@@ -1656,13 +1534,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
-        - ID: 140
-          Kind: Entry
+        - Kind: Entry
           Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x80ab98", Frameless: false}]
           Condition: null
-        - ID: 139
-          Kind: Return
+        - Kind: Return
           Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x80abd0", Frameless: false}]
           Condition: null
@@ -1675,13 +1551,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
-        - ID: 142
-          Kind: Entry
+        - Kind: Entry
           Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x80ac08", Frameless: false}]
           Condition: null
-        - ID: 141
-          Kind: Return
+        - Kind: Return
           Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x80ac3c", Frameless: false}]
           Condition: null
@@ -1694,13 +1568,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
-        - ID: 146
-          Kind: Entry
+        - Kind: Entry
           Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x80acf8", Frameless: false}]
           Condition: null
-        - ID: 145
-          Kind: Return
+        - Kind: Return
           Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
           Condition: null
@@ -1713,13 +1585,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 158
-          Kind: Entry
+        - Kind: Entry
           Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x80b048", Frameless: false}]
           Condition: null
-        - ID: 157
-          Kind: Return
+        - Kind: Return
           Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x80b084", Frameless: false}]
           Condition: null
@@ -1732,13 +1602,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
-        - ID: 134
-          Kind: Entry
+        - Kind: Entry
           Type: 1450 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x80a9d8", Frameless: false}]
           Condition: null
-        - ID: 133
-          Kind: Return
+        - Kind: Return
           Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x80aa20", Frameless: false}]
           Condition: null
@@ -1752,13 +1620,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 116
-          Kind: Entry
+        - Kind: Entry
           Type: 1432 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x80a168", Frameless: false}]
           Condition: null
-        - ID: 115
-          Kind: Return
+        - Kind: Return
           Type: 1433 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x80a194"
@@ -1775,13 +1641,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 110
-          Kind: Entry
+        - Kind: Entry
           Type: 1426 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x809f78", Frameless: false}]
           Condition: null
-        - ID: 109
-          Kind: Return
+        - Kind: Return
           Type: 1427 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x809fb8", Frameless: false}]
           Condition: null
@@ -1794,13 +1658,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 114
-          Kind: Entry
+        - Kind: Entry
           Type: 1430 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x80a098", Frameless: false}]
           Condition: null
-        - ID: 113
-          Kind: Return
+        - Kind: Return
           Type: 1431 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x80a124", Frameless: false}]
           Condition: null
@@ -1813,13 +1675,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 112
-          Kind: Entry
+        - Kind: Entry
           Type: 1428 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x809ff8", Frameless: false}]
           Condition: null
-        - ID: 111
-          Kind: Return
+        - Kind: Return
           Type: 1429 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x80a054", Frameless: false}]
           Condition: null
@@ -1833,13 +1693,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
-        - ID: 122
-          Kind: Entry
+        - Kind: Entry
           Type: 1438 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x80a538", Frameless: false}]
           Condition: null
-        - ID: 121
-          Kind: Return
+        - Kind: Return
           Type: 1439 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x80a5f0"
@@ -1856,13 +1714,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
-        - ID: 136
-          Kind: Entry
+        - Kind: Entry
           Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x80aa60", Frameless: false}]
           Condition: null
-        - ID: 135
-          Kind: Return
+        - Kind: Return
           Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x80aadc", Frameless: false}]
           Condition: null
@@ -1875,13 +1731,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
-        - ID: 132
-          Kind: Entry
+        - Kind: Entry
           Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x80a928", Frameless: false}]
           Condition: null
-        - ID: 131
-          Kind: Return
+        - Kind: Return
           Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x80a9a8", Frameless: false}]
           Condition: null
@@ -1894,13 +1748,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
-        - ID: 150
-          Kind: Entry
+        - Kind: Entry
           Type: 1466 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
           Condition: null
-        - ID: 149
-          Kind: Return
+        - Kind: Return
           Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80aeac", Frameless: false}]
           Condition: null
@@ -1913,13 +1765,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 144
-          Kind: Entry
+        - Kind: Entry
           Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x80ac78", Frameless: false}]
           Condition: null
-        - ID: 143
-          Kind: Return
+        - Kind: Return
           Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80acbc", Frameless: false}]
           Condition: null
@@ -1932,13 +1782,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
-        - ID: 156
-          Kind: Entry
+        - Kind: Entry
           Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x80afd8", Frameless: false}]
           Condition: null
-        - ID: 155
-          Kind: Return
+        - Kind: Return
           Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x80b018", Frameless: false}]
           Condition: null
@@ -1951,13 +1799,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
-        - ID: 154
-          Kind: Entry
+        - Kind: Entry
           Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x80af68", Frameless: false}]
           Condition: null
-        - ID: 153
-          Kind: Return
+        - Kind: Return
           Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x80afa4", Frameless: false}]
           Condition: null
@@ -1970,13 +1816,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
-        - ID: 130
-          Kind: Entry
+        - Kind: Entry
           Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x80a898", Frameless: false}]
           Condition: null
-        - ID: 129
-          Kind: Return
+        - Kind: Return
           Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80a8ec", Frameless: false}]
           Condition: null
@@ -1989,13 +1833,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
-        - ID: 152
-          Kind: Entry
+        - Kind: Entry
           Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x80aeec", Frameless: false}]
           Condition: null
-        - ID: 151
-          Kind: Return
+        - Kind: Return
           Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x80af38", Frameless: false}]
           Condition: null
@@ -2008,13 +1850,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
-        - ID: 148
-          Kind: Entry
+        - Kind: Entry
           Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x80ad90", Frameless: false}]
           Condition: null
-        - ID: 147
-          Kind: Return
+        - Kind: Return
           Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x80ae1c", Frameless: false}]
           Condition: null
@@ -2028,8 +1868,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 1319 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
@@ -2043,8 +1882,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 1340 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
@@ -2058,8 +1896,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 1338 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
@@ -2073,8 +1910,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
-        - ID: 34
-          Kind: Entry
+        - Kind: Entry
           Type: 1351 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
@@ -2088,8 +1924,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
-          Kind: Entry
+        - Kind: Entry
           Type: 1352 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067e0", Frameless: true}]
           Condition: null
@@ -2103,8 +1938,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 1341 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
@@ -2118,8 +1952,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
-        - ID: 26
-          Kind: Entry
+        - Kind: Entry
           Type: 1343 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
@@ -2133,8 +1966,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
-        - ID: 27
-          Kind: Entry
+        - Kind: Entry
           Type: 1344 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
@@ -2148,8 +1980,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
-        - ID: 28
-          Kind: Entry
+        - Kind: Entry
           Type: 1345 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
@@ -2163,8 +1994,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 1342 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
@@ -2178,8 +2008,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
-        - ID: 22
-          Kind: Entry
+        - Kind: Entry
           Type: 1339 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
@@ -2193,8 +2022,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
-        - ID: 191
-          Kind: Entry
+        - Kind: Entry
           Type: 1508 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80c330", Frameless: true}]
           Condition: null
@@ -2208,8 +2036,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
-        - ID: 29
-          Kind: Entry
+        - Kind: Entry
           Type: 1346 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
@@ -2223,8 +2050,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
-        - ID: 31
-          Kind: Entry
+        - Kind: Entry
           Type: 1348 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
@@ -2238,8 +2064,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
-        - ID: 32
-          Kind: Entry
+        - Kind: Entry
           Type: 1349 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
@@ -2253,8 +2078,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
-        - ID: 33
-          Kind: Entry
+        - Kind: Entry
           Type: 1350 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
@@ -2268,8 +2092,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
-        - ID: 30
-          Kind: Entry
+        - Kind: Entry
           Type: 1347 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
@@ -2283,8 +2106,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
-        - ID: 188
-          Kind: Entry
+        - Kind: Entry
           Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
@@ -2298,8 +2120,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
-        - ID: 179
-          Kind: Entry
+        - Kind: Entry
           Type: 1496 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80bfa0", Frameless: true}]
           Condition: null
@@ -2313,8 +2134,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
-        - ID: 79
-          Kind: Entry
+        - Kind: Entry
           Type: 1396 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x808270", Frameless: true}]
           Condition: null
@@ -2327,13 +2147,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
-        - ID: 128
-          Kind: Entry
+        - Kind: Entry
           Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a7d8", Frameless: false}]
           Condition: null
-        - ID: 127
-          Kind: Return
+        - Kind: Return
           Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a85c", Frameless: false}]
           Condition: null
@@ -2346,13 +2164,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
-        - ID: 170
-          Kind: Entry
+        - Kind: Entry
           Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x80b8a8", Frameless: false}]
           Condition: null
-        - ID: 169
-          Kind: Return
+        - Kind: Return
           Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x80b900", Frameless: false}]
           Condition: null
@@ -2366,8 +2182,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 3
-          Kind: Entry
+        - Kind: Entry
           Type: 1320 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
@@ -2381,8 +2196,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
-          Kind: Entry
+        - Kind: Entry
           Type: 1423 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809c10", Frameless: true}]
           Condition: null
@@ -2396,8 +2210,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
-        - ID: 183
-          Kind: Entry
+        - Kind: Entry
           Type: 1500 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
@@ -2411,8 +2224,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
-          Kind: Entry
+        - Kind: Entry
           Type: 1362 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806cb0", Frameless: true}]
           Condition: null
@@ -2426,8 +2238,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 46
-          Kind: Entry
+        - Kind: Entry
           Type: 1363 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806cc0", Frameless: true}]
           Condition: null
@@ -2441,13 +2252,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
-        - ID: 205
-          Kind: Entry
+        - Kind: Entry
           Type: 1521 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
           Condition: null
-        - ID: 204
-          Kind: Return
+        - Kind: Return
           Type: 1522 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
@@ -2461,8 +2270,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
-        - ID: 180
-          Kind: Entry
+        - Kind: Entry
           Type: 1497 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80bfb0", Frameless: true}]
           Condition: null
@@ -2476,8 +2284,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
-        - ID: 73
-          Kind: Entry
+        - Kind: Entry
           Type: 1390 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x807cd0", Frameless: true}]
           Condition: null
@@ -2490,13 +2297,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
-        - ID: 174
-          Kind: Entry
+        - Kind: Entry
           Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x80ba0c", Frameless: false}]
           Condition: null
-        - ID: 173
-          Kind: Return
+        - Kind: Return
           Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x80ba90", Frameless: false}]
           Condition: null
@@ -2509,13 +2314,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
-        - ID: 203
-          Kind: Entry
+        - Kind: Entry
           Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80c4f0", Frameless: true}]
           Condition: null
-        - ID: 202
-          Kind: Return
+        - Kind: Return
           Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80c4fc", Frameless: true}]
           Condition: null
@@ -2528,8 +2331,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
-        - ID: 201
-          Kind: Entry
+        - Kind: Entry
           Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80c4e0", Frameless: true}]
           Condition: null
@@ -2543,8 +2345,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
-        - ID: 74
-          Kind: Entry
+        - Kind: Entry
           Type: 1391 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808220", Frameless: true}]
           Condition: null
@@ -2558,8 +2359,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
-        - ID: 192
-          Kind: Entry
+        - Kind: Entry
           Type: 1509 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80c340", Frameless: true}]
           Condition: null
@@ -2573,13 +2373,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
-        - ID: 194
-          Kind: Entry
+        - Kind: Entry
           Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80c350", Frameless: true}]
           Condition: null
-        - ID: 193
-          Kind: Return
+        - Kind: Return
           Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c35c", Frameless: true}]
           Condition: null
@@ -2593,8 +2391,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
-        - ID: 195
-          Kind: Entry
+        - Kind: Entry
           Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c360", Frameless: true}]
           Condition: null
@@ -2608,8 +2405,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
-        - ID: 36
-          Kind: Entry
+        - Kind: Entry
           Type: 1353 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067f0", Frameless: true}]
           Condition: null
@@ -2623,8 +2419,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 1329 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
@@ -2638,8 +2433,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 1330 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
@@ -2653,8 +2447,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 14
-          Kind: Entry
+        - Kind: Entry
           Type: 1331 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
@@ -2668,8 +2461,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 11
-          Kind: Entry
+        - Kind: Entry
           Type: 1328 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
@@ -2683,8 +2475,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 1327 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
@@ -2698,8 +2489,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 105
-          Kind: Entry
+        - Kind: Entry
           Type: 1422 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
           Condition: null
@@ -2713,8 +2503,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
-        - ID: 177
-          Kind: Entry
+        - Kind: Entry
           Type: 1494 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80bf80", Frameless: true}]
           Condition: null
@@ -2728,8 +2517,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
-        - ID: 199
-          Kind: Entry
+        - Kind: Entry
           Type: 1516 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80c390", Frameless: true}]
           Condition: null
@@ -2743,8 +2531,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 104
-          Kind: Entry
+        - Kind: Entry
           Type: 1421 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809b80", Frameless: true}]
           Condition: null
@@ -2758,8 +2545,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
-        - ID: 20
-          Kind: Entry
+        - Kind: Entry
           Type: 1337 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
           Condition: null
@@ -2773,8 +2559,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 186
-          Kind: Entry
+        - Kind: Entry
           Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
@@ -2788,8 +2573,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
-        - ID: 187
-          Kind: Entry
+        - Kind: Entry
           Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
@@ -2802,13 +2586,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
-        - ID: 176
-          Kind: Entry
+        - Kind: Entry
           Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
           Condition: null
-        - ID: 175
-          Kind: Return
+        - Kind: Return
           Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80bb28", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,8 +10,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 184 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6046", Frameless: false}]
           Condition: null
@@ -25,8 +24,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 185 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6090", Frameless: false}]
           Condition: null
@@ -39,13 +37,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 176 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
-        - ID: 16
-          Kind: Return
+        - Kind: Return
           Type: 177 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a65de", Frameless: false}]
           Condition: null
@@ -59,8 +55,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 182 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5e0e"
@@ -68,8 +63,7 @@ Probes:
             - PC: "0x4a642a"
               Frameless: false
           Condition: null
-        - ID: 22
-          Kind: Return
+        - Kind: Return
           Type: 183 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a646a", Frameless: false}]
           Condition: null
@@ -82,13 +76,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 161 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a610a", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 162 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a614a", Frameless: false}]
           Condition: null
@@ -101,13 +93,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 167 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
-        - ID: 7
-          Kind: Return
+        - Kind: Return
           Type: 168 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a62d6", Frameless: false}]
           Condition: null
@@ -120,8 +110,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 173 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a6400", Frameless: true}]
           Condition: null
@@ -134,13 +123,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 165 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
-        - ID: 5
-          Kind: Return
+        - Kind: Return
           Type: 166 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a624f", Frameless: false}]
           Condition: null
@@ -153,13 +140,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 174 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
-        - ID: 14
-          Kind: Return
+        - Kind: Return
           Type: 175 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a651f", Frameless: false}]
           Condition: null
@@ -172,13 +157,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 178 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a660a", Frameless: false}]
           Condition: null
-        - ID: 18
-          Kind: Return
+        - Kind: Return
           Type: 179 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a6646", Frameless: false}]
           Condition: null
@@ -191,13 +174,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 163 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 164 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
           Condition: null
@@ -210,13 +191,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 171 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
-        - ID: 11
-          Kind: Return
+        - Kind: Return
           Type: 172 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a63d6", Frameless: false}]
           Condition: null
@@ -229,13 +208,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 169 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
           Condition: null
-        - ID: 9
-          Kind: Return
+        - Kind: Return
           Type: 170 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
           Condition: null
@@ -249,13 +226,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 180 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a6676", Frameless: false}]
           Condition: null
-        - ID: 20
-          Kind: Return
+        - Kind: Return
           Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a682e", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,8 +10,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 201 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8046", Frameless: false}]
           Condition: null
@@ -25,8 +24,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 202 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8090", Frameless: false}]
           Condition: null
@@ -39,13 +37,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 193 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a8553", Frameless: false}]
           Condition: null
-        - ID: 16
-          Kind: Return
+        - Kind: Return
           Type: 194 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a85de", Frameless: false}]
           Condition: null
@@ -59,8 +55,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 199 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a7e0e"
@@ -68,8 +63,7 @@ Probes:
             - PC: "0x4a842a"
               Frameless: false
           Condition: null
-        - ID: 22
-          Kind: Return
+        - Kind: Return
           Type: 200 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a846a", Frameless: false}]
           Condition: null
@@ -82,13 +76,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 178 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a810a", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 179 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a814a", Frameless: false}]
           Condition: null
@@ -101,13 +93,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 184 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a828a", Frameless: false}]
           Condition: null
-        - ID: 7
-          Kind: Return
+        - Kind: Return
           Type: 185 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a82d6", Frameless: false}]
           Condition: null
@@ -120,8 +110,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 190 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a8400", Frameless: true}]
           Condition: null
@@ -134,13 +123,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 182 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a820a", Frameless: false}]
           Condition: null
-        - ID: 5
-          Kind: Return
+        - Kind: Return
           Type: 183 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a824f", Frameless: false}]
           Condition: null
@@ -153,13 +140,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 191 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a84ea", Frameless: false}]
           Condition: null
-        - ID: 14
-          Kind: Return
+        - Kind: Return
           Type: 192 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a851f", Frameless: false}]
           Condition: null
@@ -172,13 +157,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 195 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a860a", Frameless: false}]
           Condition: null
-        - ID: 18
-          Kind: Return
+        - Kind: Return
           Type: 196 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a8646", Frameless: false}]
           Condition: null
@@ -191,13 +174,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 180 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 181 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
           Condition: null
@@ -210,13 +191,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 188 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a838a", Frameless: false}]
           Condition: null
-        - ID: 11
-          Kind: Return
+        - Kind: Return
           Type: 189 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a83d6", Frameless: false}]
           Condition: null
@@ -229,13 +208,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 186 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
           Condition: null
-        - ID: 9
-          Kind: Return
+        - Kind: Return
           Type: 187 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a834f", Frameless: false}]
           Condition: null
@@ -249,13 +226,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 197 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
-        - ID: 20
-          Kind: Return
+        - Kind: Return
           Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a883c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,8 +10,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 206 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae646", Frameless: false}]
           Condition: null
@@ -25,8 +24,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 207 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae690", Frameless: false}]
           Condition: null
@@ -39,13 +37,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 198 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4aeb53", Frameless: false}]
           Condition: null
-        - ID: 16
-          Kind: Return
+        - Kind: Return
           Type: 199 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4aebde", Frameless: false}]
           Condition: null
@@ -59,8 +55,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 204 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae40e"
@@ -68,8 +63,7 @@ Probes:
             - PC: "0x4aea2a"
               Frameless: false
           Condition: null
-        - ID: 22
-          Kind: Return
+        - Kind: Return
           Type: 205 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4aea6a", Frameless: false}]
           Condition: null
@@ -82,13 +76,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 183 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4ae70a", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 184 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4ae74a", Frameless: false}]
           Condition: null
@@ -101,13 +93,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 189 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4ae88a", Frameless: false}]
           Condition: null
-        - ID: 7
-          Kind: Return
+        - Kind: Return
           Type: 190 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4ae8d6", Frameless: false}]
           Condition: null
@@ -120,8 +110,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 195 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4aea00", Frameless: true}]
           Condition: null
@@ -134,13 +123,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 187 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4ae80a", Frameless: false}]
           Condition: null
-        - ID: 5
-          Kind: Return
+        - Kind: Return
           Type: 188 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4ae84f", Frameless: false}]
           Condition: null
@@ -153,13 +140,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 196 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4aeaea", Frameless: false}]
           Condition: null
-        - ID: 14
-          Kind: Return
+        - Kind: Return
           Type: 197 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4aeb1f", Frameless: false}]
           Condition: null
@@ -172,13 +157,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 200 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4aec0a", Frameless: false}]
           Condition: null
-        - ID: 18
-          Kind: Return
+        - Kind: Return
           Type: 201 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4aec46", Frameless: false}]
           Condition: null
@@ -191,13 +174,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 185 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 186 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
           Condition: null
@@ -210,13 +191,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 193 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4ae98a", Frameless: false}]
           Condition: null
-        - ID: 11
-          Kind: Return
+        - Kind: Return
           Type: 194 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4ae9d6", Frameless: false}]
           Condition: null
@@ -229,13 +208,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 191 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
           Condition: null
-        - ID: 9
-          Kind: Return
+        - Kind: Return
           Type: 192 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4ae94f", Frameless: false}]
           Condition: null
@@ -249,13 +226,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 202 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aec76", Frameless: false}]
           Condition: null
-        - ID: 20
-          Kind: Return
+        - Kind: Return
           Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4aee44", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,8 +10,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 185 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5388", Frameless: false}]
           Condition: null
@@ -25,8 +24,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 186 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb53c0", Frameless: false}]
           Condition: null
@@ -39,13 +37,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 177 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb5880", Frameless: false}]
           Condition: null
-        - ID: 16
-          Kind: Return
+        - Kind: Return
           Type: 178 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb58f4", Frameless: false}]
           Condition: null
@@ -59,8 +55,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 183 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb519c"
@@ -68,8 +63,7 @@ Probes:
             - PC: "0xb5748"
               Frameless: false
           Condition: null
-        - ID: 22
-          Kind: Return
+        - Kind: Return
           Type: 184 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb5780", Frameless: false}]
           Condition: null
@@ -82,13 +76,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 162 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 163 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb5460", Frameless: false}]
           Condition: null
@@ -101,13 +93,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 168 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb55a8", Frameless: false}]
           Condition: null
-        - ID: 7
-          Kind: Return
+        - Kind: Return
           Type: 169 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb55ec", Frameless: false}]
           Condition: null
@@ -120,8 +110,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 174 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5720", Frameless: true}]
           Condition: null
@@ -134,13 +123,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 166 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5518", Frameless: false}]
           Condition: null
-        - ID: 5
-          Kind: Return
+        - Kind: Return
           Type: 167 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5554", Frameless: false}]
           Condition: null
@@ -153,13 +140,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 175 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5808", Frameless: false}]
           Condition: null
-        - ID: 14
-          Kind: Return
+        - Kind: Return
           Type: 176 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb5838", Frameless: false}]
           Condition: null
@@ -172,13 +157,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 179 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb5938", Frameless: false}]
           Condition: null
-        - ID: 18
-          Kind: Return
+        - Kind: Return
           Type: 180 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb5970", Frameless: false}]
           Condition: null
@@ -191,13 +174,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 164 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5498", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 165 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
           Condition: null
@@ -210,13 +191,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 172 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb56b8", Frameless: false}]
           Condition: null
-        - ID: 11
-          Kind: Return
+        - Kind: Return
           Type: 173 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb56fc", Frameless: false}]
           Condition: null
@@ -229,13 +208,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 170 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb5628", Frameless: false}]
           Condition: null
-        - ID: 9
-          Kind: Return
+        - Kind: Return
           Type: 171 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb5664", Frameless: false}]
           Condition: null
@@ -249,13 +226,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb59b0", Frameless: false}]
           Condition: null
-        - ID: 20
-          Kind: Return
+        - Kind: Return
           Type: 182 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb5b24", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,8 +10,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 202 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb520c", Frameless: false}]
           Condition: null
@@ -25,8 +24,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 203 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb5244", Frameless: false}]
           Condition: null
@@ -39,13 +37,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 194 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb56f0", Frameless: false}]
           Condition: null
-        - ID: 16
-          Kind: Return
+        - Kind: Return
           Type: 195 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb5764", Frameless: false}]
           Condition: null
@@ -59,8 +55,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 200 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb502c"
@@ -68,8 +63,7 @@ Probes:
             - PC: "0xb55b8"
               Frameless: false
           Condition: null
-        - ID: 22
-          Kind: Return
+        - Kind: Return
           Type: 201 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb55f0", Frameless: false}]
           Condition: null
@@ -82,13 +76,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 179 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb52b8", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 180 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb52f0", Frameless: false}]
           Condition: null
@@ -101,13 +93,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 185 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
-        - ID: 7
-          Kind: Return
+        - Kind: Return
           Type: 186 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb546c", Frameless: false}]
           Condition: null
@@ -120,8 +110,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 191 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5590", Frameless: true}]
           Condition: null
@@ -134,13 +123,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 183 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb53a8", Frameless: false}]
           Condition: null
-        - ID: 5
-          Kind: Return
+        - Kind: Return
           Type: 184 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb53e4", Frameless: false}]
           Condition: null
@@ -153,13 +140,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 192 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5678", Frameless: false}]
           Condition: null
-        - ID: 14
-          Kind: Return
+        - Kind: Return
           Type: 193 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb56a8", Frameless: false}]
           Condition: null
@@ -172,13 +157,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 196 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb57a8", Frameless: false}]
           Condition: null
-        - ID: 18
-          Kind: Return
+        - Kind: Return
           Type: 197 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb57e0", Frameless: false}]
           Condition: null
@@ -191,13 +174,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 181 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5328", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 182 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5364", Frameless: false}]
           Condition: null
@@ -210,13 +191,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 189 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb5528", Frameless: false}]
           Condition: null
-        - ID: 11
-          Kind: Return
+        - Kind: Return
           Type: 190 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb556c", Frameless: false}]
           Condition: null
@@ -229,13 +208,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 187 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb54a8", Frameless: false}]
           Condition: null
-        - ID: 9
-          Kind: Return
+        - Kind: Return
           Type: 188 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb54e4", Frameless: false}]
           Condition: null
@@ -249,13 +226,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb5820", Frameless: false}]
           Condition: null
-        - ID: 20
-          Kind: Return
+        - Kind: Return
           Type: 199 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb59a0", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,8 +10,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
-        - ID: 24
-          Kind: Entry
+        - Kind: Entry
           Type: 207 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7da0", Frameless: false}]
           Condition: null
@@ -25,8 +24,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
-        - ID: 25
-          Kind: Entry
+        - Kind: Entry
           Type: 208 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7dd4", Frameless: false}]
           Condition: null
@@ -39,13 +37,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 17
-          Kind: Entry
+        - Kind: Entry
           Type: 199 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb8240", Frameless: false}]
           Condition: null
-        - ID: 16
-          Kind: Return
+        - Kind: Return
           Type: 200 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb82b0", Frameless: false}]
           Condition: null
@@ -59,8 +55,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 23
-          Kind: Entry
+        - Kind: Entry
           Type: 205 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb7bc8"
@@ -68,8 +63,7 @@ Probes:
             - PC: "0xb8108"
               Frameless: false
           Condition: null
-        - ID: 22
-          Kind: Return
+        - Kind: Return
           Type: 206 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb813c", Frameless: false}]
           Condition: null
@@ -82,13 +76,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 2
-          Kind: Entry
+        - Kind: Entry
           Type: 184 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb7e38", Frameless: false}]
           Condition: null
-        - ID: 1
-          Kind: Return
+        - Kind: Return
           Type: 185 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb7e6c", Frameless: false}]
           Condition: null
@@ -101,13 +93,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 8
-          Kind: Entry
+        - Kind: Entry
           Type: 190 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb7f98", Frameless: false}]
           Condition: null
-        - ID: 7
-          Kind: Return
+        - Kind: Return
           Type: 191 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb7fd8", Frameless: false}]
           Condition: null
@@ -120,8 +110,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
-        - ID: 13
-          Kind: Entry
+        - Kind: Entry
           Type: 196 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb80e0", Frameless: true}]
           Condition: null
@@ -134,13 +123,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 6
-          Kind: Entry
+        - Kind: Entry
           Type: 188 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb7f18", Frameless: false}]
           Condition: null
-        - ID: 5
-          Kind: Return
+        - Kind: Return
           Type: 189 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb7f50", Frameless: false}]
           Condition: null
@@ -153,13 +140,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 15
-          Kind: Entry
+        - Kind: Entry
           Type: 197 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb81c8", Frameless: false}]
           Condition: null
-        - ID: 14
-          Kind: Return
+        - Kind: Return
           Type: 198 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb81f4", Frameless: false}]
           Condition: null
@@ -172,13 +157,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 19
-          Kind: Entry
+        - Kind: Entry
           Type: 201 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb82e8", Frameless: false}]
           Condition: null
-        - ID: 18
-          Kind: Return
+        - Kind: Return
           Type: 202 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb831c", Frameless: false}]
           Condition: null
@@ -191,13 +174,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 4
-          Kind: Entry
+        - Kind: Entry
           Type: 186 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
           Condition: null
-        - ID: 3
-          Kind: Return
+        - Kind: Return
           Type: 187 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
           Condition: null
@@ -210,13 +191,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 12
-          Kind: Entry
+        - Kind: Entry
           Type: 194 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb8088", Frameless: false}]
           Condition: null
-        - ID: 11
-          Kind: Return
+        - Kind: Return
           Type: 195 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb80c8", Frameless: false}]
           Condition: null
@@ -229,13 +208,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 10
-          Kind: Entry
+        - Kind: Entry
           Type: 192 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb8008", Frameless: false}]
           Condition: null
-        - ID: 9
-          Kind: Return
+        - Kind: Return
           Type: 193 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb8040", Frameless: false}]
           Condition: null
@@ -249,13 +226,11 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 21
-          Kind: Entry
+        - Kind: Entry
           Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb8360", Frameless: false}]
           Condition: null
-        - ID: 20
-          Kind: Return
+        - Kind: Return
           Type: 204 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb84d8", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/rcscrape/ir_generator.go
+++ b/pkg/dyninst/rcscrape/ir_generator.go
@@ -235,7 +235,6 @@ func addRcProbe(
 		ProbeDefinition: probeDef,
 		Subprogram:      subprogram,
 		Events: []*ir.Event{{
-			ID:   ir.EventID(subprogram.ID),
 			Type: rootType,
 			InjectionPoints: []ir.InjectionPoint{
 				{PC: symbol.Entry, Frameless: true},
@@ -317,7 +316,6 @@ func addSymdbProbe(
 		ProbeDefinition: probeDef,
 		Subprogram:      subprogram,
 		Events: []*ir.Event{{
-			ID:   ir.EventID(subprogram.ID),
 			Type: rootType,
 			InjectionPoints: []ir.InjectionPoint{
 				{PC: symbol.Entry, Frameless: true},


### PR DESCRIPTION
It wasn't used. We end up using the corresponding type ID to identify the event off the ring buffer. There's no extra layer of enveloping like existed once upon a time for events.