### PR TITLE
dyninst: protect against repeated crashes when placing probes

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -682,6 +682,7 @@ type fakeProcessSubscriber func(process.ProcessesUpdate)
 func (f *fakeProcessSubscriber) Subscribe(cb func(process.ProcessesUpdate)) {
 	*f = cb
 }
+func (f *fakeProcessSubscriber) Start() {}
 
 // Make a redactor for the onlyOnAmd64_17 float
 // return value in the testReturnsManyFloats function. This function is expected

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -17,6 +17,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/module/tombstone"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
@@ -31,6 +32,10 @@ type Config struct {
 	DiagsUploaderURL   string
 	SymDBUploadEnabled bool
 	SymDBUploaderURL   string
+	// ProbeTombstoneFilePath is the path to the tombstone file used to detect
+	// if we crashed while loading programs. Empty means don't use tombstone
+	// file.
+	ProbeTombstoneFilePath string
 	// The directory for the persistent cache tracking SymDB uploads. If empty,
 	// no cache will be used.
 	SymDBCacheDir string
@@ -49,6 +54,7 @@ type Config struct {
 		LoaderOptions             []loader.Option
 		IRGeneratorOverride       func(IRGenerator) IRGenerator
 		ProcessSubscriberOverride func(ProcessSubscriber) ProcessSubscriber
+		TombstoneSleepKnobs       tombstone.WaitTestingKnobs
 	}
 }
 
@@ -74,14 +80,15 @@ func NewConfig(_ *sysconfigtypes.Config) (*Config, error) {
 	}
 
 	c := &Config{
-		Config:             *ebpf.NewConfig(),
-		LogUploaderURL:     withPath(traceAgentURL, logUploaderPath),
-		DiagsUploaderURL:   withPath(traceAgentURL, diagsUploaderPath),
-		SymDBUploadEnabled: pkgconfigsetup.SystemProbe().GetBool("dynamic_instrumentation.symdb_upload_enabled"),
-		SymDBUploaderURL:   withPath(traceAgentURL, symdbUploaderPath),
-		SymDBCacheDir:      "/var/tmp/datadog-agent/system-probe/dynamic-instrumentation/symdb_uploads",
-		DiskCacheEnabled:   cacheEnabled,
-		DiskCacheConfig:    cacheConfig,
+		Config:                 *ebpf.NewConfig(),
+		LogUploaderURL:         withPath(traceAgentURL, logUploaderPath),
+		DiagsUploaderURL:       withPath(traceAgentURL, diagsUploaderPath),
+		SymDBUploadEnabled:     pkgconfigsetup.SystemProbe().GetBool("dynamic_instrumentation.symdb_upload_enabled"),
+		SymDBUploaderURL:       withPath(traceAgentURL, symdbUploaderPath),
+		SymDBCacheDir:          "/var/tmp/datadog-agent/system-probe/dynamic-instrumentation/symdb_uploads",
+		ProbeTombstoneFilePath: "/var/tmp/datadog-agent/system-probe/dynamic-instrumentation/debugger_probes_tombstone.json",
+		DiskCacheEnabled:       cacheEnabled,
+		DiskCacheConfig:        cacheConfig,
 	}
 	return c, nil
 }

