### PR TITLE
(fleet) properly disable connectivity check when `inventories_diagnostics_enabled: false`

### DIFF
--- a/comp/connectivitychecker/impl/connectivitychecker.go
+++ b/comp/connectivitychecker/impl/connectivitychecker.go
@@ -67,6 +67,10 @@ func NewComponent(reqs Requires) (Provides, error) {
 }
 
 func (c *inventoryImpl) startTimer(delay time.Duration) {
+	if !c.config.GetBool("inventories_diagnostics_enabled") {
+		c.log.Debug("Connectivity check disabled: inventories_diagnostics_enabled is false")
+		return
+	}
 	go func() {
 		// Initial delay before first run
 		select {

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -513,10 +513,6 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 
 	ia.getConfigs(data)
 
-	if !ia.conf.GetBool("inventories_diagnostics_enabled") {
-		delete(data, "diagnostics")
-	}
-
 	return &Payload{
 		Hostname:  ia.hostname,
 		Timestamp: time.Now().UnixNano(),

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -772,27 +772,3 @@ func TestGetProvidedConfigurationOnly(t *testing.T) {
 
 	assert.Equal(t, expected, keys)
 }
-
-func TestGetDiagnosticsDisabled(t *testing.T) {
-	ia := getTestInventoryPayload(t, map[string]any{
-		"inventories_diagnostics_enabled": false,
-	}, nil)
-	ia.Set("diagnostics", "test")
-
-	payload := ia.getPayload().(*Payload)
-
-	// No configuration should be in the payload
-	assert.NotContains(t, payload.Metadata, "diagnostics")
-}
-
-func TestGetDiagnosticsEnabled(t *testing.T) {
-	ia := getTestInventoryPayload(t, map[string]any{
-		"inventories_diagnostics_enabled": true,
-	}, nil)
-	ia.Set("diagnostics", "test")
-
-	payload := ia.getPayload().(*Payload)
-
-	// No configuration should be in the payload
-	assert.Contains(t, payload.Metadata, "diagnostics")
-}


### PR DESCRIPTION
This PR properly disables connectivity checks when `inventories_diagnostics_enabled: false`. Previously it was just preventing the data from being sent but connectivity check queries were still being made. This PR disables the queries as well.