### PR TITLE
[CWS] increase probe attach/detach retry amount

### DIFF
--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -23,6 +23,8 @@ func NewDefaultOptions(kretprobeMaxActive int) manager.Options {
 		DefaultPerfRingBufferSize: probes.EventsPerfRingBufferSize,
 
 		RemoveRlimit: true,
+
+		DefaultProbeRetry: 5, // in some rare cases, we can get an -EBUSY on some probes during detach, so let's add some retry
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR increases the amount of retries done when attaching/detaching eBPF probes in the event monitor. This is done especially to handle better the case where detaching some probes is returning some `EBUSY` errors.

### Motivation

### Describe how you validated your changes

### Additional Notes
