### PR TITLE
Consolidate part of the domains configuration for the forwarder

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -103,7 +103,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				core.Bundle(),
 				secretsfx.Module(),
-				forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithResolvers())),
+				forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithAllowOPW(false))),
 				demultiplexerimpl.Module(demultiplexerimpl.NewDefaultParams()),
 				orchestratorForwarderImpl.Module(orchestratorForwarderImpl.NewDisabledParams()),
 				eventplatformimpl.Module(eventplatformimpl.NewDisabledParams()),

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -153,7 +153,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				core.Bundle(),
 				secretsfx.Module(),
-				forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithResolvers(), defaultforwarder.WithDisableAPIKeyChecking())),
+				forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithAllowOPW(false), defaultforwarder.WithDisableAPIKeyChecking())),
 				demultiplexerimpl.Module(demultiplexerimpl.NewDefaultParams()),
 				orchestratorForwarderImpl.Module(orchestratorForwarderImpl.NewDefaultParams()),
 				eventplatformimpl.Module(eventplatformimpl.NewDisabledParams()),

--- a/comp/forwarder/defaultforwarder/default_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder_test.go
@@ -9,12 +9,14 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
-	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
 )
 
 // domainAPIKeyMap used by tests to get API keys from each domain resolver
@@ -41,8 +43,9 @@ func TestDefaultForwarderUpdateAPIKey(t *testing.T) {
 			utils.NewAPIKeys("additional_endpoints", "api_key3"),
 		},
 	}
-	forwarderOptions, err := NewOptions(mockConfig, log, keysPerDomains)
+	resolvers, err := resolver.NewSingleDomainResolvers(keysPerDomains)
 	require.NoError(t, err)
+	forwarderOptions := NewOptionsWithResolvers(mockConfig, log, resolvers)
 	forwarder := NewDefaultForwarder(mockConfig, log, forwarderOptions)
 
 	// API keys from the domain resolvers match
@@ -79,8 +82,9 @@ func TestDefaultForwarderUpdateAdditionalEndpointAPIKey(t *testing.T) {
 			utils.NewAPIKeys("additional_endpoints", "api_key3"),
 		},
 	}
-	forwarderOptions, err := NewOptions(mockConfig, log, keysPerDomains)
+	resolvers, err := resolver.NewSingleDomainResolvers(keysPerDomains)
 	require.NoError(t, err)
+	forwarderOptions := NewOptionsWithResolvers(mockConfig, log, resolvers)
 	forwarder := NewDefaultForwarder(mockConfig, log, forwarderOptions)
 
 	// API keys from the domain resolvers match

