### PR TITLE
[incident-44801] Updated test infra to fix argo rollouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/DataDog/datadog-agent
 
-go 1.24.6
-
-toolchain go1.24.9
+go 1.24.9
 
 // v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
 // to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/DataDog/datadog-agent
 
 go 1.24.9
 
+toolchain go1.24.9
+
 // v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
 // to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)
 // that retracts itself and the previous version.

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/DataDog/datadog-agent
 
 go 1.24.9
 
-toolchain go1.24.9
-
 // v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
 // to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)
 // that retracts itself and the previous version.

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -21,7 +21,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.6-0.20251029104703-e5aee8004e1b
+	github.com/DataDog/test-infra-definitions v0.0.6-0.20251030085244-f068acd734c6
 	github.com/aws/aws-sdk-go-v2 v1.39.2
 	github.com/aws/aws-sdk-go-v2/config v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.256.0

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -21,7 +21,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.6-0.20251029101827-8d4753a314bb
+	github.com/DataDog/test-infra-definitions v0.0.6-0.20251029104703-e5aee8004e1b
 	github.com/aws/aws-sdk-go-v2 v1.39.2
 	github.com/aws/aws-sdk-go-v2/config v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.256.0

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -21,7 +21,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.6-0.20251027095737-d6e5c4066496
+	github.com/DataDog/test-infra-definitions v0.0.6-0.20251029101827-8d4753a314bb
 	github.com/aws/aws-sdk-go-v2 v1.39.2
 	github.com/aws/aws-sdk-go-v2/config v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.256.0

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -32,8 +32,8 @@ github.com/DataDog/orchestrion v1.4.0 h1:A1qePK5sZAo1d3VbgPy5vXhlftCMsPbzyxImOuM
 github.com/DataDog/orchestrion v1.4.0/go.mod h1:0xkQCBMS/9mLCExmGlmN0aEwEdStZ8RttapVRQHt518=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=
 github.com/DataDog/sketches-go v1.4.7/go.mod h1:eAmQ/EBmtSO+nQp7IZMZVRPT4BQTmIc5RZQ+deGlTPM=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251029104703-e5aee8004e1b h1:2M5RX7cjSYT3gqt+pt+yRoZbJSaYYq4qSC99nAHHmtg=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251029104703-e5aee8004e1b/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251030085244-f068acd734c6 h1:w0d0rMnFkSJteUl4retIB0YR9H+uFtJBH+Y3diCnekg=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251030085244-f068acd734c6/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -32,8 +32,8 @@ github.com/DataDog/orchestrion v1.4.0 h1:A1qePK5sZAo1d3VbgPy5vXhlftCMsPbzyxImOuM
 github.com/DataDog/orchestrion v1.4.0/go.mod h1:0xkQCBMS/9mLCExmGlmN0aEwEdStZ8RttapVRQHt518=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=
 github.com/DataDog/sketches-go v1.4.7/go.mod h1:eAmQ/EBmtSO+nQp7IZMZVRPT4BQTmIc5RZQ+deGlTPM=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251027095737-d6e5c4066496 h1:ENBSsXDIPnsucsjq9jeaeImxlOxdgygG2N1xktRnBdY=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251027095737-d6e5c4066496/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251029101827-8d4753a314bb h1:xW/0t+miani9EffYdhxbULemkwMMfyAy4Zq6qrE2I58=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251029101827-8d4753a314bb/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -32,8 +32,8 @@ github.com/DataDog/orchestrion v1.4.0 h1:A1qePK5sZAo1d3VbgPy5vXhlftCMsPbzyxImOuM
 github.com/DataDog/orchestrion v1.4.0/go.mod h1:0xkQCBMS/9mLCExmGlmN0aEwEdStZ8RttapVRQHt518=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=
 github.com/DataDog/sketches-go v1.4.7/go.mod h1:eAmQ/EBmtSO+nQp7IZMZVRPT4BQTmIc5RZQ+deGlTPM=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251029101827-8d4753a314bb h1:xW/0t+miani9EffYdhxbULemkwMMfyAy4Zq6qrE2I58=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251029101827-8d4753a314bb/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251029104703-e5aee8004e1b h1:2M5RX7cjSYT3gqt+pt+yRoZbJSaYYq4qSC99nAHHmtg=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251029104703-e5aee8004e1b/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/pkg/provisioners/aws/kubernetes/eks.go
+++ b/test/new-e2e/pkg/provisioners/aws/kubernetes/eks.go
@@ -104,7 +104,7 @@ func EKSRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Provi
 		if err != nil {
 			return err
 		}
-		argoHelm, err := argorollouts.NewHelmInstallation(&awsEnv, argoParams, pulumi.Provider(cluster.KubeProvider))
+		argoHelm, err := argorollouts.NewHelmInstallation(&awsEnv, argoParams, cluster.KubeProvider)
 		if err != nil {
 			return err
 		}

--- a/test/new-e2e/pkg/provisioners/aws/kubernetes/kind.go
+++ b/test/new-e2e/pkg/provisioners/aws/kubernetes/kind.go
@@ -149,7 +149,7 @@ func KindRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Prov
 		if err != nil {
 			return err
 		}
-		argoHelm, err := argorollouts.NewHelmInstallation(&awsEnv, argoParams, pulumi.Provider(kubeProvider))
+		argoHelm, err := argorollouts.NewHelmInstallation(&awsEnv, argoParams, kubeProvider)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

[incident-44801]

> [!NOTE]
> See this [PR](https://github.com/DataDog/test-infra-definitions/pull/1761) first.

This bumps test-infra to include this [PR](https://github.com/DataDog/test-infra-definitions/pull/1761) which enable EKS clusters to be destroyed again and avoid leaks.

### Motivation

### Describe how you validated your changes

### Additional Notes
