### PR TITLE
[CWS] make sure to use the correct Pid when sorting events

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -830,7 +830,7 @@ func (p *EBPFProbe) playSnapshot(notifyConsumers bool) {
 		tsA := eventA.ProcessContext.ExecTime
 		tsB := eventB.ProcessContext.ExecTime
 		if tsA.IsZero() || tsB.IsZero() || tsA.Equal(tsB) {
-			return eventA.PIDContext.Pid < eventB.PIDContext.Pid
+			return eventA.ProcessContext.Pid < eventB.ProcessContext.Pid
 		}
 
 		return tsA.Before(tsB)


### PR DESCRIPTION
### What does this PR do?

When re-playing the snapshot, the `PIDContext` is not set, this PR fixes this by reading the pid from the process context instead.

### Motivation

### Describe how you validated your changes

### Additional Notes
