### PR TITLE
Rename old logs health module to avoid conflicts with new agent health initiative

### DIFF
--- a/comp/README.md
+++ b/comp/README.md
@@ -328,14 +328,14 @@ Package auditor records the log files the agent is tracking. It tracks
 filename, time last updated, offset (how far into the file the agent has
 read), and tailing mode for each log file.
 
-### [comp/logs/health](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/logs/health)
-
-Package health provides a dependency-injectible health object for kubernetes liveness checks
-
 ### [comp/logs/integrations](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/logs/integrations)
 
 Package integrations adds a go interface for integrations to register and
 send logs.
+
+### [comp/logs/kubehealth](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/logs/kubehealth)
+
+Package kubehealth provides a dependency-injectible health object for kubernetes liveness checks
 
 ### [comp/logs/streamlogs](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/logs/streamlogs)
 

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -38,8 +38,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent"
 
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
-	healthdef "github.com/DataDog/datadog-agent/comp/logs/health/def"
-	healthmock "github.com/DataDog/datadog-agent/comp/logs/health/mock"
+	kubehealthdef "github.com/DataDog/datadog-agent/comp/logs/kubehealth/def"
+	kubehealthmock "github.com/DataDog/datadog-agent/comp/logs/kubehealth/mock"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
 	compressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
@@ -63,20 +63,20 @@ type AgentTestSuite struct {
 	testLogFile string
 	fakeLogs    int64
 
-	source          *sources.LogSource
-	configOverrides map[string]interface{}
-	tagger          tagger.Component
-	healthRegistrar healthdef.Component
+	source              *sources.LogSource
+	configOverrides     map[string]interface{}
+	tagger              tagger.Component
+	kubeHealthRegistrar kubehealthdef.Component
 }
 
 type testDeps struct {
 	fx.In
 
-	Config          configComponent.Component
-	Log             log.Component
-	InventoryAgent  inventoryagent.Component
-	Auditor         auditor.Component
-	HealthRegistrar healthdef.Component
+	Config              configComponent.Component
+	Log                 log.Component
+	InventoryAgent      inventoryagent.Component
+	Auditor             auditor.Component
+	KubeHealthRegistrar kubehealthdef.Component
 }
 
 func (suite *AgentTestSuite) SetupTest() {
@@ -136,11 +136,11 @@ func createAgent(suite *AgentTestSuite, endpoints *config.Endpoints) (*logAgent,
 		hostnameimpl.MockModule(),
 		inventoryagentimpl.MockModule(),
 		auditorfx.Module(),
-		fx.Provide(healthmock.NewProvides),
+		fx.Provide(kubehealthmock.NewProvides),
 	))
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(suite.T())
-	suite.healthRegistrar = deps.HealthRegistrar
+	suite.kubeHealthRegistrar = deps.KubeHealthRegistrar
 
 	agent := &logAgent{
 		log:              deps.Log,
@@ -320,7 +320,7 @@ func (suite *AgentTestSuite) TestAgentLiveness() {
 
 	var count int
 	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, 1*time.Second, func() bool {
-		count = suite.healthRegistrar.(*healthmock.Registrar).CountRegistered("logs-agent")
+		count = suite.kubeHealthRegistrar.(*kubehealthmock.Registrar).CountRegistered("logs-agent")
 		return count > 0
 	})
 
@@ -504,7 +504,7 @@ func (suite *AgentTestSuite) createDeps() dependencies {
 			return suite.tagger
 		}),
 		auditorfx.Module(),
-		fx.Provide(healthmock.NewProvides),
+		fx.Provide(kubehealthmock.NewProvides),
 	))
 }
 