--- a/comp/forwarder/defaultforwarder/params.go
+++ b/comp/forwarder/defaultforwarder/params.go
@@ -9,7 +9,7 @@ import "github.com/DataDog/datadog-agent/pkg/util/option"
 
 // Params contains the parameters to create a forwarder.
 type Params struct {
-	withResolver bool
+	allowOPW bool
 
 	// Use optional to override Options.DisableAPIKeyChecking only if WithFeatures was called
 	disableAPIKeyCheckingOverride option.Option[bool]
@@ -20,17 +20,19 @@ type optionParams = func(*Params)
 
 // NewParams initializes a new Params struct
 func NewParams(options ...optionParams) Params {
-	p := Params{}
+	p := Params{
+		allowOPW: true,
+	}
 	for _, option := range options {
 		option(&p)
 	}
 	return p
 }
 
-// WithResolvers enables the forwarder to use resolvers
-func WithResolvers() optionParams {
+// WithAllowOPW sets whether observability_pipelines and vector config keys need to be honored.
+func WithAllowOPW(allow bool) optionParams {
 	return func(p *Params) {
-		p.withResolver = true
+		p.allowOPW = allow
 	}
 }
 

--- a/comp/forwarder/defaultforwarder/resolver/config.go
+++ b/comp/forwarder/defaultforwarder/resolver/config.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package resolver
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
+)
+
+// DomainSet represents a set of domains and their associated resolvers
+type DomainSet = map[string]DomainResolver
+
+// FromConfig creates a ResolverSet from the configuration.
+//
+// allowOPW specifies if observability_pipelines and vector config keys need to be honored.
+func FromConfig(config config.Component, log log.Component, allowOPW bool) (DomainSet, error) {
+	keysPerDomain, err := utils.GetMultipleEndpoints(config)
+	if err != nil {
+		return nil, fmt.Errorf("Misconfiguration of agent endpoints: %s", err)
+	}
+
+	resolvers, err := NewSingleDomainResolvers(keysPerDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	if allowOPW {
+		err := configureOPW(config, log, resolvers)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return resolvers, nil
+}
+
+func configureOPW(config config.Component, log log.Component, resolvers DomainSet) error {
+	vectorMetricsURL, err := getObsPipelineURL(log, pkgconfigsetup.Metrics, config)
+	if err != nil {
+		log.Error("Misconfiguration of agent observability_pipelines_worker endpoint for metrics: ", err)
+	}
+	if r, ok := resolvers[utils.GetInfraEndpoint(config)]; ok && vectorMetricsURL != "" {
+		log.Debugf("Configuring forwarder to send metrics to observability_pipelines_worker: %s", vectorMetricsURL)
+		apiKeys, _ := r.GetAPIKeysInfo()
+		resolver, err := NewDomainResolverWithMetricToVector(
+			r.GetBaseDomain(),
+			apiKeys,
+			vectorMetricsURL,
+		)
+		if err != nil {
+			return err
+		}
+		resolvers[utils.GetInfraEndpoint(config)] = resolver
+	}
+
+	return nil
+}
+
+// getObsPipelineURL returns the URL under the 'observability_pipelines_worker.' prefix for the given datatype
+func getObsPipelineURL(log log.Component, datatype string, config config.Component) (string, error) {
+	if config.GetBool(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype)) {
+		return getObsPipelineURLForPrefix(log, datatype, "observability_pipelines_worker", config)
+	} else if config.GetBool(fmt.Sprintf("vector.%s.enabled", datatype)) {
+		// Fallback to the `vector` config if observability_pipelines_worker is not set.
+		return getObsPipelineURLForPrefix(log, datatype, "vector", config)
+	}
+	return "", nil
+}
+
+func getObsPipelineURLForPrefix(log log.Component, datatype string, prefix string, config config.Component) (string, error) {
+	if config.GetBool(fmt.Sprintf("%s.%s.enabled", prefix, datatype)) {
+		pipelineURL := config.GetString(fmt.Sprintf("%s.%s.url", prefix, datatype))
+		if pipelineURL == "" {
+			log.Errorf("%s.%s.enabled is set to true, but %s.%s.url is empty", prefix, datatype, prefix, datatype)
+			return "", nil
+		}
+		_, err := url.Parse(pipelineURL)
+		if err != nil {
+			return "", fmt.Errorf("could not parse %s %s endpoint: %s", prefix, datatype, err)
+		}
+		return pipelineURL, nil
+	}
+	return "", nil
+}

--- a/comp/forwarder/defaultforwarder/sync_forwarder.go
+++ b/comp/forwarder/defaultforwarder/sync_forwarder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	utilhttp "github.com/DataDog/datadog-agent/pkg/util/http"
@@ -29,7 +30,12 @@ type SyncForwarder struct {
 
 // NewSyncForwarder returns a new synchronous forwarder.
 func NewSyncForwarder(config config.Component, log log.Component, keysPerDomain map[string][]utils.APIKeys, timeout time.Duration) (*SyncForwarder, error) {
-	options, err := NewOptions(config, log, keysPerDomain)
+	resolvers, err := resolver.NewSingleDomainResolvers(keysPerDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	options := NewOptionsWithResolvers(config, log, resolvers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Move bits of logic split between the component (forwarder.go) and the package (defaultforwarder.go) into the resolver package, so it can provide a more unified front.

Now defaultforwarder-the-library always gets the resolvers ready to use, and it is responsibility of the callers to provide one. Everything was doing that already, except the defaultforwarder-the-component.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
