### PR TITLE
CAP-3054 add OriginCollector to CollectorManifest

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/processors/common/base.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/common/base.go
@@ -54,14 +54,15 @@ func ExtractModelManifests(ctx processors.ProcessorContext, resourceManifests []
 	}
 
 	cm := &model.CollectorManifest{
-		ClusterName:  pctx.Cfg.KubeClusterName,
-		ClusterId:    pctx.ClusterID,
-		Manifests:    manifests,
-		GroupId:      pctx.MsgGroupID,
-		GroupSize:    int32(groupSize),
-		Tags:         pctx.Cfg.ExtraTags,
-		HostName:     pctx.HostName,
-		AgentVersion: ctx.GetAgentVersion(),
+		ClusterName:     pctx.Cfg.KubeClusterName,
+		ClusterId:       pctx.ClusterID,
+		Manifests:       manifests,
+		GroupId:         pctx.MsgGroupID,
+		GroupSize:       int32(groupSize),
+		Tags:            pctx.Cfg.ExtraTags,
+		HostName:        pctx.HostName,
+		AgentVersion:    ctx.GetAgentVersion(),
+		OriginCollector: model.OriginCollector_datadogAgent,
 	}
 	return cm
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster.go
@@ -195,8 +195,9 @@ func (p *ClusterProcessor) Process(ctx processors.ProcessorContext, list interfa
 					Tags: pctx.GetCollectorTags(),
 				},
 			},
-			Tags:         pctx.Cfg.ExtraTags,
-			AgentVersion: ctx.GetAgentVersion(),
+			Tags:            pctx.Cfg.ExtraTags,
+			AgentVersion:    ctx.GetAgentVersion(),
+			OriginCollector: model.OriginCollector_datadogAgent,
 		},
 	}
 	processResult = processors.ProcessResult{

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster_test.go
@@ -137,6 +137,7 @@ func TestClusterProcessor_Process_Success(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 1)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	manifest := manifestMsg.Manifests[0]
 	assert.Equal(t, "test-cluster-id", manifest.Uid)

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole_test.go
@@ -339,6 +339,8 @@ func TestClusterRoleProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding_test.go
@@ -336,6 +336,7 @@ func TestClusterRoleBindingProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1_test.go
@@ -330,6 +330,7 @@ func TestCronJobV1Processor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1_test.go
@@ -331,6 +331,7 @@ func TestCronJobV1Beta1Processor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset_test.go
@@ -328,6 +328,7 @@ func TestDaemonSetProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment_test.go
@@ -340,6 +340,7 @@ func TestDeploymentProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler_test.go
@@ -329,6 +329,7 @@ func TestHorizontalPodAutoscalerProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress_test.go
@@ -328,6 +328,7 @@ func TestIngressProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job_test.go
@@ -330,6 +330,7 @@ func TestJobProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange_test.go
@@ -330,6 +330,7 @@ func TestLimitRangeProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace_test.go
@@ -332,6 +332,7 @@ func TestNamespaceProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy_test.go
@@ -334,6 +334,7 @@ func TestNetworkPolicyProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
@@ -346,6 +346,7 @@ func TestNodeProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume_test.go
@@ -333,6 +333,7 @@ func TestPersistentVolumeProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim_test.go
@@ -334,6 +334,7 @@ func TestPersistentVolumeClaimProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_test.go
@@ -377,6 +377,7 @@ func TestPodProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget_test.go
@@ -326,6 +326,7 @@ func TestPodDisruptionBudgetProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset_test.go
@@ -334,6 +334,7 @@ func TestReplicaSetProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role_test.go
@@ -325,6 +325,7 @@ func TestRoleProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding_test.go
@@ -328,6 +328,7 @@ func TestRoleBindingProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service_test.go
@@ -330,6 +330,7 @@ func TestServiceProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount_test.go
@@ -331,6 +331,7 @@ func TestServiceAccountProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset_test.go
@@ -332,6 +332,7 @@ func TestStatefulSetProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass_test.go
@@ -340,6 +340,7 @@ func TestStorageClassProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler_test.go
@@ -336,6 +336,7 @@ func TestVerticalPodAutoscalerProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifestMsg.GroupId)
 	assert.Equal(t, "test-host", manifestMsg.HostName)
 	assert.Len(t, manifestMsg.Manifests, 2)
+	assert.Equal(t, manifestMsg.OriginCollector, model.OriginCollector_datadogAgent)
 
 	// Validate manifest details
 	manifest1 := manifestMsg.Manifests[0]

--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig.go
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig.go
@@ -13,11 +13,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/twmb/murmur3"
 	"go.uber.org/atomic"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/twmb/murmur3"
-
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -199,13 +198,14 @@ func (c *Check) Run() error {
 
 	msg := []model.MessageBody{
 		&model.CollectorManifest{
-			ClusterName:  c.config.KubeClusterName,
-			ClusterId:    c.clusterID,
-			GroupId:      nextGroupID(),
-			HostName:     c.hostName,
-			Manifests:    []*model.Manifest{manifest},
-			Tags:         c.config.ExtraTags,
-			AgentVersion: c.agentVersion,
+			ClusterName:     c.config.KubeClusterName,
+			ClusterId:       c.clusterID,
+			GroupId:         nextGroupID(),
+			HostName:        c.hostName,
+			Manifests:       []*model.Manifest{manifest},
+			Tags:            c.config.ExtraTags,
+			AgentVersion:    c.agentVersion,
+			OriginCollector: model.OriginCollector_datadogAgent,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Add OriginCollector field to CollectorManifest to differentiate manifest payloads between the Datadog agent and Datadog exporter.

### Motivation

Just to be consistent, no behavior change.

### Describe how you validated your changes

Minor change, nothing is really using this field yet.