### PR TITLE
[CWS] Fix accessor template to check legacy fields

### DIFF
--- a/pkg/security/generators/accessors/accessors.tmpl
+++ b/pkg/security/generators/accessors/accessors.tmpl
@@ -35,10 +35,8 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 
 	switch field {
@@ -279,10 +277,9 @@ func (ev *Event) GetFields() []eval.Field {
 	}
 	
 	// Add legacy field names if mapping is available
-	if defaultLegacyFields != nil {
-		for legacyField := range defaultLegacyFields {
-			fields = append(fields, legacyField)
-		}
+	legacyKeys := GetDefaultLegacyFieldsKeys()
+	if legacyKeys != nil {
+		fields = append(fields, legacyKeys...)
 	}
 	
 	return fields
@@ -291,10 +288,8 @@ func (ev *Event) GetFields() []eval.Field {
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
 	originalField := field
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 
 	switch field {
@@ -314,10 +309,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	// handle legacy field mapping
 	mappedField := field
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			mappedField = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		mappedField = newField
 	}
 
 	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {

--- a/pkg/security/generators/accessors/accessors.tmpl
+++ b/pkg/security/generators/accessors/accessors.tmpl
@@ -35,8 +35,10 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	// handle legacy field mapping
-	if newField, found := SECLLegacyFields[field]; found {
-		field = newField
+	if defaultLegacyFields != nil {
+		if newField, found := defaultLegacyFields[field]; found {
+			field = newField
+		}
 	}
 
 	switch field {
@@ -52,11 +54,6 @@ func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 }
 
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
-	// handle legacy field mapping
-	if newField, found := SECLLegacyFields[field]; found {
-		field = newField
-	}
-
 	switch field {
 	{{range $Name, $Field := .Fields}}
 	{{- if $Field.GettersOnly }}
@@ -271,7 +268,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 }
 
 func (ev *Event) GetFields() []eval.Field {
-	return []eval.Field{
+	fields := []eval.Field{
 		{{range $Name, $Field := .Fields}}
 			{{- if $Field.GettersOnly }}
 				{{continue}}
@@ -280,12 +277,24 @@ func (ev *Event) GetFields() []eval.Field {
 			"{{$Name}}",
 		{{end}}
 	}
+	
+	// Add legacy field names if mapping is available
+	if defaultLegacyFields != nil {
+		for legacyField := range defaultLegacyFields {
+			fields = append(fields, legacyField)
+		}
+	}
+	
+	return fields
 }
 
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
+	originalField := field
 	// handle legacy field mapping
-	if newField, found := SECLLegacyFields[field]; found {
-		field = newField
+	if defaultLegacyFields != nil {
+		if newField, found := defaultLegacyFields[field]; found {
+			field = newField
+		}
 	}
 
 	switch field {
@@ -299,14 +308,16 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	{{end}}
 	}
 
-	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
+	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: originalField}
 }
 
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	// handle legacy field mapping
 	mappedField := field
-	if newField, found := SECLLegacyFields[field]; found {
-		mappedField = newField
+	if defaultLegacyFields != nil {
+		if newField, found := defaultLegacyFields[field]; found {
+			mappedField = newField
+		}
 	}
 
 	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {

--- a/pkg/security/generators/accessors/accessors.tmpl
+++ b/pkg/security/generators/accessors/accessors.tmpl
@@ -34,6 +34,11 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 }
 
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
+
 	switch field {
 	{{range $Name, $Field := .Fields}}
 	{{- if $Field.RestrictedTo }}
@@ -47,6 +52,11 @@ func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 }
 
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
+
 	switch field {
 	{{range $Name, $Field := .Fields}}
 	{{- if $Field.GettersOnly }}
@@ -273,6 +283,11 @@ func (ev *Event) GetFields() []eval.Field {
 }
 
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
+
 	switch field {
 	{{range $Name, $Field := .Fields}}
 	{{- if $Field.GettersOnly }}
@@ -288,11 +303,17 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 }
 
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
-	if strings.HasPrefix(field, "process.") || strings.HasPrefix(field, "exec.") {
+	// handle legacy field mapping
+	mappedField := field
+	if newField, found := SECLLegacyFields[field]; found {
+		mappedField = newField
+	}
+
+	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
 		ev.initProcess()
 	}
 
-	switch field {
+	switch mappedField {
 		{{range $Name, $Field := .Fields}}
 		{{- if $Field.GettersOnly }}
 			{{continue}}

--- a/pkg/security/secl/model/accessors_helpers.go
+++ b/pkg/security/secl/model/accessors_helpers.go
@@ -15,10 +15,8 @@ import (
 // GetFieldValue retrieves the value of a field from the event using the evaluator.
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 
 	m := &Model{}

--- a/pkg/security/secl/model/accessors_helpers.go
+++ b/pkg/security/secl/model/accessors_helpers.go
@@ -14,6 +14,13 @@ import (
 
 // GetFieldValue retrieves the value of a field from the event using the evaluator.
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
+	// handle legacy field mapping
+	if defaultLegacyFields != nil {
+		if newField, found := defaultLegacyFields[field]; found {
+			field = newField
+		}
+	}
+
 	m := &Model{}
 	evaluator, err := m.GetEvaluator(field, "", 0)
 	if err != nil {

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -69,10 +69,8 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 }
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 	switch field {
 	case "network.destination.ip":
@@ -36602,20 +36600,17 @@ func (ev *Event) GetFields() []eval.Field {
 		"utimes.syscall.path",
 	}
 	// Add legacy field names if mapping is available
-	if defaultLegacyFields != nil {
-		for legacyField := range defaultLegacyFields {
-			fields = append(fields, legacyField)
-		}
+	legacyKeys := GetDefaultLegacyFieldsKeys()
+	if legacyKeys != nil {
+		fields = append(fields, legacyKeys...)
 	}
 	return fields
 }
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
 	originalField := field
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 	switch field {
 	case "accept.addr.family":
@@ -40918,10 +40913,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	// handle legacy field mapping
 	mappedField := field
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			mappedField = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		mappedField = newField
 	}
 	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
 		ev.initProcess()

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -68,6 +68,10 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 	}
 }
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	case "network.destination.ip":
 		return []eval.EventType{"dns", "imds", "packet"}
@@ -97,6 +101,10 @@ func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	return nil
 }
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	case "accept.addr.family":
 		return &eval.IntEvaluator{
@@ -36597,6 +36605,10 @@ func (ev *Event) GetFields() []eval.Field {
 	}
 }
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	case "accept.addr.family":
 		return "accept", reflect.Int, "int", nil
@@ -40896,10 +40908,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
 }
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
-	if strings.HasPrefix(field, "process.") || strings.HasPrefix(field, "exec.") {
+	// handle legacy field mapping
+	mappedField := field
+	if newField, found := SECLLegacyFields[field]; found {
+		mappedField = newField
+	}
+	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
 		ev.initProcess()
 	}
-	switch field {
+	switch mappedField {
 	case "accept.addr.family":
 		return ev.setUint16FieldValue("accept.addr.family", &ev.Accept.AddrFamily, value)
 	case "accept.addr.hostname":

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -38,10 +38,8 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 }
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 	switch field {
 	}
@@ -2463,20 +2461,17 @@ func (ev *Event) GetFields() []eval.Field {
 		"write.file.path.length",
 	}
 	// Add legacy field names if mapping is available
-	if defaultLegacyFields != nil {
-		for legacyField := range defaultLegacyFields {
-			fields = append(fields, legacyField)
-		}
+	legacyKeys := GetDefaultLegacyFieldsKeys()
+	if legacyKeys != nil {
+		fields = append(fields, legacyKeys...)
 	}
 	return fields
 }
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
 	originalField := field
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 	switch field {
 	case "change_permission.new_sd":
@@ -2823,10 +2818,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	// handle legacy field mapping
 	mappedField := field
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			mappedField = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		mappedField = newField
 	}
 	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
 		ev.initProcess()

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -37,11 +37,19 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 	}
 }
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	}
 	return nil
 }
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	case "change_permission.new_sd":
 		return &eval.StringEvaluator{
@@ -2458,6 +2466,10 @@ func (ev *Event) GetFields() []eval.Field {
 	}
 }
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	case "change_permission.new_sd":
 		return "change_permission", reflect.String, "string", nil
@@ -2801,10 +2813,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
 }
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
-	if strings.HasPrefix(field, "process.") || strings.HasPrefix(field, "exec.") {
+	// handle legacy field mapping
+	mappedField := field
+	if newField, found := SECLLegacyFields[field]; found {
+		mappedField = newField
+	}
+	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
 		ev.initProcess()
 	}
-	switch field {
+	switch mappedField {
 	case "change_permission.new_sd":
 		return ev.setStringFieldValue("change_permission.new_sd", &ev.ChangePermission.NewSd, value)
 	case "change_permission.old_sd":

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -38,18 +38,16 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 }
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	// handle legacy field mapping
-	if newField, found := SECLLegacyFields[field]; found {
-		field = newField
+	if defaultLegacyFields != nil {
+		if newField, found := defaultLegacyFields[field]; found {
+			field = newField
+		}
 	}
 	switch field {
 	}
 	return nil
 }
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
-	// handle legacy field mapping
-	if newField, found := SECLLegacyFields[field]; found {
-		field = newField
-	}
 	switch field {
 	case "change_permission.new_sd":
 		return &eval.StringEvaluator{
@@ -2293,7 +2291,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 	return nil, &eval.ErrFieldNotFound{Field: field}
 }
 func (ev *Event) GetFields() []eval.Field {
-	return []eval.Field{
+	fields := []eval.Field{
 		"change_permission.new_sd",
 		"change_permission.old_sd",
 		"change_permission.path",
@@ -2464,11 +2462,21 @@ func (ev *Event) GetFields() []eval.Field {
 		"write.file.path",
 		"write.file.path.length",
 	}
+	// Add legacy field names if mapping is available
+	if defaultLegacyFields != nil {
+		for legacyField := range defaultLegacyFields {
+			fields = append(fields, legacyField)
+		}
+	}
+	return fields
 }
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
+	originalField := field
 	// handle legacy field mapping
-	if newField, found := SECLLegacyFields[field]; found {
-		field = newField
+	if defaultLegacyFields != nil {
+		if newField, found := defaultLegacyFields[field]; found {
+			field = newField
+		}
 	}
 	switch field {
 	case "change_permission.new_sd":
@@ -2810,13 +2818,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	case "write.file.path.length":
 		return "write", reflect.Int, "int", nil
 	}
-	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
+	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: originalField}
 }
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	// handle legacy field mapping
 	mappedField := field
-	if newField, found := SECLLegacyFields[field]; found {
-		mappedField = newField
+	if defaultLegacyFields != nil {
+		if newField, found := defaultLegacyFields[field]; found {
+			mappedField = newField
+		}
 	}
 	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
 		ev.initProcess()

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -19,9 +19,28 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/utils"
 )
 
+var (
+	// defaultLegacyFields holds the default legacy field mapping for backward compatibility
+	// It is set by SetLegacyFields when the model is initialized with the correct mapping for the platform
+	defaultLegacyFields map[eval.Field]eval.Field
+)
+
+// SetDefaultLegacyFields sets the default legacy field mapping used by the accessors
+func SetDefaultLegacyFields(legacyFields map[eval.Field]eval.Field) {
+	defaultLegacyFields = legacyFields
+}
+
 // Model describes the data model for the runtime security agent events
 type Model struct {
 	ExtraValidateFieldFnc func(field eval.Field, fieldValue eval.FieldValue) error
+	legacyFields          map[eval.Field]eval.Field
+}
+
+// SetLegacyFields sets the legacy field mapping for backwards compatibility
+func (m *Model) SetLegacyFields(legacyFields map[eval.Field]eval.Field) {
+	m.legacyFields = legacyFields
+	// Also set as default for accessors
+	SetDefaultLegacyFields(legacyFields)
 }
 
 // Releasable represents an object than can be released

--- a/pkg/security/seclwin/model/accessors_helpers.go
+++ b/pkg/security/seclwin/model/accessors_helpers.go
@@ -15,10 +15,8 @@ import (
 // GetFieldValue retrieves the value of a field from the event using the evaluator.
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 
 	m := &Model{}

--- a/pkg/security/seclwin/model/accessors_helpers.go
+++ b/pkg/security/seclwin/model/accessors_helpers.go
@@ -14,6 +14,13 @@ import (
 
 // GetFieldValue retrieves the value of a field from the event using the evaluator.
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
+	// handle legacy field mapping
+	if defaultLegacyFields != nil {
+		if newField, found := defaultLegacyFields[field]; found {
+			field = newField
+		}
+	}
+
 	m := &Model{}
 	evaluator, err := m.GetEvaluator(field, "", 0)
 	if err != nil {

--- a/pkg/security/seclwin/model/accessors_win.go
+++ b/pkg/security/seclwin/model/accessors_win.go
@@ -36,10 +36,8 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 }
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 	switch field {
 	}
@@ -2461,20 +2459,17 @@ func (ev *Event) GetFields() []eval.Field {
 		"write.file.path.length",
 	}
 	// Add legacy field names if mapping is available
-	if defaultLegacyFields != nil {
-		for legacyField := range defaultLegacyFields {
-			fields = append(fields, legacyField)
-		}
+	legacyKeys := GetDefaultLegacyFieldsKeys()
+	if legacyKeys != nil {
+		fields = append(fields, legacyKeys...)
 	}
 	return fields
 }
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
 	originalField := field
 	// handle legacy field mapping
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			field = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		field = newField
 	}
 	switch field {
 	case "change_permission.new_sd":
@@ -2821,10 +2816,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	// handle legacy field mapping
 	mappedField := field
-	if defaultLegacyFields != nil {
-		if newField, found := defaultLegacyFields[field]; found {
-			mappedField = newField
-		}
+	if newField, found := GetDefaultLegacyFields(field); found {
+		mappedField = newField
 	}
 	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
 		ev.initProcess()

--- a/pkg/security/seclwin/model/accessors_win.go
+++ b/pkg/security/seclwin/model/accessors_win.go
@@ -35,11 +35,19 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 	}
 }
 func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	}
 	return nil
 }
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	case "change_permission.new_sd":
 		return &eval.StringEvaluator{
@@ -2456,6 +2464,10 @@ func (ev *Event) GetFields() []eval.Field {
 	}
 }
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
+	// handle legacy field mapping
+	if newField, found := SECLLegacyFields[field]; found {
+		field = newField
+	}
 	switch field {
 	case "change_permission.new_sd":
 		return "change_permission", reflect.String, "string", nil
@@ -2799,10 +2811,15 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
 }
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
-	if strings.HasPrefix(field, "process.") || strings.HasPrefix(field, "exec.") {
+	// handle legacy field mapping
+	mappedField := field
+	if newField, found := SECLLegacyFields[field]; found {
+		mappedField = newField
+	}
+	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
 		ev.initProcess()
 	}
-	switch field {
+	switch mappedField {
 	case "change_permission.new_sd":
 		return ev.setStringFieldValue("change_permission.new_sd", &ev.ChangePermission.NewSd, value)
 	case "change_permission.old_sd":

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -19,9 +19,28 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/utils"
 )
 
+var (
+	// defaultLegacyFields holds the default legacy field mapping for backward compatibility
+	// It is set by SetLegacyFields when the model is initialized with the correct mapping for the platform
+	defaultLegacyFields map[eval.Field]eval.Field
+)
+
+// SetDefaultLegacyFields sets the default legacy field mapping used by the accessors
+func SetDefaultLegacyFields(legacyFields map[eval.Field]eval.Field) {
+	defaultLegacyFields = legacyFields
+}
+
 // Model describes the data model for the runtime security agent events
 type Model struct {
 	ExtraValidateFieldFnc func(field eval.Field, fieldValue eval.FieldValue) error
+	legacyFields          map[eval.Field]eval.Field
+}
+
+// SetLegacyFields sets the legacy field mapping for backwards compatibility
+func (m *Model) SetLegacyFields(legacyFields map[eval.Field]eval.Field) {
+	m.legacyFields = legacyFields
+	// Also set as default for accessors
+	SetDefaultLegacyFields(legacyFields)
 }
 
 // Releasable represents an object than can be released


### PR DESCRIPTION
### What does this PR do?

It modifies the accessor template to look at legacy fields to make the correct mapping

### Motivation

With https://github.com/DataDog/datadog-agent/pull/42280 rules using a set action by specifying a field as value generated errors (https://github.com/DataDog/security-monitoring/actions/runs/18879398397/job/53877961880?pr=6799)

### Describe how you validated your changes

Validated with this rule:
```

  - id: BUG
    expression: exec.file.path == "/tmp/foo" && container.id != "" && container.id != ${container.foo}
    actions:
      - set:
          name: foo
          field: container.id
          scope: container

```
and a sudo ./bin/system-probe/system-probe runtime policy check

### Additional Notes
