### PR TITLE
[incident-44861] Use AMI pin from test-infra on windows-service

### DIFF
--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	e2eos "github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 
 	"testing"
 
@@ -407,9 +405,6 @@ func run[Env any](t *testing.T, s e2e.Suite[Env], systemProbeConfig string, agen
 		),
 		awsHostWindows.WithAgentClientOptions(
 			agentclientparams.WithSkipWaitForAgentReady(),
-		),
-		awsHostWindows.WithEC2InstanceOptions(
-			ec2.WithAMI("ami-0345f44fe05216fc4", e2eos.WindowsServer2022, e2eos.AMD64Arch),
 		),
 	))}
 	e2e.Run(t, s, opts...)


### PR DESCRIPTION
[incident-44861]

Reverts #38810. This reverts commit 1763479f34009f1725bd663d2320f6e21550518b.

Now it is pinned in test-infra with an up to date version, the image could be found like that.
