### PR TITLE
[CWS] fix TestProcessContext/args-options on ubuntu 25.10

### DIFF
--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -401,11 +401,16 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	t.Run("args-options", func(t *testing.T) {
-		lsExecutable := which(t, "ls")
-
 		test.WaitSignal(t, func() error {
-			cmd := exec.Command(lsExecutable, "--block-size", "123")
-			return cmd.Run()
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "check", "--block-size=123")
+		}, test.validateExecEvent(t, noWrapperType, func(_ *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_args_options")
+		}))
+	})
+
+	t.Run("args-options-2", func(t *testing.T) {
+		test.WaitSignal(t, func() error {
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "check", "--block-size", "123")
 		}, test.validateExecEvent(t, noWrapperType, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_options")
 		}))

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1340,9 +1340,7 @@ func TestProcessExec(t *testing.T) {
 
 	t.Run("exec-in-pthread", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			args := []string{"exec-in-pthread", executable, "/dev/null"}
-			cmd := exec.Command(syscallTester, args...)
-			return cmd.Run()
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "exec-in-pthread", executable, "/dev/null")
 		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, _ *rules.Rule) {
 			assertFieldEqual(t, event, "exec.file.path", executable)
 			assertFieldEqual(t, event, "process.parent.file.name", "syscall_tester", "wrong process parent file name")


### PR DESCRIPTION
### What does this PR do?

On ubuntu 25.10:
```
$ ls --block-size 123
error: equal sign is needed when assigning values to '--block-size=<BLOCK_SIZE>'

For more information, try '--help'.
```
you need to use `ls --block-size=123`.

`TestProcessContext/args-options` depends on this behavior, so this PR fixes this by using the syscall tester instead, and testing both options passing strategies.

### Motivation

### Describe how you validated your changes

### Additional Notes
