### PR TITLE
[NDMII-3672] Cleanup `snmpscan` component and fix overriden errors

### DIFF
--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -7,10 +7,10 @@
 package snmpscan
 
 import (
-	"github.com/gosnmp/gosnmp"
-
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+
+	"github.com/gosnmp/gosnmp"
 )
 
 // team: ndm-core

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -7,18 +7,16 @@
 package snmpscan
 
 import (
+	"github.com/gosnmp/gosnmp"
+
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
-	"github.com/gosnmp/gosnmp"
 )
 
 // team: ndm-core
 
 // Component is the component type.
 type Component interface {
-	// Triggers a device scan
-	RunDeviceScan(snmpConection *gosnmp.GoSNMP, deviceNamespace string, deviceID string) error
 	RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error
-	SendPayload(payload metadata.NetworkDevicesMetadata) error
 	ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanType metadata.ScanType) error
 }

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -7,15 +7,86 @@ package snmpscanimpl
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 	"time"
+
+	"github.com/gosnmp/gosnmp"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
-	"github.com/gosnmp/gosnmp"
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 )
 
-func (s snmpScannerImpl) RunDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceNamespace string, deviceID string) error {
+func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanType metadata.ScanType) error {
+	// Establish connection
+	snmp, err := snmpparse.NewSNMP(connParams, s.log)
+	if err != nil {
+		return err
+	}
+	deviceID := namespace + ":" + connParams.IPAddress
+	// Since the snmp connection can take a while, start by sending an in progress status for the start of the scan
+	// before connecting to the agent
+	inProgressStatusPayload := metadata.NetworkDevicesMetadata{
+		DeviceScanStatus: &metadata.ScanStatusMetadata{
+			DeviceID:   deviceID,
+			ScanStatus: metadata.ScanStatusInProgress,
+			ScanType:   scanType,
+		},
+		CollectTimestamp: time.Now().Unix(),
+		Namespace:        namespace,
+	}
+	if err = s.sendPayload(inProgressStatusPayload); err != nil {
+		return fmt.Errorf("unable to send in progress status: %v", err)
+	}
+	if err = snmp.Connect(); err != nil {
+		// Send an error status if we can't connect to the agent
+		errorStatusPayload := metadata.NetworkDevicesMetadata{
+			DeviceScanStatus: &metadata.ScanStatusMetadata{
+				DeviceID:   deviceID,
+				ScanStatus: metadata.ScanStatusError,
+				ScanType:   scanType,
+			},
+			CollectTimestamp: time.Now().Unix(),
+			Namespace:        namespace,
+		}
+		if err = s.sendPayload(errorStatusPayload); err != nil {
+			return fmt.Errorf("unable to send error status: %v", err)
+		}
+		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
+	}
+	err = s.runDeviceScan(snmp, namespace, deviceID)
+	if err != nil {
+		// Send an error status if we can't scan the device
+		errorStatusPayload := metadata.NetworkDevicesMetadata{
+			DeviceScanStatus: &metadata.ScanStatusMetadata{
+				DeviceID:   deviceID,
+				ScanStatus: metadata.ScanStatusError,
+				ScanType:   scanType,
+			},
+			CollectTimestamp: time.Now().Unix(),
+			Namespace:        namespace,
+		}
+		if err = s.sendPayload(errorStatusPayload); err != nil {
+			return fmt.Errorf("unable to send error status: %v", err)
+		}
+		return fmt.Errorf("unable to perform device scan: %v", err)
+	}
+	// Send a completed status if the scan was successful
+	completedStatusPayload := metadata.NetworkDevicesMetadata{
+		DeviceScanStatus: &metadata.ScanStatusMetadata{
+			DeviceID:   deviceID,
+			ScanStatus: metadata.ScanStatusCompleted,
+			ScanType:   scanType,
+		},
+		CollectTimestamp: time.Now().Unix(),
+		Namespace:        namespace,
+	}
+	if err = s.sendPayload(completedStatusPayload); err != nil {
+		return fmt.Errorf("unable to send completed status: %v", err)
+	}
+	return nil
+}
+
+func (s snmpScannerImpl) runDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceNamespace string, deviceID string) error {
 	// execute the scan
 	pdus, err := gatherPDUs(snmpConnection)
 	if err != nil {
@@ -34,7 +105,7 @@ func (s snmpScannerImpl) RunDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceName
 
 	metadataPayloads := metadata.BatchDeviceScan(deviceNamespace, time.Now(), metadata.PayloadMetadataBatchSize, deviceOids)
 	for _, payload := range metadataPayloads {
-		err := s.SendPayload(payload)
+		err := s.sendPayload(payload)
 		if err != nil {
 			return err
 		}
@@ -55,74 +126,4 @@ func gatherPDUs(snmp *gosnmp.GoSNMP) ([]*gosnmp.SnmpPDU, error) {
 		return nil, err
 	}
 	return pdus, nil
-}
-
-func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanType metadata.ScanType) error {
-	// Establish connection
-	snmp, err := snmpparse.NewSNMP(connParams, s.log)
-	if err != nil {
-		return err
-	}
-	deviceID := namespace + ":" + connParams.IPAddress
-	// Since the snmp connection can take a while, start by sending an in progress status for the start of the scan
-	// before connecting to the agent
-	inProgressStatusPayload := metadata.NetworkDevicesMetadata{
-		DeviceScanStatus: &metadata.ScanStatusMetadata{
-			DeviceID:   deviceID,
-			ScanStatus: metadata.ScanStatusInProgress,
-			ScanType:   scanType,
-		},
-		CollectTimestamp: time.Now().Unix(),
-		Namespace:        namespace,
-	}
-	if err = s.SendPayload(inProgressStatusPayload); err != nil {
-		return fmt.Errorf("unable to send in progress status: %v", err)
-	}
-	if err = snmp.Connect(); err != nil {
-		// Send an error status if we can't connect to the agent
-		errorStatusPayload := metadata.NetworkDevicesMetadata{
-			DeviceScanStatus: &metadata.ScanStatusMetadata{
-				DeviceID:   deviceID,
-				ScanStatus: metadata.ScanStatusError,
-				ScanType:   scanType,
-			},
-			CollectTimestamp: time.Now().Unix(),
-			Namespace:        namespace,
-		}
-		if err = s.SendPayload(errorStatusPayload); err != nil {
-			return fmt.Errorf("unable to send error status: %v", err)
-		}
-		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
-	}
-	err = s.RunDeviceScan(snmp, namespace, deviceID)
-	if err != nil {
-		// Send an error status if we can't scan the device
-		errorStatusPayload := metadata.NetworkDevicesMetadata{
-			DeviceScanStatus: &metadata.ScanStatusMetadata{
-				DeviceID:   deviceID,
-				ScanStatus: metadata.ScanStatusError,
-				ScanType:   scanType,
-			},
-			CollectTimestamp: time.Now().Unix(),
-			Namespace:        namespace,
-		}
-		if err = s.SendPayload(errorStatusPayload); err != nil {
-			return fmt.Errorf("unable to send error status: %v", err)
-		}
-		return fmt.Errorf("unable to perform device scan: %v", err)
-	}
-	// Send a completed status if the scan was successful
-	completedStatusPayload := metadata.NetworkDevicesMetadata{
-		DeviceScanStatus: &metadata.ScanStatusMetadata{
-			DeviceID:   deviceID,
-			ScanStatus: metadata.ScanStatusCompleted,
-			ScanType:   scanType,
-		},
-		CollectTimestamp: time.Now().Unix(),
-		Namespace:        namespace,
-	}
-	if err = s.SendPayload(completedStatusPayload); err != nil {
-		return fmt.Errorf("unable to send completed status: %v", err)
-	}
-	return nil
 }

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -48,8 +48,8 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 			CollectTimestamp: time.Now().Unix(),
 			Namespace:        namespace,
 		}
