### PR TITLE
Revert "[incident-44801] Temporarily disable Stack Cleaner on EKS"

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -274,7 +274,6 @@ new-e2e-containers-eks:
     EXTRA_PARAMS: --run TestEKSSuite
     E2E_PRE_INITIALIZED: "true"
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "false"  # TODO(celian): Restore stack cleaner on EKS once errors are fixed
 
 new-e2e-remote-config:
   extends: .new_e2e_template_needs_deb_x64
@@ -304,6 +303,7 @@ new-e2e-agent-runtimes:
     TARGETS: ./tests/agent-runtimes
     TEAM: agent-runtimes
     ON_NIGHTLY_FIPS: "true"
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-agent-subcommands:
   extends: .new_e2e_template_needs_deb_windows_x64
@@ -314,6 +314,7 @@ new-e2e-agent-subcommands:
     TARGETS: ./tests/agent-subcommands
     TEAM: agent-configuration
     ON_NIGHTLY_FIPS: "true"
+    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run "Test(Linux|Windows)StatusSuite"
@@ -376,6 +377,7 @@ new-e2e-windows-service-test:
     TARGETS: ./tests/windows/service-test
     TEAM: windows-products
     ON_NIGHTLY_FIPS: "true"
+    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestServiceBehaviorAgentCommand
@@ -403,6 +405,7 @@ new-e2e-windows-certificate:
     TARGETS: ./tests/windows/windows-certificate
     TEAM: windows-products
     EXTRA_PARAMS: --run "TestRemoteCertificates$"
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-language-detection:
   extends: .new_e2e_template_needs_deb_x64
@@ -413,6 +416,7 @@ new-e2e-language-detection:
     TARGETS: ./tests/language-detection
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-npm-packages:
   extends: .new_e2e_template
@@ -480,7 +484,6 @@ new-e2e-npm-eks:
     EXTRA_PARAMS: --run "TestEKSVMSuite"
     E2E_PRE_INITIALIZED: "true"
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "false"  # TODO(celian): Restore stack cleaner on EKS once errors are fixed
 
 new-e2e-npm:
   extends: .new_e2e_template
@@ -590,6 +593,7 @@ new-e2e-process:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-orchestrator:
   extends:
@@ -646,6 +650,7 @@ new-e2e-installer-script:
     FLEET_INSTALL_METHOD: "install_script"
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer:
   extends: .new_e2e_template
@@ -671,6 +676,7 @@ new-e2e-installer:
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer-ansible:
   extends: .new_e2e_template
@@ -693,6 +699,7 @@ new-e2e-installer-ansible:
     FLEET_INSTALL_METHOD: "ansible"
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template
@@ -732,6 +739,7 @@ new-e2e-ha-agent:
     # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
     EXTRA_PARAMS: --skip TestHAAgentFailoverSuite
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-ha-agent-failover:
   extends: .new_e2e_template_needs_deb_x64
@@ -768,6 +776,7 @@ new-e2e-windows-systemprobe:
   variables:
     TARGETS: ./tests/sysprobe-functional
     TEAM: windows-products
+    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestUSMAutoTaggingSuite
@@ -785,6 +794,7 @@ new-e2e-windows-security-agent:
   variables:
     TARGETS: ./tests/security-agent-functional
     TEAM: windows-products
+    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-otel-eks-init:
   stage: e2e_init
@@ -821,7 +831,6 @@ new-e2e-otel-eks:
     EXTRA_PARAMS: --run "TestOTelAgentIA(EKS|USTEKS)"
     TEAM: otel
     E2E_PRE_INITIALIZED: "true"
-    REMOTE_STACK_CLEANING: "false"  # TODO(celian): Restore stack cleaner on EKS once errors are fixed
 
 new-e2e-otel:
   extends: .new_e2e_template
@@ -897,6 +906,7 @@ new-e2e-gpu:
     TEAM: ebpf-platform
     E2E_PULUMI_LOG_LEVEL: 10 # incident-33572
     ON_NIGHTLY_FIPS: "true"
+    REMOTE_STACK_CLEANING: "true"
   needs: # list of required jobs. By default gitlab waits for any previous jobs.
     - !reference [.new_e2e_template_needs_container_deploy, needs]
     - agent_deb-x64-a7 # agent 7 debian package


### PR DESCRIPTION
Reverts DataDog/datadog-agent#42309.

This will reduce the impact on devs