### PR TITLE
[EBPF-875] gpu: do not re-emit errors for driver not loaded in wmeta collector

### DIFF
--- a/pkg/gpu/safenvml/errors.go
+++ b/pkg/gpu/safenvml/errors.go
@@ -61,3 +61,9 @@ func IsTimeout(err error) bool {
 	var nvmlErr *NvmlAPIError
 	return err != nil && errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_TIMEOUT)
 }
+
+// IsDriverNotLoaded checks if an error indicates that the driver is not loaded
+func IsDriverNotLoaded(err error) bool {
+	var nvmlErr *NvmlAPIError
+	return err != nil && errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_DRIVER_NOT_LOADED)
+}

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -320,7 +320,7 @@ func (s *safeNvml) ensureInitWithOpts(nvmlNewFunc func(opts ...nvml.LibraryOptio
 
 	ret := lib.Init()
 	if ret != nvml.SUCCESS && ret != nvml.ERROR_ALREADY_INITIALIZED {
-		return fmt.Errorf("error initializing NVML library: %s", nvml.ErrorString(ret))
+		return NewNvmlAPIErrorOrNil("Init", ret)
 	}
 
 	// Populate and verify critical capabilities

--- a/releasenotes/notes/nvml-wmeta-collector-errors-76aebe5106624a12.yaml
+++ b/releasenotes/notes/nvml-wmeta-collector-errors-76aebe5106624a12.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - "gpu: the workloadmeta collector will no longer send multiple warn logs if the driver is not loaded"


### PR DESCRIPTION
### What does this PR do?

Changes the NVML workloadmeta collector so that it will only report the driver not loaded once as an error, then it will ignore it the next appearances.

### Motivation

Some agents run in systems where drivers are installed but there are no GPUs. While we can't completely disable the collector in these cases, as the driver might load later, we can stop reporting the errors to avoid log spam.

https://datadoghq.atlassian.net/browse/EBPF-875

### Describe how you validated your changes

### Additional Notes
