### PR TITLE
[CWS] Add condition to GetNodesInProcessCache execution

### DIFF
--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -762,7 +762,7 @@ func (m *Manager) GetNodesInProcessCache() map[activity_tree.ImageProcessKey]boo
 		for _, pid := range pids {
 			pce := pr.Resolve(pid, pid, 0, true, nil)
 			if pce == nil {
-				seclog.Errorf("couldn't resolve process cache entry for pid %d", pid)
+				seclog.Warnf("couldn't resolve process cache entry for pid %d, this process may have exited", pid)
 				continue
 			}
 

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -385,7 +385,10 @@ func (m *Manager) unlinkProfile(profile *profile.Profile, workload *tags.Workloa
 
 func (m *Manager) onWorkloadSelectorResolvedEvent(workload *tags.Workload) {
 
-	filepathsInProcessCache := m.GetNodesInProcessCache()
+	var filepathsInProcessCache map[activity_tree.ImageProcessKey]bool
+	if m.config.RuntimeSecurity.SecurityProfileNodeEvictionTimeout > 0 {
+		filepathsInProcessCache = m.GetNodesInProcessCache()
+	}
 
 	m.profilesLock.Lock()
 	defer m.profilesLock.Unlock()


### PR DESCRIPTION
### What does this PR do?
This PR does the following:
- only execute GetNodesInProcessCache when the process node eviction is actually enabled
- convert the error log to a warning in GetNodesInProcessCache, as it's a situation that can happen normally.
### Motivation

### Describe how you validated your changes

### Additional Notes
