### PR TITLE
[Agent Innovation Week 2025] Lightweight overlay for Windows Datadog System Tray

### DIFF
--- a/comp/systray/systray/systrayimpl/dooverlay.go
+++ b/comp/systray/systray/systrayimpl/dooverlay.go
@@ -1,0 +1,425 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows
+
+package systrayimpl
+
+// #cgo CFLAGS:  -DUNICODE -D_UNICODE -DWINVER=0x0601 -D_WIN32_WINNT=0x0601
+// #cgo LDFLAGS: -ld2d1 -ldwrite -lole32 -luuid -lgdi32
+// #include <windows.h>
+// #include <d2d1.h>
+// #include <dwrite.h>
+// #include "overlay.h"
+import "C"
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/lxn/win"
+)
+
+type overlayWindow struct {
+	windowHandle win.HWND
+	log          log.Component
+}
+type overlayWindowOpts struct {
+	// Pass a real parent HWND for a true child; 0 => top-level
+	Parent win.HWND
+	Log    log.Component
+	Title  string
+
+	Left   int
+	Top    int
+	Width  int
+	Height int
+
+	TextContent string
+}
+
+var (
+	overlay *overlayWindow
+)
+
+// onOverlay is a callback from systray to issue a background command and
+// present the output in an overlay window.
+func onOverlay(s *systrayImpl) {
+	if overlay == nil {
+		// Create the overlay for the first time.
+		var err error
+
+		// TODO: Potentially support other commands.
+		status, err := queryAgentStatus()
+		if err != nil {
+			status = fmt.Sprintf("Failed to query agent status: %v", err)
+			s.log.Error(status)
+		}
+
+		overlayOpts := overlayWindowOpts{
+			Title:       "Datadog Overlay",
+			Log:         s.log,
+			TextContent: status,
+		}
+
+		calculateOverlayArea(&overlayOpts, s.log)
+		overlay, err = launchOverlayWindow(&overlayOpts)
+		if err != nil {
+			overlay = nil
+			s.log.Errorf("Failed to launch overlay: %v", err)
+		}
+
+	} else {
+		// The overlay exists, toggle its visibility.
+		overlay.onShow(!win.IsWindowVisible(overlay.windowHandle))
+	}
+}
+
+// launchOverlayWindow creates the overlay window on a dedicated UI thread
+// and returns immediately. The window message loop in the dedicated thread will
+// run forever until the window is closed (WM_QUIT).
+func launchOverlayWindow(opts *overlayWindowOpts) (*overlayWindow, error) {
+	log := opts.Log
+	ow := &overlayWindow{
+		log: log,
+	}
+
+	className, err := syscall.UTF16PtrFromString("DatadogOverlayClass")
+	if err != nil {
+		return nil, syscall.GetLastError()
+	}
+
+	errc := make(chan error, 1)
+
+	go func() {
+		// Pin all Win32 UI work to this single OS thread.
+		// This will detach the overlay window from system tray.
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		log.Infof("Creating overlay")
+
+		title, err := syscall.UTF16PtrFromString(opts.Title)
+		if err != nil {
+			errc <- syscall.GetLastError()
+			return
+		}
+
+		// Register the overlay window class and tie the message handler to it.
+		var wc win.WNDCLASSEX
+		wc.CbSize = uint32(unsafe.Sizeof(wc))
+		wc.Style = win.CS_HREDRAW | win.CS_VREDRAW
+		wc.LpfnWndProc = syscall.NewCallback(ow.wndProc)
+		wc.HInstance = win.GetModuleHandle(nil)
+		wc.HCursor = win.LoadCursor(0, win.MAKEINTRESOURCE(win.IDC_ARROW))
+		wc.HbrBackground = win.COLOR_WINDOW + 1
+		wc.LpszClassName = className
+
+		var atom win.ATOM
+		if atom = win.RegisterClassEx(&wc); atom == 0 {
+			// Failing to register the window class means the message handler
+			// will not be active.
+			errCode := syscall.GetLastError()
+			log.Errorf("Failed to register window class: %v", errCode)
+			errc <- errCode
+			return
+		}
+
+		defer func() {
+			// UnregisterClass may fail with code 824637302304, leaving the message handler stuck,
+			// and causing new overlay windows to not have message handling.
+			// As long as we reuse the same overlay window, avoid recreating it, and
+			// bail out completely on termination, this should be fine.
+			if atom != 0 && !win.UnregisterClass(className) {
+				log.Warnf("Failed to unregister window class: %v", syscall.GetLastError())
+			}
+		}()
+
+		hwnd := win.CreateWindowEx(
+			win.WS_EX_LAYERED|win.WS_EX_TOPMOST|win.WS_EX_TOOLWINDOW,
+			className,
+			title,
+			win.WS_POPUP,
+			int32(opts.Left),
+			int32(opts.Top),
+			int32(opts.Width),
+			int32(opts.Height),
+			opts.Parent,
+			0,
+			wc.HInstance,
+			nil,
+		)
+		if hwnd == 0 {
+			errCode := syscall.GetLastError()
+			log.Errorf("Failed to create overlay window: %v", errCode)
+			errc <- errCode
+			return
+		}
+
+		// This must be setup before the message handling starts.
+		textContent := C.CString(opts.TextContent)
+		C.InitOverlayA((C.uintptr_t)(hwnd), textContent)
+		C.free(unsafe.Pointer(textContent))
+
+		ow.windowHandle = hwnd
+		log.Infof("Overlay created")
+		win.ShowWindow(hwnd, win.SW_SHOWNOACTIVATE)
+
+		// The message loop will run forever, let the caller proceed.
+		errc <- nil
+
+		var msg win.MSG
+		for {
+			ret := win.GetMessage(&msg, 0, 0, 0)
+			if (ret == 0) || (ret == -1) {
+				// Stop message loop.
+				break
+			}
+
+			win.TranslateMessage(&msg)
+			win.DispatchMessage(&msg)
+		}
+
+		C.CleanupOverlay()
+
+		log.Infof("Overlay closed")
+	}()
+
+	// Wait for the window creation to complete.
+	err = <-errc
+
+	if err != nil {
+		log.Errorf("failed to create overlay: %v)", errc)
+		return nil, err
+	}
+
+	return ow, nil
+}
+
+//
+// Window handling functions
+//
+
+// wndProc handles Windows messages, specifically showing/hiding the overlay, and key inputs.
+func (w *overlayWindow) wndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) uintptr {
+	switch msg {
+	case win.WM_PAINT:
+		C.RenderOverlay((C.uintptr_t)(hwnd))
+		return 0
+	case win.WM_LBUTTONDOWN:
+		return 0
+	case win.WM_KEYDOWN:
+		if w.handleKeyDown(hwnd, wParam) {
+			return 0
+		}
+	case win.WM_KEYUP:
+		if w.handleKeyUp(hwnd, wParam) {
+			return 0
+		}
+	case win.WM_SHOWWINDOW:
+		if wParam != 0 {
+			// The overlay will be shown.
+			C.ShowOverlay((C.uintptr_t)(hwnd), win.TRUE)
+		} else {
+			// The overlay will be hidden. Release rendering resources.
+			C.ShowOverlay((C.uintptr_t)(hwnd), win.FALSE)
+		}
+		return 0
+	case win.WM_CREATE:
+		// Always first message.
+		return 0
+	case win.WM_CLOSE:
+		win.DestroyWindow(hwnd)
+		return 0
+	case win.WM_DESTROY:
+		// This will stop the message loop.
+		win.PostQuitMessage(0)
+		return 0
+	}
+
+	return win.DefWindowProc(hwnd, msg, wParam, lParam)
+}
+
+// handleKeyDown handles when the user presses or holds a key down.
+func (w *overlayWindow) handleKeyDown(_ win.HWND, wParam uintptr) bool {
+	switch wParam {
+	case win.VK_DOWN:
+		C.ScrollOverlayVertical(C.float(20.0))
+		return true
+	case win.VK_UP:
+		C.ScrollOverlayVertical(C.float(-20.0))
+		return true
+	case win.VK_NEXT:
+		C.ScrollOverlayVertical(C.float(100.0))
+		return true
+	case win.VK_PRIOR:
+		C.ScrollOverlayVertical(C.float(-100.0))
+		return true
+	default:
+		return false
+	}
+}
+
+// handleKeyUp handles when the user releases a key press.
+func (w *overlayWindow) handleKeyUp(_ win.HWND, wParam uintptr) bool {
+	switch wParam {
+	case win.VK_DOWN:
+		fallthrough
+	case win.VK_UP:
+		fallthrough
+	case win.VK_NEXT:
+		fallthrough
+	case win.VK_PRIOR:
+		// Managed by handleKeyDown.
+		return true
+	case win.VK_HOME:
+		C.ScrollOverlayToEnd(win.TRUE)
+		return true
+	case win.VK_END:
+		C.ScrollOverlayToEnd(win.FALSE)
+		return true
+	default:
+		if win.GetKeyState(win.VK_CONTROL) < 0 {
+			if wParam == 'C' {
+				// Copy to clipboard.
+				errCode := C.CopyOverlayTextToClipboard()
+				if int(errCode) != 0 {
+					w.log.Errorf("failed to copy to clipboard: %d", errCode)
+				}
+			}
+
+			return true
+		} else if !(win.GetKeyState(win.VK_SHIFT) < 0) {
+			// Hide the overlay with any other key press.
+			w.onShow(false)
+			return true
+		}
+	}
+
+	return false
+}
+
+// onShow initiates showing or hiding the overlay.
+// When called to show, it first issues a background command to query the Agent status.
+func (w *overlayWindow) onShow(show bool) {
+	if w.windowHandle == 0 {
+		return
+	}
+
+	if show {
+		status, err := queryAgentStatus()
+		if err != nil {
+			status := fmt.Sprintf("Failed to query agent status: %v", err)
+			w.log.Error(status)
+		}
+
+		win.EnableWindow(w.windowHandle, true)
+		C.SetOverlayTextA(C.CString(status))
+		win.ShowWindow(w.windowHandle, win.SW_SHOWNOACTIVATE)
+		win.InvalidateRect(w.windowHandle, nil, false)
+	} else {
+		win.ShowWindow(w.windowHandle, win.SW_HIDE)
+		win.EnableWindow(w.windowHandle, false)
+	}
+}
+
+//
+// Support functions
+//
+
+// queryAgentStatus issues a background system command to query the Agent status.
+func queryAgentStatus() (string, error) {
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	programFilesPath := os.Getenv("ProgramFiles")
+	agentPath := filepath.Join(
+		programFilesPath,
+		"Datadog",
+		"Datadog Agent",
+		"bin",
+		"agent.exe")
+	cmd := exec.Command("cmd.exe", "/C", agentPath, "status", "2>&1")
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	err := cmd.Run()
+
+	if err != nil {
+		return "", err
+	}
+
+	return stdoutBuf.String(), nil
+}
+
+// calculateOverlayArea determines the position and size of the overlay.
+func calculateOverlayArea(opts *overlayWindowOpts, log log.Component) {
+	var rect win.RECT
+
+	user32 := syscall.NewLazyDLL("user32.dll")
+	procGetWindowRect := user32.NewProc("GetWindowRect")
+
+	// Defaults
+	padding := 20
+	overlayWidth := 640
+	overlayHeight := 200
+	opts.Left = 0
+	opts.Top = 0
+	opts.Width = overlayWidth
+	opts.Height = overlayHeight
+
+	// Get the screen client area
+	desktopHandle, _, _ := procGetDesktopWindow.Call()
+	if desktopHandle == uintptr(0) {
+		log.Errorf("failed to get desktop handle")
+		return
+	}
+
+	r, _, _ := procGetWindowRect.Call(desktopHandle, uintptr(unsafe.Pointer(&rect)))
+	if r == 0 {
+		log.Errorf("failed to get desktop window rect")
+		return
+	}
+
+	desktopWidth := int(rect.Right - rect.Left)
+	desktopHeight := int(rect.Bottom - rect.Top)
+
+	if desktopWidth < overlayWidth {
+		overlayWidth = desktopWidth
+	}
+
+	if desktopHeight < (overlayHeight + padding) {
+		overlayHeight = desktopHeight
+		padding = 0
+	}
+
+	opts.Left = (desktopWidth / 2) - (overlayWidth / 2)
+	opts.Top = desktopHeight - overlayHeight - padding
+	opts.Width = overlayWidth
+	opts.Height = overlayHeight
+}
+
+// closeOverlayWindow requests the overlay to exit.
+func closeOverlayWindow() {
+	if overlay != nil {
+		win.PostMessage(overlay.windowHandle, win.WM_CLOSE, 0, 0)
+	}
+}
+
+// goReportErrorCallback is a callback for the native (C++) code to report errors for logging.
+//
+//export goReportErrorCallback
+func goReportErrorCallback(errorCode C.uint, message *C.char) {
+	if overlay != nil {
+		// Do not free or modify the original message.
+		goMessage := C.GoString(message)
+		overlay.log.Errorf("Error 0x%X. %s", errorCode, goMessage)
+	}
+}

