### PR TITLE
usm - Add heuristics for Erlang application name generation

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/erlang.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/erlang.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package usm
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+type erlangDetector struct {
+	ctx DetectionContext
+}
+
+func newErlangDetector(ctx DetectionContext) detector {
+	return &erlangDetector{ctx: ctx}
+}
+
+func (e erlangDetector) detect(args []string) (ServiceMetadata, bool) {
+	name := detectErlangAppName(args)
+	if name != "" && name != "beam" {
+		return NewServiceMetadata(name, CommandLine), true
+	}
+	return ServiceMetadata{}, false
+}
+
+func detectErlangAppName(cmdline []string) string {
+	var progname string
+	var home string
+
+	// Parse command line looking for -progname and -home flags.
+	// We support both separated (-progname erl) and concatenated (-prognameerl) forms.
+	for i := 0; i < len(cmdline); i++ {
+		arg := cmdline[i]
+
+		// Check for -progname flag (with value in next arg)
+		if arg == "-progname" && i+1 < len(cmdline) {
+			progname = strings.TrimSpace(cmdline[i+1])
+			i++
+			continue
+		}
+
+		// Check for -progname with concatenated value (e.g., -prognameerl)
+		if strings.HasPrefix(arg, "-progname") && len(arg) > 9 {
+			progname = strings.TrimSpace(arg[9:])
+			continue
+		}
+
+		// Check for -home flag (with value in next arg)
+		if arg == "-home" && i+1 < len(cmdline) {
+			home = strings.TrimSpace(cmdline[i+1])
+			i++
+			continue
+		}
+
+		// Check for -home with concatenated value (e.g., -home/var/lib/rabbitmq)
+		if strings.HasPrefix(arg, "-home") && len(arg) > 5 {
+			home = strings.TrimSpace(arg[5:])
+			continue
+		}
+	}
+
+	// Apply heuristics according to requirements.
+	// Compare progname case-insensitively to handle edge cases.
+	if progname != "" && !strings.EqualFold(progname, "erl") {
+		return progname
+	}
+
+	// Only use home if progname is explicitly "erl"
+	if strings.EqualFold(progname, "erl") && home != "" {
+		// Extract the last component of the home path
+		base := filepath.Base(home)
+		if base != "" && base != "." && base != "/" {
+			return base
+		}
+	}
+
+	// Fallback to "beam"
+	return "beam"
+}

