### PR TITLE
[NDMII-3666] SNMP device scan by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -378,6 +378,7 @@
 /comp/serializer/logscompression @DataDog/agent-log-pipelines
 /comp/serializer/metricscompression @DataDog/agent-metric-pipelines
 /comp/snmpscan @DataDog/ndm-core
+/comp/snmpscanmanager @DataDog/ndm-core
 /comp/softwareinventory @DataDog/windows-products
 /comp/syntheticstestscheduler @DataDog/synthetics-executing
 /comp/workloadselection @DataDog/injection-platform

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -39,6 +39,7 @@ import (
 
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	snmpscanfx "github.com/DataDog/datadog-agent/comp/snmpscan/fx"
+	snmpscanmanagerfx "github.com/DataDog/datadog-agent/comp/snmpscanmanager/fx"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/connectivity"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/firewallscanner"
@@ -153,6 +154,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf/rcservicemrfimpl"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rctelemetryreporter/rctelemetryreporterimpl"
 	metricscompressorfx "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
 	"github.com/DataDog/datadog-agent/comp/snmptraps"
 	snmptrapsServer "github.com/DataDog/datadog-agent/comp/snmptraps/server"
 	syntheticsTestsfx "github.com/DataDog/datadog-agent/comp/syntheticstestscheduler/fx"
@@ -298,6 +300,7 @@ func run(log log.Component,
 	_ healthplatform.Component,
 	hostname hostnameinterface.Component,
 	ipc ipc.Component,
+	snmpScanManager snmpscanmanager.Component,
 ) error {
 	defer func() {
 		stopAgent()
@@ -357,6 +360,7 @@ func run(log log.Component,
 		agenttelemetryComponent,
 		hostname,
 		ipc,
+		snmpScanManager,
 	); err != nil {
 		return err
 	}
@@ -501,6 +505,7 @@ func getSharedFxOption() fx.Option {
 		rdnsquerierfx.Module(),
 		snmptraps.Bundle(),
 		snmpscanfx.Module(),
+		snmpscanmanagerfx.Module(),
 		collectorimpl.Module(),
 		fx.Provide(func(demux demultiplexer.Component, hostname hostnameinterface.Component) (ddgostatsd.ClientInterface, error) {
 			return aggregator.NewStatsdDirect(demux, hostname)
@@ -574,6 +579,7 @@ func startAgent(
 	agenttelemetryComponent agenttelemetry.Component,
 	hostname hostnameinterface.Component,
 	ipc ipc.Component,
+	snmpScanManager snmpscanmanager.Component,
 ) error {
 	var err error
 
@@ -661,7 +667,7 @@ func startAgent(
 	jmxfetch.RegisterWith(ac)
 
 	// Set up check collector
-	commonchecks.RegisterChecks(wmeta, filterStore, tagger, cfg, telemetry, rcclient, flare)
+	commonchecks.RegisterChecks(wmeta, filterStore, tagger, cfg, telemetry, rcclient, flare, snmpScanManager)
 	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collectorComponent), demultiplexer, logReceiver, tagger, filterStore), true)
 
 	demultiplexer.AddAgentStartupTelemetry(version.AgentVersion)

--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -79,6 +79,7 @@ import (
 	processAgent "github.com/DataDog/datadog-agent/comp/process/agent"
 	publishermetadatacachefx "github.com/DataDog/datadog-agent/comp/publishermetadatacache/fx"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
 	softwareinventoryfx "github.com/DataDog/datadog-agent/comp/softwareinventory/fx"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
@@ -144,6 +145,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 			agenttelemetryComponent agenttelemetry.Component,
 			hostname hostnameinterface.Component,
 			ipc ipc.Component,
+			snmpScanManager snmpscanmanager.Component,
 		) error {
 			defer StopAgentWithDefaults()
 
@@ -167,6 +169,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 				agenttelemetryComponent,
 				hostname,
 				ipc,
+				snmpScanManager,
 			)
 			if err != nil {
 				return err

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -7,6 +7,7 @@
 package snmp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -283,9 +284,10 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	deviceID := namespace + ":" + connParams.IPAddress
 	// Start the scan
 	fmt.Printf("Launching scan for device: %s\n", deviceID)
-	err := snmpScanner.ScanDeviceAndSendData(connParams, namespace, snmpscan.ScanParams{
-		ScanType: metadata.ManualScan,
-	})
+	err := snmpScanner.ScanDeviceAndSendData(context.Background(), connParams, namespace,
+		snmpscan.ScanParams{
+			ScanType: metadata.ManualScan,
+		})
 	if err != nil {
 		fmt.Printf("Unable to perform device scan for device %s: %v\n", deviceID, err)
 		return err

--- a/comp/README.md
+++ b/comp/README.md
@@ -812,6 +812,12 @@ Package metricscompression provides the component for metrics compression
 
 Package snmpscan is a light component that can be used to perform a scan or a walk of a particular device
 
+### [comp/snmpscanmanager](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/snmpscanmanager)
+
+*Datadog Team*: ndm-core
+
+Package snmpscanmanager is a component that is used to manage SNMP device scans
+
 ### [comp/softwareinventory](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/softwareinventory)
 
 *Datadog Team*: windows-products

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -7,6 +7,7 @@
 package snmpscan
 
 import (
+	"context"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
@@ -20,7 +21,7 @@ import (
 // Component is the component type.
 type Component interface {
 	RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error
-	ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanParams ScanParams) error
+	ScanDeviceAndSendData(ctx context.Context, connParams *snmpparse.SNMPConfig, namespace string, scanParams ScanParams) error
 }
 
 // ScanParams contains options for a device scan

--- a/comp/snmpscan/impl/snmpscan.go
+++ b/comp/snmpscan/impl/snmpscan.go
@@ -7,6 +7,7 @@
 package snmpscanimpl
 
 import (
+	"context"
 	"errors"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -80,7 +81,8 @@ func (s snmpScannerImpl) startDeviceScan(task rcclienttypes.AgentTaskConfig) err
 		namespace = deviceNamespace
 	}
 
-	return s.ScanDeviceAndSendData(instance, namespace, snmpscan.ScanParams{
-		ScanType: metadata.RCTriggeredScan,
-	})
+	return s.ScanDeviceAndSendData(context.Background(), instance, namespace,
+		snmpscan.ScanParams{
+			ScanType: metadata.RCTriggeredScan,
+		})
 }

--- a/comp/snmpscan/mock/mock.go
+++ b/comp/snmpscan/mock/mock.go
@@ -9,34 +9,34 @@
 package mock
 
 import (
+	"context"
 	"testing"
 
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 
 	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/mock"
 )
 
-type snmpScanMock struct {
-	Logger log.Component
+// SnmpScanMock mocks snmpscan.Component
+type SnmpScanMock struct {
+	mock.Mock
 }
 
-// Provides that defines the output of mocked snmpscan component
-type Provides struct {
-	comp snmpscan.Component
+// Mock returns a mock for snmpscan component
+func Mock(_ *testing.T) snmpscan.Component {
+	return &SnmpScanMock{}
 }
 
-// New returns a mock snmpscanner
-func New(_ *testing.T) Provides {
-	return Provides{
-		comp: snmpScanMock{},
-	}
+// RunSnmpWalk is a mock function
+func (m *SnmpScanMock) RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error {
+	args := m.Called(snmpConection, firstOid)
+	return args.Error(0)
 }
 
-func (m snmpScanMock) RunSnmpWalk(_ *gosnmp.GoSNMP, _ string) error {
-	return nil
-}
-func (m snmpScanMock) ScanDeviceAndSendData(_ *snmpparse.SNMPConfig, _ string, _ snmpscan.ScanParams) error {
-	return nil
+// ScanDeviceAndSendData is a mock function
+func (m *SnmpScanMock) ScanDeviceAndSendData(ctx context.Context, connParams *snmpparse.SNMPConfig, namespace string, scanParams snmpscan.ScanParams) error {
+	args := m.Called(ctx, connParams, namespace, scanParams)
+	return args.Error(0)
 }

--- a/comp/snmpscanmanager/def/component.go
+++ b/comp/snmpscanmanager/def/component.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package snmpscanmanager is a component that is used to manage SNMP device scans
+package snmpscanmanager
+
+// team: ndm-core
+
+// Component is the component type
+type Component interface {
+	RequestScan(req ScanRequest)
+}
+
+// ScanRequest represents a device scan request
+type ScanRequest struct {
+	DeviceIP string
+}

--- a/comp/snmpscanmanager/fx/fx.go
+++ b/comp/snmpscanmanager/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the snmpscanmanager component
+package fx
+
+import (
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+	snmpscanmanagerimpl "github.com/DataDog/datadog-agent/comp/snmpscanmanager/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			snmpscanmanagerimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[snmpscanmanager.Component](),
+	)
+}

--- a/comp/snmpscanmanager/impl/devicescan.go
+++ b/comp/snmpscanmanager/impl/devicescan.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package snmpscanmanagerimpl
+
+import (
+	"time"
+)
+
+type deviceScansByIP map[string]deviceScan
+
+type deviceScan struct {
+	DeviceIP   string     `json:"device_ip"`
+	ScanStatus scanStatus `json:"scan_status"`
+	ScanEndTs  *time.Time `json:"scan_end_ts,omitempty"`
+}
+
+type scanStatus string
+
+const (
+	pendingStatus scanStatus = "pending"
+	successStatus scanStatus = "success"
+	failedStatus  scanStatus = "failed"
+)
+
+func (ds *deviceScan) isCacheable() bool {
+	return ds.ScanStatus == successStatus || ds.ScanStatus == failedStatus
+}

--- a/comp/snmpscanmanager/impl/devicescan_test.go
+++ b/comp/snmpscanmanager/impl/devicescan_test.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package snmpscanmanagerimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCacheable(t *testing.T) {
+	tests := []struct {
+		name               string
+		deviceScan         deviceScan
+		expectedIsCachable bool
+	}{
+		{
+			name: "pending device scan is not cachable",
+			deviceScan: deviceScan{
+				ScanStatus: pendingStatus,
+			},
+			expectedIsCachable: false,
+		},
+		{
+			name: "success device scan is cachable",
+			deviceScan: deviceScan{
+				ScanStatus: successStatus,
+			},
+			expectedIsCachable: true,
+		},
+		{
+			name: "failed device scan is cachable",
+			deviceScan: deviceScan{
+				ScanStatus: failedStatus,
+			},
+			expectedIsCachable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedIsCachable, tt.deviceScan.isCacheable())
+		})
+	}
+}

--- a/comp/snmpscanmanager/impl/mocks.go
+++ b/comp/snmpscanmanager/impl/mocks.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package snmpscanmanagerimpl
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type snmpConfigProviderMock struct {
+	mock.Mock
+}
+
+func newSnmpConfigProviderMock() *snmpConfigProviderMock {
+	return &snmpConfigProviderMock{}
+}
+
+func (m *snmpConfigProviderMock) GetDeviceConfig(deviceIP string, agentConfig config.Component, httpClient ipc.HTTPClient) (*snmpparse.SNMPConfig, string, error) {
+	args := m.Called(deviceIP, agentConfig, httpClient)
+
+	var snmpConfig *snmpparse.SNMPConfig
+	if v := args.Get(0); v != nil {
+		snmpConfig = v.(*snmpparse.SNMPConfig)
+	}
+
+	return snmpConfig, args.String(1), args.Error(2)
+}

--- a/comp/snmpscanmanager/impl/snmpconfigprovider.go
+++ b/comp/snmpscanmanager/impl/snmpconfigprovider.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package snmpscanmanagerimpl
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+)
+
+type snmpConfigProvider interface {
+	GetDeviceConfig(deviceIP string, agentConfig config.Component, httpClient ipc.HTTPClient) (*snmpparse.SNMPConfig, string, error)
+}
+
+type snmpConfigProviderImpl struct {
+}
+
+func newSnmpConfigProvider() snmpConfigProvider {
+	return &snmpConfigProviderImpl{}
+}
+
+func (p *snmpConfigProviderImpl) GetDeviceConfig(deviceIP string, agentConfig config.Component, httpClient ipc.HTTPClient) (*snmpparse.SNMPConfig, string, error) {
+	return snmpparse.GetParamsFromAgent(deviceIP, agentConfig, httpClient)
+}

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -66,6 +66,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		ctx:        ctx,
 		cancelFunc: cancelFunc,
 	}
+	scanManager.loadCache()
 
 	reqs.Lifecycle.Append(compdef.Hook{
 		OnStart: func(_ context.Context) error {
@@ -101,8 +102,6 @@ type snmpScanManagerImpl struct {
 }
 
 func (m *snmpScanManagerImpl) start() {
-	m.loadCache()
-
 	for i := 0; i < scanWorkers; i++ {
 		m.wg.Add(1)
 		go m.scanWorker()

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -141,9 +141,9 @@ func (m *snmpScanManagerImpl) RequestScan(req snmpscanmanager.ScanRequest) {
 			DeviceIP:   req.DeviceIP,
 			ScanStatus: pendingStatus,
 		}
-		m.log.Infof("Queued scan request for device %s", req.DeviceIP)
+		m.log.Infof("Queued default scan request for device %s", req.DeviceIP)
 	default:
-		m.log.Warnf("Dropping scan request for device %s, scan queue is full", req.DeviceIP)
+		m.log.Warnf("Dropping default scan request for device %s, scan queue is full", req.DeviceIP)
 	}
 }
 
@@ -161,7 +161,7 @@ func (m *snmpScanManagerImpl) scanWorker() {
 
 			err := m.processScanRequest(req)
 			if err != nil {
-				m.log.Errorf("Error processing scan request for device '%s': %v", req.DeviceIP, err)
+				m.log.Errorf("Error processing default scan request for device '%s': %v", req.DeviceIP, err)
 			}
 		}
 	}
@@ -208,7 +208,7 @@ func (m *snmpScanManagerImpl) processScanRequest(req snmpscanmanager.ScanRequest
 	})
 	m.writeCache()
 
-	m.log.Infof("Successfully processed scan request for device '%s'", req.DeviceIP)
+	m.log.Infof("Successfully processed default scan request for device '%s'", req.DeviceIP)
 
 	return nil
 }

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -1,0 +1,274 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package snmpscanmanagerimpl implements the snmpscanmanager component interface
+package snmpscanmanagerimpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+	"github.com/DataDog/datadog-agent/pkg/persistentcache"
+)
+
+const (
+	scanWorkers   = 2 // Max concurrent scans allowed
+	scanQueueSize = 10000
+
+	snmpCallsPerSecond = 8
+	snmpCallInterval   = time.Second / snmpCallsPerSecond
+
+	cacheKey = "snmp_scanned_devices"
+)
+
+// Requires defines the dependencies for the snmpscanmanager component
+type Requires struct {
+	compdef.In
+	Lifecycle  compdef.Lifecycle
+	Logger     log.Component
+	Config     config.Component
+	HTTPClient ipc.HTTPClient
+	Scanner    snmpscan.Component
+}
+
+// Provides defines the output of the snmpscanmanager component
+type Provides struct {
+	Comp snmpscanmanager.Component
+}
+
+// NewComponent creates a new snmpscanmanager component
+func NewComponent(reqs Requires) (Provides, error) {
+	scanManager := &snmpScanManagerImpl{
+		log:         reqs.Logger,
+		scanner:     reqs.Scanner,
+		agentConfig: reqs.Config,
+		httpClient:  reqs.HTTPClient,
+	}
+
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: func(_ context.Context) error {
+			scanManager.start()
+			return nil
+		},
+		OnStop: func(_ context.Context) error {
+			scanManager.stop()
+			return nil
+		},
+	})
+
+	return Provides{
+		Comp: scanManager,
+	}, nil
+}
+
+type snmpScanManagerImpl struct {
+	log         log.Component
+	scanner     snmpscan.Component
+	agentConfig config.Component
+	httpClient  ipc.HTTPClient
+
+	snmpConfigProvider snmpConfigProvider
+
+	scanQueue   chan snmpscanmanager.ScanRequest
+	deviceScans deviceScansByIP
+
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	wg         sync.WaitGroup
+	mtx        sync.Mutex
+}
+
+func (m *snmpScanManagerImpl) start() {
+	m.snmpConfigProvider = newSnmpConfigProvider()
+
+	m.scanQueue = make(chan snmpscanmanager.ScanRequest, scanQueueSize)
+	m.deviceScans = make(deviceScansByIP)
+	m.loadCache()
+
+	m.ctx, m.cancelFunc = context.WithCancel(context.Background())
+
+	for i := 0; i < scanWorkers; i++ {
+		m.wg.Add(1)
+		go m.scanWorker()
+	}
+}
+
+func (m *snmpScanManagerImpl) stop() {
+	m.cancelFunc()
+	close(m.scanQueue)
+
+	m.wg.Wait()
+}
+
+// RequestScan queues a new scan request when the device has not been already scanned
+func (m *snmpScanManagerImpl) RequestScan(req snmpscanmanager.ScanRequest) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	select {
+	case <-m.ctx.Done():
+		return
+	default:
+	}
+
+	if m.agentConfig.GetBool("network_devices.default_scan.disabled") {
+		return
+	}
+
+	_, exists := m.deviceScans[req.DeviceIP]
+	if exists {
+		return
+	}
+
+	select {
+	case m.scanQueue <- req:
+		m.deviceScans[req.DeviceIP] = deviceScan{
+			DeviceIP:   req.DeviceIP,
+			ScanStatus: pendingStatus,
+		}
+		m.log.Infof("Queued scan request for device %s", req.DeviceIP)
+	default:
+		m.log.Warnf("Dropping scan request for device %s, scan queue is full", req.DeviceIP)
+	}
+}
+
+func (m *snmpScanManagerImpl) scanWorker() {
+	defer m.wg.Done()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case req, ok := <-m.scanQueue:
+			if !ok {
+				return
+			}
+
+			err := m.processScanRequest(req)
+			if err != nil {
+				m.log.Errorf("Error processing scan request for device '%s': %v", req.DeviceIP, err)
+			}
+		}
+	}
+}
+
+func (m *snmpScanManagerImpl) processScanRequest(req snmpscanmanager.ScanRequest) error {
+	snmpConfig, namespace, err := m.snmpConfigProvider.GetDeviceConfig(req.DeviceIP, m.agentConfig, m.httpClient)
+	if err != nil {
+		now := time.Now()
+		m.setDeviceScan(deviceScan{
+			DeviceIP:   req.DeviceIP,
+			ScanStatus: failedStatus,
+			ScanEndTs:  &now,
+		})
+		m.writeCache()
+		return err
+	}
+
+	err = m.scanner.ScanDeviceAndSendData(m.ctx, snmpConfig, namespace,
+		snmpscan.ScanParams{
+			ScanType:     metadata.DefaultScan,
+			CallInterval: snmpCallInterval,
+		})
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+
+		now := time.Now()
+		m.setDeviceScan(deviceScan{
+			DeviceIP:   req.DeviceIP,
+			ScanStatus: failedStatus,
+			ScanEndTs:  &now,
+		})
+		m.writeCache()
+		return err
+	}
+
+	now := time.Now()
+	m.setDeviceScan(deviceScan{
+		DeviceIP:   req.DeviceIP,
+		ScanStatus: successStatus,
+		ScanEndTs:  &now,
+	})
+	m.writeCache()
+
+	m.log.Infof("Successfully processed scan request for device '%s'", req.DeviceIP)
+
+	return nil
+}
+
+func (m *snmpScanManagerImpl) loadCache() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	cacheValue, err := persistentcache.Read(cacheKey)
+	if err != nil {
+		m.log.Errorf("Error loading scanned devices cache: %v", err)
+		return
+	}
+	if cacheValue == "" {
+		return
+	}
+
+	var deviceScans []deviceScan
+	err = json.Unmarshal([]byte(cacheValue), &deviceScans)
+	if err != nil {
+		m.log.Errorf("Error unmarshaling scanned devices cache to JSON: %v", err)
+		return
+	}
+
+	for _, scan := range deviceScans {
+		m.deviceScans[scan.DeviceIP] = scan
+	}
+}
+
+func (m *snmpScanManagerImpl) writeCache() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	deviceScans := make([]deviceScan, 0)
+	for _, scan := range m.deviceScans {
+		if scan.isCacheable() {
+			deviceScans = append(deviceScans, scan)
+		}
+	}
+
+	cacheValue, err := json.Marshal(deviceScans)
+	if err != nil {
+		m.log.Errorf("Error marshaling scanned devices cache to JSON: %v", err)
+		return
+	}
+
+	err = persistentcache.Write(cacheKey, string(cacheValue))
+	if err != nil {
+		m.log.Errorf("Error writing scanned devices cache: %v", err)
+	}
+}
+
+func (m *snmpScanManagerImpl) setDeviceScan(deviceScan deviceScan) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	m.deviceScans[deviceScan.DeviceIP] = deviceScan
+}
+
+func (m *snmpScanManagerImpl) cloneDeviceScans() deviceScansByIP {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	return maps.Clone(m.deviceScans)
+}

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"maps"
 	"sync"
 	"time"
 
