### PR TITLE
[Process] Attach discovered log file paths to services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.9.2
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/DataDog/agent-payload/v5 v5.0.172
+	github.com/DataDog/agent-payload/v5 v5.0.174-0.20251104134317-dda356836e6e
 	github.com/DataDog/appsec-internal-go v1.14.0
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.72.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/CycloneDX/cyclonedx-go v0.9.2 h1:688QHn2X/5nRezKe2ueIVCt+NRqf7fl3AVQk
 github.com/CycloneDX/cyclonedx-go v0.9.2/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174-0.20251104134317-dda356836e6e h1:kvPmki21tfhkvld1WRo6TuLxrHOhMQHnqK3LpRyDq7I=
+github.com/DataDog/agent-payload/v5 v5.0.174-0.20251104134317-dda356836e6e/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/appsec-internal-go v1.14.0 h1:MIEZ015kdpeSZSFYBQteSmg8f7zkQTWbMDHbSL9zBx8=
 github.com/DataDog/appsec-internal-go v1.14.0/go.mod h1:9YppRCpElfGX+emXOKruShFYsdPq7WEPq/Fen4tYYpk=
 github.com/DataDog/aptly v1.5.3 h1:oLsRvjuXSVM4ia0N83dU3KiQeiJ6BaszYbTZOkSfDlw=

--- a/pkg/process/checks/process_linux.go
+++ b/pkg/process/checks/process_linux.go
@@ -230,11 +230,23 @@ func formatServiceDiscovery(service *procutil.Service) *model.ServiceDiscovery {
 		})
 	}
 
+	var resources []*model.Resource
+	for _, logPath := range service.LogFiles {
+		resources = append(resources, &model.Resource{
+			Resource: &model.Resource_Logs{
+				Logs: &model.LogResource{
+					Path: logPath,
+				},
+			},
+		})
+	}
+
 	return &model.ServiceDiscovery{
 		GeneratedServiceName:     generatedServiceName,
 		DdServiceName:            ddServiceName,
 		AdditionalGeneratedNames: additionalGeneratedNames,
 		TracerMetadata:           tracerMetadata,
 		ApmInstrumentation:       service.APMInstrumentation,
+		Resources:                resources,
 	}
 }

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -151,6 +151,9 @@ type Service struct {
 
 	// APMInstrumentation indicates the APM instrumentation status
 	APMInstrumentation bool
+
+	// LogFiles contains paths to log files associated with this service
+	LogFiles []string
 }
 
 // DeepCopy creates a deep copy of Stats


### PR DESCRIPTION
### What does this PR do?
[DSCVR-236](https://datadoghq.atlassian.net/browse/DSCVR-236)

We want to attach log file path information to process data. In the future, we may want to extend this log file information with additional data as new use cases arise. For example, the rate of log writes, log size, or other metadata. More about this could be read in [this document.](https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/5580787035/Processes+have+logs+attached)

### Motivation
We want to attach discovered log information to process data sent to the backend (Processes) in a generic and extensible way.

### Describe how you validated your changes


### Additional Notes


[DSCVR-236]: https://datadoghq.atlassian.net/browse/DSCVR-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