### PR TITLE
fix(settings): Include missing settings from `devcontainer.json`

### DIFF
--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -1,5 +1,6 @@
 {{
     "go.buildTags": "{build_tags}",
+    "go.testTags": "{build_tags}",
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [
         "--build-tags",
@@ -8,6 +9,9 @@
     "[go]": {{
         "editor.formatOnSave": true,
     }},
+    "go.lintOnSave": "package",
+    "go.toolsManagement.checkForUpdates": "local",
+    "go.useLanguageServer": true,
     "gopls": {{
         "formatting.local": "github.com/DataDog/datadog-agent",
         "directoryFilters": {excluded_directories},


### PR DESCRIPTION
### What does this PR do?

Copy and merge the go-related settings from the `devcontainer.json` file (created by the `devcontainer.setup` task) into the main `settings.json` file created by `vscode.setup`

### Motivation

This helps with getting the LSP to work correctly when using the new `dda`-based dev environments, as they don't (as of yet) support using a proper `devcontainer.json` specification.

### Describe how you validated your changes

Clear my `settings.json`, re-create it, run a `dda env dev start` and verify the Go LSP works correctly (it used to hang sometimes, and not find some symbols when clicking "Go To Definition" for example)

### Additional Notes
