### PR TITLE
Nodetreemodel always inserts unknown file data

### DIFF
--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -614,6 +614,5 @@ fruit:
 	assert.Equal(t, 2, ntmConf.GetInt("fruit.apple.core.seeds"))
 	assert.Equal(t, "", ntmConf.GetString("fruit.banana.peel.color"))
 	assert.Equal(t, 5, ntmConf.GetInt("fruit.cherry.seed.num"))
-	// TODO: difference, unknown key doesn't get stored
-	assert.Equal(t, 0, ntmConf.GetInt("fruit.donut.dozen"))
+	assert.Equal(t, 12, ntmConf.GetInt("fruit.donut.dozen"))
 }

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -1647,27 +1647,31 @@ fruit:
       inner(#ptr<000007>)
       > num
           leaf(#ptr<000008>), val:"1", source:environment-variable
-tree(#ptr<000009>) source=default
+  > donut
+      leaf(#ptr<000009>), val:12, source:file
+tree(#ptr<000010>) source=default
 > fruit
-  inner(#ptr<000010>)
+  inner(#ptr<000011>)
   > apple
     inner(#ptr<000002>)
     > core
       inner(#ptr<000003>)
       > seeds
           leaf(#ptr<000004>), val:2, source:default
-tree(#ptr<000011>) source=file
+tree(#ptr<000012>) source=file
 > fruit
-  inner(#ptr<000012>)
+  inner(#ptr<000013>)
   > apple
-      leaf(#ptr<000013>), val:<nil>, source:file
+      leaf(#ptr<000014>), val:<nil>, source:file
   > banana
       leaf(#ptr<000005>), val:<nil>, source:file
   > cherry
-      leaf(#ptr<000014>), val:<nil>, source:file
-tree(#ptr<000015>) source=environment-variable
+      leaf(#ptr<000015>), val:<nil>, source:file
+  > donut
+      leaf(#ptr<000009>), val:12, source:file
+tree(#ptr<000016>) source=environment-variable
 > fruit
-  inner(#ptr<000016>)
+  inner(#ptr<000017>)
   > cherry
     inner(#ptr<000006>)
     > seed

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -116,9 +116,6 @@ func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interfa
 		schemaChild, err := schema.GetChild(key)
 		if err != nil {
 			warnings = append(warnings, fmt.Errorf("unknown key from YAML: %s", currPath))
-			if !allowDynamicSchema {
-				continue
-			}
 
 			// if the key is not defined in the schema, we can still add it to the destination
 			if value == nil || isScalar(value) || isSlice(value) {

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -214,7 +214,8 @@ c:
 			"a": &leafNodeImpl{val: "orange", source: model.SourceFile},
 			"c": &innerNode{
 				children: map[string]Node{
-					"d": &leafNodeImpl{val: 1234, source: model.SourceFile},
+					"d":       &leafNodeImpl{val: 1234, source: model.SourceFile},
+					"unknown": &leafNodeImpl{val: "key", source: model.SourceFile},
 				},
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

When using nodetreemodel, always insert unknown nodes into the file layer. This more closely follows how viper works, improving compatibility.

### Motivation

Remove our dependency on viper.

### Describe how you validated your changes

Unit tests.

### Additional Notes