--- a/comp/systray/systray/systrayimpl/overlay.cpp
+++ b/comp/systray/systray/systrayimpl/overlay.cpp
@@ -1,0 +1,744 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+#include <d2d1.h>
+#include <dwrite.h>
+#include <stdint.h>
+#include "overlay.h"
+
+// Exported Go functions.
+#include "_cgo_export.h"
+
+#pragma comment(lib, "d2d1.lib")
+#pragma comment(lib, "dwrite.lib")
+
+#define DATADOG_OVERLAY_FADE_IN 2
+#define DATADOG_OVERLAY_FADE_OUT 3
+#define DATADOG_OVERLAY_MAX_ALPHA 190
+
+//
+// Types
+//
+
+// _RENDER_CONTEXT encapsulates the resources needed for rending the overlay.
+// The resources are frequently setup and released on demand.
+typedef struct _RENDER_CONTEXT
+{
+    ID2D1Factory* DFactory;
+    ID2D1HwndRenderTarget* RenderTarget;
+    ID2D1SolidColorBrush* Brush;
+    ID2D1SolidColorBrush* BorderBrush;
+    ID2D1SolidColorBrush* BarBrush;
+    IDWriteFactory* DWriteFactory;
+    IDWriteTextFormat* MainTextFormat;
+    IDWriteTextFormat* BarTextFormat;
+    ID2D1Bitmap* Icon;
+    float TextLineHeight;
+    float TextBaseHeightOffset;
+
+    float ScrollOffset;
+    float MaxScrollOffset;
+} RENDER_CONTEXT;
+
+// _OVERLAY_CONTEXT encapsulates the state and resources of the overlay window.
+typedef struct _OVERLAY_CONTEXT
+{
+    HWND WindowHandle;
+    RENDER_CONTEXT RenderCtx;
+    int FadeAlpha;
+    wchar_t* TextContent;
+    UINT32 TextContentLength;
+} OVERLAY_CONTEXT;
+
+//
+// Globals
+//
+
+static OVERLAY_CONTEXT g_Overlay = {};
+
+//
+// Forward declarations
+//
+
+static
+void
+ReportError(
+    HRESULT ErrorCode,
+    const char* Message
+    );
+
+static
+void
+SetupRenderContext(
+    HWND WindowHandle,
+    RENDER_CONTEXT* Ctx
+    );
+
+static
+void
+CleanupRenderContext(
+    RENDER_CONTEXT* Ctx
+    );
+
+static
+void
+Render(
+    OVERLAY_CONTEXT* Overlay
+    );
+
+static
+float
+ComputeMaxTextHeight(
+    const wchar_t* Text,
+    float TextLineHeight
+    );
+
+static
+void
+ReleaseOverlayResources(
+    void
+    );
+
+//
+// Implementations
+//
+
+// SetupRenderContext sets up the DirectX related resources for rendering the overlay.
+// These are not persisted throughout the systray lifetime, but are released when
+// the overlay is no longer visible to minimize the idle memory footprint.
+static
+void
+SetupRenderContext(
+    HWND WindowHandle,
+    RENDER_CONTEXT* Ctx
+    )
+{
+    const wchar_t* fontFamily = L"Segoe UI";
+    const wchar_t* localeName = L"en-us";
+    const float fontSize = 12.0f;
+    RECT rc;
+    D2D1_SIZE_U size;
+    D2D1_RENDER_TARGET_PROPERTIES rtProps = {};
+    D2D1_HWND_RENDER_TARGET_PROPERTIES hwndProps = {};
+    HRESULT hr = E_FAIL;
+
+    ZeroMemory(Ctx, sizeof(*Ctx));
+
+    hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, &Ctx->DFactory);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed create D2D1.");
+        goto Exit;
+    }
+
+    if (GetClientRect(WindowHandle, &rc) == FALSE) {
+        ReportError(E_FAIL, "Failed get client rect");
+        goto Exit;
+    }
+
+    size = D2D1::SizeU(rc.right - rc.left, rc.bottom - rc.top);
+
+    rtProps.type = D2D1_RENDER_TARGET_TYPE_DEFAULT;
+    rtProps.pixelFormat.format = DXGI_FORMAT_UNKNOWN;
+    rtProps.pixelFormat.alphaMode = D2D1_ALPHA_MODE_PREMULTIPLIED;
+    rtProps.dpiX = 0.0f;
+    rtProps.dpiY = 0.0f;
+    rtProps.usage = D2D1_RENDER_TARGET_USAGE_NONE;
+    rtProps.minLevel = D2D1_FEATURE_LEVEL_DEFAULT;
+
+    hwndProps.hwnd = WindowHandle;
+    hwndProps.pixelSize = size;
+    hwndProps.presentOptions = D2D1_PRESENT_OPTIONS_NONE;
+
+    // Create the render target.
+    // This consumes the most memory, size 748x460 => 20472 MB.
+    hr = Ctx->DFactory->CreateHwndRenderTarget(rtProps,
+                                               hwndProps,
+                                               &Ctx->RenderTarget);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to create render target.");
+        goto Exit;
+    }
+
+    // Create solid brushes.
+    hr = Ctx->RenderTarget->CreateSolidColorBrush(D2D1::ColorF(1.0f, 1.0f, 1.0f, 1.0f),
+                                                  &Ctx->Brush);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to create brush.");
+        goto Exit;
+    }
+
+    hr = Ctx->RenderTarget->CreateSolidColorBrush(D2D1::ColorF(0.3f, 0.0f, 0.3f, 0.5f),
+                                                  &Ctx->BorderBrush);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to create brush.");
+        goto Exit;
+    }
+
+    hr = Ctx->RenderTarget->CreateSolidColorBrush(D2D1::ColorF(0.5f, 0.5f, 0.5f, 1.0f),
+                                                  &Ctx->BarBrush);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to create brush.");
+        goto Exit;
+    }
+
+    // Create DirectWrite.
+    hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED,
+                            __uuidof(IDWriteFactory),
+                             reinterpret_cast<IUnknown**>(&Ctx->DWriteFactory));
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to create DWrite.");
+        goto Exit;
+    }
+
+    hr = Ctx->DWriteFactory->CreateTextFormat(fontFamily,
+                                              nullptr,
+                                              DWRITE_FONT_WEIGHT_BOLD,
+                                              DWRITE_FONT_STYLE_NORMAL,
+                                              DWRITE_FONT_STRETCH_NORMAL,
+                                              fontSize,
+                                              localeName,
+                                              &Ctx->MainTextFormat);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to create TextFormat.");
+        goto Exit;
+    }
+
+    // This aligns the text to be left (or right in RTL) of the layout rect.
+    hr = Ctx->MainTextFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to set text alignment");
+        goto Exit;
+    }
+
+    // This aligns the text to be top of the layout rect.
+    hr = Ctx->MainTextFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to set paragraph alignment");
+        goto Exit;
+    }
+
+    hr = Ctx->MainTextFormat->SetWordWrapping(DWRITE_WORD_WRAPPING_WRAP);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to set word wrapping.");
+        goto Exit;
+    }
+
+    Ctx->TextLineHeight = 15.0f;
+    Ctx->TextBaseHeightOffset = 20.0f;
+    hr = Ctx->MainTextFormat->SetLineSpacing(DWRITE_LINE_SPACING_METHOD_UNIFORM,
+                                             Ctx->TextLineHeight,
+                                             Ctx->TextBaseHeightOffset);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to set line spacing.");
+        goto Exit;
+    }
+
+    hr = Ctx->DWriteFactory->CreateTextFormat(fontFamily,
+                                              nullptr,
+                                              DWRITE_FONT_WEIGHT_BOLD,
+                                              DWRITE_FONT_STYLE_NORMAL,
+                                              DWRITE_FONT_STRETCH_NORMAL,
+                                              fontSize,
+                                              localeName,
+                                              &Ctx->BarTextFormat);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to create TextFormat.");
+        goto Exit;
+    }
+
+    hr = Ctx->BarTextFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to set text alignment");
+        goto Exit;
+    }
+
+    hr = Ctx->BarTextFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+    if (FAILED(hr)) {
+        ReportError(hr, "Failed to set paragraph alignment");
+        goto Exit;
+    }
+
+Exit:
+
+    if (FAILED(hr)) {
+        CleanupRenderContext(Ctx);
+    }
+
+    return;
+}
+
+// CleanupRenderContext releases the resources created in SetupRenderContext to
+// minimize the memory footprint when idle.
+static
+void
+CleanupRenderContext(
+    RENDER_CONTEXT* Ctx
+    )
+{
+    // Order of release matters.
+    // DirectX seems to suffer internal memory leak when the release order is not
+    // hierarchical.
+
+    if (Ctx->BarTextFormat != nullptr) {
+        Ctx->BarTextFormat->Release();
+        Ctx->BarTextFormat = nullptr;
+    }
+
+    if (Ctx->MainTextFormat != nullptr) {
+        Ctx->MainTextFormat->Release();
+        Ctx->MainTextFormat = nullptr;
+    }
+
+    if (Ctx->DWriteFactory != nullptr) {
+        Ctx->DWriteFactory->Release();
+        Ctx->DWriteFactory = nullptr;
+    }
+
+    if (Ctx->Icon != nullptr) {
+        Ctx->Icon->Release();
+        Ctx->Icon = nullptr;
+     }
+
+    if (Ctx->BarBrush != nullptr) {
+        Ctx->BarBrush->Release();
+        Ctx->BarBrush = nullptr;
+    }
+
+    if (Ctx->BorderBrush != nullptr) {
+        Ctx->BorderBrush->Release();
+        Ctx->BorderBrush = nullptr;
+    }
+
+    if (Ctx->Brush != nullptr) {
+        Ctx->Brush->Release();
+        Ctx->Brush = nullptr;
+    }
+
+    if (Ctx->RenderTarget != nullptr) {
+        Ctx->RenderTarget->Release();
+        Ctx->RenderTarget = nullptr;
+    }
+
+    if (Ctx->DFactory != nullptr) {
+        Ctx->DFactory->Release();
+        Ctx->DFactory = nullptr;
+    }
+}
+
+// ReleaseOverlayResources is a wrapper to release the resources created in SetupRenderContext
+// and any other complimentary resources to minimize the memory footprint when idle.
+// This should be called after the overlay window is hidden.
+void
+ReleaseOverlayResources(
+    OVERLAY_CONTEXT* Overlay
+    )
+{
+    CleanupRenderContext(&Overlay->RenderCtx);
+
+    if (Overlay->TextContent != nullptr) {
+        free(Overlay->TextContent);
+        Overlay->TextContent = nullptr;
+    }
+
+    Overlay->TextContentLength = 0;
+}
+
+// Render is responsible for drawing the overlay.
+static
+void
+Render(
+    OVERLAY_CONTEXT* Overlay
+    )
+{
+    const float borderPadding = 20.0f;
+    const float borderThickness = 2.0f;
+    const float borderHalfThickness = borderThickness / 2.0f;
+    const float barHeight = 16.0f;
+    const wchar_t* tip = L"Save to clipboard with Ctrl+C";
+
+    float width;
+    float height;
+    HRESULT hr = E_FAIL;
+    RECT rc;
+    D2D1_RECT_F layoutRect;
+    D2D1_RECT_F borderRect;
+    D2D1_RECT_F barRect;
+    D2D1::Matrix3x2F transform;
+    ID2D1HwndRenderTarget* renderTarget = nullptr;
+    RENDER_CONTEXT* ctx = &Overlay->RenderCtx;
+
+    // Since render is called very frequently, do not pop message boxes for errors.
+
+    if (ctx->RenderTarget == nullptr) {
+        // Create the render context only when ready to draw since
+        // the render target consumes a lot of memory.
+        CleanupRenderContext(ctx);
+        SetupRenderContext(Overlay->WindowHandle, ctx);
+
+        if (ctx->RenderTarget == nullptr) {
+            // Still failed, bail out.
+            goto Exit;
+        }
+
+        ctx->MaxScrollOffset = ComputeMaxTextHeight(Overlay->TextContent,
+                                                    ctx->TextLineHeight);
+    }
+
+    if (GetClientRect(Overlay->WindowHandle, &rc) == FALSE) {
+        // Silently drop. Do not spam errors.
+        goto Exit;
+    }
+
+    width = (float)(rc.right - rc.left);
+    height = (float)(rc.bottom - rc.top);
+    renderTarget = ctx->RenderTarget;
+
+    renderTarget->BeginDraw();
+
+    // Transparentcy is cntrolled by SetLayeredWindowAttributes.
+
+    renderTarget->Clear(D2D1::ColorF(0.1f, 0.0f, 0.1f, 1.0f));
+
+    layoutRect = D2D1::RectF(borderPadding,
+                             borderPadding,
+                             width - borderPadding,
+                             height - borderPadding);
+
+    borderRect = D2D1::RectF(borderHalfThickness,
+                             borderHalfThickness,
+                             width - borderHalfThickness,
+                             height - borderHalfThickness);
+
+    barRect = D2D1::RectF(borderThickness,
+                          borderThickness,
+                          width - borderHalfThickness,
+                          barHeight);
+
+    // Clip visible region.
+    renderTarget->PushAxisAlignedClip(layoutRect, D2D1_ANTIALIAS_MODE_ALIASED);
+
+    // Vertical scroll offset.
+    // This is moving the rect upwards, which means an effective negative translation.
+    // Flip the scroll value to negative.
+    transform = D2D1::Matrix3x2F::Translation(0, -ctx->ScrollOffset);
+    renderTarget->SetTransform(transform);
+
+    if (Overlay->TextContent != nullptr) {
+        renderTarget->DrawText(Overlay->TextContent,
+                               Overlay->TextContentLength,
+                               ctx->MainTextFormat,
+                               layoutRect,
+                               ctx->Brush);
+    }
+
+    renderTarget->SetTransform(D2D1::Matrix3x2F::Identity());
+    renderTarget->PopAxisAlignedClip();
+
+    renderTarget->FillRectangle(barRect, ctx->BarBrush);
+    renderTarget->DrawRectangle(borderRect, ctx->BorderBrush, borderThickness);
+
+    renderTarget->DrawText(tip,
+                           (UINT32)wcslen(tip),
+                           ctx->BarTextFormat,
+                           barRect,
+                           ctx->Brush);
+
+    if (ctx->Icon != nullptr) {
+        D2D1_RECT_F iconRect;
+
+        // Should match size in LoadDatadogIcon.
+        iconRect = D2D1::RectF(borderThickness,
+                               borderThickness,
+                               barHeight + borderThickness,
+                               barHeight + borderThickness);
+        renderTarget->DrawBitmap(ctx->Icon, iconRect, 1.0f);
+    }
+
+    hr = renderTarget->EndDraw();
+    if (hr == D2DERR_RECREATE_TARGET) {
+        // Recreate graphic resources.
+        CleanupRenderContext(ctx);
+    }
+
+Exit:
+
+    return;
+}
+
+// ReportError is a wrapper to redirect error codes and messages.
+void
+ReportError(
+    HRESULT ErrorCode,
+    const char* Message
+    )
+{
+    goReportErrorCallback(ErrorCode, (char*)Message);
+}
+
+// ComputeMaxTextHeight estimates the height in pixels of the overlay text to
+// assign a maximum scroll value.
+float
+ComputeMaxTextHeight(
+    const wchar_t* Text,
+    float TextLineHeight
+    )
+{
+    int lineCount = 1;
+    float maxHeight;
+    wchar_t c;
+
+    if (Text == nullptr) {
+        goto Exit;
+    }
+
+    while (*Text != L'\0') {
+        if (*Text == L'\n') {
+            ++lineCount;
+        }
+
+        ++Text;
+    }
+
+Exit:
+
+    maxHeight = TextLineHeight * ((float)(lineCount));
+
+    return maxHeight;
+}
+
+//
+// Public functions
+//
+
+extern "C"
+{
+
+// InitOverlayA initializes the internal state of the overlay.
+void
+InitOverlayA(
+    uintptr_t WindowHandle,
+    char* TextContent
+    )
+{
+    ZeroMemory(&g_Overlay, sizeof(g_Overlay));
+    g_Overlay.WindowHandle = (HWND)WindowHandle;
+    SetOverlayTextA(TextContent);
+    return;
+}
+
+// ShowOverlay handles the visibility of the overlay on WM_SHOWWINDOW.
+void
+ShowOverlay(
+    uintptr_t WindowHandle,
+    BOOL Show
+    )
+{
+    if (Show != FALSE) {
+        SetLayeredWindowAttributes((HWND)WindowHandle,
+                                   0,
+                                   DATADOG_OVERLAY_MAX_ALPHA,
+                                   LWA_ALPHA);
+
+        // The parent caller should have setup TextContent.
+        // The render context will be (re)created on Render.
+    } else {
+        SetLayeredWindowAttributes((HWND)WindowHandle,
+                                   0,
+                                   0,
+                                   LWA_ALPHA);
+
+        // Release resources on hide.
+        ReleaseOverlayResources(&g_Overlay);
+    }
+}
+
+// RenderOverlay draws the overlay on WM_PAINT.
+void
+RenderOverlay(
+    uintptr_t WindowHandle
+    )
+{
+    PAINTSTRUCT ps;
+
+    BeginPaint((HWND)WindowHandle, &ps);
+    Render(&g_Overlay);
+    EndPaint((HWND)WindowHandle, &ps);
+}
+
+// CleanupOverlay releases all resources when the overlay is terminated.
+void
+CleanupOverlay(
+    void
+    )
+{
+    ReleaseOverlayResources(&g_Overlay);
+    ZeroMemory(&g_Overlay, sizeof(g_Overlay));
+}
+
+// CopyOverlayTextToClipboard copies the existing text in the overlay to the Clipboard.
+int
+CopyOverlayTextToClipboard(
+    void
+    )
+{
+    const wchar_t* text;
+    wchar_t* buffer = nullptr;
+    UINT32 textLength;
+    size_t size;
+    HGLOBAL memHandle = NULL;
+    bool opened = false;
+    int err = ERROR_SUCCESS;
+
+    text = g_Overlay.TextContent;
+    textLength = g_Overlay.TextContentLength;
+
+    if ((text == nullptr) || (textLength == 0)) {
+        goto Exit;
+    }
+
+    if (OpenClipboard(nullptr) == FALSE) {
+        err = GetLastError();
+        goto Exit;
+    }
+
+    opened = true;
+
+    size = (textLength + 1) * sizeof(wchar_t);
+    memHandle = GlobalAlloc(GMEM_MOVEABLE, size);
+    if (memHandle == NULL) {
+        err = ERROR_NOT_ENOUGH_MEMORY;
+        goto Exit;
+    }
+
+    buffer = (wchar_t*)(GlobalLock(memHandle));
+    CopyMemory(buffer,text, textLength);
+    GlobalUnlock(memHandle);
+
+    EmptyClipboard();
+
+    // Do not free glob after SetClipboardData.
+    if (SetClipboardData(CF_UNICODETEXT, memHandle) == NULL) {
+        err = GetLastError();
+        GlobalFree(memHandle);
+        goto Exit;
+    }
+
+Exit:
+
+    if (opened) {
+        CloseClipboard();
+    }
+
+    return err;
+}
+
+// SetOverlayTextA sets the text to display in the overlay.
+// Do not modify the input text.
+void
+SetOverlayTextA(
+    char* TextContent
+    )
+{
+    wchar_t* content = nullptr;
+    int charCount = 0;
+    int wideCharCount = 0;
+
+    if (TextContent == nullptr) {
+        goto Exit;
+    }
+
+    // Sanity check for null termination.
+    charCount = strnlen_s(TextContent, 0xFFFE);
+    if (charCount == (0xFFFE)) {
+        goto Exit;
+    }
+
+    wideCharCount = MultiByteToWideChar(CP_UTF8,
+                                        0,
+                                        TextContent,
+                                        -1,
+                                        nullptr,
+                                        0);
+    if (wideCharCount == 0) {
+        goto Exit;
+    }
+
+    content = (wchar_t*)malloc(sizeof(wchar_t) * wideCharCount);
+    if (content == nullptr) {
+        ReportError(E_OUTOFMEMORY, "Failed to allocate memory");
+        goto Exit;
+    }
+
+    if (MultiByteToWideChar(CP_UTF8,
+                            0,
+                            TextContent,
+                            -1,
+                            content,
+                            wideCharCount) == 0) {
+        ReportError(E_FAIL, "Failed to convert to wide string");
+        goto Exit;
+    }
+
+    if (g_Overlay.TextContent != nullptr) {
+        free(g_Overlay.TextContent);
+    }
+
+    g_Overlay.TextContentLength = wideCharCount;
+    g_Overlay.TextContent = content;
+    content = nullptr;
+
+Exit:
+
+    if (content != nullptr) {
+        free(content);
+    }
+
+    return;
+}
+
+// ScrollOverlayVertical updates the vertical position of the content in the overlay for scrolling.
+// This responds to VK_UP, VK_DOWN, VK_NEXT, VK_PRIOR.
+void
+ScrollOverlayVertical(
+    float Delta
+    )
+{
+    RENDER_CONTEXT& ctx = g_Overlay.RenderCtx;
+    float newOffset = ctx.ScrollOffset + Delta;
+
+    if (newOffset < 0) {
+        newOffset = 0;
+    } else if(newOffset > ctx.MaxScrollOffset) {
+        newOffset = ctx.MaxScrollOffset;
+    }
+
+    if (newOffset != ctx.ScrollOffset) {
+        ctx.ScrollOffset = newOffset;
+        InvalidateRect(g_Overlay.WindowHandle, NULL, FALSE);
+    }
+}
+
+// ScrollOverlayVertical sets the vertical position of the content in the overlay to
+// the top-most or bottom-most position. This responds to VK_HOME, VK_END.
+void
+ScrollOverlayToEnd(
+    BOOL Front
+    )
+{
+    float newOffset;
+
+    if (Front != FALSE) {
+        newOffset = 0.0f;
+    } else {
+        newOffset = g_Overlay.RenderCtx.MaxScrollOffset;
+    }
+
+    if (newOffset != g_Overlay.RenderCtx.ScrollOffset) {
+        g_Overlay.RenderCtx.ScrollOffset = newOffset;
+        InvalidateRect(g_Overlay.WindowHandle, NULL, FALSE);
+    }
+}
+
+}

