### PR TITLE
Add nil checks in trace-agent transports to avoid panics

### DIFF
--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -117,7 +117,9 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 				// Ignoring bodyclose lint here because of a bug in the linter:
 				// https://github.com/timakin/bodyclose/issues/30.
 				rres, rerr = m.rt.RoundTrip(newreq) //nolint:bodyclose
-				rres.Body.Close()
+				if rres != nil && rres.Body != nil {
+					_ = rres.Body.Close()
+				}
 				return
 			}
 			resp, err := m.rt.RoundTrip(newreq)
@@ -127,7 +129,9 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 			} else {
 				log.Error(err)
 			}
-			resp.Body.Close()
+			if resp != nil && resp.Body != nil {
+				_ = resp.Body.Close()
+			}
 
 		}(i, u)
 	}


### PR DESCRIPTION
### What does this PR do?
Add nil checks in trace-agent transports around closing response body.

### Motivation
Avoid panics.

### Describe how you validated your changes
CI

### Additional Notes
I think this code is doing very weird things, but didn't want to change the behavior (just fix the bugs).

I think we could just check whether the response is nil (not whether the body is), but the standard library checks the body directly so I'd rather do the same here.