### PR TITLE
[CWS] Add 6 new metrics for cgroup resolver

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -314,12 +314,12 @@ var (
 	// MetricCGroupResolverFallbackFailed is the name of the metric used to report the number of failed fallbacks
 	// Tags: -
 	MetricCGroupResolverFallbackFailed = newRuntimeMetric(".cgroup_resolver.fallback_failed")
-	// MetricCGroupResolverAddPIDCgroupPresent is the name of the metric used to report the number of calls of ADDPid() with an empty cgroup context
+	// MetricCGroupResolverAddPIDCgroupPresent is the name of the metric used to report the number of calls of ADDPid() with an cgroup context
 	// Tags: -
-	MetricCGroupResolverAddPIDCgroupPresent = newRuntimeMetric(".cgroup_resolver.addpid_cgroup_empty")
-	// MetricCGroupResolverAddPIDCgroupAbsent is the name of the metric used to report the number of calls of ADDPid() with an empty cgroup context
+	MetricCGroupResolverAddPIDCgroupPresent = newRuntimeMetric(".cgroup_resolver.addpid_cgroup_present")
+	// MetricCGroupResolverAddPIDCgroupAbsent is the name of the metric used to report the number of calls of ADDPid() with no cgroup context
 	// Tags: -
-	MetricCGroupResolverAddPIDCgroupAbsent = newRuntimeMetric(".cgroup_resolver.addpid_cgroup_empty")
+	MetricCGroupResolverAddPIDCgroupAbsent = newRuntimeMetric(".cgroup_resolver.addpid_cgroup_absent")
 
 	// Security Profile metrics
 

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -302,6 +302,24 @@ var (
 	// MetricCGroupResolverActiveHostWorkloads is the name of the metric used to report the count of active cgroups not corresponding to a container kept in memory
 	// Tags: -
 	MetricCGroupResolverActiveHostWorkloads = newRuntimeMetric(".cgroup_resolver.active_non_containers")
+	// MetricCGroupResolverAddedCgroups is the name of the metric used to report the number of added cgroups
+	// Tags: -
+	MetricCGroupResolverAddedCgroups = newRuntimeMetric(".cgroup_resolver.added_cgroups")
+	// MetricCGroupResolverDeletedCgroups is the name of the metric used to report the number of deleted cgroups
+	// Tags: -
+	MetricCGroupResolverDeletedCgroups = newRuntimeMetric(".cgroup_resolver.deleted_cgroups")
+	// MetricCGroupResolverFallbackSucceed is the name of the metric used to report the number of succeed fallbacks
+	// Tags: -
+	MetricCGroupResolverFallbackSucceed = newRuntimeMetric(".cgroup_resolver.fallback_succeed")
+	// MetricCGroupResolverFallbackFailed is the name of the metric used to report the number of failed fallbacks
+	// Tags: -
+	MetricCGroupResolverFallbackFailed = newRuntimeMetric(".cgroup_resolver.fallback_failed")
+	// MetricCGroupResolverAddPIDCgroupPresent is the name of the metric used to report the number of calls of ADDPid() with an empty cgroup context
+	// Tags: -
+	MetricCGroupResolverAddPIDCgroupPresent = newRuntimeMetric(".cgroup_resolver.addpid_cgroup_empty")
+	// MetricCGroupResolverAddPIDCgroupAbsent is the name of the metric used to report the number of calls of ADDPid() with an empty cgroup context
+	// Tags: -
+	MetricCGroupResolverAddPIDCgroupAbsent = newRuntimeMetric(".cgroup_resolver.addpid_cgroup_empty")
 
 	// Security Profile metrics
 

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -10,9 +10,12 @@ package cgroup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
+
+	"go.uber.org/atomic"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 
@@ -70,6 +73,14 @@ type Resolver struct {
 	hostWorkloads      *simplelru.LRU[containerutils.CGroupID, *cgroupModel.CacheEntry]
 	containerWorkloads *simplelru.LRU[containerutils.ContainerID, *cgroupModel.CacheEntry]
 	history            *simplelru.LRU[uint32, uint64]
+
+	// metrics
+	addedCgroups        *atomic.Int64
+	deletedCgroups      *atomic.Int64
+	fallbackSucceed     *atomic.Int64
+	fallbackFailed      *atomic.Int64
+	addPidCgroupPresent *atomic.Int64
+	addPidCgroupAbsent  *atomic.Int64
 }
 
 // NewResolver returns a new cgroups monitor
@@ -79,9 +90,15 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupFS FSInterface) (*Re
 	}
 
 	cr := &Resolver{
-		Notifier:     utils.NewNotifier[Event, *cgroupModel.CacheEntry](),
-		statsdClient: statsdClient,
-		cgroupFS:     cgroupFS,
+		Notifier:            utils.NewNotifier[Event, *cgroupModel.CacheEntry](),
+		statsdClient:        statsdClient,
+		cgroupFS:            cgroupFS,
+		addedCgroups:        atomic.NewInt64(0),
+		deletedCgroups:      atomic.NewInt64(0),
+		fallbackSucceed:     atomic.NewInt64(0),
+		fallbackFailed:      atomic.NewInt64(0),
+		addPidCgroupPresent: atomic.NewInt64(0),
+		addPidCgroupAbsent:  atomic.NewInt64(0),
 	}
 
 	cleanup := func(value *cgroupModel.CacheEntry) {
@@ -133,6 +150,7 @@ func (cr *Resolver) removeCgroup(cgroup *cgroupModel.CacheEntry) {
 	if cgroup.ContainerID != "" {
 		cr.containerWorkloads.Remove(cgroup.ContainerID)
 	}
+	cr.deletedCgroups.Inc()
 }
 
 // cgroup already locked
@@ -165,11 +183,12 @@ func (cr *Resolver) syncOrDeleteCgroup(cgroup *cgroupModel.CacheEntry, deletedPi
 
 // currentCgroup already locked
 func (cr *Resolver) cleanupPidsWithMultipleCgroups(pids []uint32, currentCgroup *cgroupModel.CacheEntry) {
-	for _, cgroup := range cr.containerWorkloads.Values() {
+	cr.iterate(func(cgroup *cgroupModel.CacheEntry) bool {
 		if cgroup.CGroupFile.Inode == currentCgroup.CGroupFile.Inode {
-			continue
+			return false
 		}
 		cgroup.Lock()
+		defer cgroup.Unlock()
 		for _, pid := range pids {
 			delete(cgroup.PIDs, pid)
 		}
@@ -179,25 +198,8 @@ func (cr *Resolver) cleanupPidsWithMultipleCgroups(pids []uint32, currentCgroup 
 			// No need to introduce a recursion here.
 			cr.removeCgroup(cgroup)
 		}
-		cgroup.Unlock()
-	}
-
-	for _, cgroup := range cr.hostWorkloads.Values() {
-		if cgroup.CGroupFile.Inode == currentCgroup.CGroupFile.Inode {
-			continue
-		}
-		cgroup.Lock()
-		for _, pid := range pids {
-			delete(cgroup.PIDs, pid)
-		}
-		if len(cgroup.PIDs) == 0 {
-			// No double check here to ensure that the cgroup is REALLY empty,
-			// because we already are in such a double check for another cgroup.
-			// No need to introduce a recursion here.
-			cr.removeCgroup(cgroup)
-		}
-		cgroup.Unlock()
-	}
+		return false
+	})
 }
 
 func (cr *Resolver) pushNewCacheEntry(process *model.ProcessCacheEntry) {
@@ -216,6 +218,7 @@ func (cr *Resolver) pushNewCacheEntry(process *model.ProcessCacheEntry) {
 	cr.cgroups.Add(process.CGroup.CGroupFile.Inode, &cgroupCopy)
 
 	cr.NotifyListeners(CGroupCreated, newCGroup)
+	cr.deletedCgroups.Inc()
 }
 
 // returns false if the fallback failed
@@ -233,7 +236,7 @@ func (cr *Resolver) resolvePidCgroupFallback(process *model.ProcessCacheEntry) b
 
 	// fallback can fail for short lived processes, in this case we try to assign the parent cgroup
 	if process.PPid == process.Pid || process.PPid <= 0 {
-		seclog.Warnf("Fallback to resolve cgroup for %d, missing parend PPID: %d", process.Pid, process.PPid)
+		seclog.Infof("Failed to fallback to resolve cgroup for %d, missing parend PPID: %d", process.Pid, process.PPid)
 		return false
 	}
 
@@ -261,7 +264,10 @@ func (cr *Resolver) resolvePidCgroupFallback(process *model.ProcessCacheEntry) b
 		return true
 	}
 
-	seclog.Warnf("Failed to add pid %d, error on fallback to resolve its cgroup: %v", process.Pid, err)
+	if err == nil {
+		err = errors.New("FindCGroupContext returned an empty cgroup")
+	}
+	seclog.Infof("Failed to add pid %d, error on fallback to resolve its cgroup: %v", process.Pid, err)
 	return false
 }
 
@@ -272,10 +278,16 @@ func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
 	defer cr.Unlock()
 
 	if process.CGroup.CGroupID == "" || process.CGroup.CGroupFile.Inode == 0 {
+		cr.addPidCgroupAbsent.Inc()
 		if !cr.resolvePidCgroupFallback(process) {
 			// all fallback failed :/
+			cr.fallbackFailed.Inc()
 			return
+		} else {
+			cr.fallbackSucceed.Inc()
 		}
+	} else {
+		cr.addPidCgroupPresent.Inc()
 	}
 
 	// push pid:cgroup pair to an history cache for fallbacks for short lived processes
@@ -419,6 +431,39 @@ func (cr *Resolver) SendStats() error {
 	if val := float64(cr.cgroups.Len()); val > 0 {
 		if err := cr.statsdClient.Gauge(metrics.MetricCGroupResolverActiveCGroups, val, []string{}, 1.0); err != nil {
 			return fmt.Errorf("couldn't send MetricCGroupResolverActiveCGroups: %w", err)
+		}
+	}
+
+	if count := cr.addedCgroups.Swap(0); count > 0 {
+		if err := cr.statsdClient.Count(metrics.MetricCGroupResolverAddedCgroups, count, []string{}, 1.0); err != nil {
+			return fmt.Errorf("failed to send cgroup_resolver metric: %w", err)
+		}
+	}
+	if count := cr.deletedCgroups.Swap(0); count > 0 {
+		if err := cr.statsdClient.Count(metrics.MetricCGroupResolverDeletedCgroups, count, []string{}, 1.0); err != nil {
+			return fmt.Errorf("failed to send cgroup_resolver metric: %w", err)
+		}
+	}
+
+	if count := cr.fallbackSucceed.Swap(0); count > 0 {
+		if err := cr.statsdClient.Count(metrics.MetricCGroupResolverFallbackSucceed, count, []string{}, 1.0); err != nil {
+			return fmt.Errorf("failed to send cgroup_resolver metric: %w", err)
+		}
+	}
+	if count := cr.fallbackFailed.Swap(0); count > 0 {
+		if err := cr.statsdClient.Count(metrics.MetricCGroupResolverFallbackFailed, count, []string{}, 1.0); err != nil {
+			return fmt.Errorf("failed to send cgroup_resolver metric: %w", err)
+		}
+	}
+
+	if count := cr.addPidCgroupPresent.Swap(0); count > 0 {
+		if err := cr.statsdClient.Count(metrics.MetricCGroupResolverAddPIDCgroupPresent, count, []string{}, 1.0); err != nil {
+			return fmt.Errorf("failed to send cgroup_resolver metric: %w", err)
+		}
+	}
+	if count := cr.addPidCgroupAbsent.Swap(0); count > 0 {
+		if err := cr.statsdClient.Count(metrics.MetricCGroupResolverAddPIDCgroupAbsent, count, []string{}, 1.0); err != nil {
+			return fmt.Errorf("failed to send cgroup_resolver metric: %w", err)
 		}
 	}
 

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -283,9 +283,8 @@ func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
 			// all fallback failed :/
 			cr.fallbackFailed.Inc()
 			return
-		} else {
-			cr.fallbackSucceed.Inc()
 		}
+		cr.fallbackSucceed.Inc()
 	} else {
 		cr.addPidCgroupPresent.Inc()
 	}

--- a/pkg/security/security_profile/testing.go
+++ b/pkg/security/security_profile/testing.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/profile"
 	"github.com/cilium/ebpf"
@@ -131,18 +130,4 @@ func (m *Manager) ClearTracedCgroups() {
 		// Then delete from traced map
 		_ = m.tracedCgroupsMap.Delete(cgroupInode)
 	}
-
-	// Also iterate through all currently running containers on the system
-	// and add them to the discarded map to prevent automatic tracing
-
-	// Walk through all process cache entries and blacklist their cgroups
-	m.resolvers.ProcessResolver.Walk(func(entry *model.ProcessCacheEntry) {
-		if entry.ContainerContext.ContainerID != "" && !entry.CGroup.CGroupFile.IsNull() {
-			if err := m.tracedCgroupsDiscardedMap.Put(entry.CGroup.CGroupFile.Inode, uint8(1)); err != nil {
-				if !errors.Is(err, ebpf.ErrKeyNotExist) {
-					seclog.Warnf("couldn't add system container cgroup to discarded map: %v", err)
-				}
-			}
-		}
-	})
 }

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -101,7 +101,7 @@ func parseProcControlGroupsData(data []byte, validateCgroupEntry func(string, st
 		data = data[nextStart:]
 	}
 
-	// return the lastest error
+	// return the latest error
 	return err
 }
 
