### PR TITLE
omnibus: fix dbus install location

### DIFF
--- a/omnibus/config/software/dbus.rb
+++ b/omnibus/config/software/dbus.rb
@@ -28,6 +28,7 @@ build do
     "-Dtools=false",
     "-Dmodular_tests=disabled",
     "--prefix=#{install_dir}/embedded",
+    "--libdir=lib",
     "-Dbuildtype=release",
   ]
 

--- a/omnibus/config/software/dbus.rb
+++ b/omnibus/config/software/dbus.rb
@@ -35,7 +35,7 @@ build do
   # meson requires a dedicated build folder
   meson_build_dir = "#{project_dir}/build"
   command "mkdir #{meson_build_dir}", env: env
-  command "meson setup " + meson_options.join(' ').strip + " ..", cwd: meson_build_dir
+  command "meson setup " + meson_options.join(' ').strip + " ..", cwd: meson_build_dir, env: env
   command "ninja install", env: env, cwd: meson_build_dir
 
   # Remove dbus tools.


### PR DESCRIPTION
### What does this PR do?

Fix the `dbus` lib install location

### Motivation

meson defaults to installing into "$prefix"/lib/x86_64-linux-gnu while we (and our other dependencies) expect it to be in `$prefix/lib` This was causing openscap not to enable its dbus based probes

### Describe how you validated your changes

Local build & looking into openscap's configuration logs:
before:
```
D | 2025-10-28T12:52:11+00:00 | --   Linux systemdunitdependency probe (depends on dbus): OFF
D | 2025-10-28T12:52:11+00:00 | --   Linux systemdunitproperty probe (depends on dbus): OFF
D | 2025-10-28T12:52:11+00:00 | --   Linux fwupdsecurityattr probe (depends on dbus): OFF
```
after:
```
D | 2025-10-28T13:03:40+00:00 | --   Linux systemdunitdependency probe (depends on dbus): ON
D | 2025-10-28T13:03:40+00:00 | --   Linux systemdunitproperty probe (depends on dbus): ON
D | 2025-10-28T13:03:40+00:00 | --   Linux fwupdsecurityattr probe (depends on dbus): ON
```

### Additional Notes
