### PR TITLE
[CWS] skip early on non-regular files in hash resolver

### DIFF
--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -293,8 +293,14 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, ctrID contain
 	)
 	for _, pidCandidate := range rootPIDs {
 		path := utils.ProcRootFilePath(pidCandidate, file.PathnameStr)
-		if mode, size, fkey, lastErr = getFileInfo(path); !mode.IsRegular() {
+		mode, size, fkey, lastErr = getFileInfo(path)
+		if lastErr != nil {
 			continue
+		}
+
+		if !mode.IsRegular() {
+			// the file is not regular, break out early and the error will be reported in the `if f == nil` check
+			break
 		}
 
 		if _, ok := failedCache[fkey]; ok {
@@ -303,10 +309,13 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, ctrID contain
 		}
 
 		f, lastErr = os.Open(path)
-		if lastErr == nil {
-			break
+		if lastErr != nil {
+			failedCache[fkey] = struct{}{}
+			continue
 		}
-		failedCache[fkey] = struct{}{}
+
+		// we manage to open the file
+		break
 	}
 	if lastErr != nil {
 		rateReservation.Cancel()


### PR DESCRIPTION
### What does this PR do?

Currently, if a file is not regular (say `/dev/nvidiaX`), the hash resolver will stat the same file for every pid in the cgroup/container. This can result in a big amount of stats.

This PR improves the flow to:
- in case of a stat error, try accessing through another pid
- if the stat is successful, but the file is not regular, exit early (instead of doing as if it was an error)

### Motivation

### Describe how you validated your changes

### Additional Notes
