### PR TITLE
Run Static Quality Gates in Merge Queue

### DIFF
--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -2,7 +2,6 @@
 .cluster_agent-build_common:
   stage: binary_build
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["go_mod_tidy_check", "go_deps"]
   before_script:

--- a/.gitlab/binary_build/cws_instrumentation.yml
+++ b/.gitlab/binary_build/cws_instrumentation.yml
@@ -12,7 +12,6 @@
 cws_instrumentation-build_amd64:
   extends: .cws_instrumentation-build_common
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
@@ -25,7 +24,6 @@ cws_instrumentation-build_amd64:
 cws_instrumentation-build_arm64:
   extends: .cws_instrumentation-build_common
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -16,7 +16,6 @@ build_dogstatsd_static-binary_x64:
 build_dogstatsd_static-binary_arm64:
   stage: binary_build
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -1,7 +1,6 @@
 ---
 .system-probe_build_common:
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -126,7 +126,6 @@
 .docker_build_agent7:
   extends: [.docker_build_job_definition, .docker_build_artifact]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
@@ -299,7 +298,6 @@ docker_build_agent7_full_arm64:
 .docker_build_cluster_agent:
   extends: .docker_build_job_definition
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/cluster-agent
@@ -368,7 +366,6 @@ docker_build_cluster_agent_fips_arm64:
 .docker_build_cws_instrumentation:
   extends: .docker_build_job_definition
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/cws-instrumentation
@@ -396,7 +393,6 @@ docker_build_cws_instrumentation_arm64:
 .docker_build_dogstatsd:
   extends: [.docker_build_job_definition, .docker_build_s3]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/dogstatsd

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -2,6 +2,7 @@ static_quality_gates:
   stage: functional_test
   rules:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a special artifact that will not pass the quality gate
+    - !reference [.on_mergequeue]
     - !reference [.on_main_or_release_branch]
     - !reference [.on_dev_branches]
     - when: on_success

--- a/.gitlab/package_build/heroku.yml
+++ b/.gitlab/package_build/heroku.yml
@@ -2,7 +2,6 @@
 .heroku_build_base:
   stage: package_build
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -168,7 +168,6 @@ powershell_script_signing:
 installer-amd64:
   extends: .installer_build_common
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   stage: package_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
@@ -183,7 +182,6 @@ installer-amd64:
 installer-arm64:
   extends: .installer_build_common
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   stage: package_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX

--- a/.gitlab/package_build/linux.yml
+++ b/.gitlab/package_build/linux.yml
@@ -159,7 +159,6 @@ dogstatsd-arm64:
 .otel_build_common:
   needs: ["go_mod_tidy_check", "go_deps"]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   stage: package_build
   script:

--- a/.gitlab/package_build/linux.yml
+++ b/.gitlab/package_build/linux.yml
@@ -17,7 +17,6 @@
 
 .agent_build_common:
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   stage: package_build
   script:
@@ -120,7 +119,6 @@ iot-agent-armhf:
 .dogstatsd_build_common:
   needs: ["go_mod_tidy_check", "go_deps"]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   stage: package_build
   script:

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -62,7 +62,6 @@
 windows_msi_and_bosh_zip_x64-a7:
   extends: .windows_main_agent_base
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     ARCH: "x64"

--- a/.gitlab/package_deps_build/package_deps_build.yml
+++ b/.gitlab/package_deps_build/package_deps_build.yml
@@ -5,7 +5,6 @@
 .generate_minimized_btfs_common:
   stage: package_deps_build
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/btf-gen$CI_IMAGE_BTF_GEN_SUFFIX:$CI_IMAGE_BTF_GEN
   tags: ["arch:amd64", "specific:true"]

--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -41,7 +41,6 @@ include:
 agent_deb-x64-a7:
   extends: [.package_deb_common, .package_deb_x86]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["datadog-agent-7-x64"]
   variables:
@@ -60,7 +59,6 @@ agent_deb-arm64-a7:
 agent_deb-x64-a7-fips:
   extends: [.package_deb_common, .package_deb_x86]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["datadog-agent-7-x64-fips"]
   variables:
@@ -126,7 +124,6 @@ installer_deb-arm64:
 
 .package_iot_deb_common:
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   stage: packaging
   script:
@@ -181,7 +178,6 @@ iot_agent_deb-armhf:
 dogstatsd_deb-x64:
   extends: [.package_deb_common, .package_deb_x86]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["dogstatsd-x64"]
   variables:
@@ -194,7 +190,6 @@ dogstatsd_deb-x64:
 dogstatsd_deb-arm64:
   extends: [.package_deb_common, .package_deb_arm64]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["dogstatsd-arm64"]
   variables:

--- a/.gitlab/packaging/rpm.yml
+++ b/.gitlab/packaging/rpm.yml
@@ -4,7 +4,6 @@ include:
 
 .package_rpm_common:
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   before_script:
   script:
@@ -195,7 +194,6 @@ installer_suse_rpm-arm64:
 
 .package_iot_rpm_common:
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   script:
     - !reference [.cache_omnibus_ruby_deps, setup]


### PR DESCRIPTION
### What does this PR do?
It enables certain jobs that are SQG's dependencies to run in MQ pipeline.

### Motivation
Every now and then when we exceed size threshold the pipeline starts to fail in main **after** a violating PR has been merged. This change prolongs the duration of MQ pipeline, but should ensure that a violating PR is blocked before merged, therefore, allowing other PRs to be merged successfully.

### Describe how you validated your changes
