### PR TITLE
Remove exit code `101` workaround on extraction failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1193,7 +1193,6 @@ workflow:
     max: 2
     exit_codes:
       - 42
-      - 101 # Failed to extract dependencies
     when:
       - runner_system_failure
       - stuck_or_timeout_failure

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -4,15 +4,15 @@
 # to reuse them in further jobs that need them.
 
 .retrieve_linux_go_deps:
-  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache.tar.xz -C $GOPATH/pkg/mod/cache || exit 101
+  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache.tar.xz -C $GOPATH/pkg/mod/cache
   - rm -f modcache.tar.xz
 
 .retrieve_linux_go_tools_deps:
-  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache_tools.tar.xz -C $GOPATH/pkg/mod/cache || exit 101
+  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache_tools.tar.xz -C $GOPATH/pkg/mod/cache
   - rm -f modcache_tools.tar.xz
 
 .retrieve_linux_go_e2e_deps:
-  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache_e2e.tar.xz -C $GOPATH/pkg/mod/cache || exit 101
+  - mkdir -p $GOPATH/pkg/mod/cache && tar xJf modcache_e2e.tar.xz -C $GOPATH/pkg/mod/cache
   - rm -f modcache_e2e.tar.xz
 
 .cache:

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -51,7 +51,6 @@ static_quality_gates:
     max: 2
     exit_codes:
       - 42
-      - 101 # Failed to extract dependencies
     when:
       - runner_system_failure
       - stuck_or_timeout_failure


### PR DESCRIPTION
### What does this PR do?
Reverts the workaround added in #32671 that used special exit code `101` to trigger automatic retries when tar extraction of Go dependency caches failed.

### Motivation
This workaround should now be bysuperseded by the newly enabled `FF_CLEAN_UP_FAILED_CACHE_EXTRACT` (#42400), which addresses the problem closer to its root by instructing GitLab runners to automatically delete corrupted/partial caches when extraction fails, ensuring a clean cache is rebuilt on the next run rather than retrying with the same corrupted archive.

### Describe how you validated your changes
Here's a [practical case](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1203961079#L31) where the feature got triggered and worked as expected:
```
Checking cache for bazel-gitlab-runner-macos-datadog-agent-ventura-amd64-1-protected...
Runtime platform                                    arch=amd64 os=darwin pid=86837 revision=658cb9b6 version=17.5.0~pre.6.g658cb9b6
No URL provided, cache will not be downloaded from shared cache server. Instead a local version of cache will be extracted.
FATAL: zip: checksum error
Failed to extract cache
Removing .cache/bazel/cache
Removing .cache/bazel/disk
Removing .cache/bazel/repo-contents
```