### PR TITLE
fix: Make whatLog selection wait context expiring with configurable timeout

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -89,6 +89,9 @@ const (
 	// DefaultAuditorTTL is the default logs auditor TTL in hours
 	DefaultAuditorTTL = 23
 
+	// DefaultRuntimeWaitingTimeout is the default timeout in seconds for executing containers or pods chooser Wait.
+	DefaultRuntimeWaitingTimeout = 3
+
 	// DefaultRuntimePoliciesDir is the default policies directory used by the runtime security module
 	DefaultRuntimePoliciesDir = "/etc/datadog-agent/runtime-security.d"
 
@@ -1805,6 +1808,13 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// See more documentation here:
 	// https://docs.docker.com/engine/reference/commandline/dockerd/.
 	config.BindEnvAndSetDefault("logs_config.docker_path_override", "")
+
+	// Amount of time to wait for the container runtime to respond while determining what to log, containers or pods.
+	// If the container runtime doesn't respond after specified timeout, log source marked as failed
+	// which is reflected in the Agent status output for the Logs.
+	// If this such behavior undesired, set the value to a significantly large number.
+	// Timeout is in seconds.
+	config.BindEnvAndSetDefault("logs_config.container_runtime_waiting_timeout", DefaultRuntimeWaitingTimeout)
 
 	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
 	// Timeout in milliseonds used when performing agreggation operations,

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -89,9 +89,6 @@ const (
 	// DefaultAuditorTTL is the default logs auditor TTL in hours
 	DefaultAuditorTTL = 23
 
-	// DefaultRuntimeWaitingTimeout is the default timeout in seconds for executing containers or pods chooser Wait.
-	DefaultRuntimeWaitingTimeout = 3
-
 	// DefaultRuntimePoliciesDir is the default policies directory used by the runtime security module
 	DefaultRuntimePoliciesDir = "/etc/datadog-agent/runtime-security.d"
 
@@ -1814,7 +1811,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// which is reflected in the Agent status output for the Logs.
 	// If this such behavior undesired, set the value to a significantly large number.
 	// Timeout is in seconds.
-	config.BindEnvAndSetDefault("logs_config.container_runtime_waiting_timeout", DefaultRuntimeWaitingTimeout)
+	config.BindEnvAndSetDefault("logs_config.container_runtime_waiting_timeout", "3s")
 
 	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
 	// Timeout in milliseonds used when performing agreggation operations,

--- a/pkg/logs/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/launchers/container/tailerfactory/file.go
@@ -58,8 +58,8 @@ func (tf *factory) makeFileSource(source *sources.LogSource) (*sources.LogSource
 	// from AD, it is clear what we are logging.  The `Wait` here should return
 	// quickly. But it doesn't if there is no docker socket, in case of Podman for example.
 	// Make expiring context to run detection on.
-	to := pkgconfigsetup.Datadog().GetInt("logs_config.container_runtime_waiting_timeout")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(to)*time.Second)
+	to := pkgconfigsetup.Datadog().GetDuration("logs_config.container_runtime_waiting_timeout")
+	ctx, cancel := context.WithTimeout(context.Background(), to*time.Second)
 	defer cancel()
 	logWhat := tf.cop.Wait(ctx)
 

--- a/pkg/logs/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/launchers/container/tailerfactory/file.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"time"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -59,8 +58,9 @@ func (tf *factory) makeFileSource(source *sources.LogSource) (*sources.LogSource
 	// quickly. But it doesn't if there is no docker socket, in case of Podman for example.
 	// Make expiring context to run detection on.
 	to := pkgconfigsetup.Datadog().GetDuration("logs_config.container_runtime_waiting_timeout")
-	ctx, cancel := context.WithTimeout(context.Background(), to*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), to)
 	defer cancel()
+
 	logWhat := tf.cop.Wait(ctx)
 
 	switch logWhat {

--- a/pkg/logs/launchers/container/tailerfactory/whichtailer.go
+++ b/pkg/logs/launchers/container/tailerfactory/whichtailer.go
@@ -12,7 +12,6 @@ package tailerfactory
 import (
 	"context"
 	"fmt"
-	"time"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
@@ -43,7 +42,7 @@ func (tf *factory) whichTailer(source *sources.LogSource) whichTailer {
 	// quickly. But it doesn't if there is no docker socket, in case of Podman for example.
 	// Make expiring context to run detection on.
 	to := pkgconfigsetup.Datadog().GetDuration("logs_config.container_runtime_waiting_timeout")
-	ctx, cancel := context.WithTimeout(context.Background(), to*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), to)
 	defer cancel()
 
 	logWhat := tf.cop.Wait(ctx)

--- a/pkg/logs/launchers/container/tailerfactory/whichtailer.go
+++ b/pkg/logs/launchers/container/tailerfactory/whichtailer.go
@@ -42,8 +42,8 @@ func (tf *factory) whichTailer(source *sources.LogSource) whichTailer {
 	// from AD, it is clear what we are logging.  The `Wait` here should return
 	// quickly. But it doesn't if there is no docker socket, in case of Podman for example.
 	// Make expiring context to run detection on.
-	to := pkgconfigsetup.Datadog().GetInt("logs_config.container_runtime_waiting_timeout")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(to)*time.Second)
+	to := pkgconfigsetup.Datadog().GetDuration("logs_config.container_runtime_waiting_timeout")
+	ctx, cancel := context.WithTimeout(context.Background(), to*time.Second)
 	defer cancel()
 
 	logWhat := tf.cop.Wait(ctx)

--- a/releasenotes/notes/fix-infinite-log-selection-context-6513bd90667b7869.yaml
+++ b/releasenotes/notes/fix-infinite-log-selection-context-6513bd90667b7869.yaml
@@ -8,7 +8,7 @@
 ---
 fixes:
   - |
-    Make context expiring with configurable timeout when selecting log source type.
+    Make context expire with configurable timeout when selecting log source type.
     Infinite context was masking an error of missing runtime sockets.
     With this change, expiring context eventually reflects as log source error in `agent status` log section.
     Timeout value could be changed by setting `logs_config.container_runtime_waiting_timeout` in the Agent configuration file.

--- a/releasenotes/notes/fix-infinite-log-selection-context-6513bd90667b7869.yaml
+++ b/releasenotes/notes/fix-infinite-log-selection-context-6513bd90667b7869.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Make context expiring with configurable timeout when selecting log source type.
+    Infinite context was masking an error of missing runtime sockets.
+    With this change, expiring context eventually reflects as log source error in `agent status` log section.
+    Timeout value could be changed by setting `logs_config.container_runtime_waiting_timeout` in the Agent configuration file.
+    Timeout value provided in seconds.


### PR DESCRIPTION
### What does this PR do?
Make whatLog selection wait context expiring with configurable timeout.

### Motivation
This improves debugability and properly reflects issues with the logging.

### Describe how you validated your changes
1. Locally revert: https://github.com/DataDog/datadog-agent/pull/42197
2. Spin up EC2 instance with RHEL 9
3. Follow the steps to deploy rootless agent: https://docs.google.com/document/d/1bJWG2gJlF6y2rI3VnFcl3WkOdNwO3SiQ-iRmmAGa9-M
4. deploy test workload as: podman run -d --log-driver=k8s-file docker.io/chentex/random-logger
5. check `agent status` reflects log error

### Additional Notes
