### PR TITLE
dyninst: keep track of SymDB uploads across restarts

### DIFF
--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	DiagsUploaderURL   string
 	SymDBUploadEnabled bool
 	SymDBUploaderURL   string
+	// The directory for the persistent cache tracking SymDB uploads. If empty,
+	// no cache will be used.
+	SymDBCacheDir string
 
 	// DiskCacheEnabled enables the disk cache for debug info.  If this is
 	// false, no disk cache will be used and the debug info will be stored in
@@ -76,6 +79,7 @@ func NewConfig(_ *sysconfigtypes.Config) (*Config, error) {
 		DiagsUploaderURL:   withPath(traceAgentURL, diagsUploaderPath),
 		SymDBUploadEnabled: pkgconfigsetup.SystemProbe().GetBool("dynamic_instrumentation.symdb_upload_enabled"),
 		SymDBUploaderURL:   withPath(traceAgentURL, symdbUploaderPath),
+		SymDBCacheDir:      "/var/tmp/datadog-agent/system-probe/dynamic-instrumentation/symdb_uploads",
 		DiskCacheEnabled:   cacheEnabled,
 		DiskCacheConfig:    cacheConfig,
 	}

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -242,7 +242,7 @@ func makeRealDependencies(
 
 	approximateBootTime := time.Now().Add(time.Duration(-ts.Nano()))
 	ret.decoderFactory = decoderFactory{approximateBootTime: approximateBootTime}
-	ret.symdbManager = newSymdbManager(symdbUploaderURL, ret.objectLoader)
+	ret.symdbManager = newSymdbManager(symdbUploaderURL, ret.objectLoader, config.SymDBCacheDir)
 	ret.attacher = &defaultAttacher{}
 	ret.programCompiler = &stackMachineCompiler{}
 	return ret, nil

--- a/pkg/dyninst/module/persistent_upload_cache.go
+++ b/pkg/dyninst/module/persistent_upload_cache.go
@@ -1,0 +1,282 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// entryType represents the type of upload entry.
+type entryType int
+
+const (
+	// entryTypeAttempt represents an upload attempt entry. An attempt is
+	// inserted in the cache before an upload is started; the entry is then
+	// converted to a completed one if the upload is successful.
+	entryTypeUnknown entryType = iota
+	entryTypeAttempt
+	// entryTypeCompleted represents a completed upload entry.
+	entryTypeCompleted
+)
+
+// uploadEntry represents an entry in the upload cache.
+type uploadEntry struct {
+	Type           entryType `json:"type"`
+	PID            int32     `json:"pid"`
+	ServiceName    string    `json:"servicename"`
+	ServiceVersion string    `json:"serviceversion"`
+	// AgentVersion is the version of the agent that wrote this entry.
+	AgentVersion string    `json:"agentversion"`
+	Timestamp    time.Time `json:"timestamp"`
+	// ErrorNumber counts how many times that upload failed.
+	ErrorNumber int    `json:"errornumber,omitempty"` // Only used for entryTypeAttempt
+	Error       string `json:"error,omitempty"`       // Optional error message for failed attempts
+}
+
+// persistentUploadCache stores information about attempted and completed debug
+// info processing and uploads to SymDB for different processes. The info is
+// stored on disk so it persists across agent restarts. Information about past
+// upload attempts can be used after a restart to decide if uploads should be
+// attempted again.
+type persistentUploadCache struct {
+	// The directory in which the cache entries are stored (each file in this
+	// dir represents one entry).
+	dir string
+}
+
+// AddAttempt adds a new upload attempt entry to the cache. If the entry for the
+// pid already exists, it is updated.
+func (c *persistentUploadCache) AddAttempt(
+	pid int32, serviceName, serviceVersion string, errorNumber int, errMsg string,
+) error {
+	entry := uploadEntry{
+		Type:           entryTypeAttempt,
+		PID:            pid,
+		ServiceName:    serviceName,
+		ServiceVersion: serviceVersion,
+		AgentVersion:   version.AgentVersion,
+		Timestamp:      time.Now(),
+		ErrorNumber:    errorNumber,
+	}
+	if errMsg != "" {
+		entry.Error = errMsg
+	}
+	return c.saveEntry(pid, entry)
+}
+
+// AddCompleted adds a new completed upload entry to the cache.
+func (c *persistentUploadCache) AddCompleted(pid int32, serviceName, serviceVersion string) error {
+	entry := uploadEntry{
+		Type:           entryTypeCompleted,
+		PID:            pid,
+		ServiceName:    serviceName,
+		ServiceVersion: serviceVersion,
+		AgentVersion:   version.AgentVersion,
+		Timestamp:      time.Now(),
+	}
+	return c.saveEntry(pid, entry)
+}
+
+// GetEntry retrieves an upload entry for the given PID.
+func (c *persistentUploadCache) GetEntry(pid int32) (*uploadEntry, error) {
+	path := c.entryPath(pid)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read entry file: %w", err)
+	}
+
+	var entry uploadEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal entry: %w", err)
+	}
+
+	return &entry, nil
+}
+
+// RemoveEntry removes the entry for the given PID.
+func (c *persistentUploadCache) RemoveEntry(pid int32) error {
+	path := c.entryPath(pid)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove entry: %w", err)
+	}
+	return nil
+}
+
+type cacheTestingKnobs struct {
+	processExists func(pid int) bool
+}
+
+type cacheOption func(*cacheTestingKnobs)
+
+func withProcessExistsCheck(fn func(pid int) bool) cacheOption {
+	return func(c *cacheTestingKnobs) {
+		c.processExists = fn
+	}
+}
+
+// NewPersistentUploadCache initializes a cache in the given directory. If the
+// directory already exists, its state is update to match the current state of
+// the processes on the box: files corresponding to processes that no longer
+// exist are deleted and files corresponding to pending uploads for processes
+// that do exist are updated with an error to mark the fact that the agent
+// restarted while that update was in progress.
+func newPersistentUploadCache(dir string, opts ...cacheOption) (*persistentUploadCache, error) {
+	// Ensure the cache directory exists or can be created.
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	cfg := cacheTestingKnobs{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	cache := &persistentUploadCache{
+		dir: dir,
+	}
+
+	entries, err := os.ReadDir(cache.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cache, nil // Directory doesn't exist yet, no entries to clean.
+		}
+		return nil, fmt.Errorf("failed to read cache directory: %w", err)
+	}
+
+	removedVersionMismatch := 0
+	for _, entry := range entries {
+		filePath := filepath.Join(cache.dir, entry.Name())
+		name := entry.Name()
+
+		if entry.IsDir() {
+			// Delete unexpected directories.
+			if err := os.RemoveAll(filePath); err != nil {
+				return nil, fmt.Errorf("failed to remove directory %s: %w", name, err)
+			}
+			continue
+		}
+
+		// Check if the filename has the expected format.
+		if !strings.HasSuffix(name, ".json") {
+			// Delete files with invalid extensions.
+			if err := os.Remove(filePath); err != nil {
+				return nil, fmt.Errorf("failed to remove invalid file %s: %w", name, err)
+			}
+			continue
+		}
+
+		// Parse PID from filename (e.g., "1234.json" -> 1234).
+		pidStr := strings.TrimSuffix(name, ".json")
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			// Delete files with invalid names.
+			if err := os.Remove(filePath); err != nil {
+				return nil, fmt.Errorf("failed to remove file with invalid name %s: %w", name, err)
+			}
+			continue
+		}
+
+		// Try to read and parse the file contents.
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			// Delete files that can't be read.
+			if err := os.Remove(filePath); err != nil {
+				return nil, fmt.Errorf("failed to remove unreadable file %s: %w", name, err)
+			}
+			continue
+		}
+
+		var uploadEntry uploadEntry
+		if err := json.Unmarshal(data, &uploadEntry); err != nil {
+			// Delete files with invalid JSON contents.
+			if err := os.Remove(filePath); err != nil {
+				return nil, fmt.Errorf("failed to remove file with invalid JSON %s: %w", name, err)
+			}
+			continue
+		}
+
+		// Validate that the entry type is a known enum value.
+		if uploadEntry.Type != entryTypeAttempt && uploadEntry.Type != entryTypeCompleted {
+			// Delete files with invalid entry type.
+			if err := os.Remove(filePath); err != nil {
+				return nil, fmt.Errorf("failed to remove file with invalid entry type %s: %w", name, err)
+			}
+			continue
+		}
+
+		// Delete entries from different agent versions; we want to upload again
+		// when the agent version changes.
+		if uploadEntry.AgentVersion != version.AgentVersion {
+			if err := os.Remove(filePath); err != nil {
+				return nil, fmt.Errorf("failed to remove entry with old version for PID %d: %w", pid, err)
+			}
+			removedVersionMismatch++
+			continue
+		}
+
+		// Check if the process still exists.
+		var processExists bool
+		if cfg.processExists != nil {
+			processExists = cfg.processExists(pid)
+		} else {
+			_, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid)))
+			processExists = !os.IsNotExist(err)
+		}
+
+		if !processExists {
+			log.Debugf("Removing stale cache entry for PID %d (process no longer exists)", pid)
+			if err := os.Remove(filePath); err != nil {
+				return nil, fmt.Errorf("failed to remove stale entry for PID %d: %w", pid, err)
+			}
+			continue
+		}
+
+		// For processes that still exist, mark pending uploads as failed due to restart.
+		if uploadEntry.Type == entryTypeAttempt {
+			uploadEntry.Error = "agent restarted during upload"
+			if err := cache.saveEntry(int32(pid), uploadEntry); err != nil {
+				return nil, fmt.Errorf("failed to update entry for PID %d: %w", pid, err)
+			}
+		}
+	}
+
+	if removedVersionMismatch > 0 {
+		log.Infof("Removed %d cache entries created by a different agent version (current version: %s)",
+			removedVersionMismatch, version.AgentVersion)
+	}
+
+	return cache, nil
+}
+
+func (c *persistentUploadCache) saveEntry(pid int32, entry uploadEntry) error {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache entry: %w", err)
+	}
+	entryPath := c.entryPath(pid)
+	if err := os.WriteFile(entryPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write cache entry file: %w", err)
+	}
+	return nil
+}
+
+func (c *persistentUploadCache) entryPath(pid int32) string {
+	return filepath.Join(c.dir, fmt.Sprintf("%d.json", pid))
+}

