### PR TITLE
Fix default value for automountServiceAccountToken on ServiceAccount

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/serviceaccount.go
@@ -24,6 +24,9 @@ func ExtractServiceAccount(ctx processors.ProcessorContext, sa *corev1.ServiceAc
 	}
 	if sa.AutomountServiceAccountToken != nil {
 		serviceAccount.AutomountServiceAccountToken = *sa.AutomountServiceAccountToken
+	} else {
+		// Default to true if not set see https://github.com/kubernetes/kubernetes/blob/71fa43e37f198ae8035a96ff9f1c112b03b9e0fa/plugin/pkg/admission/serviceaccount/admission.go#L264.
+		serviceAccount.AutomountServiceAccountToken = true
 	}
 	// Extract secret references.
 	for _, secret := range sa.Secrets {

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/serviceaccount_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/serviceaccount_test.go
@@ -33,7 +33,66 @@ func TestExtractServiceAccount(t *testing.T) {
 	}{
 		"standard": {
 			input: corev1.ServiceAccount{
-				AutomountServiceAccountToken: pointer.Ptr(true),
+				AutomountServiceAccountToken: pointer.Ptr(false),
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{
+						Name: "registry-key",
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"annotation": "my-annotation",
+					},
+					CreationTimestamp: creationTime,
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Name:            "service-account",
+					Namespace:       "namespace",
+					ResourceVersion: "1234",
+					UID:             types.UID("e42e5adc-0749-11e8-a2b8-000c29dea4f6"),
+				},
+				Secrets: []corev1.ObjectReference{
+					{
+						Name: "default-token-uudge",
+					},
+				},
+			},
+			labelsAsTags: map[string]string{
+				"app": "application",
+			},
+			annotationsAsTags: map[string]string{
+				"annotation": "annotation_key",
+			},
+			expected: model.ServiceAccount{
+				AutomountServiceAccountToken: false,
+				ImagePullSecrets: []*model.TypedLocalObjectReference{
+					{
+						Name: "registry-key",
+					},
+				},
+				Metadata: &model.Metadata{
+					Annotations:       []string{"annotation:my-annotation"},
+					CreationTimestamp: creationTime.Unix(),
+					Labels:            []string{"app:my-app"},
+					Name:              "service-account",
+					Namespace:         "namespace",
+					ResourceVersion:   "1234",
+					Uid:               "e42e5adc-0749-11e8-a2b8-000c29dea4f6",
+				},
+				Secrets: []*model.ObjectReference{
+					{
+						Name: "default-token-uudge",
+					},
+				},
+				Tags: []string{
+					"application:my-app",
+					"annotation_key:my-annotation",
+				},
+			},
+		},
+		"missing service account token automount": {
+			input: corev1.ServiceAccount{
 				ImagePullSecrets: []corev1.LocalObjectReference{
 					{
 						Name: "registry-key",

--- a/releasenotes-dca/notes/k8s-serviceaccount-automount-04d2f8f39d16a71d.yaml
+++ b/releasenotes-dca/notes/k8s-serviceaccount-automount-04d2f8f39d16a71d.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix default value of automountServiceAccountToken on ServiceAccounts when not set.


### PR DESCRIPTION
### What does this PR do?
Fix the orchestrator check extraction logic of automountServiceAccountToken for ServiceAccount objects which were not reported with the right value when the property is not set.

### Change validation
- Added/updated unit tests.
- Deployed this image locally and verified the field was properly reported.