### PR TITLE
[CSPM] remove some unused CLI compliance commands

### DIFF
--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/shirou/gopsutil/v4/process"
 	"github.com/spf13/cobra"
@@ -22,21 +21,14 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/check"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
-	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
 	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
-	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
-	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/aptconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/types"
 	complianceutils "github.com/DataDog/datadog-agent/pkg/compliance/utils"
-	"github.com/DataDog/datadog-agent/pkg/security/common"
-	"github.com/DataDog/datadog-agent/pkg/security/utils/hostnameutils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -48,19 +40,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 
 	complianceCmd.AddCommand(check.SecurityAgentCommands(globalParams)...)
-	complianceCmd.AddCommand(complianceEventCommand(globalParams))
 	complianceCmd.AddCommand(complianceLoadCommand(globalParams))
 
 	return []*cobra.Command{complianceCmd}
-}
-
-type eventCliParams struct {
-	*command.GlobalParams
-
-	sourceName string
-	sourceType string
-	event      compliance.CheckEvent
-	data       []string
 }
 
 type loadCliParams struct {
@@ -148,66 +130,4 @@ func getProcMeta(hostroot string, pid int32) (*process.Process, complianceutils.
 		rootPath = "/"
 	}
 	return proc, containerID, filepath.Join(hostroot, rootPath), nil
-}
-
-func complianceEventCommand(globalParams *command.GlobalParams) *cobra.Command {
-	eventArgs := &eventCliParams{
-		GlobalParams: globalParams,
-	}
-
-	eventCmd := &cobra.Command{
-		Use:   "event",
-		Short: "Issue logs to test Security Agent compliance events",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fxutil.OneShot(eventRun,
-				fx.Supply(eventArgs),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths, config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
-					LogParams:    log.ForOneShot(command.LoggerName, "info", true),
-				}),
-				core.Bundle(),
-				secretsfx.Module(),
-				logscompressionfx.Module(),
-				ipcfx.ModuleReadOnly(),
-			)
-		},
-		Hidden: true,
-	}
-
-	eventCmd.Flags().StringVarP(&eventArgs.sourceType, "source-type", "", "compliance", "Log source name")
-	eventCmd.Flags().StringVarP(&eventArgs.sourceName, "source-name", "", "compliance-agent", "Log source name")
-	eventCmd.Flags().StringVarP(&eventArgs.event.RuleID, "rule-id", "", "", "Rule ID")
-	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceID, "resource-id", "", "", "Resource ID")
-	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceType, "resource-type", "", "", "Resource type")
-	eventCmd.Flags().StringSliceVarP(&eventArgs.event.Tags, "tags", "t", []string{"security:compliance"}, "Tags")
-	eventCmd.Flags().StringSliceVarP(&eventArgs.data, "data", "d", []string{}, "Data KV fields")
-
-	return eventCmd
-}
-
-func eventRun(log log.Component, eventArgs *eventCliParams, compression compression.Component, ipc ipc.Component) error {
-	hostnameDetected, err := hostnameutils.GetHostnameWithContextAndFallback(context.Background(), ipc)
-	if err != nil {
-		return log.Errorf("Error while getting hostname, exiting: %v", err)
-	}
-
-	endpoints, dstContext, err := common.NewLogContextCompliance()
-	if err != nil {
-		return err
-	}
-
-	reporter := compliance.NewLogReporter(hostnameDetected, eventArgs.sourceName, eventArgs.sourceType, endpoints, dstContext, compression)
-	defer reporter.Stop()
-
-	eventData := make(map[string]interface{})
-	for _, d := range eventArgs.data {
-		kv := strings.SplitN(d, ":", 2)
-		if len(kv) != 2 {
-			continue
-		}
-		eventData[kv[0]] = kv[1]
-	}
-	eventArgs.event.Data = eventData
-	reporter.ReportEvent(eventData)
-	return nil
 }

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -23,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
-	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
 	"github.com/DataDog/datadog-agent/pkg/compliance/aptconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
