### PR TITLE
[CWS] split new-e2e-cws for EC2 and GCP in 2 jobs

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -555,7 +555,8 @@ new-e2e-cws:
     # ON_NIGHTLY_FIPS: "true"
   parallel:
     matrix:
-      - EXTRA_PARAMS: --run TestAgentSuite(EC2|GCP)
+      - EXTRA_PARAMS: --run TestAgentSuiteEC2
+      - EXTRA_PARAMS: --run TestAgentSuiteGCP
       - EXTRA_PARAMS: --run TestECSFargate
       - EXTRA_PARAMS: --run TestKindSuite
       - EXTRA_PARAMS: --run TestAgentWindowsSuite


### PR DESCRIPTION
### What does this PR do?

This job is fairly slow and the EC2 and GCP tests run one after the other. This PR splits this into 2 jobs to have them run in parallel.

### Motivation

### Describe how you validated your changes

### Additional Notes
