### PR TITLE
system-probe: Enable discovery when USM is enabled

### DIFF
--- a/pkg/system-probe/config/adjust.go
+++ b/pkg/system-probe/config/adjust.go
@@ -50,6 +50,10 @@ func Adjust(cfg model.Config) {
 	adjustUSM(cfg)
 	adjustSecurity(cfg)
 
+	if usmEnabled {
+		applyDefault(cfg, discoveryNS("enabled"), true)
+	}
+
 	if cfg.GetBool(spNS("process_service_inference", "enabled")) &&
 		!usmEnabled &&
 		!npmEnabled {

--- a/pkg/system-probe/config/config_test.go
+++ b/pkg/system-probe/config/config_test.go
@@ -95,4 +95,21 @@ func TestEnableDiscovery(t *testing.T) {
 		cfg := mock.NewSystemProbe(t)
 		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
 	})
+
+	t.Run("default enabled with USM", func(t *testing.T) {
+		t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
+
+		cfg := mock.NewSystemProbe(t)
+		Adjust(cfg)
+		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
+	})
+
+	t.Run("force disabled with USM", func(t *testing.T) {
+		t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
+		t.Setenv("DD_DISCOVERY_ENABLED", "false")
+
+		cfg := mock.NewSystemProbe(t)
+		Adjust(cfg)
+		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Process meta data from discovery (via the workloadmeta and tagger
components) is used to propagate tracer process tags to USM in some cases
(such as for services which were running before the agent started up),
so ensure that discovery is enabled if USM is enabled.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-197

### Describe how you validated your changes

Tests added.

### Additional information

CNM would also need it eventually but since it's primarily USM where there
is currently a push to align names with APM it's being done for USM first.

Note that similar code to enable discovery when USM is enabled existed
[earlier](https://github.com/DataDog/datadog-agent/pull/31475) but was [reverted](https://github.com/DataDog/datadog-agent/pull/38473) since at that time there was no dependency
between the two.