### PR TITLE
discovery: Disable node test

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_services_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_services_test.go
@@ -485,9 +485,6 @@ func TestServicesPythonFromBashScript(t *testing.T) {
 }
 
 func TestServicesAPMInstrumentationProvided(t *testing.T) {
-	curDir, err := testutil.CurDir()
-	assert.NoError(t, err)
-
 	testCases := map[string]struct {
 		commandline []string // The command line of the fake server
 		language    language.Language
@@ -507,10 +504,6 @@ func TestServicesAPMInstrumentationProvided(t *testing.T) {
 		"java - datadog.jar": {
 			commandline: []string{"java", "-javaagent:/path/to/datadog-java-agent.jar", "-jar", "foo.jar"},
 			language:    language.Java,
-		},
-		"node": {
-			commandline: []string{"node", filepath.Join(curDir, "testdata", "server.js")},
-			language:    language.Node,
 		},
 	}
 
@@ -570,6 +563,7 @@ func TestServicesCommandLineSanitization(t *testing.T) {
 }
 
 func TestServicesNodeDocker(t *testing.T) {
+	t.Skip("Skip temporarily")
 	cert, key, err := testutil.GetCertsPaths()
 	require.NoError(t, err)
 


### PR DESCRIPTION
### What does this PR do?

Temporarily disable node test until the issues are investigated.

### Motivation

Failures on main.
https://datadoghq.atlassian.net/browse/DSCVR-234