### PR TITLE
[incident-44801] Temporarily disable Stack Cleaner on EKS

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -274,6 +274,7 @@ new-e2e-containers-eks:
     EXTRA_PARAMS: --run TestEKSSuite
     E2E_PRE_INITIALIZED: "true"
     ON_NIGHTLY_FIPS: "true"
+    REMOTE_STACK_CLEANING: "false"  # TODO(celian): Restore stack cleaner on EKS once errors are fixed
 
 new-e2e-remote-config:
   extends: .new_e2e_template_needs_deb_x64
@@ -303,7 +304,6 @@ new-e2e-agent-runtimes:
     TARGETS: ./tests/agent-runtimes
     TEAM: agent-runtimes
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-agent-subcommands:
   extends: .new_e2e_template_needs_deb_windows_x64
@@ -314,7 +314,6 @@ new-e2e-agent-subcommands:
     TARGETS: ./tests/agent-subcommands
     TEAM: agent-configuration
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run "Test(Linux|Windows)StatusSuite"
@@ -377,7 +376,6 @@ new-e2e-windows-service-test:
     TARGETS: ./tests/windows/service-test
     TEAM: windows-products
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestServiceBehaviorAgentCommand
@@ -405,7 +403,6 @@ new-e2e-windows-certificate:
     TARGETS: ./tests/windows/windows-certificate
     TEAM: windows-products
     EXTRA_PARAMS: --run "TestRemoteCertificates$"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-language-detection:
   extends: .new_e2e_template_needs_deb_x64
@@ -416,7 +413,6 @@ new-e2e-language-detection:
     TARGETS: ./tests/language-detection
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-npm-packages:
   extends: .new_e2e_template
@@ -484,6 +480,7 @@ new-e2e-npm-eks:
     EXTRA_PARAMS: --run "TestEKSVMSuite"
     E2E_PRE_INITIALIZED: "true"
     ON_NIGHTLY_FIPS: "true"
+    REMOTE_STACK_CLEANING: "false"  # TODO(celian): Restore stack cleaner on EKS once errors are fixed
 
 new-e2e-npm:
   extends: .new_e2e_template
@@ -592,7 +589,6 @@ new-e2e-process:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-orchestrator:
   extends:
@@ -649,7 +645,6 @@ new-e2e-installer-script:
     FLEET_INSTALL_METHOD: "install_script"
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer:
   extends: .new_e2e_template
@@ -675,7 +670,6 @@ new-e2e-installer:
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer-ansible:
   extends: .new_e2e_template
@@ -698,7 +692,6 @@ new-e2e-installer-ansible:
     FLEET_INSTALL_METHOD: "ansible"
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template
@@ -738,7 +731,6 @@ new-e2e-ha-agent:
     # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
     EXTRA_PARAMS: --skip TestHAAgentFailoverSuite
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-ha-agent-failover:
   extends: .new_e2e_template_needs_deb_x64
@@ -775,7 +767,6 @@ new-e2e-windows-systemprobe:
   variables:
     TARGETS: ./tests/sysprobe-functional
     TEAM: windows-products
-    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestUSMAutoTaggingSuite
@@ -793,7 +784,6 @@ new-e2e-windows-security-agent:
   variables:
     TARGETS: ./tests/security-agent-functional
     TEAM: windows-products
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-otel-eks-init:
   stage: e2e_init
@@ -830,6 +820,7 @@ new-e2e-otel-eks:
     EXTRA_PARAMS: --run "TestOTelAgentIA(EKS|USTEKS)"
     TEAM: otel
     E2E_PRE_INITIALIZED: "true"
+    REMOTE_STACK_CLEANING: "false"  # TODO(celian): Restore stack cleaner on EKS once errors are fixed
 
 new-e2e-otel:
   extends: .new_e2e_template
@@ -905,7 +896,6 @@ new-e2e-gpu:
     TEAM: ebpf-platform
     E2E_PULUMI_LOG_LEVEL: 10 # incident-33572
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
   needs: # list of required jobs. By default gitlab waits for any previous jobs.
     - !reference [.new_e2e_template_needs_container_deploy, needs]
     - agent_deb-x64-a7 # agent 7 debian package


### PR DESCRIPTION
### What does this PR do?

[incident-44801]

The Stack Cleaner has some issues deleting EKS clusters, temporarily disable it only on EKS tests to clean them inside the test.

See the [dashboard](https://app.datadoghq.com/dashboard/vmy-pw7-sv8/stackcleaner?fromUser=false&refresh_mode=sliding&from_ts=1761123886883&to_ts=1761296686883&live=true) for more information.

### Motivation

### Describe how you validated your changes

### Additional Notes
