### PR TITLE
Check Windows legacy path length limit is lifted for `bazel`

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -4,7 +4,7 @@ set -euo pipefail
 # Check `bazelisk` properly bootstraps `bazel` or fail with instructions
 if [ -z "${BAZEL_REAL:-}" ] || [ "${BAZELISK_SKIP_WRAPPER:-}" != "true" ]; then
   >&2 cat "$(dirname "$0")/bazelisk.md"
-  exit 1
+  exit 2
 fi
 
 # Not in CI: simply execute `bazel` - done

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -3,12 +3,23 @@ setlocal EnableDelayedExpansion
 >nul chcp 65001
 
 :: Check `bazelisk` properly bootstraps `bazel` or fail with instructions
-if not defined BAZEL_REAL (
-  >&2 type "%~dp0bazelisk.md"
-  exit /b 1
-) else if not "%BAZELISK_SKIP_WRAPPER%"=="true" (
-  >&2 type "%~dp0bazelisk.md"
-  exit /b 2
+if defined BAZEL_REAL if "%BAZELISK_SKIP_WRAPPER%"=="true" goto :bazelisk_ok
+>&2 type "%~dp0bazelisk.md"
+exit /b 2
+:bazelisk_ok
+
+:: Check legacy max path length of 260 characters got lifted, or fail with instructions
+if defined XDG_CACHE_HOME (set "cache_home=%XDG_CACHE_HOME%") else (set "cache_home=%~dp0..\.cache")
+set "more_than_260_chars=!cache_home!\more-than-260-chars"
+for /l %%i in (1,1,26) do set "more_than_260_chars=!more_than_260_chars!\123456789"
+if not exist "!more_than_260_chars!" (
+  2>nul mkdir "!more_than_260_chars!"
+  if !errorlevel! neq 0 (
+    >&2 echo 🔴 For `bazel` to work properly, please lift the 260-character path limit from your Windows OS as per:
+    >&2 echo - either https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+    >&2 echo - or https://andrewlock.net/fixing-max_path-issues-in-gitlab/#window-s-maximum-path-length-limitation-
+    exit /b 2
+  )
 )
 
 :: Not in CI: simply execute `bazel` - done
@@ -21,7 +32,7 @@ if not defined CI_PROJECT_DIR (
 for %%v in (BAZEL_DISK_CACHE BAZEL_OUTPUT_USER_ROOT BAZEL_REPO_CONTENTS_CACHE RUNNER_TEMP_PROJECT_DIR VSTUDIO_ROOT) do (
   if not defined %%v (
     >&2 echo %~nx0: %%v: unbound variable
-    exit /b 3
+    exit /b 2
   )
   :: Path separators: `bazel` is fine with both `/` and `\\` but fails with `\`, so the simplest is to favor `/`
   set "%%v=!%%v:\=/!"


### PR DESCRIPTION
### What does this PR do?
Adds a proactive check in `tools/bazel.bat` to verify that Windows long paths (>260 characters) are enabled before running `bazel`, failing fast with clear instructions if not.

### Motivation
`bazel` creates deep directory structures that frequently exceed Windows' legacy 260-character path limit. When this limit isn't lifted, `bazel` may fail with errors like:
- > The filename, directory name, or volume label syntax is incorrect
- > The system cannot find the path specified
- random build failures in cache operations

These errors waste developer time debugging what appears to be a `bazel` or configuration issue, when the root cause is an _artificial_ Windows OS limitation.

By checking upfront and failing with clear instructions, we save developers from this debugging rabbit hole and make the fix obvious.

### Additional Notes
The check creates a nested directory structure exceeding 260 characters:
```batch
<cache_home>\more-than-260-chars\123456789\123456789\...\123456789
```

If `mkdir` fails, so does the script after displaying links to online guides:
- [Microsoft official docs](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation)
- [Andrew Lock's practical guide](https://andrewlock.net/fixing-max_path-issues-in-gitlab/#window-s-maximum-path-length-limitation-)

The test directory is cached for subsequent runs, making the check nearly instant after the first execution.

Exit codes are standardized to `2` across all checks (`bazelisk`, unbound variables) for consistency with [`bazel` exit codes](https://bazel.build/run/scripts#exit-codes):
> Command Line Problem, Bad or Illegal flags or command combination, or Bad Environment Variables.

### Describe how you validated your changes
Local Windows VM.