--- a/pkg/dyninst/module/persistent_upload_cache_test.go
+++ b/pkg/dyninst/module/persistent_upload_cache_test.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+func TestNewPersistentUploadCache_CleanupOnInit(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	// Define which PIDs should be considered "alive" for this test.
+	alivePIDs := map[int]bool{
+		1000: true,
+		2000: true,
+	}
+
+	// Create various test files.
+	testFiles := []struct {
+		name        string
+		content     interface{}
+		shouldExist bool
+		description string
+	}{
+		{
+			name: "1000.json",
+			content: uploadEntry{
+				Type:           entryTypeCompleted,
+				PID:            1000,
+				ServiceName:    "test-service",
+				ServiceVersion: "1.0.0",
+				AgentVersion:   version.AgentVersion,
+				Timestamp:      time.Now(),
+			},
+			shouldExist: true,
+			description: "valid entry for alive process with current agent version",
+		},
+		{
+			name: "2000.json",
+			content: uploadEntry{
+				Type:           entryTypeAttempt,
+				PID:            2000,
+				ServiceName:    "test-service",
+				ServiceVersion: "1.0.0",
+				AgentVersion:   version.AgentVersion,
+				Timestamp:      time.Now(),
+				ErrorNumber:    1,
+				Error:          "some error",
+			},
+			shouldExist: true,
+			description: "valid attempt entry for alive process - should be updated with restart error",
+		},
+		{
+			name: "3000.json",
+			content: uploadEntry{
+				Type:           entryTypeCompleted,
+				PID:            3000,
+				ServiceName:    "test-service",
+				ServiceVersion: "1.0.0",
+				AgentVersion:   version.AgentVersion,
+				Timestamp:      time.Now(),
+			},
+			shouldExist: false,
+			description: "entry for dead process",
+		},
+		{
+			name: "4000.json",
+			content: uploadEntry{
+				Type:           entryTypeCompleted,
+				PID:            4000,
+				ServiceName:    "test-service",
+				ServiceVersion: "1.0.0",
+				AgentVersion:   "3.2.1", // Different version.
+				Timestamp:      time.Now(),
+			},
+			shouldExist: false,
+			description: "entry with old agent version",
+		},
+		{
+			name:        "invalid.json",
+			content:     "not valid json content",
+			shouldExist: false,
+			description: "file with invalid JSON",
+		},
+		{
+			name:        "5000.txt",
+			content:     "some text content",
+			shouldExist: false,
+			description: "file with wrong extension",
+		},
+		{
+			name:        "notanumber.json",
+			content:     `{"type": 0}`,
+			shouldExist: false,
+			description: "file with non-numeric PID in filename",
+		},
+		{
+			name: "6000.json",
+			content: map[string]interface{}{
+				"type":         999, // Invalid entry type.
+				"pid":          6000,
+				"agentversion": version.AgentVersion,
+			},
+			shouldExist: false,
+			description: "entry with invalid entry type",
+		},
+	}
+
+	// Create test files.
+	for _, tf := range testFiles {
+		filePath := filepath.Join(cacheDir, tf.name)
+		var data []byte
+		var err error
+
+		switch content := tf.content.(type) {
+		case uploadEntry:
+			data, err = json.Marshal(content)
+			require.NoError(t, err, "failed to marshal %s", tf.description)
+		case string:
+			data = []byte(content)
+		case map[string]interface{}:
+			data, err = json.Marshal(content)
+			require.NoError(t, err, "failed to marshal %s", tf.description)
+		}
+
+		err = os.WriteFile(filePath, data, 0644)
+		require.NoError(t, err, "failed to write test file %s", tf.name)
+	}
+
+	// Create a directory to test cleanup of unexpected directories.
+	unexpectedDir := filepath.Join(cacheDir, "unexpected_directory")
+	err := os.Mkdir(unexpectedDir, 0755)
+	require.NoError(t, err)
+
+	// Initialize the cache with process existence check.
+	cache, err := newPersistentUploadCache(cacheDir, withProcessExistsCheck(func(pid int) bool {
+		return alivePIDs[pid]
+	}))
+	require.NoError(t, err)
+	require.Equal(t, cacheDir, cache.dir)
+
+	// Verify that files exist or don't exist as expected.
+	for _, tf := range testFiles {
+		filePath := filepath.Join(cacheDir, tf.name)
+		_, err := os.Stat(filePath)
+		if tf.shouldExist {
+			require.NoError(t, err, "%s should exist: %s", tf.name, tf.description)
+		} else {
+			require.True(t, os.IsNotExist(err), "%s should be deleted: %s", tf.name, tf.description)
+		}
+	}
+
+	// Verify unexpected directory was removed.
+	_, err = os.Stat(unexpectedDir)
+	require.True(t, os.IsNotExist(err), "unexpected directory should be deleted")
+
+	// Verify that the attempt entry for PID 2000 was updated with restart error.
+	entry, err := cache.GetEntry(2000)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.Equal(t, entryTypeAttempt, entry.Type)
+	require.Equal(t, "agent restarted during upload", entry.Error)
+
+	// Verify that the completed entry for PID 1000 was not modified.
+	entry, err = cache.GetEntry(1000)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.Equal(t, entryTypeCompleted, entry.Type)
+}
+
+func TestNewPersistentUploadCache_NonExistentDirectory(t *testing.T) {
+	parentDir := t.TempDir()
+	cacheDir := filepath.Join(parentDir, "nested", "cache")
+
+	cache, err := newPersistentUploadCache(cacheDir)
+	require.NoError(t, err)
+	require.Equal(t, cacheDir, cache.dir)
+
+	// Verify directory was created.
+	_, err = os.Stat(cacheDir)
+	require.NoError(t, err)
+}

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -50,8 +50,20 @@ type symdbManager struct {
 }
 
 type symdbManagerInterface interface {
+	// queueUpload queues a new upload request, if the process' data has not
+	// been uploaded previously (since the last corresponding removeUpload()
+	// call, if any). Calling queueUpload() again for the same process is a
+	// no-op.
+	//
+	// The upload will be performed asynchronously. A single upload can be in
+	// progress at a time. Returns an error if the manager has been stopped.
 	queueUpload(runtimeID procRuntimeID, executablePath string) error
+	// removeUpload removes the queued upload for the given process ID, if any. If
+	// the upload is currently being processed, it will be cancelled and the call
+	// will block until the upload stops. If no upload for the respective process is
+	// in progress or queued, the call is a no-op.
 	removeUpload(runtimeID procRuntimeID)
+	// removeUploadByPID removes the queued upload(s) for the given process ID.
 	removeUploadByPID(pid process.ID)
 }
 

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -13,11 +13,13 @@ import (
 	"fmt"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/process"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/uploader"
+	"github.com/DataDog/datadog-agent/pkg/util/backoff"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -29,10 +31,17 @@ type symdbManager struct {
 	uploadURL    *url.URL
 	objectLoader object.Loader
 	cfg          symdbManagerConfig
-	mu           struct {
+
+	// The cache persisting information about uploads across agent restarts. Nil
+	// if the cache could not be created.
+	persistentCache *persistentUploadCache
+
+	// Channel for notifications for modifications to mu.queuedUploads.
+	workNotification chan struct{}
+
+	mu struct {
 		sync.Mutex
-		queuedUploads []uploadRequest
-		cond          *sync.Cond
+		queuedUploads []scheduledUpload
 		currentUpload *uploadRequest // nil if no upload is in progress
 		currentCancel context.CancelCauseFunc
 		currentDone   chan struct{} // closed when current upload finishes
@@ -45,10 +54,20 @@ type symdbManager struct {
 		// no-ops. However, removeUpload() can be called to remove a process
 		// from this map, making future queueProcess() calls for it actually
 		// upload data again.
+		//
+		// Note that uploads are also tracked in persistentCache (if we're
+		// configured with a persistent cache), in addition to trackedProcesses.
+		// This double tracking is redundant, except the cache is not always
+		// present.
 		trackedProcesses map[processKey]struct{}
 	}
 	workerWg     sync.WaitGroup
 	workerCancel context.CancelCauseFunc
+}
+
+type scheduledUpload struct {
+	scheduledTime time.Time
+	req           uploadRequest
 }
 
 type symdbManagerInterface interface {
@@ -88,9 +107,13 @@ type uploadRequest struct {
 // newSymdbManager creates a new symdbManager and starts the upload worker.
 //
 // If uploadURL is nil, the manager is disabled and no uploads are performed.
+//
+// If cacheDir is not empty, the path will be used to track the status of SymDB
+// uploads across agent restarts.
 func newSymdbManager(
 	uploadURL *url.URL,
 	objectLoader object.Loader,
+	cacheDir string,
 	opts ...option,
 ) *symdbManager {
 	cfg := symdbManagerConfig{
@@ -107,9 +130,23 @@ func newSymdbManager(
 		objectLoader: objectLoader,
 		cfg:          cfg,
 		workerCancel: cancel,
+		// Channel with a buffer of one, so that a notifier can leave a
+		// notification even if the worker is not yet reading from the channel
+		// (to avoid a race where the worker checks the works queue, releases
+		// the lock, and misses a notification that happened before it starts
+		// waiting on the channel).
+		workNotification: make(chan struct{}, 1),
 	}
-	m.mu.cond = sync.NewCond(&m.mu.Mutex)
 	m.mu.trackedProcesses = make(map[processKey]struct{})
+
+	if cacheDir != "" {
+		cache, err := newPersistentUploadCache(cacheDir, cfg.testingKnobs.cacheOptions...)
+		if err != nil {
+			log.Errorf("Failed to create persistent upload cache dir %s: %v", cacheDir, err)
+		} else {
+			m.persistentCache = cache
+		}
+	}
 
 	// Start the worker goroutine with tracking.
 	m.workerWg.Add(1)
@@ -122,6 +159,13 @@ func newSymdbManager(
 
 type symdbManagerConfig struct {
 	maxBufferFuncs int
+	testingKnobs   struct {
+		onDeferUpload                     func()
+		onUploadRejectedByPersistentCache func()
+		onUploadQueued                    func()
+		cacheOptions                      []cacheOption
+		backoffPolicy                     backoff.Policy
+	}
 }
 
 type option func(config *symdbManagerConfig)
@@ -132,18 +176,44 @@ func withMaxBufferFuncs(maxBufferFuncs int) option {
 	}
 }
 
+func withTestingKnobOnDeferUpload(onDeferUpload func()) option {
+	return func(c *symdbManagerConfig) {
+		c.testingKnobs.onDeferUpload = onDeferUpload
+	}
+}
+
+func withTestingKnobOnUploadRejectedByPersistentCache(onUploadRejectedByPersistentCache func()) option {
+	return func(c *symdbManagerConfig) {
+		c.testingKnobs.onUploadRejectedByPersistentCache = onUploadRejectedByPersistentCache
+	}
+}
+
+func withCacheOptions(opts ...cacheOption) option {
+	return func(c *symdbManagerConfig) {
+		c.testingKnobs.cacheOptions = opts
+	}
+}
+
+func withBackoffPolicy(policy backoff.Policy) option {
+	return func(c *symdbManagerConfig) {
+		c.testingKnobs.backoffPolicy = policy
+	}
+}
+
+func withTestingKnobOnUploadQueued(onUploadQueued func()) option {
+	return func(c *symdbManagerConfig) {
+		c.testingKnobs.onUploadQueued = onUploadQueued
+	}
+}
+
 // stop gracefully shuts down the symdbManager, cancelling any ongoing uploads
 // and waiting for the worker goroutine to exit.
 func (m *symdbManager) stop() {
-	// Cancel the worker context to signal shutdown
-	m.workerCancel(errors.New("SymDB manager shutting down"))
-
-	// Signal the worker in case it's waiting on the condition variable
 	m.mu.Lock()
 	m.mu.stopped = true
-	m.mu.cond.Signal()
 	m.mu.Unlock()
-
+	// Cancel the worker context to signal shutdown.
+	m.workerCancel(errors.New("SymDB manager shutting down"))
 	// Wait for the worker to terminate.
 	m.workerWg.Wait()
 }
@@ -182,16 +252,99 @@ func (m *symdbManager) queueUpload(runtimeID procRuntimeID, executablePath strin
 	if _, ok := m.mu.trackedProcesses[key]; ok {
 		return nil
 	}
+	// Track this process so that we don't upload it multiple times.
+	// TODO(andrei): We will never retry an upload on errors until the
+	// system-probe restarts; we should use an exponential backoff like we do
+	// across restarts.
 	m.mu.trackedProcesses[key] = struct{}{}
 
-	m.mu.queuedUploads = append(m.mu.queuedUploads, uploadRequest{
+	// Check if we already have performed, or attempted to perform, an upload
+	// for this process before. If we have and the attempt succeeded, there's
+	// nothing to do. If it failed, we only retry it according to an exponential
+	// backoff policy.
+	if m.persistentCache != nil {
+		entry, err := m.persistentCache.GetEntry(runtimeID.ID.PID)
+		if err != nil {
+			log.Warnf("failed to check upload cache for process %s", runtimeID.String())
+		}
+		if entry != nil && entry.ServiceName == runtimeID.service && entry.ServiceVersion == runtimeID.version {
+			switch entry.Type {
+			case entryTypeCompleted:
+				// We already uploaded symbols for this process before the agent
+				// restarted. Nothing more to do, now that we added the process
+				// to m.mmu.trackedProcesses.
+				if m.cfg.testingKnobs.onUploadRejectedByPersistentCache != nil {
+					m.cfg.testingKnobs.onUploadRejectedByPersistentCache()
+				}
+				log.Debugf("skipping SymDB upload for %s (%s) because it was previously uploaded", runtimeID.service, runtimeID.ID)
+				return nil
+			case entryTypeAttempt:
+				// We already attempted to upload symbols for this process
+				// before the agent restarted. We'll retry it according to an
+				// exponential backoff policy.
+				policy := m.cfg.testingKnobs.backoffPolicy
+				if policy == nil {
+					policy = backoff.NewExpBackoffPolicy(
+						2,
+						600,    /* baseBackoffTime - start at 10 minutes */
+						2*3600, /* maxBackoffTime */
+						0, false /* recoveryReset */)
+				}
+				backoffDuration := policy.GetBackoffDuration(entry.ErrorNumber)
+				elapsed := time.Since(entry.Timestamp)
+				remainingWait := backoffDuration - elapsed
+				if remainingWait < 0 {
+					// The backoff duration has expired. Allow the upload to proceed.
+					break
+				}
+				log.Infof("SymDB: scheduling retry upload for process %s after backoff of %v (error number %d, elapsed since last attempt: %s)",
+					runtimeID.ID, remainingWait, entry.ErrorNumber, elapsed)
+
+				if m.cfg.testingKnobs.onDeferUpload != nil {
+					m.cfg.testingKnobs.onDeferUpload()
+				}
+
+				// Schedule the retry after the remaining backoff duration.
+				m.addToQueueLocked(uploadRequest{
+					procID:         key,
+					runtimeID:      runtimeID.runtimeID,
+					executablePath: executablePath,
+				}, time.Now().Add(remainingWait))
+
+				return nil
+			default:
+				log.Warnf("invalid entry type in cache for process %s: %d", runtimeID, entry.Type)
+			}
+		}
+	}
+
+	m.addToQueueLocked(uploadRequest{
 		procID:         key,
 		runtimeID:      runtimeID.runtimeID,
 		executablePath: executablePath,
-	})
-	// Signal the worker that a new request is available.
-	m.mu.cond.Signal()
+	}, time.Now())
+
 	return nil
+}
+
+func (m *symdbManager) addToQueueLocked(req uploadRequest, scheduledTime time.Time) {
+	m.mu.queuedUploads = append(m.mu.queuedUploads, scheduledUpload{
+		req:           req,
+		scheduledTime: scheduledTime,
+	})
+	m.notifyWorker()
+	if m.cfg.testingKnobs.onUploadQueued != nil {
+		m.cfg.testingKnobs.onUploadQueued()
+	}
+}
+
+// Signal the worker that a new request is available.
+func (m *symdbManager) notifyWorker() {
+	select {
+	case m.workNotification <- struct{}{}:
+	default:
+		// The channel is already full; nothing to do.
+	}
 }
 
 // removeUpload removes the queued upload for the given process ID, if any. If
@@ -215,11 +368,16 @@ func (m *symdbManager) removeUploadInner(key processKey) {
 		return
 	}
 	delete(m.mu.trackedProcesses, key)
+	if m.persistentCache != nil {
+		if err := m.persistentCache.RemoveEntry(key.pid.PID); err != nil {
+			log.Warnf("failed to remove cache entry for process %s", key.pid)
+		}
+	}
 
 	// Remove future uploads from queue.
 	filtered := m.mu.queuedUploads[:0]
 	for _, req := range m.mu.queuedUploads {
-		if req.procID != key {
+		if req.req.procID != key {
 			filtered = append(filtered, req)
 		}
 	}
@@ -274,30 +432,66 @@ func (m *symdbManager) queueSize() int {
 	return len(m.mu.queuedUploads) + inProgress
 }
 
-// worker processes upload requests from the queue one by one.
+// worker processes upload requests from the queue one by one. Runs until ctx is
+// canceled.
 func (m *symdbManager) worker(ctx context.Context) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Create a timer once and reuse it throughout the loop.
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
 	for {
-		// Check if we should shutdown
-		if ctx.Err() != nil {
-			return
+		timer.Stop() // We'll recompute the timer below.
+
+		// Find the upload with the earliest scheduled time and check if it's ready.
+		earliestIdx := -1
+		workReady := false
+		if len(m.mu.queuedUploads) > 0 {
+			earliestIdx = 0
+			earliestTime := m.mu.queuedUploads[0].scheduledTime
+			for i := 1; i < len(m.mu.queuedUploads); i++ {
+				if m.mu.queuedUploads[i].scheduledTime.Before(earliestTime) {
+					earliestIdx = i
+					earliestTime = m.mu.queuedUploads[i].scheduledTime
+				}
+			}
+			// Check if the earliest upload is ready to be processed.
+			workReady = time.Now().After(earliestTime)
 		}
 
-		// Wait for work.
-		for len(m.mu.queuedUploads) == 0 {
-			// Check for shutdown before waiting
+		// If there's no work ready, wait for either new work to come in, or the
+		// timer of the earliest scheduled upload to expire.
+		if !workReady {
+			// If we have work scheduled for the future, reset the timer. If we
+			// don't have work in the future, the read from timer.C below will
+			// block indefinitely.
+			if earliestIdx >= 0 {
+				earliestTime := m.mu.queuedUploads[earliestIdx].scheduledTime
+				timer.Reset(time.Until(earliestTime))
+			}
+
+			m.mu.Unlock()
+			select {
+			case <-m.workNotification:
+			case <-timer.C:
+			case <-ctx.Done():
+			}
+			m.mu.Lock()
 			if ctx.Err() != nil {
 				return
 			}
-			m.mu.cond.Wait()
+
+			// Loop back to re-check the queue.
+			continue
 		}
 
-		// Take the first request from the queue.
-		req := m.mu.queuedUploads[0]
-		m.mu.queuedUploads = m.mu.queuedUploads[1:]
+		// Take the upload with the earliest time from the queue.
+		upload := m.mu.queuedUploads[earliestIdx]
+		m.mu.queuedUploads = append(m.mu.queuedUploads[:earliestIdx], m.mu.queuedUploads[earliestIdx+1:]...)
 
+		req := upload.req
 		uploadCtx, cancel := context.WithCancelCause(ctx)
 		m.mu.currentUpload = &req
 		m.mu.currentCancel = cancel
@@ -325,7 +519,49 @@ func (m *symdbManager) worker(ctx context.Context) {
 	}
 }
 
-func (m *symdbManager) performUpload(ctx context.Context, procID processKey, runtimeID string, executablePath string) error {
+func (m *symdbManager) performUpload(
+	ctx context.Context, procID processKey, runtimeID string, executablePath string,
+) (retErr error) {
+	// Create or update the cache entry to track this upload attempt.
+	if m.persistentCache != nil {
+		errorNumber := 1
+		// Check if an entry already exists. If it does, we'll increment the
+		// error number.
+		entry, err := m.persistentCache.GetEntry(procID.pid.PID)
+		if err != nil {
+			return fmt.Errorf("failed to read cache entry for process %v: %w", procID.pid, err)
+		}
+		if entry != nil && entry.Type == entryTypeAttempt {
+			errorNumber = entry.ErrorNumber + 1
+		}
+
+		// Record this attempt in the cache.
+		if err := m.persistentCache.AddAttempt(procID.pid.PID, procID.service, procID.version, errorNumber, "" /* errMsg */); err != nil {
+			return fmt.Errorf("failed to create cache entry for process %v: %w", procID.pid, err)
+		}
+
+		// Update the cache entry when the upload is complete.
+		defer func() {
+			if retErr == nil {
+				// Upload succeeded, mark it as completed. If the agent
+				// restarts, it will use this completed entry to avoid uploading
+				// the data again for this process.
+				if err := m.persistentCache.AddCompleted(
+					procID.pid.PID, procID.service, procID.version,
+				); err != nil {
+					retErr = fmt.Errorf("failed to update cache entry for process %v: %w", procID.pid, err)
+				}
+			} else {
+				// Upload failed, update the entry with the error message.
+				if err := m.persistentCache.AddAttempt(
+					procID.pid.PID, procID.service, procID.version, errorNumber, retErr.Error(),
+				); err != nil {
+					log.Errorf("Failed to update cache entry with error for process %v: %v", procID.pid, err)
+				}
+			}
+		}()
+	}
+
 	log.Infof("SymDB: uploading symbols for process %v (service: %s, version: %s, executable: %s)",
 		procID.pid, procID.service, procID.version, executablePath)
 	it, err := symdb.PackagesIterator(

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -38,9 +38,11 @@ type symdbManager struct {
 		currentDone   chan struct{} // closed when current upload finishes
 		stopped       bool
 
-		// trackedProcesses stores processes for which an upload was requested.
+		// trackedProcesses stores processes for which an upload was requested
+		// (and perhaps completed).
+		//
 		// Repeated requests for the same process (through queueProcess()) are
-		// no-ops. However, untrackProcess() can be called to remove a process
+		// no-ops. However, removeUpload() can be called to remove a process
 		// from this map, making future queueProcess() calls for it actually
 		// upload data again.
 		trackedProcesses map[processKey]struct{}
@@ -194,8 +196,8 @@ func (m *symdbManager) queueUpload(runtimeID procRuntimeID, executablePath strin
 
 // removeUpload removes the queued upload for the given process ID, if any. If
 // the upload is currently being processed, it will be cancelled and the call
-// will block until the upload stops. If no upload for the respective process is
-// in progress or queued, the call is a no-op.
+// will block until the upload stops. Future calls to queueUpload() for the
+// respective process will result in a new upload being queued.
 func (m *symdbManager) removeUpload(runtimeID procRuntimeID) {
 	key := processKey{
 		pid:     runtimeID.ID,

--- a/pkg/dyninst/module/symdb_test.go
+++ b/pkg/dyninst/module/symdb_test.go
@@ -22,6 +22,24 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 )
 
+// shortBackoffPolicy is a test backoff policy that returns a very short duration.
+type shortBackoffPolicy struct{}
+
+func (p *shortBackoffPolicy) GetBackoffDuration(_ int) time.Duration {
+	return 100 * time.Millisecond
+}
+
+func (p *shortBackoffPolicy) IncError(numErrors int) int {
+	return numErrors + 1
+}
+
+func (p *shortBackoffPolicy) DecError(numErrors int) int {
+	if numErrors > 0 {
+		return numErrors - 1
+	}
+	return 0
+}
+
 func TestSymdbManagerUpload(t *testing.T) {
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	cfg := cfgs[0] // use first config
@@ -53,12 +71,12 @@ func TestSymdbManagerUpload(t *testing.T) {
 	}))
 	defer symdbServer.Close()
 
-	// Parse server URL for manager
 	symdbURL, err := url.Parse(symdbServer.URL)
 	require.NoError(t, err)
 
 	// Create process store and symdb manager
-	manager := newSymdbManager(symdbURL, object.NewInMemoryLoader())
+	const cacheDir = "" // no cache
+	manager := newSymdbManager(symdbURL, object.NewInMemoryLoader(), cacheDir)
 	t.Cleanup(manager.stop)
 
 	// Create runtime ID for testing
@@ -132,6 +150,7 @@ func testSymdbManagerCancellation(t *testing.T, useStop bool) {
 	manager := newSymdbManager(
 		symdbURL,
 		object.NewInMemoryLoader(),
+		"", /* cacheDir - no cache */
 		// Use a small buffer (which will force a flush after every package)
 		// in order to have an opportunity to cancel the uploads in between
 		// flushes.
@@ -206,5 +225,166 @@ func testSymdbManagerCancellation(t *testing.T, useStop bool) {
 		// rejected.
 		err := manager.queueUpload(runtimeID, binPath)
 		require.ErrorContains(t, err, "stopped")
+	}
+}
+
+// Test that SymDBManager respects entries in the persistent cache which control
+// which uploads should be deferred or rejected.
+func TestSymdbManagerRespectsPersistentCache(t *testing.T) {
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	cfg := cfgs[0] // use first config
+	binPath := testprogs.MustGetBinary(t, "rc_tester", cfg)
+
+	tests := []struct {
+		name            string
+		entryType       entryType
+		errorNumber     int
+		errorMsg        string
+		timestampOffset time.Duration // Offset from current time (negative = in the past).
+		expectDeferred  bool
+		expectRejected  bool
+	}{
+		{
+			// The upload should be retried after a wait, since it previously
+			// failed.
+			name:           "FailedUpload",
+			entryType:      entryTypeAttempt,
+			errorNumber:    1,
+			errorMsg:       "previous upload failed",
+			expectDeferred: true,
+		},
+		{
+			// The upload should be rejected because it previously succeeded.
+			name:           "CompletedUpload",
+			entryType:      entryTypeCompleted,
+			expectRejected: true,
+		},
+		{
+			// The upload should be performed immediately because the backoff
+			// has expired.
+			name:            "FailedUploadBackoffExpired",
+			entryType:       entryTypeAttempt,
+			errorNumber:     1,
+			errorMsg:        "previous upload failed",
+			timestampOffset: -20 * time.Hour, // Backoff has expired.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary cache directory for this subtest.
+			cacheDir := t.TempDir()
+
+			pid := int32(12345)
+
+			// Create and populate the cache with the test entry.
+			cache, err := newPersistentUploadCache(cacheDir)
+			require.NoError(t, err)
+			if tt.entryType == entryTypeAttempt {
+				err = cache.AddAttempt(pid, "test_service", "1.0.0", tt.errorNumber, tt.errorMsg)
+				require.NoError(t, err)
+			} else {
+				err = cache.AddCompleted(pid, "test_service", "1.0.0")
+				require.NoError(t, err)
+			}
+
+			// Adjust timestamp if needed.
+			if tt.timestampOffset != 0 {
+				entry, err := cache.GetEntry(pid)
+				require.NoError(t, err)
+				require.NotNil(t, entry)
+				entry.Timestamp = time.Now().Add(tt.timestampOffset)
+				err = cache.saveEntry(pid, *entry)
+				require.NoError(t, err)
+			}
+
+			// Track whether callbacks were invoked.
+			deferredCalled := false
+			rejectedCalled := false
+			uploadQueuedCh := make(chan struct{}, 1)
+
+			// Build manager options.
+			managerOpts := []option{
+				withTestingKnobOnDeferUpload(func() {
+					deferredCalled = true
+				}),
+				withTestingKnobOnUploadRejectedByPersistentCache(func() {
+					rejectedCalled = true
+				}),
+				withTestingKnobOnUploadQueued(func() {
+					uploadQueuedCh <- struct{}{}
+				}),
+				withCacheOptions(withProcessExistsCheck(func(p int) bool {
+					return p == int(pid) // Test process exists.
+				})),
+			}
+
+			// For failed uploads, use a short backoff policy so the retry happens quickly.
+			if tt.expectDeferred {
+				managerOpts = append(managerOpts, withBackoffPolicy(&shortBackoffPolicy{}))
+			}
+
+			uploadCh := make(chan struct{}, 1)
+
+			// Set up mock SymDB backend.
+			symdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				uploadCh <- struct{}{}
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status": "ok"}`))
+			}))
+			defer symdbServer.Close()
+
+			symdbURL, err := url.Parse(symdbServer.URL)
+			require.NoError(t, err)
+
+			manager := newSymdbManager(
+				symdbURL,
+				object.NewInMemoryLoader(),
+				cacheDir,
+				managerOpts...,
+			)
+			t.Cleanup(manager.stop)
+
+			// Create runtime ID for testing.
+			runtimeID := procRuntimeID{
+				ID:          process.ID{PID: pid},
+				service:     "test_service",
+				environment: "test_env",
+				version:     "1.0.0",
+				runtimeID:   "dummy-runtime-id",
+			}
+
+			// Request an upload.
+			err = manager.queueUpload(runtimeID, binPath)
+			require.NoError(t, err)
+
+			// Verify expectations.
+			if tt.expectDeferred {
+				require.True(t, deferredCalled, "expected upload to be deferred")
+				require.False(t, rejectedCalled, "upload should not be rejected")
+
+				// Wait for the upload to happen asynchronously.
+				select {
+				case <-uploadCh:
+					// Success - upload was queued.
+				case <-time.After(time.Second):
+					t.Fatal("expected upload to be retried")
+				}
+			} else if tt.expectRejected {
+				require.True(t, rejectedCalled, "expected upload to be rejected")
+				require.False(t, deferredCalled, "upload should not be deferred")
+			} else {
+				// Upload should be queued immediately.
+				require.False(t, deferredCalled, "upload should not be deferred")
+				require.False(t, rejectedCalled, "upload should not be rejected")
+
+				select {
+				case <-uploadQueuedCh:
+				// Success - upload was queued synchronously.
+				default:
+					t.Fatal("expected upload to be queued immediately")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Keep track of successful and failed SymDB uploads across system-probe
restarts. Upon restart, uploads for previously-successful processes will
not be performed again, and uploads for failed processes will be done
according to an exponential backoff.

This should help in two ways:
- for successful uploads, don't redo the work after a system-probe
  restart
- for uplods that cause the system-probe to fail (e.g. because of an OOM
  caused by DWARF processing), don't OOM again too eagerly

Uploads are tracked in files under /opt/datadog-agent/run/symdb_uploads.
These files are processed on startup to remove stale ones.

https://datadoghq.atlassian.net/browse/DEBUG-4601