### PR TITLE
Stop editing the Stable Nightly Pipeline scheduled pipeline in the release.cleanup command

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -83,7 +83,7 @@ from tasks.libs.releasing.version import (
     next_rc_version,
 )
 from tasks.notify import post_message
-from tasks.pipeline import edit_schedule, run
+from tasks.pipeline import run
 from tasks.release_metrics.metrics import get_prs_metrics, get_release_lead_time
 
 BACKPORT_LABEL_COLOR = "5319e7"
@@ -961,9 +961,6 @@ def cleanup(ctx, release_branch):
             )
 
         create_release_pr(commit_message, main_branch, cleanup_branch, version, milestone=current_milestone)
-
-    if major_version != 6:
-        edit_schedule(ctx, 2555, ref=version.branch())
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Stop editing the Stable Nightly Pipeline scheduled pipeline in the release.cleanup command.

I updated the documentation accordingly so we no longer need the special GitLab token for this step

### Motivation

We're migrating to Conductor to trigger this workflow, some more context in https://github.com/DataDog/datadog-agent/pull/42314

Next step will be to bump the version in the service.datadog.yaml file for the pipeline triggered by conductor

https://datadoghq.atlassian.net/browse/BARX-1186

### Describe how you validated your changes

### Additional Notes
