### PR TITLE
[EBPF-883] sharedlibs: allow upgrading to ring buffers

### DIFF
--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -78,11 +78,19 @@ static __always_inline void push_event_if_relevant(void *ctx, lib_path_t *path, 
     if (i + LIB_SO_SUFFIX_SIZE > path->len) {
         return;
     }
+    u64 ringbuffers_enabled = 0;
+    LOAD_CONSTANT("ringbuffers_enabled", ringbuffers_enabled);
+
     u64 crypto_libset_enabled = 0;
     LOAD_CONSTANT("crypto_libset_enabled", crypto_libset_enabled);
 
     if (crypto_libset_enabled && (match6chars(0, 'l', 'i', 'b', 's', 's', 'l') || match6chars(0, 'c', 'r', 'y', 'p', 't', 'o') || match6chars(0, 'g', 'n', 'u', 't', 'l', 's'))) {
-        bpf_perf_event_output(ctx, &crypto_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
+        if (ringbuffers_enabled) {
+            bpf_ringbuf_output_with_telemetry(&crypto_shared_libraries, path, sizeof(lib_path_t), 0);
+        } else {
+            bpf_perf_event_output_with_telemetry(ctx, &crypto_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
+        }
+
         return;
     }
 
@@ -90,14 +98,26 @@ static __always_inline void push_event_if_relevant(void *ctx, lib_path_t *path, 
     LOAD_CONSTANT("gpu_libset_enabled", gpu_libset_enabled);
 
     if (gpu_libset_enabled && (match6chars(0, 'c', 'u', 'd', 'a', 'r', 't') || match6chars(0, '4', 'j', 'c', 'u', 'd', 'a'))) {
-        bpf_perf_event_output(ctx, &gpu_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
+        if (ringbuffers_enabled) {
+            bpf_ringbuf_output_with_telemetry(&gpu_shared_libraries, path, sizeof(lib_path_t), 0);
+        } else {
+            bpf_perf_event_output(ctx, &gpu_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
+        }
+
+        return;
     }
 
     u64 libc_libset_enabled = 0;
     LOAD_CONSTANT("libc_libset_enabled", libc_libset_enabled);
 
     if (libc_libset_enabled && (match4chars(2, 'l', 'i', 'b', 'c'))) {
-        bpf_perf_event_output(ctx, &libc_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
+        if (ringbuffers_enabled) {
+            bpf_ringbuf_output_with_telemetry(&libc_shared_libraries, path, sizeof(lib_path_t), 0);
+        } else {
+            bpf_perf_event_output_with_telemetry(ctx, &libc_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
+        }
+
+        return;
     }
 }
 

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -26,8 +26,10 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	bugs "github.com/DataDog/datadog-agent/pkg/ebpf/kernelbugs"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/perf"
 	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -36,6 +38,8 @@ const (
 	maxActive              = 1024
 	sharedLibrariesPerfMap = "shared_libraries"
 	probeUID               = "so"
+	perCPUBufferPages      = 8
+	dataChannelSize        = 100
 
 	// probe used for streaming shared library events
 	openSysCall    = "open"
@@ -61,25 +65,14 @@ type libsetHandler struct {
 	// callbacks is a map of the callbacks that are subscribed to this libset
 	callbacks map[*LibraryCallback]struct{}
 
-	// done is a channel that is closed when the handler stops, to signal the goroutine to end
-	done chan struct{}
-
 	// perfHandler is the perf handler for this libset, that will get the events from the perf buffer
-	perfHandler *ddebpf.PerfHandler
+	// the lifetime of the perf handler is tied to the lifetime of the eBPF manager
+	perfHandler *perf.EventHandler
 
 	// enabled is true if the eBPF program has been enabled for this libset,
-	// which means that the perf buffer is being read, the eBPF program has been
-	// edited to enable this libset, and the handler that redirects events to
-	// callbacks is running.
+	// which means that the perf buffer is being read and the eBPF program has been
+	// edited to enable this libset.
 	enabled bool
-
-	// requested means that the libset has been requested to be enabled, but it
-	// might not be enabled yet. We need to have this distinction as the init flow
-	// is different depending on whether a libset is enabled/requested or none.
-	// For example, an enabled program will need to stop the handlers and re-start them
-	// as the underlying eBPF probe is updated. Meanwhile, a requested program will not
-	// need to stop the handlers, as they are not running yet.
-	requested bool
 }
 
 // EbpfProgram represents the shared libraries eBPF program.
@@ -99,9 +92,6 @@ type EbpfProgram struct {
 	// refcount is the number of times the program has been initialized. It is used to
 	// stop the program only when the refcount reaches 0.
 	refcount uint16
-
-	// initMutex is a mutex to protect the initialization variables and the libset map
-	wg sync.WaitGroup
 
 	// We need to protect the initialization variables and libset map with a
 	// mutex, as the program can be initialized from multiple goroutines at the
@@ -176,36 +166,39 @@ func (e *EbpfProgram) isLibsetEnabled(libset Libset) bool {
 	return ok && data.enabled
 }
 
-// isLibsetEnabled checks if the libset has been requested to be enabled. Assumes initMutex is locked
-func (e *EbpfProgram) isLibsetRequested(libset Libset) bool {
-	data, ok := e.libsets[libset]
-	return ok && data.requested
-}
-
 // setupManagerAndPerfHandlers sets up the manager and perf handlers for the eBPF program, creating the perf handlers
 // Assumes initMutex is locked
-func (e *EbpfProgram) setupManagerAndPerfHandlers() {
+func (e *EbpfProgram) setupManagerAndPerfHandlers() error {
 	mgr := &manager.Manager{}
+	numCPUs, err := kernel.PossibleCPUs()
+	if err != nil {
+		numCPUs = 1
 
-	// Tell the manager to load all possible maps
+	}
+	perfBufferSize := perCPUBufferPages * os.Getpagesize()
+	ringBufferSize := common.ToPowerOf2(perfBufferSize * numCPUs)
+
+	managerMods := []ddebpf.Modifier{
+		&ebpftelemetry.ErrorsTelemetryModifier{},
+	}
+
+	// Load perf handlers for all enabled libsets
 	for libset, handler := range e.libsets {
-		perfHandler := ddebpf.NewPerfHandler(100)
-		pm := &manager.PerfMap{
-			Map: manager.Map{
-				Name: fmt.Sprintf("%s_%s", string(libset), sharedLibrariesPerfMap),
-			},
-			PerfMapOptions: manager.PerfMapOptions{
-				PerfRingBufferSize: 8 * os.Getpagesize(),
-				Watermark:          1,
-				RecordHandler:      perfHandler.RecordHandler,
-				LostHandler:        perfHandler.LostHandler,
-				RecordGetter:       perfHandler.RecordGetter,
-				TelemetryEnabled:   e.cfg.InternalTelemetryEnabled,
-			},
+		if !handler.enabled {
+			continue
 		}
-		mgr.PerfMaps = append(mgr.PerfMaps, pm)
-		ebpftelemetry.ReportPerfMapTelemetry(pm)
-		handler.perfHandler = perfHandler
+
+		mapName := fmt.Sprintf("%s_%s", string(libset), sharedLibrariesPerfMap)
+		mode := perf.UpgradePerfBuffers(perfBufferSize, dataChannelSize, perf.Watermark(1), ringBufferSize)
+
+		perfHandler, err := perf.NewEventHandler(mapName, handler.handleEvent, mode,
+			perf.SendTelemetry(e.cfg.InternalTelemetryEnabled),
+			perf.RingBufferEnabledConstantName("ringbuffers_enabled"))
+		if err != nil {
+			return fmt.Errorf("failed to create perf handler for map %s: %w", mapName, err)
+		}
+
+		managerMods = append(managerMods, perfHandler)
 	}
 
 	e.initializeProbes()
@@ -217,7 +210,9 @@ func (e *EbpfProgram) setupManagerAndPerfHandlers() {
 		mgr.Probes = append(mgr.Probes, probe)
 	}
 
-	e.Manager = ddebpf.NewManager(mgr, "shared-libraries", &ebpftelemetry.ErrorsTelemetryModifier{})
+	e.Manager = ddebpf.NewManager(mgr, "shared-libraries", managerMods...)
+
+	return nil
 }
 
 // areLibsetsAlreadyEnabled checks if the eBPF program is already enabled for the given libsets
@@ -298,13 +293,14 @@ func (e *EbpfProgram) InitWithLibsets(libsets ...Libset) error {
 		e.stopImpl()
 	}
 
-	e.setupManagerAndPerfHandlers()
-
-	// Mark the libsets as requested so they can be started
-	// Note that other libsets might be requested from previous executions
+	// Mark the libsets as enabled, so that we will edit the corresponding constants and
+	// enable the corresponding perf handlers.
+	// Note that other libsets might be enabled from previous executions
 	for _, libset := range libsets {
-		e.libsets[libset].requested = true
+		e.libsets[libset].enabled = true
 	}
+
+	e.setupManagerAndPerfHandlers()
 
 	if err := e.loadProgram(); err != nil {
 		return fmt.Errorf("cannot load program: %w", err)
@@ -321,6 +317,7 @@ func (e *EbpfProgram) InitWithLibsets(libsets ...Libset) error {
 
 // start starts the eBPF program and the perf handlers, assumes the initMutex is locked
 func (e *EbpfProgram) start() error {
+	// Manager.Start will also start all the perf handlers that were added to the manager
 	err := e.Manager.Start()
 	if err != nil {
 		return err
@@ -328,42 +325,7 @@ func (e *EbpfProgram) start() error {
 
 	ddebpf.AddProbeFDMappings(e.Manager.Manager)
 
-	for _, handler := range e.libsets {
-		if !handler.requested {
-			continue
-		}
-
-		// Init the "done" channel for the handler, it will be closed when the handler stops
-		handler.done = make(chan struct{})
-		e.wg.Add(1)
-		go handler.eventLoop(&e.wg)
-
-		handler.enabled = true
-	}
-
 	return nil
-}
-
-// eventLoop is the main loop for a single libset. Should be called with all perfHandlers initialized.
-func (l *libsetHandler) eventLoop(wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	dataChan := l.perfHandler.DataChannel()
-	lostChan := l.perfHandler.LostChannel()
-	for {
-		select {
-		case <-l.done:
-			return
-		case event, ok := <-dataChan:
-			if !ok {
-				return
-			}
-			l.handleEvent(&event)
-		case <-lostChan:
-			// Nothing to do in this case
-			break
-		}
-	}
 }
 
 // toLibPath casts the perf event data to the LibPath structure
@@ -371,10 +333,8 @@ func toLibPath(data []byte) LibPath {
 	return *(*LibPath)(unsafe.Pointer(&data[0]))
 }
 
-func (l *libsetHandler) handleEvent(event *ddebpf.DataEvent) {
-	defer event.Done()
-
-	libpath := toLibPath(event.Data)
+func (l *libsetHandler) handleEvent(data []byte) {
+	libpath := toLibPath(data)
 
 	l.callbacksMutex.RLock()
 	defer l.callbacksMutex.RUnlock()
@@ -382,21 +342,6 @@ func (l *libsetHandler) handleEvent(event *ddebpf.DataEvent) {
 		// Not using a callback runner for now, as we don't have a lot of callbacks
 		(*callback)(libpath)
 	}
-}
-
-// stop stops the libset handler. Assumes the initMutex for the main ebpfProgram is locked. To be called
-func (l *libsetHandler) stop() {
-	// The done channel might not be initialized if the program is stopped before it starts (e.g., two sequential calls to InitWithLibsets()).
-	if l.done != nil {
-		close(l.done)
-	}
-
-	// stop the perf handler after the event loop is done
-	if l.perfHandler != nil {
-		l.perfHandler.Stop()
-	}
-
-	l.enabled = false
 }
 
 // subscribe subscribes to the shared libraries events for this libset, returns the function
@@ -487,14 +432,6 @@ func (e *EbpfProgram) stopImpl() {
 		}
 	}
 
-	for _, handler := range e.libsets {
-		if handler.enabled {
-			handler.stop()
-		}
-	}
-
-	e.wg.Wait()
-
 	e.Manager = nil
 }
 
@@ -515,7 +452,7 @@ func (e *EbpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 	var enabledMsgs []string
 	for libset := range LibsetToLibSuffixes {
 		value := uint64(0)
-		if e.isLibsetRequested(libset) {
+		if e.isLibsetEnabled(libset) {
 			value = uint64(1)
 		}
 

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -169,8 +169,8 @@ func (e *EbpfProgram) setupManagerAndPerfHandlers() error {
 	numCPUs, err := kernel.PossibleCPUs()
 	if err != nil {
 		numCPUs = 1
-
 	}
+
 	perfBufferSize := perCPUBufferPages * os.Getpagesize()
 	ringBufferSize := common.ToPowerOf2(perfBufferSize * numCPUs)
 

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -65,10 +65,6 @@ type libsetHandler struct {
 	// callbacks is a map of the callbacks that are subscribed to this libset
 	callbacks map[*LibraryCallback]struct{}
 
-	// perfHandler is the perf handler for this libset, that will get the events from the perf buffer
-	// the lifetime of the perf handler is tied to the lifetime of the eBPF manager
-	perfHandler *perf.EventHandler
-
 	// enabled is true if the eBPF program has been enabled for this libset,
 	// which means that the perf buffer is being read and the eBPF program has been
 	// edited to enable this libset.
@@ -300,7 +296,9 @@ func (e *EbpfProgram) InitWithLibsets(libsets ...Libset) error {
 		e.libsets[libset].enabled = true
 	}
 
-	e.setupManagerAndPerfHandlers()
+	if err := e.setupManagerAndPerfHandlers(); err != nil {
+		return fmt.Errorf("cannot setup manager and perf handlers: %w", err)
+	}
 
 	if err := e.loadProgram(); err != nil {
 		return fmt.Errorf("cannot load program: %w", err)

--- a/pkg/util/common/math.go
+++ b/pkg/util/common/math.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"math"
+)
+
+// ToPowerOf2 converts a number to its nearest power of 2
+func ToPowerOf2(x int) int {
+	log := math.Log2(float64(x))
+	return int(math.Pow(2, math.Round(log)))
+}


### PR DESCRIPTION
### What does this PR do?

Changes the shared library eBPF program to be able to upgrade to ring buffers if available. It does that by using the new perf event handler, which also simplifies the code.

### Motivation

Use rings with better performance and simplify code.

### Describe how you validated your changes

CI is passing. Validated in load-test environment with the processes scenario  ([dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=gj-shlib-base&tpl_var_client-service%5B0%5D=golang-k6-client-http&tpl_var_compare_agent-env%5B0%5D=gj-shlib-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=sp-test-env-1&tpl_var_server-service%5B0%5D=golang-httpbin&tpl_var_tls.library%5B0%5D=go&tpl_var_tls.library%5B1%5D=openssl&from_ts=1761674493726&to_ts=1761678801861&live=false)) comparing against 7.71.

![system-probe avg k8s CPU Usage by env (1).png](https://app.graphite.dev/user-attachments/assets/e55694a1-2fe2-4d4a-8892-10cf5081d419.png)

### Additional Notes
