### PR TITLE
[NDMII-3673] Add option to sleep between SNMP calls in SNMP device scan

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -287,7 +287,9 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	deviceID := namespace + ":" + connParams.IPAddress
 	// Start the scan
 	fmt.Printf("Launching scan for device: %s\n", deviceID)
-	err := snmpScanner.ScanDeviceAndSendData(connParams, namespace, metadata.ManualScan)
+	err := snmpScanner.ScanDeviceAndSendData(connParams, namespace, snmpscan.ScanParams{
+		ScanType: metadata.ManualScan,
+	})
 	if err != nil {
 		fmt.Printf("Unable to perform device scan for device %s : %e", deviceID, err)
 	}

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -18,5 +18,9 @@ import (
 // Component is the component type.
 type Component interface {
 	RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error
-	ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanType metadata.ScanType) error
+	ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanParams ScanParams) error
+}
+
+type ScanParams struct {
+	ScanType metadata.ScanType
 }

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -7,6 +7,8 @@
 package snmpscan
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 
@@ -22,5 +24,6 @@ type Component interface {
 }
 
 type ScanParams struct {
-	ScanType metadata.ScanType
+	ScanType     metadata.ScanType
+	CallInterval time.Duration // Duration to sleep between SNMP calls
 }

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -23,6 +23,7 @@ type Component interface {
 	ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanParams ScanParams) error
 }
 
