### PR TITLE
[CWS] injector only mode for cws-instrumentation

### DIFF
--- a/.gitlab/binary_build/cws_instrumentation.yml
+++ b/.gitlab/binary_build/cws_instrumentation.yml
@@ -9,8 +9,7 @@
     paths:
       - $CWS_INSTRUMENTATION_BINARIES_DIR/cws-instrumentation.$ARCH
 
-cws_instrumentation-build_amd64:
-  extends: .cws_instrumentation-build_common
+.cws_instrumentation_amd64:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -22,8 +21,7 @@ cws_instrumentation-build_amd64:
   before_script:
     - !reference [.retrieve_linux_go_deps]
 
-cws_instrumentation-build_arm64:
-  extends: .cws_instrumentation-build_common
+.cws_instrumentation_arm64:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -34,3 +32,27 @@ cws_instrumentation-build_arm64:
     ARCH: arm64
   before_script:
     - !reference [.retrieve_linux_go_deps]
+
+
+cws_instrumentation-build_amd64:
+  extends: [.cws_instrumentation-build_common, .cws_instrumentation_amd64]
+
+
+cws_instrumentation-build_arm64:
+  extends: [.cws_instrumentation-build_common, .cws_instrumentation_arm64]
+
+.cws_instrumentation-build_injector_common:
+  stage: binary_build
+  needs: ["go_mod_tidy_check"]
+  script:
+    - dda inv -- check-go-version
+    - dda inv -- -e cws-instrumentation.build --arch-suffix --injector-only
+  artifacts:
+    paths:
+      - $CWS_INSTRUMENTATION_BINARIES_DIR/cws-instrumentation.$ARCH
+
+cws_instrumentation-build_injector_amd64:
+  extends: [.cws_instrumentation-build_injector_common, .cws_instrumentation_amd64]
+
+cws_instrumentation-build_injector_arm64:
+  extends: [.cws_instrumentation-build_injector_common, .cws_instrumentation_arm64]

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -317,9 +317,9 @@ docker_build_cluster_agent_amd64:
   needs:
     - job: cluster_agent-build_amd64
       artifacts: true
-    - job: cws_instrumentation-build_amd64
+    - job: cws_instrumentation-build_injector_amd64
       artifacts: true
-    - job: cws_instrumentation-build_arm64
+    - job: cws_instrumentation-build_injector_arm64
       artifacts: true
   variables:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_cluster_agent_amd64"
@@ -329,9 +329,9 @@ docker_build_cluster_agent_arm64:
   needs:
     - job: cluster_agent-build_arm64
       artifacts: true
-    - job: cws_instrumentation-build_amd64
+    - job: cws_instrumentation-build_injector_amd64
       artifacts: true
-    - job: cws_instrumentation-build_arm64
+    - job: cws_instrumentation-build_injector_arm64
       artifacts: true
   variables:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_cluster_agent_arm64"
@@ -349,9 +349,9 @@ docker_build_cluster_agent_fips_amd64:
   needs:
     - job: cluster_agent_fips-build_amd64
       artifacts: true
-    - job: cws_instrumentation-build_amd64
+    - job: cws_instrumentation-build_injector_amd64
       artifacts: true
-    - job: cws_instrumentation-build_arm64
+    - job: cws_instrumentation-build_injector_arm64
       artifacts: true
 
 docker_build_cluster_agent_fips_arm64:
@@ -359,9 +359,9 @@ docker_build_cluster_agent_fips_arm64:
   needs:
     - job: cluster_agent_fips-build_arm64
       artifacts: true
-    - job: cws_instrumentation-build_amd64
+    - job: cws_instrumentation-build_injector_amd64
       artifacts: true
-    - job: cws_instrumentation-build_arm64
+    - job: cws_instrumentation-build_injector_arm64
       artifacts: true
 
 # build the cws-instrumentation image

--- a/cmd/cws-instrumentation/main_linux.go
+++ b/cmd/cws-instrumentation/main_linux.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	rootCmd := command.MakeCommand(subcommands.CWSInjectorSubcommands())
+	rootCmd := command.MakeCommand(subcommands.CWSInjectorSubcommands)
 
 	if err := rootCmd.Execute(); err != nil {
 		// the error has already been printed

--- a/cmd/cws-instrumentation/subcommands/subcommands.go
+++ b/cmd/cws-instrumentation/subcommands/subcommands.go
@@ -13,16 +13,12 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/healthcmd"
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/injectcmd"
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/setupcmd"
-	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/tracecmd"
 )
 
 // CWSInjectorSubcommands returns SubcommandFactories for the subcommands supported
 // with the current build flags.
-func CWSInjectorSubcommands() []command.SubcommandFactory {
-	return []command.SubcommandFactory{
-		setupcmd.Command,
-		injectcmd.Command,
-		tracecmd.Command,
-		healthcmd.Command,
-	}
+var CWSInjectorSubcommands = []command.SubcommandFactory{
+	setupcmd.Command,
+	injectcmd.Command,
+	healthcmd.Command,
 }

--- a/cmd/cws-instrumentation/subcommands/subcommands_tracing.go
+++ b/cmd/cws-instrumentation/subcommands/subcommands_tracing.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && !cws_instrumentation_injector_only
+
+// Package subcommands is used to list the subcommands of CWS injector
+package subcommands
+
+import "github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/tracecmd"
+
+func init() {
+	CWSInjectorSubcommands = append(CWSInjectorSubcommands, tracecmd.Command)
+}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -67,6 +67,7 @@ ALL_TAGS = {
     "zlib",
     "zstd",
     "cel",
+    "cws_instrumentation_injector_only",  # used for building cws-instrumentation with only the injector code
 }
 
 ### Tag inclusion lists

--- a/tasks/cws_instrumentation.py
+++ b/tasks/cws_instrumentation.py
@@ -35,6 +35,7 @@ def build(
     fips_mode=False,
     no_strip_binary=False,
     arch_suffix=False,
+    injector_only=False,
 ):
     """
     Build cws-instrumentation
@@ -56,6 +57,9 @@ def build(
     ldflags += ' '.join([f"-X '{main + key}={value}'" for key, value in ld_vars.items()])
     build_tags += get_default_build_tags(build="cws-instrumentation")
     build_tags = add_fips_tags(build_tags, fips_mode)
+
+    if injector_only:
+        build_tags.append("cws_instrumentation_injector_only")
 
     agent_bin = BIN_PATH
     if arch_suffix:


### PR DESCRIPTION
### What does this PR do?

Currently we use cws-instrumentation for 2 things:
- k8s user session, with the injector part
- fargate/ebpfless, with the tracing part

We build cws-instrumentation with both features, and we ship it:
- in the regular agent package
- in the cluster agent, 2 binaries (one for each arch)
- in a separate container image

But both features are not actually used in all shipped packages, especially the cluster agent only needs the injector parts.

This PR allows building `cws-intrumentation` in injector only mode, duplicates the CI binary build jobs to build both modes, and fix the cluster agent dependency to use the injector only binary.

The win is pretty obvious:
- instead of copying a 7M binary on kubectl exec the binary is only 2.5M big
- instead of shipping 14M of cws-instrumentation binaries with the cluster-agent, we ship only 5M

### Motivation

### Describe how you validated your changes

### Additional Notes
