### PR TITLE
add ddinjector to tracked driver

### DIFF
--- a/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
+++ b/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
@@ -44,6 +44,7 @@ var (
 	ddDrivers = map[string]struct{}{
 		"ddnpm":       {}, // NPM/USM driver, used for network monitoring
 		"ddprocmon":   {}, // process monitoring driver, used for CWS
+		"ddinjector":  {}, // application tracing driver, used for APM
 		"crashdriver": {}, // this entry exists only for testing purposes.
 	}
 	// system probe enabled flags indicating we should be enabled


### PR DESCRIPTION
### What does this PR do?
This PR adds ddinjector to our tracked list of drivers. This will give us crash dump alerts if this driver crashes on any device.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1971

### Describe how you validated your changes
Manually tested by crashing ddinjector, via adding a null deref to DriverEntry. Verified that it sent an alert to us. 

### Additional Notes