--- a/comp/systray/systray/systrayimpl/overlay.h
+++ b/comp/systray/systray/systrayimpl/overlay.h
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+#include <windows.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// InitOverlayA initializes the internal state of the overlay.
+void
+InitOverlayA(
+    uintptr_t WindowHandle,
+    char* TextContent
+    );
+
+// ShowOverlay handles the visibility of the overlay on WM_SHOWWINDOW.
+void
+ShowOverlay(
+    uintptr_t WindowHandle,
+    BOOL Show
+    );
+
+// RenderOverlay draws the overlay on WM_PAINT.
+void
+RenderOverlay(
+    uintptr_t WindowHandle
+    );
+
+// CleanupOverlay releases all resources when the overlay is terminated.
+void
+CleanupOverlay(
+    void
+    );
+
+// SetOverlayTextA copies the provided text to display in the overlay.
+void
+SetOverlayTextA(
+    char* TextContent
+    );
+
+// CopyOverlayTextToClipboard copies the existing text in the overlay to the Clipboard.
+int
+CopyOverlayTextToClipboard(
+    void
+    );
+
+// ScrollOverlayVertical updates the vertical position of the content in the overlay for scrolling.
+// This responds to VK_UP, VK_DOWN, VK_NEXT, VK_PRIOR.
+void
+ScrollOverlayVertical(
+    float Delta
+    );
+
+// ScrollOverlayVertical sets the vertical position of the content in the overlay to
+// the top-most or bottom-most position. This responds to VK_HOME, VK_END.
+void
+ScrollOverlayToEnd(
+    BOOL Front
+    );
+
+#ifdef __cplusplus
+}
+#endif

