### PR TITLE
Make bazel CI templates less error-prone

### DIFF
--- a/.gitlab/bazel/build-deps.yaml
+++ b/.gitlab/bazel/build-deps.yaml
@@ -6,33 +6,29 @@
   stage: deps_build
 
 bazel:build-deps:linux-amd64:
-  extends: [ .bazel:build-deps, .bazel:persistent-runner:linux-amd64 ]
+  extends: [ .bazel:build-deps, .bazel:runner:linux-amd64 ]
   script:
     - bazel build //deps/...
 
 bazel:build-deps:linux-arm64:
-  extends: [ .bazel:build-deps, .linux_arm64 ]
+  extends: [ .bazel:build-deps, .bazel:runner:linux-arm64 ]
   script:
     - bazel build //deps/...
 
 bazel:build-deps:macos-amd64:
-  extends: .bazel:build-deps
-  tags: [ "macos:ventura-amd64", "specific:true" ]
+  extends: [ .bazel:build-deps, .bazel:runner:macos-amd64 ]
   script:
     - bazel build //deps/...
 
 bazel:build-deps:macos-arm64:
-  extends: .bazel:build-deps
-  tags: [ "macos:ventura-arm64", "specific:true" ]
+  extends: [ .bazel:build-deps, .bazel:runner:macos-arm64 ]
   script:
     - bazel build //deps/...
 
-# TODO(agent-build): re-enable when we're sure they won't cause problems (#incident-42947)
 bazel:build-deps:windows-amd64:
-  extends: [ .bazel:build-deps, .bazel:ext:windows ]
+  extends: [ .bazel:build-deps, .bazel:runner:windows-amd64 ]
   variables:
-    ARCH: x64
-    SCRIPT: |-
+    POWERSHELL_SCRIPT: |-
       [Console]::WriteLine("🟡 TODO(regis): compilation errors remain - limiting to a working subset for the time being")
       bazel build '@zlib//...' '@libffi//:ffi' '@xz//...'
       # bazel build @bzip2//...

--- a/.gitlab/bazel/buildifier-test.yaml
+++ b/.gitlab/bazel/buildifier-test.yaml
@@ -1,5 +1,6 @@
 bazel:run-buildifier-test:
-  extends: [ .bazel:defs, .lint ]
+  extends: [ .bazel:defs, .bazel:runner:linux-amd64 ]
+  stage: lint
   script:
     - bazel run //bazel/buildifier:test
   after_script:

--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -23,16 +23,26 @@
     BAZEL_REPO_CONTENTS_CACHE: "$BAZEL_OUTPUT_USER_ROOT/repo-contents"
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
 
-.bazel:persistent-runner:linux-amd64:
+.bazel:runner:linux-amd64:
   cache: []
   variables:
     XDG_CACHE_HOME: /data/bzl
   tags: [ "linux-persistent:amd64", "specific:true" ]
 
-.bazel:ext:windows:
+.bazel:runner:linux-arm64:
+  extends: .linux_arm64
+
+.bazel:runner:macos-amd64:
+  tags: [ "macos:ventura-amd64", "specific:true" ]
+
+.bazel:runner:macos-arm64:
+  tags: [ "macos:ventura-arm64", "specific:true" ]
+
+.bazel:runner:windows-amd64:
   extends: .windows_docker_default
   timeout: 60m # pulling images alone can take more than 30m
   variables:
+    ARCH: x64
     GIT_DEPTH: 2
   script:
     - |-
@@ -42,7 +52,7 @@
       Set-StrictMode -Version 3.0
       '@
       Invoke-Expression $FailFast
-      $Utf8Script = [Text.Encoding]::UTF8.GetString([Text.Encoding]::GetEncoding([Console]::OutputEncoding.CodePage).GetBytes($SCRIPT))
+      $Utf8Script = [Text.Encoding]::UTF8.GetString([Text.Encoding]::GetEncoding([Console]::OutputEncoding.CodePage).GetBytes($POWERSHELL_SCRIPT))
       $EncodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("$FailFast`n$Utf8Script"))
     - >-
       docker run

--- a/.gitlab/bazel/tests.yaml
+++ b/.gitlab/bazel/tests.yaml
@@ -6,30 +6,27 @@
   stage: source_test
 
 bazel:tests:linux-amd64:
-  extends: [ .bazel:tests, .bazel:persistent-runner:linux-amd64 ]
+  extends: [ .bazel:tests, .bazel:runner:linux-amd64 ]
   script:
     - bazel test //bazel/tests/...
 
 bazel:tests:linux-arm64:
-  extends: [ .bazel:tests, .linux_arm64 ]
+  extends: [ .bazel:tests, .bazel:runner:linux-arm64 ]
   script:
     - bazel test //bazel/tests/...
 
 bazel:tests:macos-amd64:
-  extends: .bazel:tests
-  tags: [ "macos:ventura-amd64", "specific:true" ]
+  extends: [ .bazel:tests, .bazel:runner:macos-amd64 ]
   script:
     - bazel test //bazel/tests/...
 
 bazel:tests:macos-arm64:
-  extends: .bazel:tests
-  tags: [ "macos:ventura-arm64", "specific:true" ]
+  extends: [ .bazel:tests, .bazel:runner:macos-arm64 ]
   script:
     - bazel test //bazel/tests/...
 
 bazel:tests:windows-amd64:
-  extends: [ .bazel:tests, .bazel:ext:windows ]
+  extends: [ .bazel:tests, .bazel:runner:windows-amd64 ]
   variables:
-    ARCH: x64
-    SCRIPT: |-
+    POWERSHELL_SCRIPT: |-
       bazel test //bazel/tests/...


### PR DESCRIPTION
### What does this PR do?
This refactors bazel CI job templates to use centralized platform-specific runner definitions (`.bazel:runner:*`) instead of duplicating configuration across multiple jobs.
    
### Motivation
This makes templates less error-prone because:
- platform configuration (`tags`, `extends`) is now defined once in `defs.yaml` and changes to runner configuration only need to be made in one place, which reduces copy-paste errors when creating new bazel jobs,
- same applies to the Windows `ARCH` variable. It still looks redundant with the image we inherit from the default template, but this will be addressed separately,
- renaming the Windows `SCRIPT` variable (mandated by the peculiar Docker-in-Docker setup) to `POWERSHELL_SCRIPT` makes it clear it's not to be confused with GitLab's `script`.