### PR TITLE
[EBPF] gpu: fix NVML "unknown error" access issues

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -391,6 +391,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(gpuNS, "attacher_detailed_logs"), false)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "ringbuffer_flush_interval"), 1*time.Second)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "device_cache_refresh_interval"), 5*time.Second)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "cgroup_reapply_delay"), 30*time.Second)
 
 	// gpu - stream config
 	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "max_kernel_launches"), 1000)

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -22,12 +22,14 @@ import (
 
 	"github.com/containerd/cgroups/v3"
 
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ConfigureDeviceCgroups configures the cgroups for a process to allow access to the NVIDIA character devices
-func ConfigureDeviceCgroups(pid uint32, hostRoot string) error {
+func ConfigureDeviceCgroups(pid uint32, hostRoot string, reapplyDelay time.Duration) error {
 	cgroupMode := cgroups.Mode()
 	cgroupPath, err := getAbsoluteCgroupForProcess("/", hostRoot, uint32(os.Getpid()), pid, cgroupMode)
 	if err != nil {
@@ -51,6 +53,25 @@ func ConfigureDeviceCgroups(pid uint32, hostRoot string) error {
 
 	if err != nil {
 		return fmt.Errorf("failed to configure cgroup device allow for cgroup path %s: %w", cgroupPath, err)
+	}
+
+	// Schedule background re-application if configured
+	if reapplyDelay > 0 {
+		time.AfterFunc(reapplyDelay, func() {
+			// Re-apply only the cgroup device configuration, not systemd
+			var err error
+			if cgroupMode == cgroups.Legacy {
+				err = configureCgroupV1DeviceAllow(hostRoot, cgroupPath, nvidiaDeviceMajor)
+			} else {
+				err = detachAllDeviceCgroupPrograms(hostRoot, cgroupPath)
+			}
+
+			if err != nil {
+				log.Warnf("Failed to re-apply cgroup device configuration for pid %d after delay: %v", pid, err)
+			} else {
+				log.Debugf("Successfully re-applied cgroup device configuration for pid %d after %v delay", pid, reapplyDelay)
+			}
+		})
 	}
 
 	return nil

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -82,7 +82,7 @@ const (
 	systemdTransientConfigPath = "run/systemd/transient"
 	cgroupv1DeviceAllowFile    = "devices.allow"
 	cgroupv1DeviceControlDir   = "sys/fs/cgroup/devices"
-	nvidiaSystemdDeviceAllow   = "DeviceAllow=char-nvidia rwm\n" // Allow access to the NVIDIA character devices
+	nvidiaSystemdDeviceAllow   = "DeviceAllow=char-nvidia rwm\nDeviceAllow=char-195 rwm\n" // Allow access to the NVIDIA character devices
 	nvidiaDeviceMajor          = 195
 	cgroupFsPath               = "/sys/fs/cgroup"
 )

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	AttacherDetailedLogs bool
 	// DeviceCacheRefreshInterval is the interval at which the probe scans for the latest devices
 	DeviceCacheRefreshInterval time.Duration
+	// CgroupReapplyDelay is the delay before re-applying cgroup device configuration. 0 means no re-application.
+	// Defaults to 30 seconds. It is used to fix race conditions between systemd and the system-probe permission patching.
+	CgroupReapplyDelay time.Duration
 }
 
 // StreamConfig is the configuration for the streams.
@@ -88,5 +91,6 @@ func New() *Config {
 		},
 		AttacherDetailedLogs:       spCfg.GetBool(sysconfig.FullKeyPath(consts.GPUNS, "attacher_detailed_logs")),
 		DeviceCacheRefreshInterval: spCfg.GetDuration(sysconfig.FullKeyPath(consts.GPUNS, "device_cache_refresh_interval")),
+		CgroupReapplyDelay:         spCfg.GetDuration(sysconfig.FullKeyPath(consts.GPUNS, "cgroup_reapply_delay")),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR applies two fixes to try and resolve the issue of NVML not being initializated in a small subset of pods:

* Re-apply the cgroup patching after a certain point, gated behind a config flag. 
* Use both the "nvidia" character device name but also its known major number, 195.

### Motivation

A possible cause of this issue is a race condition, where the following sequence of events might happen:

1. Systemd reads the `50-DeviceAllow.conf` file for the cgroup, without the entry for the NVIDIA devices
2. system-probe patches the `50-DeviceAllow.conf` file.
3. system-probe patches the cgroup device permissions.
4. Systemd reapplies the device cgroup permissions using the old config, denying again access to the NVIDIA devices to the agent or system-probe containers.

For context, there have been sporadic cases in our own infrastructure where the agent or system-probe container would report a failure to initialize NVML, with "Unknown error" which usually means that the access to the devices is denied because of the cgroup permissions. On inspection of these pods, the `50-DeviceAllow.conf` file was correctly configured, but the cgroup had BPF programs attached. An inspection with `strace` revealed that NVML could not read from the NVIDIA devices in `/dev/`. This could be caused by the `50-DeviceAllow.conf` being incorrect, but after running `systemctl daemon-reexec` the container could access again the NVIDIA devices, which goes against that theory.

The SystemD code does non-trivial work to generate the cgroup permissions, including reading `/proc/devices` multiple times for each `DeviceAllow` line and generating and loading the BPF program. Therefore, it's reasonable to think that the sequence explained above might happen, as the system-probe does significantly less work for the cgroup patching.

If this is the race condition causing the lack of access to NVIDIA devices, and considering we can't synchronize at all with SystemD, then re-applying the cgroup configuration after enough time has passed (30s by default) will fix the cgroup permissions in these cases where systemd is reading old configuration. 

This was demonstrated by looking at logs from both system-probe and the kubelet in one of these "access loss" cases. While SystemD does not explicitly log reloads of the permissions, we knew from [this doc](https://datadoghq.atlassian.net/wiki/spaces/K8S/pages/3164145033/Why+does+the+device+plugin+need+to+be+privileged) that the permission reload is triggered by a CPUSet update that's logged in the kubelet logs. Here are the relevant system-probe log lines:

```
2025-10-29 07:47:18 UTC | SYS-PROBE | INFO | (pkg/gpu/cgroups.go:48 in ConfigureDeviceCgroups) | Configuring PID 685502 cgroupv2 device programs, cgroup path /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod55dbf8ff_2cc7_4a8e_bc9e_cf9b2e19ad98.slice/cri-containerd-504e5c1114653965966955efd107417f26e99317798c5d765ca94183bd2e05d9.scope
2025-10-29 07:47:18 UTC | SYS-PROBE | INFO | (pkg/gpu/cgroups.go:48 in ConfigureDeviceCgroups) | Configuring PID 685259 cgroupv2 device programs, cgroup path /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod55dbf8ff_2cc7_4a8e_bc9e_cf9b2e19ad98.slice/cri-containerd-97baffd06e989d59f0017c289781423bc3b56315c926c396f4a708aa1627d72b.scope
```

and the ones from the kubelet:

```
Oct 29 07:47:18 ip-10-112-106-209 kubelet[12208]: I1029 07:47:18.800137   12208 state_mem.go:80] "Updated desired CPUSet" podUID="55dbf8ff-2cc7-4a8e-bc9e-cf9b2e19ad98" containerName="agent" cpuSet="0-15"
Oct 29 07:47:18 ip-10-112-106-209 kubelet[12208]: I1029 07:47:18.867288   12208 state_mem.go:80] "Updated desired CPUSet" podUID="55dbf8ff-2cc7-4a8e-bc9e-cf9b2e19ad98" containerName="system-probe" cpuSet="0-15"
```

Both systemd and system-probe will reload the permissions at the same time, supporting the theory that this was caused by a race issue.

However, There's one possibility still open. According to SystemD manual: 

> Note that allow lists defined this way should only reference device groups which are resolvable at the time the unit is started

[Reference, see DeviceAllow= entry](https://www.man7.org/linux/man-pages/man5/systemd.resource-control.5.html)

This would mean that, in a situation where the NVIDIA driver hasn't loaded yet but system-probe has already patched everything, SystemD might later read the `50-DeviceAllow.conf` containing the `char-nvidia` line and ignore it because there are no devices with that character major number. There is no evidence of this happening though. On one hand, this access issue has happened in pods that started way after the node was created and the previous agent pod did have access to NVML, which means that the driver issue couldn't be the cause in those cases. On the other, in the instances where this has happened on a fresh node creation, the timings didn't match, with the driver being loaded several seconds before the agent or system-probe containers were even created. 

However, lack of evidence doesn't mean this issue cannot happen. The reapplication of the cgroup patching alone will probably mitigate a lot of these cases, as long as the driver loads before that repplication. Still, this PR implements a second mitigation, where we add a line with the known NVIDIA major device number to the `50-DeviceAllow.conf` file. If the line has a numeric value, it will get added irrespective of whether there are devices with that number or not (see [SystemD code](https://github.com/systemd/systemd/blob/516df12af9679ab25c39813d6787b0f044a53990/src/core/bpf-devices.c#L339)). We keep the `char-nvidia` line to cover us against cases where the major device number might change.

### Describe how you validated your changes

Deployed to `venomoth.us1.staging.dog` to check that there were no permissions issues. 

### Additional Notes
