### PR TITLE
CAP-3054 apply RetrieveUnifiedServiceTags to pods

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
@@ -85,6 +85,7 @@ func ExtractPod(ctx processors.ProcessorContext, p *corev1.Pod) *model.Pod {
 	}
 
 	pctx := ctx.(*processors.K8sProcessorContext)
+	podModel.Tags = append(podModel.Tags, transformers.RetrieveUnifiedServiceTags(p.ObjectMeta.Labels)...)
 	podModel.Tags = append(podModel.Tags, transformers.RetrieveMetadataTags(p.ObjectMeta.Labels, p.ObjectMeta.Annotations, pctx.LabelsAsTags, pctx.AnnotationsAsTags)...)
 
 	return &podModel

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
@@ -565,6 +565,31 @@ func TestExtractPod(t *testing.T) {
 				},
 			},
 		},
+		"pod with unified tags": {
+			input: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"tags.datadoghq.com/env":     "production",
+						"tags.datadoghq.com/version": "7.70.0",
+						"tags.datadoghq.com/service": "my-service",
+					},
+				},
+			},
+			expected: model.Pod{
+				Metadata: &model.Metadata{
+					Labels: []string{
+						"tags.datadoghq.com/env:production",
+						"tags.datadoghq.com/version:7.70.0",
+						"tags.datadoghq.com/service:my-service",
+					},
+				},
+				Tags: []string{
+					"env:production",
+					"version:7.70.0",
+					"service:my-service",
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

In this PR https://github.com/DataDog/datadog-agent/pull/14536 we applied RetrieveUnifiedServiceTags to all resources except pods. This PR fixes it.

### Describe how you validated your changes

It a simple change which is covered by unit test

Deploy this pod in the cluster
```
apiVersion: v1
kind: Pod
metadata:
  name: my-service-pod
  labels:
    app: my-service
    tags.datadoghq.com/env: "production"
    tags.datadoghq.com/version: "7.70.0"
    tags.datadoghq.com/service: "my-service"
spec:
  containers:
    - name: nginx
      image: nginx:latest
      ports:
        - containerPort: 80
```

You can find it in UI


<img width="1398" height="218" alt="Screenshot 2025-10-28 at 16 11 26" src="https://github.com/user-attachments/assets/520b8deb-4917-4d20-8e9e-6bee0d68bd8c" />