+// ScanParams contains options for a device scan
 type ScanParams struct {
 	ScanType     metadata.ScanType
 	CallInterval time.Duration // Duration to sleep between SNMP calls

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
@@ -16,7 +17,7 @@ import (
 	"github.com/gosnmp/gosnmp"
 )
 
-func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanType metadata.ScanType) error {
+func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanParams snmpscan.ScanParams) error {
 	// Establish connection
 	snmp, err := snmpparse.NewSNMP(connParams, s.log)
 	if err != nil {
@@ -29,7 +30,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 		DeviceScanStatus: &metadata.ScanStatusMetadata{
 			DeviceID:   deviceID,
 			ScanStatus: metadata.ScanStatusInProgress,
-			ScanType:   scanType,
+			ScanType:   scanParams.ScanType,
 		},
 		CollectTimestamp: time.Now().Unix(),
 		Namespace:        namespace,
@@ -43,7 +44,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 			DeviceScanStatus: &metadata.ScanStatusMetadata{
 				DeviceID:   deviceID,
 				ScanStatus: metadata.ScanStatusError,
-				ScanType:   scanType,
+				ScanType:   scanParams.ScanType,
 			},
 			CollectTimestamp: time.Now().Unix(),
 			Namespace:        namespace,
@@ -60,7 +61,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 			DeviceScanStatus: &metadata.ScanStatusMetadata{
 				DeviceID:   deviceID,
 				ScanStatus: metadata.ScanStatusError,
-				ScanType:   scanType,
+				ScanType:   scanParams.ScanType,
 			},
 			CollectTimestamp: time.Now().Unix(),
 			Namespace:        namespace,
@@ -75,7 +76,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 		DeviceScanStatus: &metadata.ScanStatusMetadata{
 			DeviceID:   deviceID,
 			ScanStatus: metadata.ScanStatusCompleted,
-			ScanType:   scanType,
+			ScanType:   scanParams.ScanType,
 		},
 		CollectTimestamp: time.Now().Unix(),
 		Namespace:        namespace,

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -54,7 +54,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 		}
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}
-	err = s.runDeviceScan(snmp, namespace, deviceID)
+	err = s.runDeviceScan(snmp, namespace, deviceID, scanParams.CallInterval)
 	if err != nil {
 		// Send an error status if we can't scan the device
 		errorStatusPayload := metadata.NetworkDevicesMetadata{
@@ -87,9 +87,9 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 	return nil
 }
 
-func (s snmpScannerImpl) runDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceNamespace string, deviceID string) error {
+func (s snmpScannerImpl) runDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceNamespace string, deviceID string, callInterval time.Duration) error {
 	// execute the scan
-	pdus, err := gatherPDUs(snmpConnection)
+	pdus, err := gatherPDUs(snmpConnection, callInterval)
 	if err != nil {
 		return err
 	}
@@ -117,9 +117,9 @@ func (s snmpScannerImpl) runDeviceScan(snmpConnection *gosnmp.GoSNMP, deviceName
 
 // gatherPDUs returns PDUs from the given SNMP device that should cover ever
 // scalar value and at least one row of every table.
-func gatherPDUs(snmp *gosnmp.GoSNMP) ([]*gosnmp.SnmpPDU, error) {
+func gatherPDUs(snmp *gosnmp.GoSNMP, callInterval time.Duration) ([]*gosnmp.SnmpPDU, error) {
 	var pdus []*gosnmp.SnmpPDU
-	err := gosnmplib.ConditionalWalk(snmp, "", false, func(dataUnit gosnmp.SnmpPDU) (string, error) {
+	err := gosnmplib.ConditionalWalk(snmp, "", false, callInterval, func(dataUnit gosnmp.SnmpPDU) (string, error) {
 		pdus = append(pdus, &dataUnit)
 		return gosnmplib.SkipOIDRowsNaive(dataUnit.Name), nil
 	})

--- a/comp/snmpscan/impl/snmpscan.go
+++ b/comp/snmpscan/impl/snmpscan.go
@@ -81,6 +81,7 @@ func (s snmpScannerImpl) startDeviceScan(task rcclienttypes.AgentTaskConfig) err
 	if err != nil {
 		return err
 	}
-	return s.ScanDeviceAndSendData(instance, ns, metadata.RCTriggeredScan)
-
+	return s.ScanDeviceAndSendData(instance, ns, snmpscan.ScanParams{
+		ScanType: metadata.RCTriggeredScan,
+	})
 }

--- a/comp/snmpscan/mock/mock.go
+++ b/comp/snmpscan/mock/mock.go
@@ -13,7 +13,6 @@ import (
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
-	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 
 	"github.com/gosnmp/gosnmp"
@@ -38,6 +37,6 @@ func New(_ *testing.T) Provides {
 func (m snmpScanMock) RunSnmpWalk(_ *gosnmp.GoSNMP, _ string) error {
 	return nil
 }
-func (m snmpScanMock) ScanDeviceAndSendData(_ *snmpparse.SNMPConfig, _ string, _ metadata.ScanType) error {
+func (m snmpScanMock) ScanDeviceAndSendData(_ *snmpparse.SNMPConfig, _ string, _ snmpscan.ScanParams) error {
 	return nil
 }

--- a/pkg/snmp/gosnmplib/walk.go
+++ b/pkg/snmp/gosnmplib/walk.go
@@ -8,6 +8,7 @@ package gosnmplib
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gosnmp/gosnmp"
 )
@@ -25,7 +26,7 @@ const (
 // a next OID to walk from. Use e.g. SkipOIDRowsNaive to skip over additional
 // rows.
 // This code is adapated directly from gosnmp's walk function.
-func ConditionalWalk(session *gosnmp.GoSNMP, rootOID string, useBulk bool, walkFn func(dataUnit gosnmp.SnmpPDU) (string, error)) error {
+func ConditionalWalk(session *gosnmp.GoSNMP, rootOID string, useBulk bool, callInterval time.Duration, walkFn func(dataUnit gosnmp.SnmpPDU) (string, error)) error {
 	if rootOID == "" || rootOID == "." {
 		rootOID = baseOID
 	}
@@ -44,6 +45,10 @@ func ConditionalWalk(session *gosnmp.GoSNMP, rootOID string, useBulk bool, walkF
 
 RequestLoop:
 	for {
+		if callInterval > 0 {
+			time.Sleep(callInterval)
+		}
+
 		requests++
 		var response *gosnmp.SnmpPacket
 		var err error


### PR DESCRIPTION
### What does this PR do?

This PR adds an option to the SNMP device scan to be able to sleep between SNMP calls. This will especially be useful for the [device scan by default](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5629477420/RFC+Device+scan+by+default#Do-we-need-to-reduce-query-load-on-the-devices%3F) as we want to sleep between SNMP calls in this case.

### Motivation

### Describe how you validated your changes

### Additional Notes
