### PR TITLE
[CWS] use the threat detection policy for e2e tests

### DIFF
--- a/test/new-e2e/tests/cws/common.go
+++ b/test/new-e2e/tests/cws/common.go
@@ -70,7 +70,7 @@ func (a *agentSuite) Test00RulesetLoadedDefaultFile() {
 
 func (a *agentSuite) Test01RulesetLoadedDefaultRC() {
 	assert.EventuallyWithT(a.T(), func(c *assert.CollectT) {
-		testRulesetLoaded(c, a, "remote-config", "default.policy")
+		testRulesetLoaded(c, a, "remote-config", "threat-detection.policy")
 	}, 4*time.Minute, 10*time.Second)
 }
 

--- a/test/new-e2e/tests/cws/kind_test.go
+++ b/test/new-e2e/tests/cws/kind_test.go
@@ -107,7 +107,7 @@ func (s *kindSuite) Test00RulesetLoadedDefaultFile() {
 
 func (s *kindSuite) Test01RulesetLoadedDefaultRC() {
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		testRulesetLoaded(c, s, "remote-config", "default.policy")
+		testRulesetLoaded(c, s, "remote-config", "threat-detection.policy")
 	}, 1*time.Minute, 5*time.Second)
 }
 

--- a/test/new-e2e/tests/cws/windows_test.go
+++ b/test/new-e2e/tests/cws/windows_test.go
@@ -92,7 +92,7 @@ func (a *agentSuiteWindows) Test00RulesetLoadedDefaultFile() {
 
 func (a *agentSuiteWindows) Test01RulesetLoadedDefaultRC() {
 	assert.EventuallyWithT(a.T(), func(c *assert.CollectT) {
-		testRulesetLoaded(c, a, "remote-config", "default.policy")
+		testRulesetLoaded(c, a, "remote-config", "threat-detection.policy")
 	}, 4*time.Minute, 10*time.Second)
 }
 


### PR DESCRIPTION
### What does this PR do?

Now the default.policy sent from RC is empty thus not reported in the ruleset loaded.

### Motivation

### Describe how you validated your changes

### Additional Notes
