### PR TITLE
Fix cloudRunPrefix from 'gpc.run' to 'gcp.run'

### DIFF
--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -54,7 +54,7 @@ const (
 	resourceName      = "resource_name"
 	functionTarget    = "build_function_target"
 	functionSignature = "function_signature_type"
-	cloudRunPrefix    = "gpc.run"
+	cloudRunPrefix    = "gcp.run"
 )
 
 var metadataHelperFunc = GetMetaData


### PR DESCRIPTION
### What does this PR do?
Fix cloudRunPrefix from 'gpc.run' to 'gcp.run'

### Motivation
https://dd.slack.com/archives/C02ELF4961M/p1761409510931969

### Describe how you validated your changes

### Additional Notes