--- a/comp/logs/auditor/impl/auditor.go
+++ b/comp/logs/auditor/impl/auditor.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
-	healthdef "github.com/DataDog/datadog-agent/comp/logs/health/def"
+	kubehealthdef "github.com/DataDog/datadog-agent/comp/logs/kubehealth/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -50,29 +50,29 @@ type JSONRegistry struct {
 
 // A registryAuditor is storing the Auditor information using a registry.
 type registryAuditor struct {
-	health             *health.Handle
-	healthRegistrar    healthdef.Component
-	chansMutex         sync.Mutex
-	inputChan          chan *message.Payload
-	registry           map[string]*RegistryEntry
-	tailedSources      map[string]bool
-	registryPath       string
-	registryDirPath    string
-	registryTmpFile    string
-	registryMutex      sync.Mutex
-	entryTTL           time.Duration
-	done               chan struct{}
-	messageChannelSize int
-	registryWriter     auditor.RegistryWriter
+	health              *health.Handle
+	kubeHealthRegistrar kubehealthdef.Component
+	chansMutex          sync.Mutex
+	inputChan           chan *message.Payload
+	registry            map[string]*RegistryEntry
+	tailedSources       map[string]bool
+	registryPath        string
+	registryDirPath     string
+	registryTmpFile     string
+	registryMutex       sync.Mutex
+	entryTTL            time.Duration
+	done                chan struct{}
+	messageChannelSize  int
+	registryWriter      auditor.RegistryWriter
 
 	log log.Component
 }
 
 // Dependencies defines the dependencies of the auditor
 type Dependencies struct {
-	Log    log.Component
-	Config config.Component
-	Health healthdef.Component
+	Log        log.Component
+	Config     config.Component
+	KubeHealth kubehealthdef.Component
 }
 
 // Provides contains the auditor component
@@ -96,15 +96,15 @@ func newAuditor(deps Dependencies) *registryAuditor {
 	}
 
 	registryAuditor := &registryAuditor{
-		registryPath:       filepath.Join(runPath, filename),
-		registryDirPath:    deps.Config.GetString("logs_config.run_path"),
-		registryTmpFile:    filepath.Base(filename) + ".tmp",
-		tailedSources:      make(map[string]bool),
-		entryTTL:           ttl,
-		messageChannelSize: messageChannelSize,
-		log:                deps.Log,
-		healthRegistrar:    deps.Health,
-		registryWriter:     registryWriter,
+		registryPath:        filepath.Join(runPath, filename),
+		registryDirPath:     deps.Config.GetString("logs_config.run_path"),
+		registryTmpFile:     filepath.Base(filename) + ".tmp",
+		tailedSources:       make(map[string]bool),
+		entryTTL:            ttl,
+		messageChannelSize:  messageChannelSize,
+		log:                 deps.Log,
+		kubeHealthRegistrar: deps.KubeHealth,
+		registryWriter:      registryWriter,
 	}
 
 	return registryAuditor
