### PR TITLE
[ABLD-246] Use `bazel`-built libsqlite3

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -185,8 +185,6 @@
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
     "https://bcr.bazel.build/modules/rules_testing/0.9.0/MODULE.bazel": "d4d9a7367978b5c589437f01dba1dc80ac6f389e9991e1c1edb3c8207526ca83",
     "https://bcr.bazel.build/modules/rules_testing/0.9.0/source.json": "2a943853f3480f42a9a5205cc4881a147fecdcf7c8ee87750bbeffff9c9a1877",
-    "https://bcr.bazel.build/modules/sqlite3/3.46.1/MODULE.bazel": "7749f9825ef0221a0b6e99ce8d07bbbb5bb922b587ad15438014710cf09656d0",
-    "https://bcr.bazel.build/modules/sqlite3/3.46.1/source.json": "3e745df80e9b43455d058c38c694345a99e9f63370ad5603aacc03551d242e08",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -2,8 +2,27 @@
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
 
-# Defines a "sqlite3" target for the lib
-bazel_dep(name = "sqlite3", version = "3.46.1")
+http_file = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_file")
+
+sqlite_ver = ("3", "50", "04")
+
+sqlite_amalgamation = "sqlite-amalgamation-{}00".format("".join(sqlite_ver))
+
+http_archive(
+    name = "sqlite3",
+    build_file = "//deps:sqlite3.BUILD.bazel",
+    files = {"LICENSE.md": "@sqlite3_license//file:LICENSE.md"},
+    sha256 = "1d3049dd0f830a025a53105fc79fd2ab9431aea99e137809d064d8ee8356b032",
+    strip_prefix = sqlite_amalgamation,
+    url = "https://www.sqlite.org/2025/{}.zip".format(sqlite_amalgamation),
+)
+
+http_file(
+    name = "sqlite3_license",
+    downloaded_file_path = "LICENSE.md",
+    sha256 = "a7a58d6022c090c528e3167026167b3141d682efc6a3c188b473ba59f1788fc7",
+    url = "https://raw.githubusercontent.com/sqlite/sqlite/version-{}/LICENSE.md".format(".".join([v.lstrip("0") for v in sqlite_ver])),
+)
 
 http_archive(
     name = "xz",

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -6,15 +6,16 @@ http_file = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", 
 
 sqlite_ver = ("3", "50", "04")
 
-sqlite_amalgamation = "sqlite-amalgamation-{}00".format("".join(sqlite_ver))
+# TODO(agent-build): switch to "bare" `sqlite-amalgamation` when we drop the need for .pc files
+sqlite_amalgamation = "sqlite-autoconf-{}00".format("".join(sqlite_ver))
 
 http_archive(
     name = "sqlite3",
     build_file = "//deps:sqlite3.BUILD.bazel",
     files = {"LICENSE.md": "@sqlite3_license//file:LICENSE.md"},
-    sha256 = "1d3049dd0f830a025a53105fc79fd2ab9431aea99e137809d064d8ee8356b032",
+    sha256 = "a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18",
     strip_prefix = sqlite_amalgamation,
-    url = "https://www.sqlite.org/2025/{}.zip".format(sqlite_amalgamation),
+    url = "https://www.sqlite.org/2025/{}.tar.gz".format(sqlite_amalgamation),
 )
 
 http_file(

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -13,6 +13,8 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
+VERSION = "3.50.4"
+
 license(
     name = "license",
     license_kinds = ["@rules_license//licenses/spdx:blessing"],
@@ -52,14 +54,14 @@ so_symlink(
     name = "lib_files",
     src = ":sqlite3",
     libname = "libsqlite3",
-    version = "3.50.4",
+    version = VERSION,
 )
 
 expand_template(
     name = "gen_pkgconfig",
     out = "sqlite3.pc",
     substitutions = {
-        "@PACKAGE_VERSION@": "3.50.4",
+        "@PACKAGE_VERSION@": VERSION,
         "@prefix@": "##PREFIX##",
         "@exec_prefix@": "${prefix}",
         "@includedir@": "${prefix}/include",

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -1,6 +1,7 @@
 """Agent specific BUILD file for sqlite3."""
 
 load("@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
@@ -54,10 +55,34 @@ so_symlink(
     version = "3.50.4",
 )
 
+expand_template(
+    name = "gen_pkgconfig",
+    out = "sqlite3.pc",
+    substitutions = {
+        "@PACKAGE_VERSION@": "3.50.4",
+        "@prefix@": "##PREFIX##",
+        "@exec_prefix@": "${prefix}",
+        "@includedir@": "${prefix}/include",
+        "@libdir@": "${prefix}/lib",
+        "@LDFLAGS_MATH@": "-lm",
+        "@LDFLAGS_ZLIB@": "",
+        "@LDFLAGS_DLOPEN@": "",
+        "@LDFLAGS_PTHREAD@": "",
+        "@LDFLAGS_ICU@": "",
+    },
+    template = "sqlite3.pc.in",
+)
+
 pkg_files(
     name = "hdr_files",
     srcs = _SQLITE3_PUBLIC_HEADERS,
     prefix = "include",
+)
+
+pkg_files(
+    name = "pkgconfig",
+    srcs = [":gen_pkgconfig"],
+    prefix = "lib/pkgconfig",
 )
 
 pkg_install(
@@ -65,5 +90,6 @@ pkg_install(
     srcs = [
         ":hdr_files",
         ":lib_files",
+        ":pkgconfig",
     ],
 )

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -35,17 +35,8 @@ cc_library(
         "-Wall",
         "-DSQLITE_ENABLE_MATH_FUNCTIONS",
         "-DSQLITE_THREADSAFE=1",
-        "-O2",
-    ] + select({
-        "@platforms//os:windows": [
-            "/O2",
-            "/wd4232",  # nonstandard extension used
-            "/wd4244",  # possible loss of data
-            "/wd4267",  # possible loss of data
-            "/wd4996",  # deprecated functions
-        ],
-        "//conditions:default": ["-O3"],
-    }),
+        "-O3",
+    ],
     linkstatic = True,
     visibility = ["//visibility:public"],
 )

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -1,5 +1,3 @@
-"""Agent specific BUILD file for sqlite3."""
-
 load("@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
@@ -29,16 +27,14 @@ _SQLITE3_PUBLIC_HEADERS = [
 
 cc_library(
     name = "libsqlite3",
-    srcs = [
-        "sqlite3.c",
-    ],
+    srcs = ["sqlite3.c"],
     hdrs = _SQLITE3_PUBLIC_HEADERS,
     includes = ["."],
     copts = [
         "-Wall",
         "-DSQLITE_ENABLE_MATH_FUNCTIONS",
         "-DSQLITE_THREADSAFE=1",
-        "-O3",
+        "-O2",
     ],
     linkstatic = True,
     visibility = ["//visibility:public"],

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -1,0 +1,78 @@
+"""Agent specific BUILD file for sqlite3."""
+
+load("@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:private"],
+)
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:blessing"],
+    license_text = "LICENSE.md",
+    visibility = ["//visibility:public"],
+)
+
+_SQLITE3_PUBLIC_HEADERS = [
+    "sqlite3.h",
+    "sqlite3ext.h",
+]
+
+cc_library(
+    name = "libsqlite3",
+    srcs = [
+        "sqlite3.c",
+    ],
+    hdrs = _SQLITE3_PUBLIC_HEADERS,
+    includes = ["."],
+    copts = [
+        "-Wall",
+        "-DSQLITE_ENABLE_MATH_FUNCTIONS",
+        "-DSQLITE_THREADSAFE=1",
+        "-O2",
+    ] + select({
+        "@platforms//os:windows": [
+            "/O2",
+            "/wd4232",  # nonstandard extension used
+            "/wd4244",  # possible loss of data
+            "/wd4267",  # possible loss of data
+            "/wd4996",  # deprecated functions
+        ],
+        "//conditions:default": ["-O3"],
+    }),
+    linkstatic = True,
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "sqlite3",
+    deps = [":libsqlite3"],
+    visibility = ["//visibility:public"],
+)
+
+so_symlink(
+    name = "lib_files",
+    src = ":sqlite3",
+    libname = "libsqlite3",
+    version = "3.50.4",
+)
+
+pkg_files(
+    name = "hdr_files",
+    srcs = _SQLITE3_PUBLIC_HEADERS,
+    prefix = "include",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":hdr_files",
+        ":lib_files",
+    ],
+)

--- a/omnibus/config/software/libsqlite3.rb
+++ b/omnibus/config/software/libsqlite3.rb
@@ -12,16 +12,9 @@ relative_path "sqlite-autoconf-3500400"
 build do
   license "Public-Domain"
 
-  update_config_guess
-  env = with_standard_compiler_flags(with_embedded_path)
-  configure_options = [
-    "--disable-static",
-    "--enable-shared",
-    "--disable-editline",
-    "--disable-readline",
-  ]
-  configure(*configure_options, env: env)
-  make "-j #{workers}", env: env
-  make "install"
-  delete "#{install_dir}/embedded/bin/sqlite3"
+  command_on_repo_root "bazelisk run -- @sqlite3//:install --destdir='#{install_dir}/embedded'"
+  sh_lib = if linux_target? then "libsqlite3.so" else "libsqlite3.dylib" end
+  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+     "#{install_dir}/embedded/lib/pkgconfig/sqlite3.pc " \
+     "#{install_dir}/embedded/lib/#{sh_lib}"
 end


### PR DESCRIPTION
### What does this PR do?
Use `bazel`-built libsqlite3 instead of `omnibus`-built.

### Motivation
Ongoing `bazel` migration.

### Describe how you validated your changes
CI.

### Additional Notes
Co-authored-by: Hugo Beauzée-Luyssen <hugo.beauzee@datadoghq.com>
Co-authored-by: Alex Lopez <alex.lopez@datadoghq.com>