--- a/pkg/collector/corechecks/servicediscovery/usm/erlang_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/erlang_test.go
@@ -1,0 +1,287 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package usm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/envs"
+)
+
+func Test_detectErlangAppName(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdline  []string
+		expected string
+	}{
+		{
+			name: "CouchDB with progname",
+			cmdline: []string{
+				"-root", "/usr/lib/erlang",
+				"-progname", "couchdb",
+				"-home", "/opt/couchdb",
+			},
+			expected: "couchdb",
+		},
+		{
+			name: "Riak with progname",
+			cmdline: []string{
+				"-root", "/usr/lib/erlang",
+				"-progname", "riak",
+				"-home", "/var/lib/riak",
+			},
+			expected: "riak",
+		},
+		{
+			name: "RabbitMQ with erl progname, use home",
+			cmdline: []string{
+				"-root", "/usr/lib/erlang",
+				"-progname", "erl",
+				"-home", "/var/lib/rabbitmq",
+			},
+			expected: "rabbitmq",
+		},
+		{
+			name: "Ejabberd with erl progname, use home",
+			cmdline: []string{
+				"-root", "/usr/lib/erlang",
+				"-progname", "erl",
+				"-home", "/var/lib/ejabberd",
+			},
+			expected: "ejabberd",
+		},
+		{
+			name: "Generic Erlang process with erl progname, use home",
+			cmdline: []string{
+				"-progname", "erl",
+				"-home", "/usr/local/myapp",
+			},
+			expected: "myapp",
+		},
+		{
+			name: "Fallback to beam when no progname or home",
+			cmdline: []string{
+				"-smp", "auto",
+				"-noinput",
+			},
+			expected: "beam",
+		},
+		{
+			name: "Progname without home",
+			cmdline: []string{
+				"-progname", "myerlangapp",
+				"-smp", "auto",
+			},
+			expected: "myerlangapp",
+		},
+		{
+			name:     "Empty command line",
+			cmdline:  []string{},
+			expected: "beam",
+		},
+		{
+			name: "Only home, no progname",
+			cmdline: []string{
+				"-home", "/opt/customapp",
+				"-noshell",
+			},
+			expected: "beam",
+		},
+		{
+			name: "Home with trailing slash",
+			cmdline: []string{
+				"-progname", "erl",
+				"-home", "/var/lib/myapp/",
+			},
+			expected: "myapp",
+		},
+		{
+			name: "Complex real-world RabbitMQ command line",
+			cmdline: []string{
+				"-W", "w",
+				"-MBas", "ageffcbf",
+				"-MHas", "ageffcbf",
+				"-MBlmbcs", "512",
+				"-MHlmbcs", "512",
+				"-MMmcs", "30",
+				"-P", "1048576",
+				"-t", "5000000",
+				"-stbt", "db",
+				"-zdbbl", "128000",
+				"-sbwt", "none",
+				"-sbwtdcpu", "none",
+				"-sbwtdio", "none",
+				"-K", "true",
+				"-A", "192",
+				"-sdio", "192",
+				"-kernel", "inet_dist_listen_min", "25672",
+				"-kernel", "inet_dist_listen_max", "25672",
+				"-kernel", "shell_history", "enabled",
+				"-boot", "/usr/lib/rabbitmq/bin/../releases/3.11.5/start_clean",
+				"-lager", "crash_log", "false",
+				"-lager", "handlers", "[]",
+				"-rabbit", "product_name", "\"RabbitMQ\"",
+				"-rabbit", "product_version", "\"3.11.5\"",
+				"-progname", "erl",
+				"-home", "/var/lib/rabbitmq",
+			},
+			expected: "rabbitmq",
+		},
+		{
+			name: "CouchDB real-world command line",
+			cmdline: []string{
+				"-noshell",
+				"-noinput",
+				"+Bd",
+				"-B",
+				"-K", "true",
+				"-A", "16",
+				"-n",
+				"+A", "4",
+				"+sbtu",
+				"+sbwt", "none",
+				"+sbwtdcpu", "none",
+				"+sbwtdio", "none",
+				"-config", "/opt/couchdb/releases/3.2.2/sys.config",
+				"-sasl", "errlog_type", "error",
+				"-couch_ini", "/opt/couchdb/etc/default.ini", "/opt/couchdb/etc/local.ini",
+				"-boot", "/opt/couchdb/releases/3.2.2/couchdb",
+				"-args_file", "/opt/couchdb/etc/vm.args",
+				"-progname", "couchdb",
+			},
+			expected: "couchdb",
+		},
+		{
+			name: "Progname concatenated without space",
+			cmdline: []string{
+				"-root", "/usr/lib/erlang",
+				"-prognamecouchdb",
+				"-home", "/opt/couchdb",
+			},
+			expected: "couchdb",
+		},
+		{
+			name: "Home concatenated without space",
+			cmdline: []string{
+				"-progname", "erl",
+				"-home/var/lib/rabbitmq",
+			},
+			expected: "rabbitmq",
+		},
+		{
+			name: "Both flags concatenated",
+			cmdline: []string{
+				"-prognameerl",
+				"-home/var/lib/ejabberd",
+			},
+			expected: "ejabberd",
+		},
+		{
+			name: "Progname with spaces in value",
+			cmdline: []string{
+				"-progname", "  couchdb  ",
+			},
+			expected: "couchdb",
+		},
+		{
+			name: "Home with spaces in value",
+			cmdline: []string{
+				"-progname", "erl",
+				"-home", "  /var/lib/rabbitmq  ",
+			},
+			expected: "rabbitmq",
+		},
+		{
+			name: "Case insensitive erl - uppercase ERL",
+			cmdline: []string{
+				"-progname", "ERL",
+				"-home", "/var/lib/rabbitmq",
+			},
+			expected: "rabbitmq",
+		},
+		{
+			name: "Case insensitive erl - mixed case Erl",
+			cmdline: []string{
+				"-progname", "Erl",
+				"-home", "/var/lib/ejabberd",
+			},
+			expected: "ejabberd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectErlangAppName(tt.cmdline)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_erlangDetector(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		expectedName    string
+		expectedSuccess bool
+		expectedSource  ServiceNameSource
+	}{
+		{
+			name: "CouchDB detection",
+			args: []string{
+				"-progname", "couchdb",
+				"-home", "/opt/couchdb",
+			},
+			expectedName:    "couchdb",
+			expectedSuccess: true,
+			expectedSource:  CommandLine,
+		},
+		{
+			name: "RabbitMQ detection",
+			args: []string{
+				"-progname", "erl",
+				"-home", "/var/lib/rabbitmq",
+			},
+			expectedName:    "rabbitmq",
+			expectedSuccess: true,
+			expectedSource:  CommandLine,
+		},
+		{
+			name: "Fallback to beam returns false",
+			args: []string{
+				"-smp", "auto",
+			},
+			expectedName:    "",
+			expectedSuccess: false,
+		},
+		{
+			name: "Custom Erlang app",
+			args: []string{
+				"-progname", "myapp",
+				"-noshell",
+			},
+			expectedName:    "myapp",
+			expectedSuccess: true,
+			expectedSource:  CommandLine,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewDetectionContext(tt.args, envs.NewVariables(nil), nil)
+			detector := newErlangDetector(ctx)
+
+			meta, success := detector.detect(tt.args)
+
+			assert.Equal(t, tt.expectedSuccess, success)
+			if success {
+				assert.Equal(t, tt.expectedName, meta.Name)
+				assert.Equal(t, tt.expectedSource, meta.Source)
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/servicediscovery/usm/service.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/service.go
@@ -287,6 +287,8 @@ var executableDetectors = map[string]detectorCreatorFn{
 	"gunicorn": newGunicornDetector,
 	"puma":     newRailsDetector,
 	"sudo":     newSimpleDetector,
+	"beam.smp": newErlangDetector,
+	"beam":     newErlangDetector,
 }
 
 // ExtractServiceMetadata attempts to detect ServiceMetadata from the given process.


### PR DESCRIPTION
### What does this PR do?
[DSCVR-205](https://datadoghq.atlassian.net/browse/DSCVR-205)

This PR improves service name detection for Erlang applications by adding heuristics to distinguish between different BEAM-based services (RabbitMQ, CouchDB, Riak, Ejabberd, etc.) that all run under the generic beam.smp process name.

Implemented heuristic:
	•	If the Erlang process includes a -progname flag different from erl, use its value as the service name.
	•	If -progname is erl, use the last component of the -home flag (e.g., /var/lib/rabbitmq → rabbitmq).
	•	If no valid -progname or -home is found, return "beam" as a fallback.
	•	Both separated (-progname erl) and concatenated (-prognameerl) flag formats are supported.

### Motivation
Currently, all Erlang-based applications appear as generic beam.smp processes in service discovery, making it impossible to distinguish between critical services.

### Describe how you validated your changes
Run local test. Also some unit tests  have been added in erlang_test.go.

### Additional Notes


[DSCVR-205]: https://datadoghq.atlassian.net/browse/DSCVR-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