### PR TITLE
[OTAGENT-550] Set default batch values to match batch processor

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
@@ -38,7 +38,7 @@ const (
 type Config struct {
 	OtelSource    string
 	LogSourceName string
-	QueueSettings exporterhelper.QueueBatchConfig
+	QueueSettings exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
 
 	// HostMetadata defines the host metadata specific configuration
 	HostMetadata datadogconfig.HostMetadataConfig `mapstructure:"host_metadata"`

--- a/comp/otelcol/otlp/map_provider_config_not_serverless.go
+++ b/comp/otelcol/otlp/map_provider_config_not_serverless.go
@@ -36,6 +36,7 @@ service:
       exporters: [otlp]
 `
 
+// TODO(OTAGENT-636): make sending_queue batch configurable
 // defaultMetricsConfig is the metrics OTLP pipeline configuration.
 const defaultMetricsConfig string = `
 receivers:
@@ -48,9 +49,6 @@ exporters:
   serializer:
     sending_queue:
       batch:
-        flush_timeout: 10000ms
-        min_size: 10
-        max_size: 100
 
 service:
   telemetry:
@@ -63,6 +61,7 @@ service:
       exporters: [serializer]
 `
 
+// TODO(OTAGENT-636): make sending_queue batch configurable
 // defaultLogsConfig is the logs OTLP pipeline configuration.
 const defaultLogsConfig string = `
 receivers:
@@ -75,9 +74,6 @@ exporters:
   logsagent:
     sending_queue:
       batch:
-        flush_timeout: 10000ms
-        min_size: 10
-        max_size: 100
 
 service:
   telemetry:

--- a/comp/otelcol/otlp/map_provider_config_not_serverless.go
+++ b/comp/otelcol/otlp/map_provider_config_not_serverless.go
@@ -42,12 +42,15 @@ receivers:
   otlp:
 
 processors:
-  batch:
-    timeout: 10s
   infraattributes:
 
 exporters:
   serializer:
+    sending_queue:
+      batch:
+        flush_timeout: 10000ms
+        min_size: 10
+        max_size: 100
 
 service:
   telemetry:
@@ -56,7 +59,7 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
-      processors: [batch, infraattributes]
+      processors: [infraattributes]
       exporters: [serializer]
 `
 
@@ -66,12 +69,15 @@ receivers:
   otlp:
 
 processors:
-  batch:
-    timeout: 10s
   infraattributes:
 
 exporters:
   logsagent:
+    sending_queue:
+      batch:
+        flush_timeout: 10000ms
+        min_size: 10
+        max_size: 100
 
 service:
   telemetry:
@@ -80,6 +86,6 @@ service:
   pipelines:
     logs:
       receivers: [otlp]
-      processors: [infraattributes, batch]
+      processors: [infraattributes]
       exporters: [logsagent]
 `

--- a/comp/otelcol/otlp/map_provider_not_serverless_test.go
+++ b/comp/otelcol/otlp/map_provider_not_serverless_test.go
@@ -108,9 +108,6 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"processors": map[string]any{
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 					"infraattributes": nil,
 				},
 				"exporters": map[string]any{
@@ -134,6 +131,13 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
 				},
 				"service": map[string]any{
@@ -146,7 +150,7 @@ func TestNewMap(t *testing.T) {
 						},
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer"},
 						},
 					},
@@ -184,9 +188,6 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"processors": map[string]any{
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 					"infraattributes": nil,
 				},
 				"exporters": map[string]any{
@@ -210,6 +211,13 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
 				},
 				"service": map[string]any{
@@ -222,7 +230,7 @@ func TestNewMap(t *testing.T) {
 						},
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer"},
 						},
 					},
