### PR TITLE
[AGENTRUN] Fix RemoteAgent resource leak

### DIFF
--- a/comp/core/remoteagentregistry/impl/client.go
+++ b/comp/core/remoteagentregistry/impl/client.go
@@ -84,6 +84,11 @@ func (ra *remoteAgentRegistry) newRemoteAgentClient(registration *remoteagentreg
 	return client, nil
 }
 
+// close closes the remote agent client and its connection
+func (rac *remoteAgentClient) close() error {
+	return rac.conn.Close()
+}
+
 // validateSessionID extracts and validates the session_id from gRPC response metadata
 func (rac *remoteAgentClient) validateSessionID(responseMetadata metadata.MD) error {
 	sessionIDs := responseMetadata.Get("session_id")

--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -247,14 +247,16 @@ func (ra *remoteAgentRegistry) start() {
 				}
 
 				for _, sessionID := range agentsToRemove {
-					details, ok := ra.agentMap[sessionID]
+					remoteAgentClient, ok := ra.agentMap[sessionID]
 					if ok {
-						if details.unhealthy {
-							log.Warnf("Remote agent '%s' deregistered due to session ID validation failure (expected: %s, got: %s)", details.RegisteredAgent.DisplayName, details.RegisteredAgent.SessionID, sessionID)
+						if remoteAgentClient.unhealthy {
+							log.Warnf("Remote agent '%s' deregistered due to session ID validation failure (expected: %s, got: %s)", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentClient.RegisteredAgent.SessionID, sessionID)
 						} else {
-							log.Infof("Remote agent '%s' deregistered after being idle for %s.", details.RegisteredAgent.DisplayName, remoteAgentIdleTimeout)
+							log.Infof("Remote agent '%s' deregistered after being idle for %s.", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentIdleTimeout)
 						}
-						ra.telemetryStore.remoteAgentRegistered.Dec(details.RegisteredAgent.SanitizedDisplayName)
+						ra.telemetryStore.remoteAgentRegistered.Dec(remoteAgentClient.RegisteredAgent.SanitizedDisplayName)
+						// close the remote agent client and remove it from the registry
+						remoteAgentClient.close()
 						delete(ra.agentMap, sessionID)
 					}
 				}


### PR DESCRIPTION
### What does this PR do?
This PR ensures that all resources associated with a RemoteAgent are properly closed when the RemoteAgent is deregistered from the remoteAgentRegistry.

### Motivation
Without this cleanup step, resource references remain active, leading to memory leaks. This change addresses a regression introduced in #41338.

### Describe how you validated your changes
Tested locally by simulating a large number of RemoteAgent registrations and deregistrations. Verified through profiling that memory usage remains stable and that the leak no longer occurs.