--- a/pkg/dyninst/module/dependencies.go
+++ b/pkg/dyninst/module/dependencies.go
@@ -45,6 +45,7 @@ type dependencies struct {
 // ProcessSubscriber emits combined process lifecycle updates and configuration
 // updates.
 type ProcessSubscriber interface {
+	Start()
 	Subscribe(callback func(process.ProcessesUpdate))
 }
 

--- a/pkg/dyninst/module/module_test.go
+++ b/pkg/dyninst/module/module_test.go
@@ -44,7 +44,8 @@ func TestHappyPathEndToEnd(t *testing.T) {
 	deps := newFakeTestingDependencies(t)
 	deps.irGenerator.program = createTestProgram()
 	processUpdate := createTestProcessConfig()
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 	deps.sendUpdates(processUpdate)
 
 	require.Len(t, deps.actuator.tenant.updates, 1)
@@ -83,7 +84,8 @@ func TestProgramLifecycleFlow(t *testing.T) {
 	processUpdate.GitInfo = process.GitInfo{CommitSha: "commit-123", RepositoryURL: "https://github.com/test/test"}
 	procID := processUpdate.ProcessID
 
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 
 	collectVersions := func(status uploader.Status) map[string]int {
 		return collectDiagnosticVersions(deps.diagUploader, status)
@@ -176,7 +178,8 @@ func TestIRGenerationFailure(t *testing.T) {
 	deps := newFakeTestingDependencies(t)
 	deps.irGenerator.err = irErr
 	processUpdate := createTestProcessConfig()
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 	deps.sendUpdates(processUpdate)
 
 	_, err := deps.actuator.tenant.rt.Load(
@@ -205,7 +208,8 @@ func TestAttachmentFailure(t *testing.T) {
 	processUpdate := createTestProcessConfig()
 	deps.irGenerator.program = createTestProgram()
 	deps.attacher.err = errors.New("attachment failed")
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate)
 
@@ -237,7 +241,8 @@ func TestLoadingFailure(t *testing.T) {
 	processUpdate := createTestProcessConfig()
 	deps.irGenerator.program = createTestProgram()
 	deps.kernelLoader.err = errors.New("loading failed")
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate)
 
@@ -267,7 +272,8 @@ func TestDecoderCreationFailure(t *testing.T) {
 	processUpdate := createTestProcessConfig()
 	deps.decoderFactory.err = errors.New("decoder creation failed")
 	deps.irGenerator.program = createTestProgram()
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate)
 
@@ -295,7 +301,8 @@ func TestEventDecodingSuccess(t *testing.T) {
 	processUpdate := createTestProcessConfig()
 	deps.decoderFactory.decoder = decoder
 	deps.irGenerator.program = createTestProgram()
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate)
 
@@ -331,7 +338,8 @@ func TestEventDecodingFailure(t *testing.T) {
 	processUpdate := createTestProcessConfig()
 	deps.decoderFactory.decoder = decoder
 	deps.irGenerator.program = createTestProgram()
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate)
 
@@ -366,7 +374,8 @@ func TestDecoderErrorHandling(t *testing.T) {
 	deps.irGenerator.program = createTestProgram()
 	td := deps.toDeps()
 	td.DecoderFactory = factory
-	_ = module.NewUnstartedModule(td)
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(td, tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate)
 	received := collectDiagnosticVersions(deps.diagUploader, uploader.StatusReceived)
@@ -409,7 +418,8 @@ func TestProcessRemoval(t *testing.T) {
 	removals := []process.ID{processUpdate.ProcessID}
 	td := deps.toDeps()
 	td.IRGenerator = irgen.NewGenerator()
-	_ = module.NewUnstartedModule(td)
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(td, tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate)
 	require.Len(t, deps.actuator.tenant.updates, 1)
@@ -447,7 +457,8 @@ func TestMultipleProcesses(t *testing.T) {
 
 	td := deps.toDeps()
 	td.IRGenerator = irgen.NewGenerator()
-	_ = module.NewUnstartedModule(td)
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(td, tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate1, processUpdate2)
 
@@ -485,7 +496,8 @@ func TestProbeIssueReporting(t *testing.T) {
 
 	deps.decoderFactory.decoder = decoder
 	deps.irGenerator.program = program
-	_ = module.NewUnstartedModule(deps.toDeps())
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
 
 	deps.sendUpdates(processUpdate)
 
@@ -529,7 +541,8 @@ func TestNoSuccessfulProbes(t *testing.T) {
 	bin := testprogs.MustGetBinary(t, "simple", testprogs.MustGetCommonConfigs(t)[0])
 	processUpdate.Executable = process.Executable{Path: bin}
 
-	_ = module.NewUnstartedModule(deps)
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps, tombstoneFilePath)
 
 	fakeDeps.sendUpdates(processUpdate)
 
@@ -565,6 +578,7 @@ type fakeProcessSubscriber func(process.ProcessesUpdate)
 func (f *fakeProcessSubscriber) Subscribe(cb func(process.ProcessesUpdate)) {
 	*f = cb
 }
+func (f *fakeProcessSubscriber) Start() {}
 
 type fakeActuatorTenant struct {
 	name    string

--- a/pkg/dyninst/module/runtime_impl.go
+++ b/pkg/dyninst/module/runtime_impl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/module/tombstone"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/uprobe"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -32,6 +33,10 @@ type runtimeImpl struct {
 	logsFactory              erasedLogsUploaderFactory
 	procRuntimeIDbyProgramID *sync.Map
 	bufferedMessageTracker   *bufferedMessageTracker
+	// tombstoneFilePath is the path to the tombstone file left behind to detect
+	// crashes while loading programs. If empty, tombstone files are not
+	// created.
+	tombstoneFilePath string
 }
 
 type irGenFailedError struct {
@@ -52,6 +57,27 @@ func (rt *runtimeImpl) Load(
 	processID actuator.ProcessID,
 	probes []ir.ProbeDefinition,
 ) (_ actuator.LoadedProgram, retErr error) {
+	if rt.tombstoneFilePath != "" {
+		// Write a tombstone file so that, if we crash in the middle of loading a
+		// program, we don't attempt to load it again for a while.
+		err := tombstone.WriteTombstoneFile(
+			rt.tombstoneFilePath,
+			// ErrorNumber starts at 1 meaning that, if the file is found after
+			// crashing now, it will mean that we crashed for the first time because
+			// of this program.
+			1)
+		if err != nil {
+			log.Warnf("failed to create tombstone file %s: %v", rt.tombstoneFilePath, err)
+		} else {
+			defer func() {
+				err := tombstone.Remove(rt.tombstoneFilePath)
+				if err != nil {
+					log.Warnf("failed to remove tombstone file: %v", err)
+				}
+			}()
+		}
+	}
+
 	runtimeID, ok := rt.store.updateOnLoad(processID, executable, programID)
 	if !ok {
 		return nil, nil

--- a/pkg/dyninst/module/tombstone/tombstone.go
+++ b/pkg/dyninst/module/tombstone/tombstone.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package tombstone implements a simple mechanism to protect against repeated
+// crashes when placing probes by writing a file to disk while loading a program
+// and checking for the presence of the file on startup; if the file is present,
+// no programs will be loaded for a while.
+package tombstone
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/backoff"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// The tombstone file tracks whether we crashed while loading a program.
+
+// FileContents represents the contents of a tombstone JSON file.
+type FileContents struct {
+	// AgentVersion is the version of the agent that wrote this file.
+	AgentVersion string `json:"agent_version"`
+	// ErrorNumber counts how many crashes have occurred since the file was
+	// created.
+	ErrorNumber int `json:"attempt_number"`
+	// Timestamp is the time when the file was created, or when ErrorNumber was
+	// last incremented.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// WriteTombstoneFile creates or updates a tombstone file at the specified path.
+func WriteTombstoneFile(filePath string, errorNumber int) error {
+	contents := FileContents{
+		AgentVersion: version.AgentVersion,
+		ErrorNumber:  errorNumber,
+		Timestamp:    time.Now(),
+	}
+
+	data, err := json.Marshal(contents)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filePath, data, 0644)
+}
+
+// ReadTombstoneFile reads and unmarshals the tombstone file at the specified path.
+func ReadTombstoneFile(filePath string) (*FileContents, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var contents FileContents
+	if err := json.Unmarshal(data, &contents); err != nil {
+		return nil, err
+	}
+
+	return &contents, nil
+}
+
+// Remove removes the tombstone file at the specified path.
+func Remove(filePath string) error {
+	if filePath == "" {
+		return nil
+	}
+
+	err := os.Remove(filePath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// WaitTestingKnobs groups testing knobs for WaitOutTombstone.
+type WaitTestingKnobs struct {
+	OnSleep       func()
+	BackoffPolicy backoff.Policy
+}
+
+// WaitOutTombstone waits for a while if it looks like we're recovering from a
+// crash that happened during program loading -- i.e. if we find a tombstone
+// file.
+//
+// Note that, for simplicity, we don't take into account which probe caused the
+// crash; we simply avoid placing any probes for a while.
+//
+// knobs, if not nil, should contain a single element.
+func WaitOutTombstone(ctx context.Context, tombstoneFilePath string, knobs ...WaitTestingKnobs) {
+	if tombstoneFilePath == "" {
+		return
+	}
+	// Check if a tombstone file exists. If it does, we increment the
+	// attempt number and block according to an exponential backoff.
+	_, err := os.Stat(tombstoneFilePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		log.Warnf("failed to read tombstone file: %s", err)
+	}
+
+	// Helper function to delete the tombstone file.
+	deleteTombstone := func() {
+		err := Remove(tombstoneFilePath)
+		if err != nil {
+			log.Warnf("failed to delete tombstone file %s: %s", tombstoneFilePath, err)
+		}
+	}
+
+	contents, err := ReadTombstoneFile(tombstoneFilePath)
+	if err != nil {
+		log.Warnf("failed to read tombstone file %s: %s, deleting it", tombstoneFilePath, err)
+		deleteTombstone()
+		return
+	}
+
+	// If the agent version in the tombstone doesn't match the current agent
+	// version, delete the tombstone and don't block. This prevents blocking
+	// after an agent upgrade.
+	if contents.AgentVersion != version.AgentVersion {
+		log.Infof("tombstone file has different agent version (%s vs %s), ignoring it", contents.AgentVersion, version.AgentVersion)
+		deleteTombstone()
+		return
+	}
+
+	// Calculate backoff duration based on attempt number (exponential backoff).
+	backoffPolicy := backoff.NewExpBackoffPolicy(
+		2.0,   // minBackoffFactor
+		60,    // baseBackoffTime (seconds)
+		3600,  // maxBackoffTime (seconds)
+		1,     // recoveryInterval
+		false, // recoveryReset
+	)
+
+	var onSleep func()
+	if len(knobs) > 0 {
+		if len(knobs) > 1 {
+			panic("WaitOutTombstone called with multiple knobs")
+		}
+		if knobs[0].BackoffPolicy != nil {
+			backoffPolicy = knobs[0].BackoffPolicy
+		}
+		if knobs[0].OnSleep != nil {
+			onSleep = knobs[0].OnSleep
+		}
+	}
+
+	targetWaitDuration := backoffPolicy.GetBackoffDuration(contents.ErrorNumber)
+
+	// Wait for the tombstone to expire.
+	elapsedSinceTimestamp := time.Since(contents.Timestamp)
+	remainingWait := targetWaitDuration - elapsedSinceTimestamp
+	if onSleep != nil {
+		// If we have a knob installed, make sure remainingWait is positive.
+		remainingWait = targetWaitDuration
+	}
+
+	if remainingWait > 0 {
+		log.Warnf("tombstone file detected (previous errors: %d), waiting %s before installing probes", contents.ErrorNumber, remainingWait)
+		if onSleep != nil {
+			onSleep()
+		}
+		select {
+		case <-time.After(remainingWait):
+		case <-ctx.Done():
+			log.Debugf("waiting for tombstone canceled: %s", context.Cause(ctx))
+			return
+		}
+	} else {
+		log.Infof("tombstone file detected (previous errors: %d), backoff period already elapsed", contents.ErrorNumber)
+	}
+
+	// Increment error number and update timestamp. If we crash again, we'll
+	// wait even longer.
+	err = WriteTombstoneFile(tombstoneFilePath, contents.ErrorNumber+1)
+	if err != nil {
+		log.Warnf("failed to update tombstone file: %s", err)
+		return
+	}
+
+	// Schedule the deletion of the tombstone file in one minute, if we're still
+	// alive by then. Being alive in one minute is taken as an indication that
+	// we were able to place all the active probes without crashing again.
+	time.AfterFunc(time.Minute, func() { _ = Remove(tombstoneFilePath) })
+}

--- a/pkg/dyninst/procscrape/subscriber.go
+++ b/pkg/dyninst/procscrape/subscriber.go
@@ -119,7 +119,10 @@ func (s *Subscriber) Start() {
 // Close stops delivering updates and releases associated resources.
 func (s *Subscriber) Close() {
 	var notStarted bool
-	if s.start.Do(func() { notStarted = true }); notStarted {
+	if s.start.Do(func() {
+		notStarted = true
+		s.stop.Do(func() {})
+	}); notStarted {
 		return
 	}
 	s.stop.Do(func() {


### PR DESCRIPTION
This patch adds some protection against the system-probe crashing while generating and loading a BPF program for Dynamic Instrumentation probes (for example because of OOM) and then restarting and crashing again while placing the same probe. This is done with a simple mechanism: when starting to load a program, a "tombstone" file is written (/opt/datadog-agent/run/debugger_probes_tombstone.json). If loading finishes (successfully or not), we delete the file. If it doesn't finish, then the restarted process assumes that the previous incarnation crashed and waits for a while before starting the dynamic instrumentation module. If we crash again, the next wait is even longer. Waits start at a minute and go up to an hour. If the system-probe starts with a tombstone file and then manages to stay alive for one minute, the tombstone is deleted.

https://datadoghq.atlassian.net/browse/DEBUG-4601