### PR TITLE
[CWS] update codeowners for /pkg/process/events/consumer/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -591,6 +591,7 @@
 /pkg/process/                           @DataDog/container-experiences
 /pkg/process/util/address*.go           @DataDog/cloud-network-monitoring
 /pkg/process/checks/net*.go             @DataDog/cloud-network-monitoring
+/pkg/process/events/consumer/           @DataDog/agent-security
 /pkg/process/metadata/parser/           @DataDog/universal-service-monitoring @DataDog/container-experiences @DataDog/cloud-network-monitoring
 /pkg/process/metadata/parser/*windows*  @DataDog/universal-service-monitoring @DataDog/container-experiences @DataDog/cloud-network-monitoring @DataDog/windows-products
 /pkg/process/monitor/                   @DataDog/universal-service-monitoring


### PR DESCRIPTION
### What does this PR do?

Code in this directory is mainly maintained by CWS team, this PR makes it clear

See https://github.com/DataDog/datadog-agent/pull/42280#issuecomment-3452051675

### Motivation

### Describe how you validated your changes

### Additional Notes
