### PR TITLE
APM: no panic on forwarding transport errors

### DIFF
--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -117,7 +117,9 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 				// Ignoring bodyclose lint here because of a bug in the linter:
 				// https://github.com/timakin/bodyclose/issues/30.
 				rres, rerr = m.rt.RoundTrip(newreq) //nolint:bodyclose
-				rres.Body.Close()
+				if rres != nil && rres.Body != nil {
+					rres.Body.Close()
+				}
 				return
 			}
 			resp, err := m.rt.RoundTrip(newreq)
@@ -127,7 +129,9 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 			} else {
 				log.Error(err)
 			}
-			resp.Body.Close()
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
 
 		}(i, u)
 	}

--- a/pkg/trace/api/transports_test.go
+++ b/pkg/trace/api/transports_test.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// mockTransport is a simple mock that returns a nil response and an error
+type mockTransport struct {
+	returnNilResponse bool
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.returnNilResponse {
+		return nil, errors.New("mock error with nil response")
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+	}, nil
+}
+
+// TestForwardingTransport_NilResponse verifies that RoundTrip doesn't panic
+// when the underlying transport returns a nil response with an error.
+func TestForwardingTransport_NilResponse(t *testing.T) {
+	mockRT := &mockTransport{returnNilResponse: true}
+	mainEndpoint, _ := url.Parse("http://localhost:8080")
+
+	ft := newForwardingTransport(mockRT, mainEndpoint, "test-key", nil)
+
+	req, err := http.NewRequest("POST", "http://localhost:8080/v1/traces", strings.NewReader("test body"))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	// This should not panic even though the underlying transport returns nil response
+	resp, err := ft.RoundTrip(req)
+
+	if err == nil {
+		t.Error("expected an error from RoundTrip")
+	}
+
+	if resp != nil {
+		t.Error("expected nil response")
+	}
+}
+
+// TestForwardingTransport_MultipleTargetsNilResponse verifies that RoundTrip doesn't panic
+// when forwarding to multiple targets and the underlying transport returns a nil response.
+func TestForwardingTransport_MultipleTargetsNilResponse(t *testing.T) {
+	mockRT := &mockTransport{returnNilResponse: true}
+	mainEndpoint, _ := url.Parse("http://localhost:8080")
+	additionalEndpoints := map[string][]string{
+		"http://localhost:8081": {"key1"},
+	}
+
+	ft := newForwardingTransport(mockRT, mainEndpoint, "test-key", additionalEndpoints)
+
+	req, err := http.NewRequest("POST", "http://localhost:8080/v1/traces", strings.NewReader("test body"))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	// This should not panic even though the underlying transport returns nil response
+	resp, err := ft.RoundTrip(req)
+
+	if err == nil {
+		t.Error("expected an error from RoundTrip")
+	}
+
+	if resp != nil {
+		t.Error("expected nil response")
+	}
+}

--- a/pkg/trace/api/transports_test.go
+++ b/pkg/trace/api/transports_test.go
@@ -19,7 +19,7 @@ type mockTransport struct {
 	returnNilResponse bool
 }
 
-func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (m *mockTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	if m.returnNilResponse {
 		return nil, errors.New("mock error with nil response")
 	}
@@ -44,6 +44,9 @@ func TestForwardingTransport_NilResponse(t *testing.T) {
 
 	// This should not panic even though the underlying transport returns nil response
 	resp, err := ft.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 
 	if err == nil {
 		t.Error("expected an error from RoundTrip")
@@ -72,6 +75,9 @@ func TestForwardingTransport_MultipleTargetsNilResponse(t *testing.T) {
 
 	// This should not panic even though the underlying transport returns nil response
 	resp, err := ft.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 
 	if err == nil {
 		t.Error("expected an error from RoundTrip")

--- a/releasenotes/notes/noPanicRoundtripErr-c0c13d467c8b018e.yaml
+++ b/releasenotes/notes/noPanicRoundtripErr-c0c13d467c8b018e.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+fixes:
+  - |
+    APM: Fix issue where errors on the debugger or symdb reverse proxy could trigger a panic.


### PR DESCRIPTION
### What does this PR do?
The http roundtrip transport can return a nil response for certain kinds of errors. When this happens our attempt to close the response body results in a nil pointer exception. We don't want to crash.

### Motivation
panicking is no good for software (and people too probably)

### Describe how you validated your changes
New unit tests (Written with AI assistance but reviewed by me (a human))

### Additional Notes
