### PR TITLE
Small improvements - on memory footprint

### DIFF
--- a/comp/core/tagger/utils/concat.go
+++ b/comp/core/tagger/utils/concat.go
@@ -5,22 +5,16 @@
 
 package utils
 
+import "slices"
+
 // ConcatenateTags is a fast way to concatenate multiple tag
 // arrays in a single one.
-func ConcatenateTags(slices ...[]string) []string {
-	if len(slices) == 1 {
-		return slices[0]
+func ConcatenateTags(tags ...[]string) []string {
+	if len(tags) <= 0 {
+		return []string{}
 	}
-	var totalLen int
-	for _, s := range slices {
-		totalLen += len(s)
-	}
-	result := make([]string, totalLen)
-	var i int
-	for _, s := range slices {
-		i += copy(result[i:], s)
-	}
-	return result
+
+	return slices.Concat(tags...)
 }
 
 // ConcatenateStringTags adds string tags to existing tag array

--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -54,10 +54,10 @@ type kubeletClientConfig struct {
 }
 
 type kubeletClient struct {
-	client          http.Client
-	kubeletURL      string
-	config          kubeletClientConfig
-	ressponseBuffer *bytes.Buffer
+	client         http.Client
+	kubeletURL     string
+	config         kubeletClientConfig
+	responseBuffer *bytes.Buffer
 }
 
 func newForConfig(config kubeletClientConfig, timeout time.Duration) (*kubeletClient, error) {
@@ -114,10 +114,10 @@ func newForConfig(config kubeletClientConfig, timeout time.Duration) (*kubeletCl
 	}
 
 	return &kubeletClient{
-		client:          httpClient,
-		kubeletURL:      fmt.Sprintf("%s://%s", config.scheme, config.baseURL),
-		config:          config,
-		ressponseBuffer: bytes.NewBuffer(make([]byte, 0, 64*1024)),
+		client:         httpClient,
+		kubeletURL:     fmt.Sprintf("%s://%s", config.scheme, config.baseURL),
+		config:         config,
+		responseBuffer: bytes.NewBuffer(make([]byte, 0, 64*1024)),
 	}, nil
 }
 
@@ -187,17 +187,17 @@ func (kc *kubeletClient) query(ctx context.Context, path string) ([]byte, int, e
 
 	defer response.Body.Close()
 
-	kc.ressponseBuffer.Reset()
-	_, err = io.Copy(kc.ressponseBuffer, response.Body)
+	kc.responseBuffer.Reset()
+	_, err = io.Copy(kc.responseBuffer, response.Body)
 	if err != nil {
 		log.Errorf("Fail to read request %s body: %s", req.URL.String(), err)
 		return nil, 0, err
 	}
 
-	b := make([]byte, kc.ressponseBuffer.Len())
+	b := make([]byte, kc.responseBuffer.Len())
 
 	// Read can only return EOF or nil, don't check for errors
-	kc.ressponseBuffer.Read(b) ////nolint:errcheck
+	kc.responseBuffer.Read(b) ////nolint:errcheck
 	return b, response.StatusCode, nil
 }
 

--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -194,10 +194,16 @@ func (kc *kubeletClient) query(ctx context.Context, path string) ([]byte, int, e
 		return nil, 0, err
 	}
 
-	b := make([]byte, kc.responseBuffer.Len())
+	b := []byte{}
 
-	// Read can only return EOF or nil, don't check for errors
-	kc.responseBuffer.Read(b) ////nolint:errcheck
+	// prevent trying to allocate a negative slice size.
+	if buffLen := kc.responseBuffer.Len(); buffLen > 0 {
+		b = make([]byte, buffLen)
+		// Read can only return EOF or nil, don't check for errors
+		kc.responseBuffer.Read(b) ////nolint:errcheck
+	}
+
+	kc.responseBuffer.Reset()
 	return b, response.StatusCode, nil
 }
 

--- a/pkg/util/kubernetes/kubelet/kubelet_client_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client_test.go
@@ -8,6 +8,7 @@
 package kubelet
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -138,7 +139,8 @@ func TestQuery(t *testing.T) {
 					apiServerHost: APIServer.URL,
 					nodeName:      "abc",
 				},
-				kubeletURL: kubelet.URL,
+				kubeletURL:      kubelet.URL,
+				ressponseBuffer: bytes.NewBuffer(make([]byte, 0, 64*1024)),
 			}
 
 			_, status, err := kc.query(context.Background(), kubeletPodPath)

--- a/pkg/util/kubernetes/kubelet/kubelet_client_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client_test.go
@@ -139,8 +139,8 @@ func TestQuery(t *testing.T) {
 					apiServerHost: APIServer.URL,
 					nodeName:      "abc",
 				},
-				kubeletURL:      kubelet.URL,
-				ressponseBuffer: bytes.NewBuffer(make([]byte, 0, 64*1024)),
+				kubeletURL:     kubelet.URL,
+				responseBuffer: bytes.NewBuffer(make([]byte, 0, 64*1024)),
 			}
 
 			_, status, err := kc.query(context.Background(), kubeletPodPath)


### PR DESCRIPTION
### What does this PR do?

- use `slices` package instead of writing our own slices concat function.

- Do not allocate the prometheus text parser each time the function is called. Allocate the parser once, use it many times
  	- that requires to empty the inner map allocated by the parser to prevent it from keeping the old values in memory.

- Use a buffer to read/store response from `kubeClient.Query()` method.

  	- This allows us to allocate a large enough buffer once at init (64KB seems large enough so fare for JSON responses).
	- This allows us to then allocate 1 `[]byte` buffer with the correct size to return to the caller.
	- Before we used the function `io.ReadAll` which makes as many allocations as necessary using a buffer size of 512 bytes.

  This is the biggest improvement from the below changes, it saves
  about 20MB based on an idle cluster with only kubelet check
  enabled.

### Motivation

For innovation week, found that subject interesting to take a deeper look at the code.

### Describe how you validated your changes

- I measured how much memory was consumed before and after

#### For the prometheus text parser, this is the memory gain:
<img width="2390" height="1282" alt="agent_kubelet_perf_buffer_safe" src="https://github.com/user-attachments/assets/89e43d58-e647-436f-92dc-84f9f7c43c9b" />

#### For the kube client Query method this is the memory gain:
<img width="2390" height="1282" alt="agent_kubeletquery_save_20MB" src="https://github.com/user-attachments/assets/e08905df-b9aa-4a77-9b4d-3b1af7299a23" />

#### For the string concat method

I have no measurements, I just made the change as the standard go implem will always be better/standard than something we developed years ago.

### Additional Notes
