### PR TITLE
Instruct GitLab to delete corrupted caches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -253,6 +253,7 @@ variables:
   GET_SOURCES_ATTEMPTS: 2
   RESTORE_CACHE_ATTEMPTS: 2
   # Feature flags
+  FF_CLEAN_UP_FAILED_CACHE_EXTRACT: true # Delete corrupted caches, see https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4565
   FF_SCRIPT_SECTIONS: 1 # Prevent multiline scripts log collapsing, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/3392
   FF_KUBERNETES_HONOR_ENTRYPOINT: true # Honor the entrypoint in the Docker image when running Kubernetes jobs
   FF_TIMESTAMPS: true


### PR DESCRIPTION
### What does this PR do?
Enables `FF_CLEAN_UP_FAILED_CACHE_EXTRACT` to instruct GitLab runners to automatically delete corrupted cache archives when their extraction fails.
<img width="1083" height="82" alt="image" src="https://github.com/user-attachments/assets/7fb99fbc-62ec-4efb-b60d-c9aef9ea320e" />

### Motivation
We've experienced recurring cache corruption issues in CI, particularly affecting Omnibus, Go and Bazel (build and/or dependency) caches on macOS runners:
- > Cannot find central directory
- > Corrupted input data
- > Failed to extract dependencies
- > Input/output error
- > Unrecognized archive format
- > file is invalid or corrupted
- > missing end of central directory record
- > not a valid zip file
- etc.

When encountering a corrupted cache archive, it turns out that the default behavior of GitLab runners does not respect the "fail-fast" principle by instead continuing a clearly flawed process, merely logging a `FATAL: zip: checksum error` message (_collapsed_, so barely noticeable) and continuing, which sometimes leads to jobs using [corrupted or incomplete state](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/36988).
<img width="1022" height="194" alt="image" src="https://github.com/user-attachments/assets/aae7ad7f-3a28-4b7c-94d4-7280c384918e" />

This has caused various downstream failures including build errors and infrastructure-like issues (#incident-42947, #incident-33553). Additionally, "cosmic bit flips" have been reported in Agent-related Slack channels - single-character changes in filenames or source file contents that suggest underlying data integrity issues (hardware bit flips or software bugs in the cache handling layer).

The project has attempted various, more or less related, workarounds over the past two years:
- **2024-01** 6bf34dfd0c (#22341): Add `RESTORE_CACHE_ATTEMPTS=2` to retry cache extraction failures at the runner stage level.
- **2025-01** 6212370e6f (#32671, #incident-33553): Add exit code 101 for tar extraction failures in Go deps jobs and retry on that code.
- **2025-09** 751d570981 + 5505f7e4ab: Temporarily disable omnibus S3 cache entirely, then re-enable (investigating correlation with failures).
- **2025-10** e4dda50b81 (#41799): Hotfix to restore `$BAZEL_REAL`'s exec bit when lost in cache → reverted because it masked underlying corruption.
- **2025-10** cd5886392d (#42273): Use distinct cache key prefix for Bazel version-dependent binaries to eliminate potential GitLab confusion between cache keys.

Nevertheless, corrupted cache archives might remain in place and reused in subsequent pipeline runs or parallel jobs.

`FF_CLEAN_UP_FAILED_CACHE_EXTRACT` (introduced in [gitlab-runner!4565](https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4565#why-was-this-mr-needed) since [version 16.8](https://gitlab.com/gitlab-org/gitlab-runner/-/blob/16-8-stable/CHANGELOG.md#bug-fixes-1), Feb. 2024) addresses the problem closer to its root by deleting corrupted cache archives on extraction failure, which makes sure a clean cache is rebuilt on the next run and prevents jobs from silently continuing with partial/corrupted state.

This is safer than working around corruption because it removes risks we build Agent release candidates on top of known-bad state.

### Describe how you validated your changes
Verified that no GitLab cache `paths:` contain environment variables, which would trigger gitlab-runner#38792 (a bug where the feature flag fails with variable interpolation). All cache paths use static relative paths like `omnibus/vendor/bundle`, `modcache.tar.xz`, `.cache/bazelisk`, etc.

### Additional Notes
- [Bug report](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/36988)
- [Feature flag MR](https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4565)
- [Actual corruptions](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22FATAL%3A%20zip%3A%20not%20a%20valid%20zip%20file%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1759874400000&to_ts=1761170399999&live=false)