### PR TITLE
[Backport 7.69.x] [SUSM-143] Add kprobe fallbacks on kernels < 4.15

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -582,4 +582,11 @@ int raw_tracepoint__sched_process_exit(void *ctx) {
     return 0;
 }
 
+// kprobe fallback for kernels < 4.15 that don't support multiple tracepoint attachments
+SEC("kprobe/do_exit")
+int BPF_BYPASSABLE_KPROBE(kprobe__do_exit) {
+    delete_pid_in_maps();
+    return 0;
+}
+
 #endif

--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -101,14 +101,19 @@ static __always_inline void push_event_if_relevant(void *ctx, lib_path_t *path, 
     }
 }
 
-static __always_inline void do_sys_open_helper_exit(exit_sys_ctx *args) {
+// Helper function for syscall exit handling - takes ctx and return value separately
+// to support both tracepoint (where ctx is the tracepoint args) and kretprobe (where
+// ctx is the real eBPF context pointer) callers. This separation is critical for
+// kernel 4.14 compatibility, as the verifier rejects passing stack pointers to
+// bpf_perf_event_output (which requires a real ctx pointer).
+static __always_inline void do_sys_open_helper_exit(void *ctx, long ret) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     lib_path_t *path = bpf_map_lookup_elem(&open_at_args, &pid_tgid);
     if (path == NULL) {
         return;
     }
 
-    push_event_if_relevant(args, path, args->ret);
+    push_event_if_relevant(ctx, path, ret);
     bpf_map_delete_elem(&open_at_args, &pid_tgid);
     return;
 }
