### PR TITLE
[CSPM] allow running the full module in system-probe

### DIFF
--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -16,15 +16,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	// import the full compliance code in the system-probe (including the rego evaluator)
-	// this allows us to reserve the package size while we work on pluging things out
-	_ "github.com/DataDog/datadog-agent/pkg/compliance"
+	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
 func init() { registerModule(ComplianceModule) }
@@ -40,20 +39,48 @@ var complianceConfigNamespaces = []string{"compliance_config", "runtime_security
 var ComplianceModule = &module.Factory{
 	Name:             config.ComplianceModule,
 	ConfigNamespaces: complianceConfigNamespaces,
-	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
-		return &complianceModule{}, nil
-	},
+	Fn:               newComplianceModule,
 	NeedsEBPF: func() bool {
 		return false
 	},
 }
 
+func newComplianceModule(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
+	stopper := startstop.NewSerialStopper()
+
+	var complianceAgent *compliance.Agent
+
+	if deps.CoreConfig.GetBool("compliance_config.enabled") {
+		hostnameDetected, err := deps.Hostname.Get(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		sysProbeClient := &compliance.LocalSysProbeClient{}
+
+		// start compliance agent
+		complianceAgent, err = compliance.StartCompliance(deps.Log, deps.CoreConfig, hostnameDetected, stopper, deps.Statsd, deps.WMeta, deps.Compression, deps.Ipc, sysProbeClient)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &complianceModule{
+		stopper: stopper,
+		agent:   complianceAgent,
+	}, nil
+}
+
 type complianceModule struct {
+	agent   *compliance.Agent
+	stopper startstop.Stopper
+
 	performedChecks atomic.Uint64
 }
 
-// Close is a noop (implements module.Module)
-func (*complianceModule) Close() {
+// Close stops the compliance module (implements module.Module)
+func (m *complianceModule) Close() {
+	m.stopper.Stop()
 }
 
 // GetStats returns statistics related to the compliance module (implements module.Module)

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -98,6 +98,7 @@ func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.C
 
 func load() (*types.Config, error) {
 	cfg := pkgconfigsetup.GlobalSystemProbeConfigBuilder()
+	coreCfg := pkgconfigsetup.Datadog()
 
 	Adjust(cfg)
 
@@ -122,7 +123,7 @@ func load() (*types.Config, error) {
 	csmEnabled := cfg.GetBool(secNS("enabled"))
 	gpuEnabled := cfg.GetBool(gpuNS("enabled"))
 	diEnabled := cfg.GetBool(diNS("enabled"))
-	swEnabled := pkgconfigsetup.Datadog().GetBool(swNS("enabled"))
+	swEnabled := coreCfg.GetBool(swNS("enabled"))
 
 	if npmEnabled || usmEnabled || ccmEnabled || (csmEnabled && cfg.GetBool(secNS("network_monitoring.enabled"))) {
 		c.EnabledModules[NetworkTracerModule] = struct{}{}
@@ -142,8 +143,9 @@ func load() (*types.Config, error) {
 		diEnabled {
 		c.EnabledModules[EventMonitorModule] = struct{}{}
 	}
-	complianceEnabled := cfg.GetBool(compNS("database_benchmarks.enabled")) ||
-		(cfg.GetBool(secNS("enabled")) && cfg.GetBool(secNS("compliance_module.enabled")))
+	complianceEnabled := coreCfg.GetBool(compNS("enabled")) || // full module is enabled
+		cfg.GetBool(compNS("database_benchmarks.enabled")) || // only the DB benchmarks handler is enabled
+		(cfg.GetBool(secNS("enabled")) && cfg.GetBool(secNS("compliance_module.enabled"))) // only the DB benchmarks handler is enabled via the CWS config (legacy)
 	if complianceEnabled {
 		c.EnabledModules[ComplianceModule] = struct{}{}
 	}


### PR DESCRIPTION
### What does this PR do?

This PR allows running the full CSPM module in the system-probe process in addition (or more instead) of the security agent.

The full migration will be handle by the installation mode (for example the operator won't create the security-agent and instead enable CSPM in the system-probe).

The feature in itself is working exactly as before.

### Motivation

### Describe how you validated your changes

### Additional Notes
