### PR TITLE
[tracer] Make fentry check for sendpage on newer kernels

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/network_ebpf.go
+++ b/pkg/collector/corechecks/servicediscovery/module/network_ebpf.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	ebpfmaps "github.com/DataDog/datadog-agent/pkg/ebpf/maps"
-	kprobeconfig "github.com/DataDog/datadog-agent/pkg/network/tracer/connection/kprobe"
+	kprobeutil "github.com/DataDog/datadog-agent/pkg/network/tracer/connection/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -47,7 +47,7 @@ func (c *eBPFNetworkCollector) setupManager(buf bytecode.AssetReader, options ma
 		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kretprobe__tcp_sendmsg", UID: moduleName}, KProbeMaxActive: maxActive},
 	}
 
-	if kprobeconfig.HasTCPSendPage(kv) {
+	if kprobeutil.HasTCPSendPage(kv) {
 		probes = append(probes,
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kretprobe__tcp_sendpage", UID: moduleName}, KProbeMaxActive: maxActive})
 	}

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -175,13 +175,9 @@ func enabledPrograms(c *config.Config) (map[string]struct{}, error) {
 		if c.CustomBatchingEnabled {
 			enableProgram(enabled, udpDestroySockReturn)
 		}
-		if hasSendPage {
-			enableProgram(enabled, udpSendPageReturn)
-		}
 	}
 
 	if c.CollectUDPv6Conns {
-		enableProgram(enabled, udpSendPageReturn)
 		enableProgram(enabled, udpv6DestroySock)
 		enableProgram(enabled, inet6Bind)
 		enableProgram(enabled, inet6BindRet)
@@ -193,12 +189,12 @@ func enabledPrograms(c *config.Config) (map[string]struct{}, error) {
 		if c.CustomBatchingEnabled {
 			enableProgram(enabled, udpv6DestroySockReturn)
 		}
-		if hasSendPage {
-			enableProgram(enabled, udpSendPageReturn)
-		}
 	}
 
 	if c.CollectUDPv4Conns || c.CollectUDPv6Conns {
+		if hasSendPage {
+			enableProgram(enabled, udpSendPageReturn)
+		}
 		if err := enableAdvancedUDP(enabled); err != nil {
 			return nil, err
 		}

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -19,26 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-// HasTCPSendPage checks if the kernel has the tcp_sendpage function.
-// After kernel 6.5.0, tcp_sendpage and udp_sendpage are removed.
-// We used to only check for kv < 6.5.0 here - however, OpenSUSE 15.6 backported
-// this change into 6.4.0 to pick up a CVE so the version number is not reliable.
-// Instead, we directly check if the function exists.
-func HasTCPSendPage(kv kernel.Version) bool {
-	missing, err := ebpf.VerifyKernelFuncs("tcp_sendpage")
-	if err == nil {
-		return len(missing) == 0
-	}
-
-	log.Debugf("unable to determine whether tcp_sendpage exists, using kernel version instead: %s", err)
-
-	kv650 := kernel.VersionCode(6, 5, 0)
-	return kv < kv650
-}
 
 func enableProbe(enabled map[probes.ProbeFuncName]struct{}, name probes.ProbeFuncName) {
 	enabled[name] = struct{}{}
@@ -74,7 +57,7 @@ func enabledProbes(c *config.Config, runtimeTracer, coreTracer bool) (map[probes
 	}
 	// else: Kernel < 4.15 - keep kprobe fallback (no multiple tracepoint attachment)
 
-	hasSendPage := HasTCPSendPage(kv)
+	hasSendPage := util.HasTCPSendPage(kv)
 
 	if c.CollectTCPv4Conns || c.CollectTCPv6Conns {
 		if ClassificationSupported(c) {

--- a/pkg/network/tracer/connection/util/conn_tracer.go
+++ b/pkg/network/tracer/connection/util/conn_tracer.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-// Package util contains common helpers used in the creation of the closed connection event handler
+// Package util contains common helpers used for kernel network tracing
 package util
 
 import (

--- a/pkg/network/tracer/connection/util/kernel.go
+++ b/pkg/network/tracer/connection/util/kernel.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package util
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// HasTCPSendPage checks if the kernel has the tcp_sendpage function.
+// After kernel 6.5.0, tcp_sendpage and udp_sendpage are removed.
+// We used to only check for kv < 6.5.0 here - however, OpenSUSE 15.6 backported
+// this change into 6.4.0 to pick up a CVE so the version number is not reliable.
+// Instead, we directly check if the function exists.
+func HasTCPSendPage(kv kernel.Version) bool {
+	missing, err := ebpf.VerifyKernelFuncs("tcp_sendpage")
+	if err == nil {
+		return len(missing) == 0
+	}
+
+	log.Debugf("unable to determine whether tcp_sendpage exists, using kernel version instead: %s", err)
+
+	kv650 := kernel.VersionCode(6, 5, 0)
+	return kv < kv650
+}


### PR DESCRIPTION
### What does this PR do?
This PR makes the fentry tracer check for the presence of `tcp_sendpage` and `udp_sendpage` to avoid attaching probes to a missing function on newer kernels.

### Motivation
We want to get fentry working on newer kernels and to enable it in KMT

### Describe how you validated your changes
Ran this PR's docker image on COS 6.6 kernel, fentry started up successfully
