### PR TITLE
[CWS] skip `TestContainerCreatedAt` on centos 7

### DIFF
--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -32,6 +32,10 @@ func TestContainerCreatedAt(t *testing.T) {
 		return kv.IsOpenSUSELeap15_3Kernel()
 	})
 
+	checkKernelCompatibility(t, "ContainerCreatedAt test not consistent on CentOS7", func(kv *kernel.Version) bool {
+		return kv.IsRH7Kernel()
+	})
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_container_created_at",


### PR DESCRIPTION
### What does this PR do?

Similar to user group test, this test is flaky on centos 7. Let's skip it for now until we find a better fix.

### Motivation

### Describe how you validated your changes

### Additional Notes
