### PR TITLE
[dynamic test] Fix cluster-agent that could not compute its coverage

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -26,6 +26,7 @@ import (
 	dcametadata "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
 	clusterchecksmetadata "github.com/DataDog/datadog-agent/comp/metadata/clusterchecks/def"
 
+	"github.com/DataDog/datadog-agent/pkg/api/coverage"
 	autoscalingWorkload "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	localautoscalingworkload "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/loadstore"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -65,6 +66,9 @@ func SetupHandlers(r *mux.Router, wmeta workloadmeta.Component, ac autodiscovery
 	}).Methods("GET")
 	r.HandleFunc("/metadata/cluster-agent", dcametadataComp.WritePayloadAsJSON).Methods("GET")
 	r.HandleFunc("/metadata/cluster-checks", clusterChecksMetadataComp.WritePayloadAsJSON).Methods("GET")
+
+	// Special handler to compute running agent Code coverage
+	coverage.SetupCoverageHandler(r)
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request, statusComponent status.Component) {

--- a/cmd/cluster-agent/subcommands/coverage/command.go
+++ b/cmd/cluster-agent/subcommands/coverage/command.go
@@ -62,7 +62,7 @@ func requestCoverage(_ log.Component, config config.Component, ipc ipc.Component
 	url := url.URL{
 		Scheme: "https",
 		Host:   fmt.Sprintf("localhost:%v", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")),
-		Path:   "/status",
+		Path:   "/coverage",
 	}
 	resp, err := ipc.GetClient().Get(url.String())
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Add missing piece for cluster-agent coverage generation.
After #incident-44717 we realized that the coverage was not computed correctly for cluster-agent, which lead to skipped tests that should have been executed.

### Motivation

Fix dynamic tests

### Describe how you validated your changes

Checked the coverage generated in the new-e2e-container job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1203930856
Could confirm that the path that led to missed tests now appear in the coverage

### Additional Notes
