### PR TITLE
security: Skip tracer memfd test on RHEL 7

### DIFF
--- a/pkg/security/tests/tracer_memfd_test.go
+++ b/pkg/security/tests/tracer_memfd_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
@@ -100,6 +101,11 @@ func (c *tracerMemfdConsumer) Copy(ev *model.Event) any {
 
 func TestTracerMemfd(t *testing.T) {
 	SkipIfNotAvailable(t)
+
+	checkKernelCompatibility(t, "TracerMemfd test not supported on RHEL7", func(kv *kernel.Version) bool {
+		// Test fails on RHEL7 for unknown reasons, skip it for now
+		return kv.IsRH7Kernel()
+	})
 
 	consumer := &tracerMemfdConsumer{}
 	test, err := newTestModule(t, nil, nil, withStaticOpts(testOpts{


### PR DESCRIPTION
### What does this PR do?

The tracer memfd events are never received on RHEL/CentOS 7.  Skip the
test for now.

### Motivation

Avoid [failures](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.branch%3Amain%20%40ci.stage.name%3Akernel_matrix_testing_security_agent%20%40test.name%3ATestTracerMemfd%2Fvalidate-event-and-tracer-tags%2A%20%40ci.job.name%3A%22kmt_run_secagent_tests_x64%3A%20%5Bcentos_7.9%2C%20cws_host%5D%22&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=&fromUser=false&mode=sliding&saved-view-id=3051106&start=1761129706160&end=1761734506160&paused=false)
