### PR TITLE
cluster-agent: simplify security-agent-policies fetching

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -65,9 +65,7 @@ def build(
     build_context = "Dockerfiles/cluster-agent"
     policies_path = f"{build_context}/security-agent-policies"
     ctx.run(f"rm -rf {policies_path}")
-    ctx.run(f"git clone {POLICIES_REPO} {policies_path}")
-    if policies_version != "master":
-        ctx.run(f"cd {policies_path} && git checkout {policies_version}")
+    ctx.run(f"git clone --branch={policies_version} --depth=1 {POLICIES_REPO} {policies_path}")
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Simplify the security agent policies cloning when building the cluster agent, always downloading the correct branch, and no additional git objects. 

### Motivation

### Describe how you validated your changes

### Additional Notes
