### PR TITLE
Specify macos minimum compatible version for bazel-built artifacts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,10 @@ build:windows --strategy=standalone # Valid values are: [dynamic_worker, standal
 # Disabling them for now.
 build:windows --noexperimental_convenience_symlinks
 
+# Make sure we support the minimum macos version we advertise
+# https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
+# https://bazel.build/reference/command-line-reference#flag--macos_minimum_os
+build:macos --macos_minimum_os=11.0
 
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.


### PR DESCRIPTION
### What does this PR do?

It adds a default bazel build flag such that binaries built with Bazel are built to be compatible to support the same minimum version of mac os x as the rest.

https://github.com/DataDog/datadog-agent/blob/5891f751cef5d1cf1045f965f224c9b78359cab0/tasks/omnibus.py#L125

### Motivation

We're starting to include bazel-built libraries into release-ready artifacts, and we don't want to have compatibility problems.

### Describe how you validated your changes

TBD

### Additional Notes
