### PR TITLE
perf: optimize FormatKeyValueTag with strings.Builder and improve test coverage

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags.go
@@ -16,7 +16,7 @@
 package utils
 
 import (
-	"fmt"
+	"strings"
 )
 
 // FormatKeyValueTag takes a key-value pair, and creates a tag string out of it
@@ -25,5 +25,11 @@ func FormatKeyValueTag(key, value string) string {
 	if value == "" {
 		value = "n/a"
 	}
-	return fmt.Sprintf("%s:%s", key, value)
+	// Pre-allocate buffer with known capacity to avoid multiple allocations
+	var builder strings.Builder
+	builder.Grow(len(key) + len(value) + 1) // +1 for the colon
+	builder.WriteString(key)
+	builder.WriteString(":")
+	builder.WriteString(value)
+	return builder.String()
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/internal/utils/tags_test.go
@@ -16,21 +16,59 @@ package utils
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatKeyValueTag(t *testing.T) {
 	tests := []struct {
-		key         string
-		value       string
-		expectedTag string
+		name     string
+		key      string
+		value    string
+		expected string
 	}{
-		{"a.test.tag", "a.test.value", "a.test.tag:a.test.value"},
-		{"a.test.tag", "", "a.test.tag:n/a"},
+		{
+			name:     "normal key value pair",
+			key:      "service",
+			value:    "api",
+			expected: "service:api",
+		},
+		{
+			name:     "empty value should be replaced with n/a",
+			key:      "version",
+			value:    "",
+			expected: "version:n/a",
+		},
+		{
+			name:     "empty key with value",
+			key:      "",
+			value:    "test",
+			expected: ":test",
+		},
+		{
+			name:     "both empty",
+			key:      "",
+			value:    "",
+			expected: ":n/a",
+		},
+		{
+			name:     "special characters in key and value",
+			key:      "env:prod",
+			value:    "region:us-east-1",
+			expected: "env:prod:region:us-east-1",
+		},
+		{
+			name:     "long key and value",
+			key:      "very-long-key-name-that-might-cause-allocations",
+			value:    "very-long-value-that-might-cause-allocations",
+			expected: "very-long-key-name-that-might-cause-allocations:very-long-value-that-might-cause-allocations",
+		},
 	}
 
-	for _, testInstance := range tests {
-		assert.Equal(t, testInstance.expectedTag, FormatKeyValueTag(testInstance.key, testInstance.value))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatKeyValueTag(tt.key, tt.value)
+			if result != tt.expected {
+				t.Errorf("FormatKeyValueTag(%q, %q) = %q, want %q", tt.key, tt.value, result, tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Optimizes the `FormatKeyValueTag` function in the OpenTelemetry metrics mapping utilities by replacing `fmt.Sprintf` with `strings.Builder` for better performance. Also refactors the test suite to use standard Go testing patterns instead of the testify library and adds comprehensive test cases.

### Motivation

The `fmt.Sprintf` approach causes multiple memory allocations when formatting tag strings. By using `strings.Builder` with pre-allocated capacity, we can reduce memory allocations and improve performance, especially when processing large volumes of metrics data.

### Describe how you validated your changes

Run unit test 

### Additional Notes

- Replaced `fmt.Sprintf("%s:%s", key, value)` with `strings.Builder` approach
- Pre-allocates buffer capacity to avoid multiple allocations
- Removed dependency on testify library in tests
- Added comprehensive test cases including edge cases like empty keys/values and special characters
- Maintains backward compatibility - function behavior remains unchanged