### PR TITLE
[KMT] Use string for type in cast()

### DIFF
--- a/tasks/kernel_matrix_testing/infra.py
+++ b/tasks/kernel_matrix_testing/infra.py
@@ -262,7 +262,7 @@ def build_alien_infrastructure(alien_vms: Path) -> dict[KMTArchNameOrLocal, Host
                 "",
                 [],
                 vm["ssh_key_path"],
-                cast(KMTArchNameOrLocal, vm["arch"]),
+                cast("KMTArchNameOrLocal", vm["arch"]),
                 instance,
                 ssh_user,
             )


### PR DESCRIPTION
### What does this PR do?
This changes the type parameter of `cast()` to take in a string instead of an actual value

### Motivation
Fixes a NameError when `TYPE_CHECKING` is false (I think `from __future__ import annotations` only applies to type annotations, not the parameters of `cast()`)

### Describe how you validated your changes
Error stopped occurring after this change

