### PR TITLE
discovery: Remove recursive link in test data

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/testdata/root/testdata/bins/notjs
+++ b/pkg/collector/corechecks/servicediscovery/usm/testdata/root/testdata/bins/notjs
@@ -1,1 +1,1 @@
-../
+package.json


### PR DESCRIPTION
### What does this PR do?

There's a recursive link in the discovery test data which apparently
causes problems on Windows. We don't actually need a recursive link for
the test, we just need the "notjs" to be a valid symlink to a
non-Javascript file whose parent directory contains a package.json.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-1184

### Describe how you validated your changes

Tested by introducing a bug by removing the isJs() check after
the call to ReadlinkFS() in
pkg/collector/corechecks/servicediscovery/usm/nodejs.go and ensuring
that the test still fails and catches the bug with this new symlink (if
the symlink is dangling, the test passes and doesn't catch the bug).
