### PR TITLE
Trigger the stable nightly build from conductor

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -90,6 +90,12 @@ extensions:
           # Create and push to this branch to test changes with conductor if needed without merging to main
           branch: "conductor-sandbox"
           parent_environments: ["staging"]
+        - name: "stable-nightly-build"
+          ci_pipeline: "//fake_placeholder:fake_placeholder"
+          branch: "7.71.x"
+          schedule: "30 2 * * *"
+          parent_environments: ["staging"]
+          build_only: true
   datadoghq.com/change-detection:
     source_patterns:
       - service.datadog.yaml


### PR DESCRIPTION
### What does this PR do?

Trigger the stable nightly build from conductor 

### Motivation

We are currently running a pipeline every night on the stable release branch (currently 7.71.x) to be sure everything is still OK. This pipeline is currently triggered from a GitLab scheduled pipeline. This is not very convenient because we need a specific GitLab token to update it to switch to the new latest release branch. 

With this approach, we only need to update the `branch` field in this config to start using the new branch, without using a GitLab token. 

Once this PR merged, I'll make sure the pipeline is running as expected and I'll delete the scheduled pipeline next week.

https://datadoghq.atlassian.net/browse/BARX-1186

### Describe how you validated your changes

### Additional Notes