-		if err = s.sendPayload(errorStatusPayload); err != nil {
-			return fmt.Errorf("unable to send error status: %v", err)
+		if sendErr := s.sendPayload(errorStatusPayload); sendErr != nil {
+			return fmt.Errorf("unable to send error status: %v", sendErr)
 		}
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}
@@ -65,8 +65,8 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 			CollectTimestamp: time.Now().Unix(),
 			Namespace:        namespace,
 		}
-		if err = s.sendPayload(errorStatusPayload); err != nil {
-			return fmt.Errorf("unable to send error status: %v", err)
+		if sendErr := s.sendPayload(errorStatusPayload); sendErr != nil {
+			return fmt.Errorf("unable to send error status: %v", sendErr)
 		}
 		return fmt.Errorf("unable to perform device scan: %v", err)
 	}

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gosnmp/gosnmp"
-
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+
+	"github.com/gosnmp/gosnmp"
 )
 
 func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanType metadata.ScanType) error {

--- a/comp/snmpscan/impl/sendpayload.go
+++ b/comp/snmpscan/impl/sendpayload.go
@@ -7,12 +7,13 @@ package snmpscanimpl
 
 import (
 	"encoding/json"
+
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 )
 
-func (s snmpScannerImpl) SendPayload(payload metadata.NetworkDevicesMetadata) error {
+func (s snmpScannerImpl) sendPayload(payload metadata.NetworkDevicesMetadata) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		s.log.Errorf("Error marshalling device metadata: %v", err)

--- a/comp/snmpscan/impl/snmpscan_test.go
+++ b/comp/snmpscan/impl/snmpscan_test.go
@@ -40,9 +40,9 @@ func TestSnmpScanComp(t *testing.T) {
 	snmpConnection.LocalAddr = "127.0.0.1"
 	snmpConnection.Port = 0
 
-	err = snmpScanner.Comp.RunSnmpWalk(snmpConnection, "1")
+	err = snmpScanner.Comp.RunSnmpWalk(snmpConnection, "1.0")
 	assert.ErrorContains(t, err, "&GoSNMP.Conn is missing. Provide a connection or use Connect()")
 
-	err = snmpScanner.Comp.RunSnmpWalk(snmpConnection, "1")
+	err = snmpScanner.Comp.RunSnmpWalk(snmpConnection, "1.0")
 	assert.ErrorContains(t, err, "&GoSNMP.Conn is missing. Provide a connection or use Connect()")
 }

--- a/comp/snmpscan/impl/snmpscan_test.go
+++ b/comp/snmpscan/impl/snmpscan_test.go
@@ -10,16 +10,16 @@ package snmpscanimpl
 import (
 	"testing"
 
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
 	logscomp "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
-	"go.uber.org/fx"
-
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/gosnmp/gosnmp"
-	"github.com/stretchr/testify/assert"
 )
 
 type deps struct {
@@ -40,9 +40,9 @@ func TestSnmpScanComp(t *testing.T) {
 	snmpConnection.LocalAddr = "127.0.0.1"
 	snmpConnection.Port = 0
 
-	err = snmpScanner.Comp.RunDeviceScan(snmpConnection, "default", "127.0.0.1")
+	err = snmpScanner.Comp.RunSnmpWalk(snmpConnection, "1")
 	assert.ErrorContains(t, err, "&GoSNMP.Conn is missing. Provide a connection or use Connect()")
 
-	err = snmpScanner.Comp.RunDeviceScan(snmpConnection, "default", "127.0.0.1")
+	err = snmpScanner.Comp.RunSnmpWalk(snmpConnection, "1")
 	assert.ErrorContains(t, err, "&GoSNMP.Conn is missing. Provide a connection or use Connect()")
 }

--- a/comp/snmpscan/impl/snmpscan_test.go
+++ b/comp/snmpscan/impl/snmpscan_test.go
@@ -10,16 +10,16 @@ package snmpscanimpl
 import (
 	"testing"
 
-	"github.com/gosnmp/gosnmp"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
-
 	"github.com/DataDog/datadog-agent/comp/core"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
 	logscomp "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
 )
 
 type deps struct {

--- a/comp/snmpscan/impl/walkdevice.go
+++ b/comp/snmpscan/impl/walkdevice.go
@@ -10,8 +10,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/gosnmp/gosnmp"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 )
 
 // RunSnmpWalk prints every SNMP value, in the style of the unix snmpwalk command.

--- a/comp/snmpscan/impl/walkdevice.go
+++ b/comp/snmpscan/impl/walkdevice.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gosnmp/gosnmp"
-
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+
+	"github.com/gosnmp/gosnmp"
 )
 
 // RunSnmpWalk prints every SNMP value, in the style of the unix snmpwalk command.

--- a/comp/snmpscan/mock/mock.go
+++ b/comp/snmpscan/mock/mock.go
@@ -11,12 +11,12 @@ package mock
 import (
 	"testing"
 
-	"github.com/gosnmp/gosnmp"
-
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+
+	"github.com/gosnmp/gosnmp"
 )
 
 type snmpScanMock struct {

--- a/comp/snmpscan/mock/mock.go
+++ b/comp/snmpscan/mock/mock.go
@@ -9,16 +9,17 @@
 package mock
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 	"testing"
+
+	"github.com/gosnmp/gosnmp"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
-	"github.com/gosnmp/gosnmp"
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 )
 
-type mock struct {
+type snmpScanMock struct {
 	Logger log.Component
 }
 
@@ -28,21 +29,15 @@ type Provides struct {
 }
 
 // New returns a mock snmpscanner
-func New(*testing.T) Provides {
+func New(_ *testing.T) Provides {
 	return Provides{
-		comp: mock{},
+		comp: snmpScanMock{},
 	}
 }
 
-func (m mock) RunDeviceScan(_ *gosnmp.GoSNMP, _ string, _ string) error {
+func (m snmpScanMock) RunSnmpWalk(_ *gosnmp.GoSNMP, _ string) error {
 	return nil
 }
-func (m mock) RunSnmpWalk(_ *gosnmp.GoSNMP, _ string) error {
-	return nil
-}
-func (m mock) SendPayload(_ metadata.NetworkDevicesMetadata) error {
-	return nil
-}
-func (m mock) ScanDeviceAndSendData(_ *snmpparse.SNMPConfig, _ string, _ metadata.ScanType) error {
+func (m snmpScanMock) ScanDeviceAndSendData(_ *snmpparse.SNMPConfig, _ string, _ metadata.ScanType) error {
 	return nil
 }

--- a/pkg/snmp/gosnmplib/walk.go
+++ b/pkg/snmp/gosnmplib/walk.go
@@ -31,7 +31,7 @@ func ConditionalWalk(session *gosnmp.GoSNMP, rootOID string, useBulk bool, walkF
 	}
 
 	if !strings.HasPrefix(rootOID, ".") {
-		rootOID = string(".") + rootOID
+		rootOID = "." + rootOID
 	}
 
 	oid := rootOID


### PR DESCRIPTION
### What does this PR do?

This PR cleans up the `snmpscan` component by removing the `RunDeviceScan` and `SendPayload` from the component interface, as these functions should only be used internally in the component and not outside.
This PR also fixes some errors that were overridden by other errors in [e71fe8c](https://github.com/DataDog/datadog-agent/pull/42422/commits/e71fe8c9a1edd43e1bec293f609a1f6e2ca41bdf).

### Motivation

### Describe how you validated your changes

### Additional Notes
