### PR TITLE
[clusteragent/autoscaling] Ensure vertical recommendations are always updated

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -614,7 +614,7 @@ func getActiveScalingSources(currentTime time.Time, podAutoscalerInternal *model
 
 	// When creating a new pod autoscaler internal from a Kubernetes CR, we update the ScalingValues directly from the status
 	// If we do not have any new generated recommendations, we want to keep the previous scaling values so we return nil
-	return nil, nil
+	return nil, activeVerticalSource
 }
 
 func isTimestampStale(currentTime, receivedTime time.Time, staleTimestampThreshold time.Duration) bool {

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -569,7 +569,7 @@ func unsetTelemetry(key, _ string) {
 
 func getActiveScalingSources(currentTime time.Time, podAutoscalerInternal *model.PodAutoscalerInternal) (*datadoghqcommon.DatadogPodAutoscalerValueSource, *datadoghqcommon.DatadogPodAutoscalerValueSource) {
 	// Set default vertical scaling source
-	activeVerticalSource := (*datadoghqcommon.DatadogPodAutoscalerValueSource)(nil)
+	var activeVerticalSource *datadoghqcommon.DatadogPodAutoscalerValueSource
 	if podAutoscalerInternal.MainScalingValues().Vertical != nil {
 		activeVerticalSource = pointer.Ptr(podAutoscalerInternal.MainScalingValues().Vertical.Source)
 	}


### PR DESCRIPTION
### What does this PR do?

Update vertical recommendations even when horizontal recommendations are in error

### Motivation

A DPA that has a recommendation where the horizontal recommendations are in error causes the vertical values to not be updated either as none of the conditions in `getActiveScalingSources` are met. We handle the vertical scaling source assignment separately from the horizontal scaling source, so we should always be returning `activeVerticalSource` https://github.com/DataDog/datadog-agent/blob/fc91901f85df6d249ffdffba1455006112e05af7/pkg/clusteragent/autoscaling/workload/controller.go#L518-L521

### Describe how you validated your changes

Unit tests were added to validate this behavior and that this case was fixed

### Additional Notes
