### PR TITLE
Extract persistent runner configuration for Bazel jobs

### DIFF
--- a/.gitlab/bazel/build-deps.yaml
+++ b/.gitlab/bazel/build-deps.yaml
@@ -6,25 +6,12 @@
   stage: deps_build
 
 bazel:build-deps:linux-amd64:
-  extends: [ .bazel:build-deps, .linux_x64 ]
-  tags: ["linux-persistent:amd64", "specific:true"]
-  cache: []
+  extends: [ .bazel:build-deps, .bazel:persistent-runner:linux-amd64 ]
   script:
-    - mkdir -p $BAZELISK_HOME
-    - mkdir -p $BAZEL_DISK_CACHE
-    - mkdir -p $BAZEL_OUTPUT_USER_ROOT
-    - mkdir -p $BAZEL_REPO_CONTENTS_CACHE
     - bazel build //deps/...
-  variables:
-      BAZELISK_HOME: "$XDG_CACHE_HOME/bazelisk"
-      BAZEL_DISK_CACHE: "$XDG_CACHE_HOME/disk_cache"
-      BAZEL_OUTPUT_USER_ROOT: "$XDG_CACHE_HOME/output_user_root"
-      BAZEL_REPO_CONTENTS_CACHE: "$XDG_CACHE_HOME/repo_contents"
-      XDG_CACHE_HOME: "/data/bzl"
 
 bazel:build-deps:linux-arm64:
   extends: [ .bazel:build-deps, .linux_arm64 ]
-  tags: [ "arch:arm64", "specific:true" ]
   script:
     - bazel build //deps/...
 

--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -23,6 +23,12 @@
     BAZEL_REPO_CONTENTS_CACHE: "$BAZEL_OUTPUT_USER_ROOT/repo-contents"
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
 
+.bazel:persistent-runner:linux-amd64:
+  cache: []
+  variables:
+    XDG_CACHE_HOME: /data/bzl
+  tags: [ "linux-persistent:amd64", "specific:true" ]
+
 .bazel:ext:windows:
   extends: .windows_docker_default
   timeout: 60m # pulling images alone can take more than 30m


### PR DESCRIPTION
### What does this PR do?
Extracts persistent runner configuration into a reusable template.

### Motivation
The `bazel:build-deps:linux-amd64` job was duplicating configuration that will be shared across Linux/x86_64 persistent runner jobs:
- `XDG_CACHE_HOME: /data/bzl` (external cache directory),
- `cache: []` (disable GitLab cache since persistent runners use disk),
- `tags: ["linux-persistent:amd64", "specific:true"]`.

By extracting this into a reusable template, we reduce duplication and make the config DRY, thus making it easier to add more persistent runner jobs, centralize the persistent vs ephemeral runner distinction and maintain the entire cache directory hierarchy in a single place (`.bazel:defs`) - since GitLab's runtime variable expansion allows the whole cache structure to adjust automatically when only `XDG_CACHE_HOME` is overridden.

### Additional Notes
Following redundancies get also removed:
- `mkdir` commands from `bazel:build-deps:linux-amd64`, because both `bazelisk` and `bazel` create their own directories by default,
- `tags` from `bazel:build-deps:linux-arm64`, because they're all provided by `.linux_arm64` (since #40361).

### Describe how you validated your changes
The `bazel:build-deps:linux-amd64` job is still fast ([sub-minute](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1201703797)).
Its definition is still as expected: ([Full configuration](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/ci/editor?branch_name=regis.desgroppes%2Fextract-bazel-persistent-runner-template&tab=3))
```yaml
bazel:build-deps:linux-amd64:
  cache: []
  needs: []
  variables:
    BAZELISK_HOME: "$XDG_CACHE_HOME/bazelisk"
    BAZEL_DISK_CACHE: "$BAZEL_OUTPUT_USER_ROOT/disk"
    BAZEL_OUTPUT_USER_ROOT: "$XDG_CACHE_HOME/bazel"
    BAZEL_REPO_CONTENTS_CACHE: "$BAZEL_OUTPUT_USER_ROOT/repo-contents"
    XDG_CACHE_HOME: "/data/bzl"
  extends:
  - ".bazel:build-deps"
  - ".bazel:persistent-runner:linux-amd64"
  rules:
  - - if: "$CI_COMMIT_BRANCH =~ /^mq-working-branch-/"
      when: never
  - when: on_success
  stage: deps_build
  tags:
  - linux-persistent:amd64
  - specific:true
  script:
  - bazel build //deps/...
```