--- a/comp/systray/systray/systrayimpl/systray.go
+++ b/comp/systray/systray/systrayimpl/systray.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -100,6 +101,12 @@ const (
 	menuSeparator         = "SEPARATOR"
 )
 
+const (
+	overlayHotKeyID = 0xDD0C
+	modWin          = 0x0008
+	overlayHotKey   = win.VK_F12
+)
+
 var (
 	cmds = map[string]func(*systrayImpl){
 		cmdTextStartService:   onStart,
@@ -107,6 +114,12 @@ var (
 		cmdTextRestartService: onRestart,
 		cmdTextConfig:         onConfigure,
 	}
+
+	user32               = syscall.NewLazyDLL("user32.dll")
+	procRegisterHotKey   = user32.NewProc("RegisterHotKey")
+	procUnregisterHotKey = user32.NewProc("UnregisterHotKey")
+	hookWndProc          uintptr
+	originalWndProc      uintptr
 )
 
 // newSystray creates a new systray component, which will start and stop based on
@@ -218,6 +231,24 @@ func windowRoutine(s *systrayImpl) {
 			win.PostQuitMessage(0)
 		})
 	}
+
+	// Custom message handler to handle hot keys.
+	hookWndProc = syscall.NewCallback(func(hwnd win.HWND, msg uint32, wParam, lParam uintptr) uintptr {
+		switch msg {
+		case win.WM_HOTKEY:
+			if wParam == overlayHotKeyID {
+				onOverlay(s)
+				return 0
+			}
+		case win.WM_NCDESTROY:
+			win.SetWindowLongPtr(hwnd, win.GWLP_WNDPROC, originalWndProc)
+			unregisterHotKeys(s, hwnd)
+		}
+		return win.CallWindowProc(originalWndProc, hwnd, msg, wParam, lParam)
+	})
+
+	// Register hot keys and a custom message handler.
+	originalWndProc = registerHotKeys(s, mw.Handle(), hookWndProc)
 
 	// Run the message loop
 	// use the notifyWindowToStop function to stop the message loop