@@ -244,6 +244,11 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 				cgroupPath = filepath.Join(cfs.rootCGroupPath, path)
 			} else {
 				cgroupPath = filepath.Join(mountpoint, ctrlDirectory, path)
+			}
+
+			if mountpoint == cgroupPath { // should not happen
+				seclog.Errorf("failed to compute cgroup path with path:%s, mountpoint:%s, rootCGroupPath:%s, ctrlDirectory:%s", path, mountpoint, cfs.rootCGroupPath, ctrlDirectory)
+				continue
 			}
 
 			if exists, err = checkPidExists(cgroupPath, pid); err == nil && exists {


### PR DESCRIPTION
### What does this PR do?

Adds comprehensive metrics for the cgroup resolver to improve observability and debugging capabilities.
Added 6 new metrics to track cgroup resolver operations:
* `cgroup_resolver.added_cgroups` - Count of cgroups added
* `cgroup_resolver.deleted_cgroups` - Count of cgroups deleted
* `cgroup_resolver.fallback_succeed` - Count of successful cgroup resolution fallbacks
* `cgroup_resolver.fallback_failed` - Count of failed cgroup resolution fallbacks
* `cgroup_resolver.addpid_cgroup_present` - Count of AddPID calls with a cgroup context
* `cgroup_resolver.addpid_cgroup_absent` - Count of AddPID calls without a cgroup context


### Motivation

### Describe how you validated your changes

### Additional Notes
