### PR TITLE
Fix cloudRunPrefix from 'gpc.run' to 'gcp.run'

### DIFF
--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -54,7 +54,7 @@ const (
 	resourceName      = "resource_name"
 	functionTarget    = "build_function_target"
 	functionSignature = "function_signature_type"
-	cloudRunPrefix    = "gpc.run"
+	cloudRunPrefix    = "gcp.run"
 )
 
 var metadataHelperFunc = GetMetaData

--- a/releasenotes/notes/fix-typo-of-cloudrun-enhanced-metrics-prefix-23cf6ee85b8c2766.yaml
+++ b/releasenotes/notes/fix-typo-of-cloudrun-enhanced-metrics-prefix-23cf6ee85b8c2766.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix cloudRunPrefix from 'gpc.run' to 'gcp.run'.


### PR DESCRIPTION
(cherry picked from commit d79c8dd2952a1d09b8e7322b9fc2c8dc51d96c49)

### What does this PR do?

Fix cloudRunPrefix from 'gpc.run' to 'gcp.run'

### Motivation

https://dd.slack.com/archives/C02ELF4961M/p1761409510931969
https://datadog.zendesk.com/agent/tickets/2320869

### Describe how you validated your changes

### Additional Notes

Original PR: https://github.com/DataDog/datadog-agent/pull/42347
but CI could not run due to branch being from a forked repo
