### PR TITLE
Fix fips compliance e2e test

### DIFF
--- a/test/new-e2e/tests/fips-compliance/fips_nix_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_nix_test.go
@@ -45,11 +45,10 @@ func TestLinuxFIPSComplianceSuite(t *testing.T) {
 		awshost.WithAgentOptions(
 			agentparams.WithFlavor("datadog-fips-agent"),
 			// Install custom check that reports the FIPS mode of Python
-			// TODO ADXT-881: Need forward slashes to workaround test-infra bug
 			agentparams.WithFile(
 				`/etc/datadog-agent/checks.d/e2e_fips_test.py`,
 				fipsTestCheck,
-				false,
+				true,
 			),
 			agentparams.WithFile(
 				`/etc/datadog-agent/conf.d/e2e_fips_test.yaml`,


### PR DESCRIPTION
### What does this PR do?
Use sudo when creating the custom check file in fips compliance e2e test.

### Motivation
The test sometimes fails due to failing to delete the file during cleanup, hopefully if it's created with sudo it'll be deleted with sudo, which would fix the permission issue.
Not sure what the root cause is (probably bad timing in the framework).

### Describe how you validated your changes
CI

### Additional Notes
