### PR TITLE
[OTEL-2794] Minor improvements to cumulative-to-delta conversion

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/config.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/config.go
@@ -209,7 +209,7 @@ func WithStatsOut(statsOut chan<- []byte) TranslatorOption {
 
 // InitialCumulMonoValueMode defines what the exporter should do with the initial value
 // of a cumulative monotonic sum when under the 'cumulative_to_delta' mode.
-// It also affects the count field for summary metrics.
+// It also affects sums, counts, and bucket counts in summaries and histograms.
 // It is not used for cumulative monotonic sums when the mode is 'raw_value'.
 type InitialCumulMonoValueMode string
 

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/exponential_histograms_translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/exponential_histograms_translator.go
@@ -100,7 +100,7 @@ func (t *Translator) mapExponentialHistogramMetrics(
 		countDims := pointDims.WithSuffix("count")
 		if delta {
 			histInfo.count = p.Count()
-		} else if dx, ok := t.prevPts.Diff(countDims, startTs, ts, float64(p.Count())); ok {
+		} else if dx, ok := t.diffMonotonic(countDims, startTs, ts, float64(p.Count())); ok {
 			histInfo.count = uint64(dx)
 		} else { // not ok
 			histInfo.ok = false
@@ -110,7 +110,7 @@ func (t *Translator) mapExponentialHistogramMetrics(
 		if !t.isSkippable(sumDims.name, p.Sum()) {
 			if delta {
 				histInfo.sum = p.Sum()
-			} else if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, p.Sum()); ok {
+			} else if dx, ok := t.diffCumulative(sumDims, startTs, ts, p.Sum()); ok {
 				histInfo.sum = dx
 			} else { // not ok
 				histInfo.ok = false

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/releasenotes/notes/otlp-cumulative-to-delta-improvements-94f6a45a3521a0ff.yaml
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/releasenotes/notes/otlp-cumulative-to-delta-improvements-94f6a45a3521a0ff.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    When receiving cumulative histogram metrics or rate metrics through OTLP,
+    the first point will now be passed through as a delta using the same logic as cumulative monotonic sum metrics.
+    Additionally, added logic to better handle negative duration points and overlapping metric series.

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/test/datadog/mixed/simple_keep.json
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/test/datadog/mixed/simple_keep.json
@@ -225,6 +225,21 @@
         "Value": 1
       },
       {
+        "Name": "summary.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "OriginProduct": 10,
+        "OriginSubProduct": 17,
+        "OriginProductDetail": 0,
+        "Type": "count",
+        "Timestamp": 1667560641226420924,
+        "Value": 1
+      },
+      {
         "Name": "summary.count",
         "Tags": [
           "custom_attribute:custom_value",

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/test/datadog/summary/simple_summary_cumsum-keep.json
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/test/datadog/summary/simple_summary_cumsum-keep.json
@@ -15,6 +15,18 @@
         "Value": 1
       },
       {
+        "Name": "summary.example.sum",
+        "Tags": [],
+        "Host": "hostname",
+        "OriginID": "",
+        "OriginProduct": 10,
+        "OriginSubProduct": 17,
+        "OriginProductDetail": 0,
+        "Type": "count",
+        "Timestamp": 1669802348455623075,
+        "Value": 1
+      },
+      {
         "Name": "summary.example.count",
         "Tags": [],
         "Host": "hostname",


### PR DESCRIPTION
### What does this PR do?

This PR refactors the code performing cumulative-to-delta conversion for cumulative metrics and makes a few changes to it:
- The first point of series is now passed through, following the existing logic for monotonic sums, for:
    - histogram metrics
    - resets in the middle of a slice (it seems no one has a good justification for the `i > 0` special case)
    - rate metrics (the `dt` used for computing the rate is `ts - startTs`, with an exception for monotonicity violations)
- I added some minor sanity checks, so points are now dropped when:
    - they have negative duration (`ts < startTs`)
    - they are from an older metric series which overlaps with the current one (`new.startTs < old.startTs`)

### Motivation

The main motivation was fixing the issue where the fist histogram of series is systematically dropped, which led to a customer escalation.

### Describe how you validated your changes

I adapted the existing tests to check most of the new behavior. May want to add some more.

### Additional Notes