@@ -137,7 +142,7 @@ int tracepoint__syscalls__sys_enter_open(enter_sys_open_ctx *args) {
 SEC("tracepoint/syscalls/sys_exit_open")
 int tracepoint__syscalls__sys_exit_open(exit_sys_ctx *args) {
     CHECK_BPF_PROGRAM_BYPASSED()
-    do_sys_open_helper_exit(args);
+    do_sys_open_helper_exit(args, args->ret);
     return 0;
 }
 
@@ -156,7 +161,7 @@ int tracepoint__syscalls__sys_enter_openat(enter_sys_openat_ctx *args) {
 SEC("tracepoint/syscalls/sys_exit_openat")
 int tracepoint__syscalls__sys_exit_openat(exit_sys_ctx *args) {
     CHECK_BPF_PROGRAM_BYPASSED()
-    do_sys_open_helper_exit(args);
+    do_sys_open_helper_exit(args, args->ret);
     return 0;
 }
 
@@ -179,7 +184,7 @@ int tracepoint__syscalls__sys_enter_openat2(enter_sys_openat2_ctx *args) {
 SEC("tracepoint/syscalls/sys_exit_openat2")
 int tracepoint__syscalls__sys_exit_openat2(exit_sys_ctx *args) {
     CHECK_BPF_PROGRAM_BYPASSED()
-    do_sys_open_helper_exit(args);
+    do_sys_open_helper_exit(args, args->ret);
     return 0;
 }
 
@@ -193,6 +198,51 @@ int BPF_BYPASSABLE_PROG(do_sys_openat2_exit, int dirfd, const char *pathname, op
     if (fill_lib_path(&path, pathname)) {
         push_event_if_relevant(ctx, &path, ret);
     }
+    return 0;
+}
+
+// Kprobe fallbacks for kernels < 4.15 that don't support multiple tracepoint attachments
+//
+// Background:
+// - On kernel >= 4.15: We use tracepoint/syscalls/sys_enter_open and tracepoint/syscalls/sys_exit_open
+//                       (same for sys_enter_openat/sys_exit_openat)
+// - On kernel < 4.15: Multiple tracepoint attachments fail with "file exists" error
+//                      So we use kprobes on the underlying kernel function instead
+//
+// Important: Both open() and openat() syscalls call the same kernel function do_sys_open(),
+// so a single kprobe/kretprobe pair catches both syscalls.
+//
+// Note: We don't need fallbacks for openat2() because it was introduced in kernel 5.6,
+// which is much newer than our 4.15 cutoff.
+
+// kprobe on do_sys_open - entry point for both open() and openat() syscalls
+// Kernel function signature: long do_sys_open(int dfd, const char __user *filename, int flags, umode_t mode)
+// This replaces both:
+// - tracepoint/syscalls/sys_enter_open
+// - tracepoint/syscalls/sys_enter_openat
+SEC("kprobe/do_sys_open")
+int BPF_BYPASSABLE_KPROBE(kprobe__do_sys_open, int dfd, const char *filename, int flags) {
+    // Skip write-only opens - we only care about shared library loads (read operations)
+    if (should_ignore_flags(flags)) {
+        return 0;
+    }
+
+    // Store the filename in a map keyed by pid_tgid for correlation with the return value
+    do_sys_open_helper_enter(filename);
+    return 0;
+}
+
+// kretprobe on do_sys_open - captures the return value (file descriptor or error code)
+// This replaces both:
+// - tracepoint/syscalls/sys_exit_open
+// - tracepoint/syscalls/sys_exit_openat
+SEC("kretprobe/do_sys_open")
+int BPF_BYPASSABLE_KRETPROBE(kretprobe__do_sys_open, long ret) {
+    // Pass the real eBPF context (from BPF_BYPASSABLE_KRETPROBE) directly to the helper.
+    // This is critical for kernel 4.14 compatibility - the verifier rejects passing
+    // stack pointers (exit_sys_ctx allocated on stack) to bpf_perf_event_output,
+    // which requires a real ctx pointer.
+    do_sys_open_helper_exit(ctx, ret);
     return 0;
 }
 

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -42,6 +42,8 @@ const (
 	NetDevQueueRawTracepoint ProbeFuncName = "raw_tracepoint__net__net_dev_queue"
 	// NetDevQueueTracepoint is the tracepoint version of the same probe attach on kernels less than 4.17
 	NetDevQueueTracepoint ProbeFuncName = "tracepoint__net__net_dev_queue"
+	// DevQueueXmitNitKprobe is the kprobe fallback for net_dev_queue tracepoint on kernels < 4.15
+	DevQueueXmitNitKprobe ProbeFuncName = "kprobe__dev_queue_xmit_nit"
 
 	// TCPSendMsg traces the tcp_sendmsg() system call
 	TCPSendMsg ProbeFuncName = "kprobe__tcp_sendmsg"

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -17,6 +17,7 @@ import (
 
 var mainProbes = []probes.ProbeFuncName{
 	probes.NetDevQueueTracepoint,
+	probes.DevQueueXmitNitKprobe, // kprobe fallback for net_dev_queue on kernels < 4.15
 	probes.ProtocolClassifierEntrySocketFilter,
 	probes.ProtocolClassifierTLSClientSocketFilter,
 	probes.ProtocolClassifierTLSServerSocketFilter,

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -64,6 +64,7 @@ const (
 
 	rawTracepointSchedProcessExit = "raw_tracepoint__sched_process_exit"
 	oldTracepointSchedProcessExit = "tracepoint__sched__sched_process_exit"
+	kprobeDoExit                  = "kprobe__do_exit"
 
 	// UsmTLSAttacherName holds the name used for the uprobe attacher of tls programs. Used for tests.
 	UsmTLSAttacherName = "usm_tls"
@@ -436,6 +437,11 @@ var opensslSpec = &protocols.ProtocolSpec{
 				EBPFFuncName: oldTracepointSchedProcessExit,
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: kprobeDoExit,
+			},
+		},
 	},
 }
 
@@ -679,34 +685,50 @@ func (*sslProgram) IsBuildModeSupported(buildmode.Type) bool {
 	return true
 }
 
-// addProcessExitProbe adds a raw or regular tracepoint program depending on which is supported.
+// addProcessExitProbe selects the best probe type for intercepting process exits.
+// Strategy:
+// - Kernel >= 4.17: raw_tracepoint (if HaveProgramType succeeds)
+// - Kernel >= 4.15: regular tracepoint (multiple attachments supported)
+// - Kernel < 4.15: kprobe on do_exit (fallback for old kernels)
 func (o *sslProgram) addProcessExitProbe(options *manager.Options) {
-	if features.HaveProgramType(ebpf.RawTracepoint) == nil {
-		// use a raw tracepoint on a supported kernel to intercept terminated threads and clear the corresponding maps
-		p := &manager.Probe{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFFuncName: rawTracepointSchedProcessExit,
-				UID:          probeUID,
-			},
-			TracepointName: "sched_process_exit",
-		}
-		o.ebpfManager.Probes = append(o.ebpfManager.Probes, p)
-		options.ActivatedProbes = append(options.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: p.ProbeIdentificationPair})
-		// exclude regular tracepoint
-		options.ExcludedFunctions = append(options.ExcludedFunctions, oldTracepointSchedProcessExit)
+	// Default to kprobe fallback (works on all kernel versions)
+	selectedProbe := kprobeDoExit
+	excludeProbes := []string{rawTracepointSchedProcessExit, oldTracepointSchedProcessExit}
+	var tracepointName string
+
+	kv, err := kernel.HostVersion()
+	if err != nil {
+		log.Warnf("Failed to get kernel version, using kprobe fallback: %v", err)
 	} else {
-		// use a regular tracepoint to intercept terminated threads
-		p := &manager.Probe{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFFuncName: oldTracepointSchedProcessExit,
-				UID:          probeUID,
-			},
+		kv415 := kernel.VersionCode(4, 15, 0)
+
+		if features.HaveProgramType(ebpf.RawTracepoint) == nil {
+			// Raw tracepoint available (kernel >= 4.17 typically)
+			selectedProbe = rawTracepointSchedProcessExit
+			tracepointName = "sched_process_exit"
+			excludeProbes = []string{oldTracepointSchedProcessExit, kprobeDoExit}
+			log.Infof("Using raw tracepoint for process exit monitoring (kernel %s supports raw tracepoints)", kv)
+		} else if kv >= kv415 {
+			// Regular tracepoint with multiple attachment support (kernel >= 4.15)
+			selectedProbe = oldTracepointSchedProcessExit
+			excludeProbes = []string{rawTracepointSchedProcessExit, kprobeDoExit}
+			log.Infof("Using regular tracepoint for process exit monitoring (kernel %s >= 4.15)", kv)
+		} else {
+			// Kprobe fallback for kernel < 4.15 (no multiple tracepoint attachment)
+			log.Infof("Using kprobe fallback for process exit monitoring (kernel %s < 4.15)", kv)
 		}
-		o.ebpfManager.Probes = append(o.ebpfManager.Probes, p)
-		options.ActivatedProbes = append(options.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: p.ProbeIdentificationPair})
-		// exclude a raw tracepoint
-		options.ExcludedFunctions = append(options.ExcludedFunctions, rawTracepointSchedProcessExit)
 	}
+
+	p := &manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			EBPFFuncName: selectedProbe,
+			UID:          probeUID,
+		},
+		TracepointName: tracepointName, // Empty for kprobes, set for tracepoints
+	}
+	o.ebpfManager.Probes = append(o.ebpfManager.Probes, p)
+	options.ActivatedProbes = append(options.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: p.ProbeIdentificationPair})
+	options.ExcludedFunctions = append(options.ExcludedFunctions, excludeProbes...)
 }
 
 var sslPidKeyMaps = []string{

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -292,11 +292,6 @@ int __attribute__((always_inline)) coredump_common() {
     return 0;
 }
 
-HOOK_ENTRY("do_coredump")
-int hook_do_coredump(ctx_t *ctx) {
-    return coredump_common();
-}
-
 int __attribute__((always_inline)) handle_do_exit(ctx_t *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -100,6 +100,7 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
     struct syscall_cache_t syscall = {
         .type = EVENT_FORK,
         .fork.is_thread = 1,
+        .fork.parent_pid = bpf_get_current_pid_tgid() >> 32,
     };
 
     u32 kthread_key = 0;
@@ -166,16 +167,7 @@ int hook__do_fork(ctx_t *ctx) {
     return handle_do_fork(ctx);
 }
 
-SEC("tracepoint/sched/sched_process_fork")
-int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
-    u64 sched_process_fork_parent_pid_offset;
-    LOAD_CONSTANT("sched_process_fork_parent_pid_offset", sched_process_fork_parent_pid_offset);
-    u64 sched_process_fork_child_pid_offset;
-    LOAD_CONSTANT("sched_process_fork_child_pid_offset", sched_process_fork_child_pid_offset);
-
-    u32 pid = 0, parent_pid = 0;
-    bpf_probe_read(&pid, sizeof(pid), (void *)args + sched_process_fork_child_pid_offset);
-    bpf_probe_read(&parent_pid, sizeof(parent_pid), (void *)args + sched_process_fork_parent_pid_offset);
+int __attribute__((always_inline)) sched_process_fork_common(void *ctx, u32 pid, u32 parent_pid) {
     // ignore the rest if kworker
     struct syscall_cache_t *syscall = peek_syscall(EVENT_FORK);
     if (!syscall || syscall->fork.is_kthread || parent_pid == 2) {
@@ -253,24 +245,56 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
     bpf_map_update_elem(&pid_cache, &pid, &on_stack_pid_entry, BPF_ANY);
 
     // [activity_dump] inherit tracing state
-    inherit_traced_state(args, ppid, pid, &event->container);
+    inherit_traced_state(ctx, ppid, pid, &event->container);
 
     // send the entry to maintain userspace cache
-    send_event_ptr(args, EVENT_FORK, event);
+    send_event_ptr(ctx, EVENT_FORK, event);
 
     pop_syscall(EVENT_FORK);
 
     return 0;
 }
 
-HOOK_ENTRY("do_coredump")
-int hook_do_coredump(ctx_t *ctx) {
+HOOK_EXIT("get_task_pid")
+int rethook_get_task_pid(ctx_t *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_FORK);
+    if (!syscall) {
+        return 0;
+    }
+
+    struct pid *pid = (struct pid *)CTX_PARMRET(ctx);
+    u32 pidnr = get_root_nr_from_pid_struct(pid);
+
+    return sched_process_fork_common(ctx, pidnr, syscall->fork.parent_pid);
+}
+
+SEC("tracepoint/sched/sched_process_fork")
+int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
+    u64 sched_process_fork_parent_pid_offset;
+    LOAD_CONSTANT("sched_process_fork_parent_pid_offset", sched_process_fork_parent_pid_offset);
+    u64 sched_process_fork_child_pid_offset;
+    LOAD_CONSTANT("sched_process_fork_child_pid_offset", sched_process_fork_child_pid_offset);
+
+    u32 pid = 0, parent_pid = 0;
+    bpf_probe_read(&pid, sizeof(pid), (void *)args + sched_process_fork_child_pid_offset);
+    bpf_probe_read(&parent_pid, sizeof(parent_pid), (void *)args + sched_process_fork_parent_pid_offset);
+
+    return sched_process_fork_common(args, pid, parent_pid);
+}
+
+
+int __attribute__((always_inline)) coredump_common() {
     u64 key = bpf_get_current_pid_tgid();
     u8 in_coredump = 1;
 
     bpf_map_update_elem(&tasks_in_coredump, &key, &in_coredump, BPF_ANY);
 
     return 0;
+}
+
+HOOK_ENTRY("do_coredump")
+int hook_do_coredump(ctx_t *ctx) {
+    return coredump_common();
 }
 
 int __attribute__((always_inline)) handle_do_exit(ctx_t *ctx) {

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -282,8 +282,8 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
     return sched_process_fork_common(args, pid, parent_pid);
 }
 
-
-int __attribute__((always_inline)) coredump_common() {
+HOOK_ENTRY("do_coredump")
+int hook_do_coredump(ctx_t *ctx) {
     u64 key = bpf_get_current_pid_tgid();
     u8 in_coredump = 1;
 

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -154,6 +154,7 @@ struct syscall_cache_t {
         struct {
             u32 is_thread;
             u32 is_kthread;
+            u32 parent_pid;
         } fork;
 
         struct {

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -109,7 +109,12 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		"*": {
 			// Exec probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "sched_process_fork"}},
+				&manager.OneOf{
+					Selectors: []manager.ProbesSelector{
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "sched_process_fork"}},
+						hookFunc("rethook_get_task_pid"),
+					},
+				},
 				hookFunc("hook_do_exit"),
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
 					hookFunc("hook_prepare_binprm"),

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -53,6 +53,12 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_get_task_pid",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_user_mode_thread",
 			},
 		},

--- a/pkg/security/ebpf/probes/fork.go
+++ b/pkg/security/ebpf/probes/fork.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package probes holds probes related files
+package probes
+
+// SchedProcessForkTracepointName is the function name of the sched_process_fork tracepoint
+const SchedProcessForkTracepointName = "sched_process_fork"

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2458,6 +2458,18 @@ func (p *EBPFProbe) initManagerOptionsExcludedFunctions() error {
 	if !p.config.RuntimeSecurity.SysCtlEnabled {
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.SysCtlProbeFunctionName)
 	}
+
+	if !p.config.Probe.CapabilitiesMonitoringEnabled {
+		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetCapabilitiesMonitoringProgramFunctions()...)
+	}
+
+	// on kernel before 4.15, you can only attach one eBPF program per tracepoint
+	// to prevent conflicts with other eBPF using programs, we exclude our sched_process_fork tracepoint program
+	// and use the get_task_pid kretprobe fallback instead
+	if p.kernelVersion.Code < kernel.Kernel4_15 {
+		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.SchedProcessForkTracepointName)
+	}
+
 	return nil
 }
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2459,10 +2459,6 @@ func (p *EBPFProbe) initManagerOptionsExcludedFunctions() error {
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.SysCtlProbeFunctionName)
 	}
 
