### PR TITLE
CI: Fix discovery system-probe change paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -579,7 +579,7 @@ workflow:
 .system_probe_change_paths: &system_probe_change_paths
   - cmd/system-probe/**/*
   - pkg/collector/corechecks/ebpf/**/*
-  - pkg/collector/corechecks/servicediscovery/module/*
+  - pkg/collector/corechecks/servicediscovery/**/*
   - pkg/ebpf/**/*
   - pkg/network/**/*
   - pkg/process/monitor/*


### PR DESCRIPTION
### What does this PR do?

Pretty much all the code in pkg/collector/corechecks/servicediscovery is
run in system-probe, not just the module directory.

### Motivation

Catch test failures like https://datadoghq.atlassian.net/browse/DSCVR-234
before merge.

### Describe how you validated your changes

### Additional Notes

There is a Windows system-probe paths later in the file, I haven't changed that
since the service discovery module is only imported on Linux (from
`cmd/system-probe/modules/discovery_linux.go`).