@@ -309,9 +317,6 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"processors": map[string]any{
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 					"infraattributes": nil,
 				},
 				"exporters": map[string]any{
@@ -325,6 +330,13 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
 				},
 				"service": map[string]any{
@@ -332,7 +344,7 @@ func TestNewMap(t *testing.T) {
 					"pipelines": map[string]any{
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer"},
 						},
 					},
@@ -418,9 +430,6 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"processors": map[string]any{
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 					"infraattributes": nil,
 				},
 				"exporters": map[string]any{
@@ -433,6 +442,13 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
 					"debug": map[string]any{
 						"verbosity": "detailed",
@@ -443,7 +459,7 @@ func TestNewMap(t *testing.T) {
 					"pipelines": map[string]any{
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer", "debug"},
 						},
 					},
@@ -480,9 +496,6 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"processors": map[string]any{
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 					"infraattributes": nil,
 				},
 				"exporters": map[string]any{
@@ -505,6 +518,13 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
 					"debug": map[string]any{
 						"verbosity": "basic",
@@ -520,7 +540,7 @@ func TestNewMap(t *testing.T) {
 						},
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer", "debug"},
 						},
 					},
@@ -550,9 +570,6 @@ func TestNewMap(t *testing.T) {
 				},
 				"processors": map[string]any{
 					"infraattributes": any(nil),
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 				},
 				"exporters": map[string]any{
 					"otlp": map[string]any{
@@ -565,7 +582,15 @@ func TestNewMap(t *testing.T) {
 							"enabled": false,
 						},
 					},
-					"logsagent": any(nil),
+					"logsagent": map[string]any{
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
+					},
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{"metrics": map[string]any{"level": "none"}},
@@ -577,7 +602,7 @@ func TestNewMap(t *testing.T) {
 						},
 						"logs": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"infraattributes", "batch"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"logsagent"},
 						},
 					},
@@ -617,9 +642,6 @@ func TestNewMap(t *testing.T) {
 				},
 				"processors": map[string]any{
 					"infraattributes": any(nil),
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 				},
 				"exporters": map[string]any{
 					"otlp": map[string]any{
@@ -642,8 +664,23 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
-					"logsagent": any(nil),
+					"logsagent": map[string]any{
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
+					},
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{"metrics": map[string]any{"level": "none"}},
@@ -655,12 +692,12 @@ func TestNewMap(t *testing.T) {
 						},
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer"},
 						},
 						"logs": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"infraattributes", "batch"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"logsagent"},
 						},
 					},
@@ -700,9 +737,6 @@ func TestNewMap(t *testing.T) {
 				},
 				"processors": map[string]any{
 					"infraattributes": any(nil),
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 				},
 				"exporters": map[string]any{
 					"otlp": map[string]any{
@@ -725,8 +759,23 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
-					"logsagent": any(nil),
+					"logsagent": map[string]any{
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
+					},
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{"metrics": map[string]any{"level": "none"}},
@@ -738,12 +787,12 @@ func TestNewMap(t *testing.T) {
 						},
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer"},
 						},
 						"logs": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"infraattributes", "batch"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"logsagent"},
 						},
 					},
@@ -776,9 +825,6 @@ func TestNewMap(t *testing.T) {
 				},
 				"processors": map[string]any{
 					"infraattributes": any(nil),
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 				},
 				"exporters": map[string]any{
 					"otlp": map[string]any{
@@ -791,7 +837,15 @@ func TestNewMap(t *testing.T) {
 							"enabled": false,
 						},
 					},
-					"logsagent": any(nil),
+					"logsagent": map[string]any{
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
+					},
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{"metrics": map[string]any{"level": "none"}},
@@ -803,7 +857,7 @@ func TestNewMap(t *testing.T) {
 						},
 						"logs": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"infraattributes", "batch"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"logsagent"},
 						},
 					},
@@ -842,9 +896,6 @@ func TestNewMap(t *testing.T) {
 				},
 				"processors": map[string]any{
 					"infraattributes": any(nil),
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 				},
 				"exporters": map[string]any{
 					"serializer": map[string]any{
@@ -857,20 +908,35 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
-					"logsagent": any(nil),
+					"logsagent": map[string]any{
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
+					},
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{"metrics": map[string]any{"level": "none"}},
 					"pipelines": map[string]any{
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer"},
 						},
 						"logs": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"infraattributes", "batch"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"logsagent"},
 						},
 					},