@@ -70,7 +69,6 @@ func complianceLoadCommand(globalParams *command.GlobalParams) *cobra.Command {
 				}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
-				logscompressionfx.Module(),
 			)
 		},
 	}

--- a/cmd/security-agent/subcommands/compliance/command_kubeapiserver_test.go
+++ b/cmd/security-agent/subcommands/compliance/command_kubeapiserver_test.go
@@ -8,9 +8,10 @@
 package compliance
 
 import (
+	"testing"
+
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/check"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 
@@ -78,41 +79,6 @@ func TestLoadSubcommand(t *testing.T) {
 			Commands(&command.GlobalParams{}),
 			test.cliInput,
 			loadRun,
-			test.check,
-		)
-	}
-}
-
-func TestCommand_kubeapiserver(t *testing.T) {
-	tests := []struct {
-		name     string
-		cliInput []string
-		check    func(cliParams *eventCliParams, params core.BundleParams)
-	}{
-		{
-			name:     "compliance event tags",
-			cliInput: []string{"compliance", "event", "--tags", "test:tag"},
-			check: func(cliParams *eventCliParams, params core.BundleParams) {
-				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
-				require.Equal(t, "info", params.LogLevelFn(nil), "params.LogLevelFn not matching")
-				require.Equal(t, []string{"test:tag"}, cliParams.event.Tags, "tags arg input not matching")
-			},
-		},
-	}
-
-	for _, test := range tests {
-		rootCommand := Commands(&command.GlobalParams{})[0]
-
-		var subcommandNames []string
-		for _, subcommand := range rootCommand.Commands() {
-			subcommandNames = append(subcommandNames, subcommand.Use)
-		}
-		require.Equal(t, []string{"check", "event", "load <conf-type>"}, subcommandNames, "subcommand missing")
-
-		fxutil.TestOneShotSubcommand(t,
-			Commands(&command.GlobalParams{}),
-			test.cliInput,
-			eventRun,
 			test.check,
 		)
 	}

--- a/cmd/security-agent/subcommands/compliance/command_test.go
+++ b/cmd/security-agent/subcommands/compliance/command_test.go
@@ -8,7 +8,6 @@
 package compliance
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -21,46 +20,6 @@ import (
 
 // This test suite requires the opposite build flags of the check package
 // in order to test the compliance command in environments that cannot have the check subcommand.
-
-func TestEventCommands(t *testing.T) {
-	tests := []struct {
-		name     string
-		cliInput []string
-		check    func(cliParams *eventCliParams, params core.BundleParams)
-	}{
-		{
-			name:     "compliance event tags",
-			cliInput: []string{"compliance", "event", "--tags", "test:tag"},
-			check: func(cliParams *eventCliParams, params core.BundleParams) {
-				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
-				require.Equal(t, "info", params.LogLevelFn(nil), "log level not matching")
-				require.Equal(t, []string{"test:tag"}, cliParams.event.Tags, "tags arg input not matching")
-			},
-		},
-	}
-
-	for _, test := range tests {
-		rootCommand := Commands(&command.GlobalParams{})[0]
-
-		var subcommandNames []string
-		for _, subcommand := range rootCommand.Commands() {
-			subcommandNames = append(subcommandNames, subcommand.Use)
-		}
-
-		if runtime.GOOS == "windows" {
-			require.Equal(t, []string{"event", "load <conf-type>"}, subcommandNames, "subcommand missing")
-		} else {
-			require.Equal(t, []string{"check", "event", "load <conf-type>"}, subcommandNames, "subcommand missing")
-		}
-
-		fxutil.TestOneShotSubcommand(t,
-			Commands(&command.GlobalParams{}),
-			test.cliInput,
-			eventRun,
-			test.check,
-		)
-	}
-}
 
 func TestLoadSubcommand(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### What does this PR do?

The `security-agent compliance event` has been unused for some time (and is hidden already), in addition the `compliance load` command doesn't need the logs compression fx component. This PR cleans this up.

### Motivation

### Describe how you validated your changes

### Additional Notes