-	if !p.config.Probe.CapabilitiesMonitoringEnabled {
-		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetCapabilitiesMonitoringProgramFunctions()...)
-	}
-
 	// on kernel before 4.15, you can only attach one eBPF program per tracepoint
 	// to prevent conflicts with other eBPF using programs, we exclude our sched_process_fork tracepoint program
 	// and use the get_task_pid kretprobe fallback instead


### PR DESCRIPTION
### What does this PR do?
Cherry-picks PR #42121 into 7.69.x to provide kprobe fallbacks for USM on kernels < 4.15. This enables USM to coexist with other monitoring tools on older kernels that don't support multiple tracepoint attachments.

### Motivation
Customer is experiencing `file exists` errors when USM attempts to attach to tracepoints that are already in use by third-party monitoring tools on kernels 4.14. These older kernel don't support multiple tracepoint attachments, causing USM to fail to enable.

This backport ensures USM can operate alongside other monitoring tools by using kprobes as fallbacks, which support multiple attachments on all kernel versions.

### Describe how you validated your changes
- Cherry-pick applied cleanly with no conflicts
- Original PR was validated on kernel 4.14, x86_64 by running system-probe twice to verify kprobe fallbacks attach successfully without "file exists" errors
- Customer will validate on their specific kernel environment

### Additional Notes