@@ -900,9 +966,6 @@ func TestNewMap(t *testing.T) {
 				},
 				"processors": map[string]any{
 					"infraattributes": any(nil),
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 				},
 				"exporters": map[string]any{
 					"otlp": map[string]any{
@@ -918,7 +981,15 @@ func TestNewMap(t *testing.T) {
 					"debug": map[string]any{
 						"verbosity": "normal",
 					},
-					"logsagent": any(nil),
+					"logsagent": map[string]any{
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
+					},
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{"metrics": map[string]any{"level": "none"}},
@@ -930,7 +1001,7 @@ func TestNewMap(t *testing.T) {
 						},
 						"logs": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"infraattributes", "batch"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"logsagent", "debug"},
 						},
 					},
@@ -968,9 +1039,6 @@ func TestNewMap(t *testing.T) {
 				},
 				"processors": map[string]any{
 					"infraattributes": any(nil),
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 				},
 				"exporters": map[string]any{
 					"serializer": map[string]any{
@@ -982,23 +1050,38 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
 					"debug": map[string]any{
 						"verbosity": "detailed",
 					},
-					"logsagent": any(nil),
+					"logsagent": map[string]any{
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
+					},
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{"metrics": map[string]any{"level": "none"}},
 					"pipelines": map[string]any{
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer", "debug"},
 						},
 						"logs": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"infraattributes", "batch"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"logsagent", "debug"},
 						},
 					},
@@ -1037,9 +1120,6 @@ func TestNewMap(t *testing.T) {
 				},
 				"processors": map[string]any{
 					"infraattributes": any(nil),
-					"batch": map[string]any{
-						"timeout": "10s",
-					},
 				},
 				"exporters": map[string]any{
 					"otlp": map[string]any{
@@ -1061,11 +1141,26 @@ func TestNewMap(t *testing.T) {
 								"send_count_sum_metrics": true,
 							},
 						},
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
 					},
 					"debug": map[string]any{
 						"verbosity": "basic",
 					},
-					"logsagent": any(nil),
+					"logsagent": map[string]any{
+						"sending_queue": map[string]any{
+							"batch": map[string]any{
+								"flush_timeout": "10000ms",
+								"min_size":      10,
+								"max_size":      100,
+							},
+						},
+					},
 				},
 				"service": map[string]any{
 					"telemetry": map[string]any{"metrics": map[string]any{"level": "none"}},
@@ -1077,12 +1172,12 @@ func TestNewMap(t *testing.T) {
 						},
 						"metrics": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"batch", "infraattributes"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"serializer", "debug"},
 						},
 						"logs": map[string]any{
 							"receivers":  []any{"otlp"},
-							"processors": []any{"infraattributes", "batch"},
+							"processors": []any{"infraattributes"},
 							"exporters":  []any{"logsagent", "debug"},
 						},
 					},