@@ -120,7 +120,7 @@ func NewProvides(deps Dependencies) Provides {
 
 // Start starts the Auditor
 func (a *registryAuditor) Start() {
-	a.health = a.healthRegistrar.RegisterLiveness("logs-agent")
+	a.health = a.kubeHealthRegistrar.RegisterLiveness("logs-agent")
 
 	a.createChannels()
 	a.registry = a.recoverRegistry()

--- a/comp/logs/auditor/impl/auditor_test.go
+++ b/comp/logs/auditor/impl/auditor_test.go
@@ -18,7 +18,7 @@ import (
 	configmock "github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	healthmock "github.com/DataDog/datadog-agent/comp/logs/health/mock"
+	kubehealthmock "github.com/DataDog/datadog-agent/comp/logs/kubehealth/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
 )
@@ -41,13 +41,13 @@ func (suite *AuditorTestSuite) SetupTest() {
 
 	configComponent := configmock.NewMock(suite.T())
 	logComponent := logmock.New(suite.T())
-	healthRegistrar := healthmock.NewMockRegistrar()
+	kubeHealthRegistrar := kubehealthmock.NewMockRegistrar()
 	configComponent.SetWithoutSource("logs_config.run_path", suite.testRunPathDir)
 
 	deps := Dependencies{
-		Config: configComponent,
-		Log:    logComponent,
-		Health: healthRegistrar,
+		Config:     configComponent,
+		Log:        logComponent,
+		KubeHealth: kubeHealthRegistrar,
 	}
 
 	suite.a = newAuditor(deps)

--- a/comp/logs/bundle.go
+++ b/comp/logs/bundle.go
@@ -9,7 +9,7 @@ package logs
 import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
 	auditorfx "github.com/DataDog/datadog-agent/comp/logs/auditor/fx"
-	healthfx "github.com/DataDog/datadog-agent/comp/logs/health/fx"
+	kubehealthfx "github.com/DataDog/datadog-agent/comp/logs/kubehealth/fx"
 	streamlogs "github.com/DataDog/datadog-agent/comp/logs/streamlogs/fx"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -19,7 +19,7 @@ import (
 // Bundle defines the fx options for this bundle.
 func Bundle() fxutil.BundleOptions {
 	return fxutil.Bundle(
-		healthfx.Module(),
+		kubehealthfx.Module(),
 		agentimpl.Module(),
 		streamlogs.Module(),
 		auditorfx.Module(),

--- a/comp/logs/kubehealth/def/component.go
+++ b/comp/logs/kubehealth/def/component.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package health provides a dependency-injectible health object for kubernetes liveness checks
-package health
+// Package kubehealth provides a dependency-injectible health object for kubernetes liveness checks
+package kubehealth
 
 import "github.com/DataDog/datadog-agent/pkg/status/health"
 

--- a/comp/logs/kubehealth/fx/fx.go
+++ b/comp/logs/kubehealth/fx/fx.go
@@ -3,15 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package fx provides the fx module for the health component
+// Package fx provides the fx module for the kubehealth component
 package fx
 
 import (
-	registrarimpl "github.com/DataDog/datadog-agent/comp/logs/health/impl"
+	registrarimpl "github.com/DataDog/datadog-agent/comp/logs/kubehealth/impl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// Module returns the fx module for the health component
+// Module returns the fx module for the kubehealth component
 func Module() fxutil.Module {
 	return fxutil.Component(
 		fxutil.ProvideComponentConstructor(

--- a/comp/logs/kubehealth/impl/kubehealth.go
+++ b/comp/logs/kubehealth/impl/kubehealth.go
@@ -3,20 +3,20 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package healthimpl provides a wrapper around the health package to allow for easier registration of health checks
-package healthimpl
+// Package kubehealthimpl provides a wrapper around the health package to allow for easier registration of health checks
+package kubehealthimpl
 
 import (
-	healthdef "github.com/DataDog/datadog-agent/comp/logs/health/def"
+	kubehealthdef "github.com/DataDog/datadog-agent/comp/logs/kubehealth/def"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
-// Provides contains the auditor component
+// Provides contains the kubehealth component
 type Provides struct {
-	Comp healthdef.Component
+	Comp kubehealthdef.Component
 }
 
-// RegistrarImpl is an implementation of LogsHealthRegistrar
+// RegistrarImpl is an implementation of KubeHealthRegistrar
 type RegistrarImpl struct{}
 
 // NewRegistrar creates a new Registrar

--- a/comp/logs/kubehealth/mock/kubehealth_mock.go
+++ b/comp/logs/kubehealth/mock/kubehealth_mock.go
@@ -3,17 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package mock provides a mock implementation of the LogsHealthRegistrar
+// Package mock provides a mock implementation of the KubeHealthRegistrar
 package mock
 
 import (
 	"go.uber.org/fx"
 
-	healthdef "github.com/DataDog/datadog-agent/comp/logs/health/def"
+	kubehealthdef "github.com/DataDog/datadog-agent/comp/logs/kubehealth/def"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
-// Registrar is a mock implementation of LogsHealthRegistrar
+// Registrar is a mock implementation of KubeHealthRegistrar
 type Registrar struct {
 	registeredChecks map[string]int
 }
@@ -22,7 +22,7 @@ type Registrar struct {
 type Provides struct {
 	fx.Out
 
-	Comp healthdef.Component
+	Comp kubehealthdef.Component
 }
 
 // NewProvides provides a new MockRegistrar


### PR DESCRIPTION
### What does this PR do?
Rename the current logs health module, which serves as a wrapper to kubernetes liveness check support. This is to avoid naming conflicts with other "health" initiatives coming down the pipe.

### Motivation

### Describe how you validated your changes

### Additional Notes
