### PR TITLE
[CWS] Remove field mapping in `identToEvaluator`

### DIFF
--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -83,13 +83,6 @@ func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.
 		return nil, obj.Pos, err
 	}
 
-	// transform extracted field to support legacy SECL fields
-	if opts.LegacyFields != nil {
-		if newField, ok := opts.LegacyFields[field]; ok {
-			field = newField
-		}
-	}
-
 	evaluator, err := state.model.GetEvaluator(field, regID, obj.Pos.Offset)
 	if err != nil {
 		return nil, obj.Pos, err


### PR DESCRIPTION
### What does this PR do?

### Motivation

With https://github.com/DataDog/datadog-agent/pull/42432, mapping legacy fields in this function is no longer needed.

### Describe how you validated your changes

### Additional Notes