--- a/comp/otelcol/otlp/map_provider_not_serverless_test.go
+++ b/comp/otelcol/otlp/map_provider_not_serverless_test.go
@@ -10,14 +10,18 @@ package otlp
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/otelcol"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter"
+	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/internal/configutils"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -132,11 +136,7 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -212,11 +212,7 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -331,11 +327,7 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -443,11 +435,7 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 					"debug": map[string]any{
@@ -519,11 +507,7 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 					"debug": map[string]any{
@@ -584,11 +568,7 @@ func TestNewMap(t *testing.T) {
 					},
 					"logsagent": map[string]any{
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -665,20 +645,12 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 					"logsagent": map[string]any{
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -760,20 +732,12 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 					"logsagent": map[string]any{
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -839,11 +803,7 @@ func TestNewMap(t *testing.T) {
 					},
 					"logsagent": map[string]any{
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -909,20 +869,12 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 					"logsagent": map[string]any{
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -983,11 +935,7 @@ func TestNewMap(t *testing.T) {
 					},
 					"logsagent": map[string]any{
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -1051,11 +999,7 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 					"debug": map[string]any{
@@ -1063,11 +1007,7 @@ func TestNewMap(t *testing.T) {
 					},
 					"logsagent": map[string]any{
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -1142,11 +1082,7 @@ func TestNewMap(t *testing.T) {
 							},
 						},
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 					"debug": map[string]any{
@@ -1154,11 +1090,7 @@ func TestNewMap(t *testing.T) {
 					},
 					"logsagent": map[string]any{
 						"sending_queue": map[string]any{
-							"batch": map[string]any{
-								"flush_timeout": "10000ms",
-								"min_size":      10,
-								"max_size":      100,
-							},
+							"batch": nil,
 						},
 					},
 				},
@@ -1232,6 +1164,24 @@ func TestUnmarshal(t *testing.T) {
 	components, err := getComponents(serializermock.NewMetricSerializer(t), make(chan *message.Message), fakeTagger, hostnameimpl.NewHostnameService(), nil)
 	require.NoError(t, err)
 
-	_, err = provider.Get(context.Background(), components)
+	svccfg, err := provider.Get(context.Background(), components)
 	require.NoError(t, err)
+
+	scfgRaw := svccfg.Exporters[component.MustNewID(serializerexporter.TypeStr)]
+	require.NotNil(t, scfgRaw)
+	scfg, ok := scfgRaw.(*serializerexporter.ExporterConfig)
+	require.True(t, ok, "failed to cast serializerexporter.ExporterConfig")
+	sBatchCfg := scfg.QueueBatchConfig.Batch.Get()
+	assert.Equal(t, 200*time.Millisecond, sBatchCfg.FlushTimeout)
+	assert.Equal(t, int64(8192), sBatchCfg.MinSize)
+	assert.Equal(t, int64(0), sBatchCfg.MaxSize)
+
+	lcfgRaw := svccfg.Exporters[component.MustNewID(logsagentexporter.TypeStr)]
+	require.NotNil(t, lcfgRaw)
+	lcfg, ok := lcfgRaw.(*logsagentexporter.Config)
+	require.True(t, ok, "failed to cast logsagentexporter.Config")
+	lBatchCfg := lcfg.QueueSettings.Batch.Get()
+	assert.Equal(t, 200*time.Millisecond, lBatchCfg.FlushTimeout)
+	assert.Equal(t, int64(8192), lBatchCfg.MinSize)
+	assert.Equal(t, int64(0), lBatchCfg.MaxSize)
 }

--- a/releasenotes/notes/replace-batch-processor-by-exporter-helper-97bae7f9efac2e07.yaml
+++ b/releasenotes/notes/replace-batch-processor-by-exporter-helper-97bae7f9efac2e07.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Replace batch processor with exporter helper for OTLP ingest
+    due to the upcoming end-of-life for batch processor.
+    More details: https://github.com/open-telemetry/opentelemetry-collector/issues/8122
+    


### PR DESCRIPTION
### What does this PR do?
Set default batch values to match batch processor in OTLP ingestion: flush timeout 200ms, min size 8192, no max size

### Motivation
When we applied the default batch values in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43419 to datadog-agent, we observed a regression https://github.com/DataDog/datadog-agent/pull/41661#issuecomment-3374062392 in performance tests. Setting the batch values back to batch processor default values (also the exporter helper default) fixes the regression, thus this change.

### Describe how you validated your changes
modified tests & local build

### Additional Notes
This reverts https://github.com/DataDog/datadog-agent/commit/ad1ae7551df518712eef3d240fe736469d70a364 and  re-submits https://github.com/DataDog/datadog-agent/commit/57eccdf8326198ea54a44c411cf4de0c69e29460