### PR TITLE
[INCIDENT-44935] Revert "[BARX-1164] [Release] The update-changelog task should open backport PRs to ongoing agent releases"

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -763,7 +763,7 @@ Make sure that milestone is open before trying again.""",
     return updated_pr.html_url
 
 
-def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False, milestone=None, labels=()):
+def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False, milestone=None):
     if milestone:
         milestone_name = milestone
     else:
@@ -773,7 +773,6 @@ def create_release_pr(title, base_branch, target_branch, version, changelog_pr=F
 
     labels = [
         "team/agent-delivery",
-        *labels,
     ]
     if changelog_pr:
         labels.append(f"backport/{get_default_branch()}")

--- a/tasks/notes.py
+++ b/tasks/notes.py
@@ -1,4 +1,3 @@
-import re
 import sys
 from datetime import date
 
@@ -135,22 +134,6 @@ def update_changelog(ctx, release_branch, target="all", upstream="origin"):
                 code=1,
             )
 
-        res = ctx.run("git ls-remote --heads origin")
-        backport_labels = []
-        for line in res.splitlines():
-            sections = line.strip().split()
-            if len(sections) != 2:
-                continue
-
-            # Enforce branch release naming convention (i.e. 7.67.x)
-            branch = sections[1].removeprefix("refs/heads/")
-            if not re.match(r'^7\.[0-9]+\.x$', branch):
-                continue
-
-            minor_version = int(branch.split(".")[1])
-            if minor_version > new_version_int[1]:
-                backport_labels.append(f"backport/{branch}")
-
         create_release_pr(
             f"Changelog update for {new_version} release",
             base_branch,
@@ -158,7 +141,6 @@ def update_changelog(ctx, release_branch, target="all", upstream="origin"):
             new_version,
             changelog_pr=True,
             milestone=str(new_version),
-            labels=backport_labels,
         )
 
 


### PR DESCRIPTION
Reverts DataDog/datadog-agent#41963
[#incident-44935](https://app.datadoghq.com/incidents/44935)

A proper fix is probably just:
```diff
res = ctx.run("git ls-remote --heads origin")
backport_labels = []
- for line in res.splitlines():
+ for line in res.stdout.splitlines():
```
But just to be safe we prefer to revert.