@@ -266,11 +265,4 @@ func (m *snmpScanManagerImpl) setDeviceScan(deviceScan deviceScan) {
 	defer m.mtx.Unlock()
 
 	m.deviceScans[deviceScan.DeviceIP] = deviceScan
-}
-
-func (m *snmpScanManagerImpl) cloneDeviceScans() deviceScansByIP {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	return maps.Clone(m.deviceScans)
 }

--- a/comp/snmpscanmanager/impl/snmpscanmanager_test.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager_test.go
@@ -513,12 +513,6 @@ func TestCacheIsLoaded(t *testing.T) {
 			provides, err := NewComponent(reqs)
 			assert.NoError(t, err)
 
-			err = mockLifecycle.Start(context.Background())
-			assert.NoError(t, err)
-
-			err = mockLifecycle.Stop(context.Background())
-			assert.NoError(t, err)
-
 			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
 			assert.True(t, ok)
 			assert.Equal(t, tt.buildExpectedDeviceScans(), scanManager.cloneDeviceScans())

--- a/comp/snmpscanmanager/impl/snmpscanmanager_test.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager_test.go
@@ -1,0 +1,649 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package snmpscanmanagerimpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	snmpscanmock "github.com/DataDog/datadog-agent/comp/snmpscan/mock"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/persistentcache"
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewComponent(t *testing.T) {
+	testDir := t.TempDir()
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("run_path", testDir)
+
+	mockLifecycle := compdef.NewTestLifecycle(t)
+	mockLogger := logmock.New(t)
+	mockIPC := ipcmock.New(t)
+	mockScanner := snmpscanmock.Mock(t)
+
+	reqs := Requires{
+		Lifecycle:  mockLifecycle,
+		Logger:     mockLogger,
+		Config:     mockConfig,
+		HTTPClient: mockIPC.GetClient(),
+		Scanner:    mockScanner,
+	}
+
+	provides, err := NewComponent(reqs)
+	assert.NoError(t, err)
+	assert.NotNil(t, provides.Comp)
+
+	mockLifecycle.AssertHooksNumber(1)
+
+	err = mockLifecycle.Start(context.Background())
+	assert.NoError(t, err)
+
+	err = mockLifecycle.Stop(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestRequestScan(t *testing.T) {
+	tests := []struct {
+		name                    string
+		configContent           map[string]interface{}
+		buildMockConfigProvider func() *snmpConfigProviderMock
+		buildMockScanner        func() *snmpscanmock.SnmpScanMock
+		scanReqs                []snmpscanmanager.ScanRequest
+		expectedDeviceScans     deviceScansByIP
+	}{
+		{
+			name: "default scan is disabled via config",
+			configContent: map[string]interface{}{
+				"network_devices.default_scan.disabled": true,
+			},
+			buildMockConfigProvider: func() *snmpConfigProviderMock {
+				mockConfigProvider := newSnmpConfigProviderMock()
+				return mockConfigProvider
+			},
+			buildMockScanner: func() *snmpscanmock.SnmpScanMock {
+				scanner := snmpscanmock.Mock(t)
+				mockScanner, ok := scanner.(*snmpscanmock.SnmpScanMock)
+				assert.True(t, ok)
+
+				return mockScanner
+			},
+			scanReqs: []snmpscanmanager.ScanRequest{
+				{
+					DeviceIP: "192.168.0.1",
+				},
+				{
+					DeviceIP: "192.168.0.2",
+				},
+			},
+			expectedDeviceScans: deviceScansByIP{},
+		},
+		{
+			name:          "default scan is enabled",
+			configContent: map[string]interface{}{},
+			buildMockConfigProvider: func() *snmpConfigProviderMock {
+				mockConfigProvider := newSnmpConfigProviderMock()
+
+				mockConfigProvider.On("GetDeviceConfig",
+					"192.168.0.1", mock.Anything, mock.Anything).
+					Return(&snmpparse.SNMPConfig{
+						IPAddress:       "192.168.0.1",
+						Port:            161,
+						CommunityString: "public",
+					}, "namespace", nil).
+					Once()
+
+				mockConfigProvider.On("GetDeviceConfig",
+					"192.168.0.2", mock.Anything, mock.Anything).
+					Return(nil, "", errors.New("some error")).
+					Once()
+
+				mockConfigProvider.On("GetDeviceConfig",
+					"10.0.0.1", mock.Anything, mock.Anything).
+					Return(&snmpparse.SNMPConfig{
+						IPAddress:       "10.0.0.1",
+						Port:            161,
+						CommunityString: "public",
+					}, "namespace", nil).
+					Once()
+
+				return mockConfigProvider
+			},
+			buildMockScanner: func() *snmpscanmock.SnmpScanMock {
+				scanner := snmpscanmock.Mock(t)
+				mockScanner, ok := scanner.(*snmpscanmock.SnmpScanMock)
+				assert.True(t, ok)
+
+				mockScanner.On("ScanDeviceAndSendData",
+					mock.Anything, &snmpparse.SNMPConfig{
+						IPAddress:       "192.168.0.1",
+						Port:            161,
+						CommunityString: "public",
+					}, "namespace", mock.Anything, mock.Anything).
+					Return(nil).
+					Once()
+
+				mockScanner.On("ScanDeviceAndSendData",
+					mock.Anything, &snmpparse.SNMPConfig{
+						IPAddress:       "10.0.0.1",
+						Port:            161,
+						CommunityString: "public",
+					}, "namespace", mock.Anything, mock.Anything).
+					Return(nil).
+					Once()
+
+				return mockScanner
+			},
+			scanReqs: []snmpscanmanager.ScanRequest{
+				{
+					DeviceIP: "192.168.0.1",
+				},
+				{
+					DeviceIP: "192.168.0.2",
+				},
+				{
+					DeviceIP: "192.168.0.2",
+				},
+				{
+					DeviceIP: "10.0.0.1",
+				},
+			},
+			expectedDeviceScans: deviceScansByIP{
+				"192.168.0.1": {
+					DeviceIP:   "192.168.0.1",
+					ScanStatus: successStatus,
+				},
+				"192.168.0.2": {
+					DeviceIP:   "192.168.0.2",
+					ScanStatus: failedStatus,
+				},
+				"10.0.0.1": {
+					DeviceIP:   "10.0.0.1",
+					ScanStatus: successStatus,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("run_path", testDir)
+			for key, value := range tt.configContent {
+				mockConfig.SetWithoutSource(key, value)
+			}
+
+			mockLifecycle := compdef.NewTestLifecycle(t)
+			mockLogger := logmock.New(t)
+			mockIPC := ipcmock.New(t)
+			mockScanner := tt.buildMockScanner()
+
+			reqs := Requires{
+				Lifecycle:  mockLifecycle,
+				Logger:     mockLogger,
+				Config:     mockConfig,
+				HTTPClient: mockIPC.GetClient(),
+				Scanner:    mockScanner,
+			}
+
+			provides, err := NewComponent(reqs)
+			assert.NoError(t, err)
+
+			err = mockLifecycle.Start(context.Background())
+			assert.NoError(t, err)
+
+			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
+			assert.True(t, ok)
+
+			mockConfigProvider := tt.buildMockConfigProvider()
+			scanManager.snmpConfigProvider = mockConfigProvider
+
+			for _, req := range tt.scanReqs {
+				provides.Comp.RequestScan(req)
+			}
+
+			assert.EventuallyWithT(t, func(t *assert.CollectT) {
+				actualDeviceScans := scanManager.cloneDeviceScans()
+				assert.Equal(t, len(tt.expectedDeviceScans), len(actualDeviceScans))
+				for _, actualScan := range actualDeviceScans {
+					expectedScan, exists := tt.expectedDeviceScans[actualScan.DeviceIP]
+					assert.True(t, exists)
+
+					assert.NotNil(t, actualScan.ScanEndTs)
+					actualScan.ScanEndTs = nil
+
+					assert.Equal(t, expectedScan, actualScan)
+				}
+			}, 4*time.Second, 200*time.Millisecond)
+
+			err = mockLifecycle.Stop(context.Background())
+			assert.NoError(t, err)
+
+			mockScanner.AssertExpectations(t)
+			mockConfigProvider.AssertExpectations(t)
+		})
+	}
+}
+
+func TestProcessScanRequest(t *testing.T) {
+	tests := []struct {
+		name                    string
+		buildMockConfigProvider func() *snmpConfigProviderMock
+		buildMockScanner        func() *snmpscanmock.SnmpScanMock
+		scanRequest             snmpscanmanager.ScanRequest
+		expectedDeviceScans     deviceScansByIP
+		expectedCacheContent    []deviceScan
+		expectError             bool
+	}{
+		{
+			name: "config provider returns an error",
+			buildMockConfigProvider: func() *snmpConfigProviderMock {
+				mockConfigProvider := newSnmpConfigProviderMock()
+				mockConfigProvider.On("GetDeviceConfig",
+					"127.0.0.1", mock.Anything, mock.Anything).
+					Return(nil, "", errors.New("some error")).
+					Once()
+
+				return mockConfigProvider
+			},
+			buildMockScanner: func() *snmpscanmock.SnmpScanMock {
+				scanner := snmpscanmock.Mock(t)
+				mockScanner, ok := scanner.(*snmpscanmock.SnmpScanMock)
+				assert.True(t, ok)
+
+				return mockScanner
+			},
+			scanRequest: snmpscanmanager.ScanRequest{
+				DeviceIP: "127.0.0.1",
+			},
+			expectedDeviceScans: deviceScansByIP{
+				"127.0.0.1": {
+					DeviceIP:   "127.0.0.1",
+					ScanStatus: failedStatus,
+				},
+			},
+			expectedCacheContent: []deviceScan{
+				{
+					DeviceIP:   "127.0.0.1",
+					ScanStatus: failedStatus,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "scan returns an error",
+			buildMockConfigProvider: func() *snmpConfigProviderMock {
+				mockConfigProvider := newSnmpConfigProviderMock()
+				mockConfigProvider.On("GetDeviceConfig",
+					"127.0.0.1", mock.Anything, mock.Anything).
+					Return(&snmpparse.SNMPConfig{
+						IPAddress:       "127.0.0.1",
+						Port:            161,
+						CommunityString: "public",
+					}, "namespace", nil).
+					Once()
+
+				return mockConfigProvider
+			},
+			buildMockScanner: func() *snmpscanmock.SnmpScanMock {
+				scanner := snmpscanmock.Mock(t)
+				mockScanner, ok := scanner.(*snmpscanmock.SnmpScanMock)
+				assert.True(t, ok)
+
+				mockScanner.On("ScanDeviceAndSendData",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(errors.New("some error")).
+					Once()
+
+				return mockScanner
+			},
+			scanRequest: snmpscanmanager.ScanRequest{
+				DeviceIP: "127.0.0.1",
+			},
+			expectedDeviceScans: deviceScansByIP{
+				"127.0.0.1": {
+					DeviceIP:   "127.0.0.1",
+					ScanStatus: failedStatus,
+				},
+			},
+			expectedCacheContent: []deviceScan{
+				{
+					DeviceIP:   "127.0.0.1",
+					ScanStatus: failedStatus,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "scan ok",
+			buildMockConfigProvider: func() *snmpConfigProviderMock {
+				mockConfigProvider := newSnmpConfigProviderMock()
+				mockConfigProvider.On("GetDeviceConfig",
+					"127.0.0.1", mock.Anything, mock.Anything).
+					Return(&snmpparse.SNMPConfig{
+						IPAddress:       "127.0.0.1",
+						Port:            161,
+						CommunityString: "public",
+					}, "namespace", nil).
+					Once()
+
+				return mockConfigProvider
+			},
+			buildMockScanner: func() *snmpscanmock.SnmpScanMock {
+				scanner := snmpscanmock.Mock(t)
+				mockScanner, ok := scanner.(*snmpscanmock.SnmpScanMock)
+				assert.True(t, ok)
+
+				mockScanner.On("ScanDeviceAndSendData",
+					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil).
+					Once()
+
+				return mockScanner
+			},
+			scanRequest: snmpscanmanager.ScanRequest{
+				DeviceIP: "127.0.0.1",
+			},
+			expectedDeviceScans: deviceScansByIP{
+				"127.0.0.1": {
+					DeviceIP:   "127.0.0.1",
+					ScanStatus: successStatus,
+				},
+			},
+			expectedCacheContent: []deviceScan{
+				{
+					DeviceIP:   "127.0.0.1",
+					ScanStatus: successStatus,
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("run_path", testDir)
+
+			mockLifecycle := compdef.NewTestLifecycle(t)
+			mockLogger := logmock.New(t)
+			mockIPC := ipcmock.New(t)
+			mockScanner := tt.buildMockScanner()
+
+			reqs := Requires{
+				Lifecycle:  mockLifecycle,
+				Logger:     mockLogger,
+				Config:     mockConfig,
+				HTTPClient: mockIPC.GetClient(),
+				Scanner:    mockScanner,
+			}
+
+			provides, err := NewComponent(reqs)
+			assert.NoError(t, err)
+
+			err = mockLifecycle.Start(context.Background())
+			assert.NoError(t, err)
+
+			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
+			assert.True(t, ok)
+
+			mockConfigProvider := tt.buildMockConfigProvider()
+			scanManager.snmpConfigProvider = mockConfigProvider
+			scanErr := scanManager.processScanRequest(tt.scanRequest)
+
+			err = mockLifecycle.Stop(context.Background())
+			assert.NoError(t, err)
+
+			if tt.expectError {
+				assert.Error(t, scanErr)
+			} else {
+				assert.NoError(t, scanErr)
+
+				actualDeviceScans := scanManager.cloneDeviceScans()
+				assert.Equal(t, len(tt.expectedDeviceScans), len(actualDeviceScans))
+				for _, actualScan := range actualDeviceScans {
+					expectedScan, exists := tt.expectedDeviceScans[actualScan.DeviceIP]
+					assert.True(t, exists)
+
+					assert.NotNil(t, actualScan.ScanEndTs)
+					actualScan.ScanEndTs = nil
+
+					assert.Equal(t, expectedScan, actualScan)
+				}
+
+				cacheContent, err := persistentcache.Read(cacheKey)
+				assert.NoError(t, err)
+				var actualCacheContent []deviceScan
+				assert.NoError(t, json.Unmarshal([]byte(cacheContent), &actualCacheContent))
+				for i := range actualCacheContent {
+					assert.NotNil(t, actualCacheContent[i].ScanEndTs)
+					actualCacheContent[i].ScanEndTs = nil
+				}
+				assert.ElementsMatch(t, tt.expectedCacheContent, actualCacheContent)
+			}
+
+			mockScanner.AssertExpectations(t)
+			mockConfigProvider.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCacheIsLoaded(t *testing.T) {
+	tests := []struct {
+		name                     string
+		cacheContent             string
+		buildExpectedDeviceScans func() deviceScansByIP
+	}{
+		{
+			name:                     "empty cache",
+			cacheContent:             "",
+			buildExpectedDeviceScans: func() deviceScansByIP { return deviceScansByIP{} },
+		},
+		{
+			name: "cache with multiple device scans",
+			cacheContent: `[
+    {
+        "device_ip":"127.0.0.1",
+        "scan_status":"success",
+        "scan_end_ts":"2025-11-04T13:21:20.365221+01:00"
+    },
+    {
+        "device_ip":"127.0.0.2",
+        "scan_status":"failed"
+    }
+]`,
+			buildExpectedDeviceScans: func() deviceScansByIP {
+				scanEndTs, err := time.Parse(time.RFC3339Nano, "2025-11-04T13:21:20.365221+01:00")
+				assert.NoError(t, err)
+
+				return deviceScansByIP{
+					"127.0.0.1": {
+						DeviceIP:   "127.0.0.1",
+						ScanStatus: successStatus,
+						ScanEndTs:  &scanEndTs,
+					},
+					"127.0.0.2": {
+						DeviceIP:   "127.0.0.2",
+						ScanStatus: failedStatus,
+					},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("run_path", testDir)
+
+			err := persistentcache.Write(cacheKey, tt.cacheContent)
+			assert.NoError(t, err)
+
+			mockLifecycle := compdef.NewTestLifecycle(t)
+			mockLogger := logmock.New(t)
+			mockIPC := ipcmock.New(t)
+			mockScanner := snmpscanmock.Mock(t)
+
+			reqs := Requires{
+				Lifecycle:  mockLifecycle,
+				Logger:     mockLogger,
+				Config:     mockConfig,
+				HTTPClient: mockIPC.GetClient(),
+				Scanner:    mockScanner,
+			}
+
+			provides, err := NewComponent(reqs)
+			assert.NoError(t, err)
+
+			err = mockLifecycle.Start(context.Background())
+			assert.NoError(t, err)
+
+			err = mockLifecycle.Stop(context.Background())
+			assert.NoError(t, err)
+
+			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
+			assert.True(t, ok)
+			assert.Equal(t, tt.buildExpectedDeviceScans(), scanManager.cloneDeviceScans())
+		})
+	}
+}
+
+func TestWriteCache(t *testing.T) {
+	tests := []struct {
+		name                      string
+		buildDeviceScans          func() deviceScansByIP
+		buildExpectedCacheContent func() []deviceScan
+	}{
+		{
+			name:                      "empty",
+			buildDeviceScans:          func() deviceScansByIP { return deviceScansByIP{} },
+			buildExpectedCacheContent: func() []deviceScan { return []deviceScan{} },
+		},
+		{
+			name: "multiple device scans",
+			buildDeviceScans: func() deviceScansByIP {
+				scanEndTs, err := time.Parse(time.RFC3339Nano, "2025-11-04T13:21:20.365221+01:00")
+				assert.NoError(t, err)
+
+				return deviceScansByIP{
+					"127.0.0.1": {
+						DeviceIP:   "127.0.0.1",
+						ScanStatus: successStatus,
+						ScanEndTs:  &scanEndTs,
+					},
+					"10.0.0.1": {
+						DeviceIP:   "10.0.0.1",
+						ScanStatus: successStatus,
+						ScanEndTs:  &scanEndTs,
+					},
+					"10.0.0.2": {
+						DeviceIP:   "10.0.0.2",
+						ScanStatus: failedStatus,
+					},
+				}
+			},
+			buildExpectedCacheContent: func() []deviceScan {
+				scanEndTs, err := time.Parse(time.RFC3339Nano, "2025-11-04T13:21:20.365221+01:00")
+				assert.NoError(t, err)
+
+				return []deviceScan{
+					{
+						DeviceIP:   "127.0.0.1",
+						ScanStatus: successStatus,
+						ScanEndTs:  &scanEndTs,
+					},
+					{
+						DeviceIP:   "10.0.0.1",
+						ScanStatus: successStatus,
+						ScanEndTs:  &scanEndTs,
+					},
+					{
+						DeviceIP:   "10.0.0.2",
+						ScanStatus: failedStatus,
+					},
+				}
+			},
+		},
+		{
+			name: "pending device scans are not written",
+			buildDeviceScans: func() deviceScansByIP {
+				return deviceScansByIP{
+					"127.0.0.1": {
+						DeviceIP:   "127.0.0.1",
+						ScanStatus: failedStatus,
+					},
+					"127.0.0.2": {
+						DeviceIP:   "127.0.0.2",
+						ScanStatus: pendingStatus,
+					},
+					"10.0.0.1": {
+						DeviceIP:   "10.0.0.1",
+						ScanStatus: pendingStatus,
+					},
+				}
+			},
+			buildExpectedCacheContent: func() []deviceScan {
+				return []deviceScan{
+					{
+						DeviceIP:   "127.0.0.1",
+						ScanStatus: failedStatus,
+					},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("run_path", testDir)
+
+			mockLifecycle := compdef.NewTestLifecycle(t)
+			mockLogger := logmock.New(t)
+			mockIPC := ipcmock.New(t)
+			mockScanner := snmpscanmock.Mock(t)
+
+			reqs := Requires{
+				Lifecycle:  mockLifecycle,
+				Logger:     mockLogger,
+				Config:     mockConfig,
+				HTTPClient: mockIPC.GetClient(),
+				Scanner:    mockScanner,
+			}
+
+			provides, err := NewComponent(reqs)
+			assert.NoError(t, err)
+
+			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
+			assert.True(t, ok)
+
+			scanManager.deviceScans = tt.buildDeviceScans()
+			scanManager.writeCache()
+
+			cacheContent, err := persistentcache.Read(cacheKey)
+			assert.NoError(t, err)
+
+			var actualCacheContent []deviceScan
+			assert.NoError(t, json.Unmarshal([]byte(cacheContent), &actualCacheContent))
+			assert.ElementsMatch(t, tt.buildExpectedCacheContent(), actualCacheContent)
+		})
+	}
+}

--- a/comp/snmpscanmanager/impl/snmpscanmanager_test.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager_test.go
@@ -204,14 +204,14 @@ func TestRequestScan(t *testing.T) {
 			provides, err := NewComponent(reqs)
 			assert.NoError(t, err)
 
-			err = mockLifecycle.Start(context.Background())
-			assert.NoError(t, err)
-
 			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
 			assert.True(t, ok)
 
 			mockConfigProvider := tt.buildMockConfigProvider()
 			scanManager.snmpConfigProvider = mockConfigProvider
+
+			err = mockLifecycle.Start(context.Background())
+			assert.NoError(t, err)
 
 			for _, req := range tt.scanReqs {
 				provides.Comp.RequestScan(req)
@@ -397,14 +397,15 @@ func TestProcessScanRequest(t *testing.T) {
 			provides, err := NewComponent(reqs)
 			assert.NoError(t, err)
 
-			err = mockLifecycle.Start(context.Background())
-			assert.NoError(t, err)
-
 			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
 			assert.True(t, ok)
 
 			mockConfigProvider := tt.buildMockConfigProvider()
 			scanManager.snmpConfigProvider = mockConfigProvider
+
+			err = mockLifecycle.Start(context.Background())
+			assert.NoError(t, err)
+
 			scanErr := scanManager.processScanRequest(tt.scanRequest)
 
 			err = mockLifecycle.Stop(context.Background())

--- a/comp/snmpscanmanager/mock/mock.go
+++ b/comp/snmpscanmanager/mock/mock.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+// Package mock provides a mock for the snmpscanmanager component
+package mock
+
+import (
+	"testing"
+
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// SnmpScanManagerMock mocks snmpscanmanager.Component
+type SnmpScanManagerMock struct {
+	mock.Mock
+}
+
+// Mock returns a mock for snmpscanmanager component
+func Mock(_ *testing.T) snmpscanmanager.Component {
+	return &SnmpScanManagerMock{}
+}
+
+// RequestScan is a mock function
+func (m *SnmpScanManagerMock) RequestScan(req snmpscanmanager.ScanRequest) {
+	m.Called(req)
+}

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -294,7 +294,7 @@ func run(
 	// TODO Ideally we would support RC in the check subcommand,
 	//  but at the moment this is not possible - only one process can access the RC database at a time,
 	//  so the subcommand can't read the RC database if the agent is also running.
-	commonchecks.RegisterChecks(wmeta, filterStore, tagger, config, telemetry, nil, nil)
+	commonchecks.RegisterChecks(wmeta, filterStore, tagger, config, telemetry, nil, nil, nil)
 
 	common.LoadComponents(secretResolver, wmeta, tagger, filterStore, ac, pkgconfigsetup.Datadog().GetString("confd_path"))
 	ac.LoadAndRun(context.Background())

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -212,6 +212,11 @@ func (d *DeviceCheck) GetIPAddress() string {
 	return d.config.IPAddress
 }
 
+// GetNamespace returns namespace
+func (d *DeviceCheck) GetNamespace() string {
+	return d.config.Namespace
+}
+
 // GetDeviceID returns device ID
 func (d *DeviceCheck) GetDeviceID() string {
 	return d.config.DeviceID

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -212,11 +212,6 @@ func (d *DeviceCheck) GetIPAddress() string {
 	return d.config.IPAddress
 }
 
-// GetNamespace returns namespace
-func (d *DeviceCheck) GetNamespace() string {
-	return d.config.Namespace
-}
-
 // GetDeviceID returns device ID
 func (d *DeviceCheck) GetDeviceID() string {
 	return d.config.DeviceID

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
@@ -7,17 +7,19 @@ package discovery
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/profile"
 	"net"
 	"testing"
 	"time"
 
+	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+	snmpscanmanagermock "github.com/DataDog/datadog-agent/comp/snmpscanmanager/mock"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/profile"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/session"
+
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
-
-	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/session"
 )
 
 func waitForDiscoveredDevices(discovery *Discovery, expectedDeviceCount int, timeout time.Duration) error {
@@ -60,7 +62,7 @@ func TestDiscovery(t *testing.T) {
 		IgnoredIPAddresses: map[string]bool{"192.168.0.5": true},
 		ProfileProvider:    profile.StaticProvider(nil),
 	}
-	discovery := NewDiscovery(checkConfig, sessionFactory, config)
+	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
 	discovery.Start()
 	assert.NoError(t, waitForDiscoveredDevices(discovery, 7, 2*time.Second))
 	discovery.Stop()
@@ -111,7 +113,7 @@ func TestDiscoveryCache(t *testing.T) {
 		DiscoveryWorkers:  1,
 		ProfileProvider:   profile.StaticProvider(nil),
 	}
-	discovery := NewDiscovery(checkConfig, sessionFactory, config)
+	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
 	discovery.Start()
 	assert.NoError(t, waitForDiscoveredDevices(discovery, 4, 2*time.Second))
 	discovery.Stop()
@@ -144,7 +146,7 @@ func TestDiscoveryCache(t *testing.T) {
 		DiscoveryWorkers:  0, // no workers, the devices will be loaded from cache
 		ProfileProvider:   profile.StaticProvider(nil),
 	}
-	discovery2 := NewDiscovery(checkConfig, sessionFactory, config)
+	discovery2 := NewDiscovery(checkConfig, sessionFactory, config, nil)
 	discovery2.Start()
 	assert.NoError(t, waitForDiscoveredDevices(discovery2, 4, 2*time.Second))
 	discovery2.Stop()
@@ -187,7 +189,7 @@ func TestDiscoveryTicker(t *testing.T) {
 		DiscoveryWorkers:  1,
 		ProfileProvider:   profile.StaticProvider(nil),
 	}
-	discovery := NewDiscovery(checkConfig, sessionFactory, config)
+	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
 	discovery.Start()
 	time.Sleep(1500 * time.Millisecond)
 	discovery.Stop()
@@ -236,7 +238,7 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	}
 
 	var sess *session.MockSession
-	discovery := NewDiscovery(checkConfig, session.NewMockSession, config)
+	discovery := NewDiscovery(checkConfig, session.NewMockSession, config, nil)
 
 	checkDeviceOnce := func() {
 		sess = session.CreateMockSession()
@@ -327,7 +329,7 @@ func TestDiscovery_createDevice(t *testing.T) {
 		Namespace:                "default",
 		ProfileProvider:          profile.StaticProvider(nil),
 	}
-	discovery := NewDiscovery(checkConfig, session.NewMockSession, config)
+	discovery := NewDiscovery(checkConfig, session.NewMockSession, config, nil)
 	ipAddr, ipNet, err := net.ParseCIDR(checkConfig.Network)
 	assert.Nil(t, err)
 	startingIP := ipAddr.Mask(ipNet.Mask)
@@ -376,4 +378,57 @@ func TestDiscovery_createDevice(t *testing.T) {
 	assert.Equal(t, true, present)
 	discovery.deleteDevice(device1Digest, subnet) // really deletes the device
 	assert.Equal(t, 2, len(discovery.discoveredDevices))
+}
+
+func TestDeviceScansAreRequested(t *testing.T) {
+	config := agentconfig.NewMock(t)
+	config.SetWithoutSource("run_path", t.TempDir())
+
+	sess := session.CreateMockSession()
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
+
+	checkConfig := &checkconfig.CheckConfig{
+		Network:           "192.168.0.0/30",
+		CommunityString:   "public",
+		DiscoveryInterval: 3600,
+		DiscoveryWorkers:  1,
+		ProfileProvider:   profile.StaticProvider(nil),
+	}
+
+	scanManager := snmpscanmanagermock.Mock(t)
+	mockScanManager, ok := scanManager.(*snmpscanmanagermock.SnmpScanManagerMock)
+	assert.True(t, ok)
+
+	mockScanManager.On("RequestScan", snmpscanmanager.ScanRequest{
+		DeviceIP: "192.168.0.0",
+	}).Once()
+	mockScanManager.On("RequestScan", snmpscanmanager.ScanRequest{
+		DeviceIP: "192.168.0.1",
+	}).Once()
+	mockScanManager.On("RequestScan", snmpscanmanager.ScanRequest{
+		DeviceIP: "192.168.0.2",
+	}).Once()
+	mockScanManager.On("RequestScan", snmpscanmanager.ScanRequest{
+		DeviceIP: "192.168.0.3",
+	}).Once()
+
+	discovery := NewDiscovery(checkConfig, sessionFactory, config, scanManager)
+	discovery.Start()
+	assert.NoError(t, waitForDiscoveredDevices(discovery, 4, 2*time.Second))
+	discovery.Stop()
+
+	mockScanManager.AssertExpectations(t)
 }

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -11,14 +11,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
-
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
-
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -49,6 +48,7 @@ type Check struct {
 	sessionFactory             session.Factory
 	workerRunDeviceCheckErrors *atomic.Uint64
 	agentConfig                config.Component
+	scanManager                snmpscanmanager.Component
 }
 
 // Run executes the check
@@ -159,12 +159,20 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	}
 
 	if c.config.IsDiscovery() {
-		c.discovery = discovery.NewDiscovery(c.config, c.sessionFactory, c.agentConfig)
+		c.discovery = discovery.NewDiscovery(c.config, c.sessionFactory, c.agentConfig, c.scanManager)
 		c.discovery.Start()
 	} else {
 		c.singleDeviceCk, err = devicecheck.NewDeviceCheck(c.config, c.config.IPAddress, c.sessionFactory, c.agentConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create device check: %s", err)
+		}
+
+		if c.scanManager == nil {
+			log.Errorf("SNMP scan manager not initialized, could not request device scan for '%s'", c.singleDeviceCk.GetIPAddress())
+		} else {
+			c.scanManager.RequestScan(snmpscanmanager.ScanRequest{
+				DeviceIP: c.singleDeviceCk.GetIPAddress(),
+			})
 		}
 	}
 	return nil
@@ -205,18 +213,19 @@ func (c *Check) IsHASupported() bool {
 }
 
 // Factory creates a new check factory
-func Factory(agentConfig config.Component, rcClient rcclient.Component) option.Option[func() check.Check] {
+func Factory(agentConfig config.Component, rcClient rcclient.Component, scanManager snmpscanmanager.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {
-		return newCheck(agentConfig, rcClient)
+		return newCheck(agentConfig, rcClient, scanManager)
 	})
 }
 
-func newCheck(agentConfig config.Component, rcClient rcclient.Component) check.Check {
+func newCheck(agentConfig config.Component, rcClient rcclient.Component, scanManager snmpscanmanager.Component) check.Check {
 	return &Check{
 		rcClient:                   rcClient,
 		CheckBase:                  core.NewCheckBase(common.SnmpIntegrationName),
 		sessionFactory:             session.NewGosnmpSession,
 		workerRunDeviceCheckErrors: atomic.NewUint64(0),
 		agentConfig:                agentConfig,
+		scanManager:                scanManager,
 	}
 }

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -17,6 +17,7 @@ import (
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
 	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/agentprofiling"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm"
@@ -67,7 +68,7 @@ import (
 
 // RegisterChecks registers all core checks
 func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Component, tagger tagger.Component, cfg config.Component,
-	telemetry telemetry.Component, rcClient rcclient.Component, flare flare.Component,
+	telemetry telemetry.Component, rcClient rcclient.Component, flare flare.Component, snmpScanManager snmpscanmanager.Component,
 ) {
 	// Required checks
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
@@ -76,7 +77,7 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(telemetryCheck.CheckName, telemetryCheck.Factory(telemetry))
 	corecheckLoader.RegisterCheck(ntp.CheckName, ntp.Factory())
 	corecheckLoader.RegisterCheck(wlan.CheckName, wlan.Factory())
-	corecheckLoader.RegisterCheck(snmp.CheckName, snmp.Factory(cfg, rcClient))
+	corecheckLoader.RegisterCheck(snmp.CheckName, snmp.Factory(cfg, rcClient, snmpScanManager))
 	corecheckLoader.RegisterCheck(networkpath.CheckName, networkpath.Factory(telemetry))
 	corecheckLoader.RegisterCheck(io.CheckName, io.Factory())
 	corecheckLoader.RegisterCheck(filehandles.CheckName, filehandles.Factory())

--- a/pkg/commonchecks/corechecks_cluster.go
+++ b/pkg/commonchecks/corechecks_cluster.go
@@ -17,6 +17,7 @@ import (
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
 	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm"
@@ -26,7 +27,7 @@ import (
 
 // RegisterChecks registers the checks that can run in the Cluster Agent
 func RegisterChecks(store workloadmeta.Component, _ workloadfilter.Component, tagger tagger.Component, cfg config.Component,
-	_ telemetry.Component, _ rcclient.Component, _ flare.Component) {
+	_ telemetry.Component, _ rcclient.Component, _ flare.Component, _ snmpscanmanager.Component) {
 	corecheckLoader.RegisterCheck(kubernetesapiserver.CheckName, kubernetesapiserver.Factory(tagger))
 	corecheckLoader.RegisterCheck(ksm.CheckName, ksm.Factory(tagger, store))
 	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())

--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -106,6 +106,8 @@ const (
 	ManualScan ScanType = "manual"
 	// RCTriggeredScan represents a rc triggered scan
 	RCTriggeredScan ScanType = "rc_triggered"
+	// DefaultScan represents a default scan
+	DefaultScan ScanType = "default"
 )
 
 // ScanStatusMetadata contains scan status metadata

--- a/releasenotes/notes/snmp-device-scan-by-default-2027376e2ea7a770.yaml
+++ b/releasenotes/notes/snmp-device-scan-by-default-2027376e2ea7a770.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The SNMP integration now automatically performs a default device scan for each configured and auto-discovered device.


### PR DESCRIPTION
### What does this PR do?

This PR makes the SNMP device scan enabled by default for every SNMP devices.
It does that by creating a new `snmpscanmanager` component that will handle the device scans.

### Motivation

### Describe how you validated your changes

Tested locally that:
- Configured devices with instance configs have their scan ran.
- Devices discovered from auto-discovery have their scan ran.
- Devices discovered from the legacy auto-discovery have their scan ran.

Also tested by installing the Agent on mimic and ensure that all devices have been scanned.

### Additional Notes
