### PR TITLE
discovery: Fix and enable node test

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_services_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_services_test.go
@@ -563,7 +563,6 @@ func TestServicesCommandLineSanitization(t *testing.T) {
 }
 
 func TestServicesNodeDocker(t *testing.T) {
-	t.Skip("Skip temporarily")
 	cert, key, err := testutil.GetCertsPaths()
 	require.NoError(t, err)
 
@@ -584,7 +583,7 @@ func TestServicesNodeDocker(t *testing.T) {
 		assert.Equal(collect, svc.PID, pid)
 		assert.Equal(collect, "test_nodejs-https-server", svc.GeneratedName)
 		assert.Equal(collect, string(usm.Nodejs), svc.GeneratedNameSource)
-		assert.Equal(collect, true, svc.APMInstrumentation)
+		assert.Equal(collect, false, svc.APMInstrumentation)
 		assert.Equal(collect, "web_service", svc.Type)
 	}, 30*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
### What does this PR do?

The test server includes dd-trace in its package.json, but it doesn't
actually initialize the tracer (and besides that it uses an old version
of the tracer without metadata information), so it's not correct to
check for instrumentation = true.

We don't want to make the test service use dd-trace since the purpose of
the test server is really something else (USM TLS test).  Tracer
metadata handling is already tested in other unit tests and e2e tests.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-234
