### PR TITLE
AGTMETRICS-385 Remove response channel from orchestrator methods

### DIFF
--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -77,8 +77,8 @@ type Forwarder interface {
 	SubmitContainerChecks(payload transaction.BytesPayloads, extra http.Header) (chan Response, error)
 	SubmitRTContainerChecks(payload transaction.BytesPayloads, extra http.Header) (chan Response, error)
 	SubmitConnectionChecks(payload transaction.BytesPayloads, extra http.Header) (chan Response, error)
-	SubmitOrchestratorChecks(payload transaction.BytesPayloads, extra http.Header, payloadType int) (chan Response, error)
-	SubmitOrchestratorManifests(payload transaction.BytesPayloads, extra http.Header) (chan Response, error)
+	SubmitOrchestratorChecks(payload transaction.BytesPayloads, extra http.Header, payloadType int) error
+	SubmitOrchestratorManifests(payload transaction.BytesPayloads, extra http.Header) error
 }
 
 // Compile-time check to ensure that DefaultForwarder implements the Forwarder interface
@@ -733,21 +733,22 @@ func (f *DefaultForwarder) SubmitConnectionChecks(payload transaction.BytesPaylo
 }
 
 // SubmitOrchestratorChecks sends orchestrator checks
-func (f *DefaultForwarder) SubmitOrchestratorChecks(payload transaction.BytesPayloads, extra http.Header, payloadType int) (chan Response, error) {
+func (f *DefaultForwarder) SubmitOrchestratorChecks(payload transaction.BytesPayloads, extra http.Header, payloadType int) error {
 	bumpOrchestratorPayload(f.log, payloadType)
 
 	endpoint := endpoints.OrchestratorEndpoint
 	if f.config.IsSet("orchestrator_explorer.use_legacy_endpoint") {
 		endpoint = endpoints.LegacyOrchestratorEndpoint
 	}
-
-	return f.submitProcessLikePayload(endpoint, payload, extra, true)
+	transactions := f.createHTTPTransactions(endpoint, payload, transaction.Process, extra)
+	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitOrchestratorManifests sends orchestrator manifests
-func (f *DefaultForwarder) SubmitOrchestratorManifests(payload transaction.BytesPayloads, extra http.Header) (chan Response, error) {
+func (f *DefaultForwarder) SubmitOrchestratorManifests(payload transaction.BytesPayloads, extra http.Header) error {
 	transactionsOrchestratorManifest.Add(1)
-	return f.submitProcessLikePayload(endpoints.OrchestratorManifestEndpoint, payload, extra, true)
+	transactions := f.createHTTPTransactions(endpoints.OrchestratorManifestEndpoint, payload, transaction.Process, extra)
+	return f.sendHTTPTransactions(transactions)
 }
 
 func (f *DefaultForwarder) submitProcessLikePayload(ep transaction.Endpoint, payload transaction.BytesPayloads, extra http.Header, retryable bool) (chan Response, error) {

--- a/comp/forwarder/defaultforwarder/noop_forwarder.go
+++ b/comp/forwarder/defaultforwarder/noop_forwarder.go
@@ -96,11 +96,11 @@ func (f NoopForwarder) SubmitConnectionChecks(_ transaction.BytesPayloads, _ htt
 }
 
 // SubmitOrchestratorChecks does nothing.
-func (f NoopForwarder) SubmitOrchestratorChecks(_ transaction.BytesPayloads, _ http.Header, _ int) (chan Response, error) {
-	return nil, nil
+func (f NoopForwarder) SubmitOrchestratorChecks(_ transaction.BytesPayloads, _ http.Header, _ int) error {
+	return nil
 }
 
 // SubmitOrchestratorManifests does nothing.
-func (f NoopForwarder) SubmitOrchestratorManifests(_ transaction.BytesPayloads, _ http.Header) (chan Response, error) {
-	return nil, nil
+func (f NoopForwarder) SubmitOrchestratorManifests(_ transaction.BytesPayloads, _ http.Header) error {
+	return nil
 }

--- a/comp/forwarder/defaultforwarder/sync_forwarder.go
+++ b/comp/forwarder/defaultforwarder/sync_forwarder.go
@@ -158,11 +158,11 @@ func (f *SyncForwarder) SubmitConnectionChecks(payload transaction.BytesPayloads
 }
 
 // SubmitOrchestratorChecks sends orchestrator checks
-func (f *SyncForwarder) SubmitOrchestratorChecks(payload transaction.BytesPayloads, extra http.Header, payloadType int) (chan Response, error) {
+func (f *SyncForwarder) SubmitOrchestratorChecks(payload transaction.BytesPayloads, extra http.Header, payloadType int) error {
 	return f.defaultForwarder.SubmitOrchestratorChecks(payload, extra, payloadType)
 }
 
 // SubmitOrchestratorManifests sends orchestrator manifests
-func (f *SyncForwarder) SubmitOrchestratorManifests(payload transaction.BytesPayloads, extra http.Header) (chan Response, error) {
+func (f *SyncForwarder) SubmitOrchestratorManifests(payload transaction.BytesPayloads, extra http.Header) error {
 	return f.defaultForwarder.SubmitOrchestratorManifests(payload, extra)
 }

--- a/comp/forwarder/defaultforwarder/test_common.go
+++ b/comp/forwarder/defaultforwarder/test_common.go
@@ -201,11 +201,11 @@ func (tf *MockedForwarder) SubmitConnectionChecks(payload transaction.BytesPaylo
 }
 
 // SubmitOrchestratorChecks mock
-func (tf *MockedForwarder) SubmitOrchestratorChecks(payload transaction.BytesPayloads, extra http.Header, _ int) (chan Response, error) {
-	return nil, tf.Called(payload, extra).Error(0)
+func (tf *MockedForwarder) SubmitOrchestratorChecks(payload transaction.BytesPayloads, extra http.Header, _ int) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitOrchestratorManifests mock
-func (tf *MockedForwarder) SubmitOrchestratorManifests(payload transaction.BytesPayloads, extra http.Header) (chan Response, error) {
-	return nil, tf.Called(payload, extra).Error(0)
+func (tf *MockedForwarder) SubmitOrchestratorManifests(payload transaction.BytesPayloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -415,15 +415,9 @@ func (s *Serializer) SendOrchestratorMetadata(msgs []types.ProcessMessageBody, h
 			return s.logger.Errorf("Unable to encode message: %s", err)
 		}
 
-		responses, err := orchestratorForwarder.SubmitOrchestratorChecks(payloads, extraHeaders, payloadType)
+		err = orchestratorForwarder.SubmitOrchestratorChecks(payloads, extraHeaders, payloadType)
 		if err != nil {
 			return s.logger.Errorf("Unable to submit payload: %s", err)
-		}
-
-		// Consume the responses so that writers to the channel do not become blocked
-		// we don't need the bodies here though
-		//nolint:revive // TODO(AML) Fix revive linter
-		for range responses {
 		}
 	}
 	return nil
@@ -442,15 +436,9 @@ func (s *Serializer) SendOrchestratorManifests(msgs []types.ProcessMessageBody, 
 			continue
 		}
 
-		responses, err := orchestratorForwarder.SubmitOrchestratorManifests(payloads, extraHeaders)
+		err = orchestratorForwarder.SubmitOrchestratorManifests(payloads, extraHeaders)
 		if err != nil {
 			return s.logger.Errorf("Unable to submit payload: %s", err)
-		}
-
-		// Consume the responses so that writers to the channel do not become blocked
-		// we don't need the bodies here though
-		//nolint:revive // TODO(AML) Fix revive linter
-		for range responses {
 		}
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do?

Remove response channel from orchestrator forwarder methods.

Responses were drained without use, so there is no need to set up completion callback on these transactions. The `x-dd-agent-attempts` header is equally ineffective with the eventplatform intake. Only the process intake cares about it.

### Motivation

Simplify code.

### Describe how you validated your changes

### Additional Notes