@@ -419,6 +450,7 @@ func createMenuItems(s *systrayImpl, _ *walk.NotifyIcon) []menuItem {
 	menuitems = append(menuitems, menuItem{label: "&Restart", handler: menuHandler(cmdTextRestartService), enabled: true})
 	menuitems = append(menuitems, menuItem{label: "&Configure", handler: menuHandler(cmdTextConfig), enabled: true})
 	menuitems = append(menuitems, menuItem{label: "&Flare", handler: func() { onFlare(s) }, enabled: true})
+	menuitems = append(menuitems, menuItem{label: "Stat&us", handler: func() { onOverlay(s) }, enabled: true})
 	menuitems = append(menuitems, menuItem{label: menuSeparator})
 	menuitems = append(menuitems, menuItem{label: "E&xit", handler: func() { onExit(s) }, enabled: true})
 
@@ -442,5 +474,41 @@ func open(url string) error {
 func execCmd(s *systrayImpl, cmd string) {
 	if cmds[cmd] != nil {
 		cmds[cmd](s)
+	}
+}
+
+// registerHotKeys register global hot keys and a custom message handler to handle them.
+func registerHotKeys(s *systrayImpl, mainWnd win.HWND, customWndProc uintptr) uintptr {
+	if procRegisterHotKey == nil || procUnregisterHotKey == nil {
+		return 0
+	}
+
+	hasOverlayHotKey, _, _ := procRegisterHotKey.Call(
+		uintptr(mainWnd), uintptr(overlayHotKeyID), uintptr(modWin), uintptr(overlayHotKey))
+	if hasOverlayHotKey == win.FALSE {
+		return 0
+	}
+
+	// This replaces the message handler in the (github.com/lxn/walk/MainWindow) window
+	// with a custom one to handle hot keys.
+	prevWndProc := win.SetWindowLongPtr(mainWnd, win.GWLP_WNDPROC, customWndProc)
+	if prevWndProc == 0 {
+		unregisterHotKeys(s, mainWnd)
+		return 0
+	}
+
+	s.log.Infof("Registered Win+F12 hot key for overlay")
+	return prevWndProc
+}
+
+// unregisterHotKeys removes the previously registered global hot keys.
+func unregisterHotKeys(s *systrayImpl, mainWnd win.HWND) {
+	if procRegisterHotKey == nil || procUnregisterHotKey == nil {
+		return
+	}
+
+	retVal, _, _ := procUnregisterHotKey.Call(uintptr(mainWnd), uintptr(overlayHotKeyID))
+	if retVal == win.FALSE {
+		s.log.Errorf("Failed to unregister hot key: %v", syscall.GetLastError())
 	}
 }

--- a/releasenotes/notes/windows_systray_overlay-37f93413f279c61e.yaml
+++ b/releasenotes/notes/windows_systray_overlay-37f93413f279c61e.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Add a lightweight graphical overlay for Windows that can be launched from the Datadog system tray or hot key to quickly query and display status.


### PR DESCRIPTION
### What does this PR do?
This PR adds a lightweight overlay for the Windows Datadog System Tray, that quickly displays agent status to the user.  A major focus was to keep the overlay minimal, with very light memory footprint, overhead, and size.  On launching the overlay, it will query the agent for status and display it.  The overlay can be launched from a new "Status" menu item in the system tray or with the global hotkey WIN+F12. The content in the overlay can be copied to the Clipboard.
Although it now queries agent status, it can be modified to run other commands.

### Motivation
Agent Innovation Week 2025
https://datadoghq.atlassian.net/browse/WINA-1963

### Describe how you validated your changes
Launch ddray.exe.
Click on "Status" menu item.  Close the overlay with a key press.
Press WIN+F12.  Close the overlay with a key press.

