### PR TITLE
Add minimum supported macos version check to build

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -214,7 +214,7 @@ build do
             # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
             allow_list = [
               "libddwaf\\.dylib",
-              "secret-generic-connector",
+              #"secret-generic-connector", ## comment out for testing
             ]
             command_on_repo_root "./omnibus/scripts/check_macos_version.sh",
                                  live_stream: Omnibus.logger.live_stream(:info),

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -212,45 +212,12 @@ build do
 
             # Check that all binaries are compatible with the minimum macOS version we support
             # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
-            arch = arm_target? ? "arm64" : "x86_64"
-            command <<~SH, cwd: Dir.pwd
-set -euo pipefail
-
-satisfies_min_version() {
-    local min_acceptable_version="11.0"
-    local arch="#{arch}"
-
-    local vtool_output="$(vtool -arch "${arch}" -show-build "$1")"
-    local cmd=$(echo "$vtool_output" | awk '/cmd / {print $2}')
-
-    case $cmd in
-        "LC_VERSION_MIN_MACOSX")
-            local min_version=$(echo "$vtool_output" | awk '/version / {print $2}')
-            ;;
-        "LC_BUILD_VERSION")
-            local min_version=$(echo "$vtool_output" | awk '/minos / {print $2}')
-            ;;
-    esac
-
-    if [ -z "$min_version" ]; then
-        echo "ERROR: failed to detect minimum version of $1" >&2
-        echo "vtool output: $(vtool -show-build "$1")"
-        return 1
-    fi
-    local highest_version=$(printf '%s\n%s\n' "$min_version" "$min_acceptable_version" | sort -V | tail -1)
-    if [[ "$highest_version" != "$min_acceptable_version" ]]; then
-        echo "ERROR: minimum version for $1 (${min_version}) is higher than the minimimum acceptable (${min_acceptable_version})" >&2
-        return 1
-    fi
-}
-
-export -f satisfies_min_version
-
-find #{install_dir} -type f -print0 |
-    xargs -0 -n1000 -P9 file -n --mime-type |
-    awk -F: '/[^)]:[[:space:]]*application\\/x-mach-binary/ { printf "%s%c", $1, 0 }' |
-    xargs -0 -n1 -P9 -I {} bash -c 'satisfies_min_version "$@"' _ {}
-            SH
+            command_on_repo_root "./omnibus/scripts/check_macos_version.sh",
+                                 env: {
+                                   ARCH: arm_target? ? "arm64" : "x86_64",
+                                   MIN_ACCEPTABLE_VERSION: "11.0",
+                                   INSTALL_DIR: install_dir,
+                                 }
         end
     end
 end

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -212,11 +212,17 @@ build do
 
             # Check that all binaries are compatible with the minimum macOS version we support
             # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
+            allow_list = [
+              "libddwaf\\.dylib",
+              "secret-generic-connector",
+            ]
             command_on_repo_root "./omnibus/scripts/check_macos_version.sh",
+                                 live_stream: Omnibus.logger.live_stream(:info),
                                  env: {
                                    ARCH: arm_target? ? "arm64" : "x86_64",
                                    MIN_ACCEPTABLE_VERSION: "11.0",
                                    INSTALL_DIR: install_dir,
+                                   ALLOW_PATTERN: "(#{allow_list.join('|')})",
                                  }
         end
     end

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -214,7 +214,7 @@ build do
             # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
             allow_list = [
               "libddwaf\\.dylib",
-              #"secret-generic-connector", ## comment out for testing
+              "secret-generic-connector",
             ]
             command_on_repo_root "./omnibus/scripts/check_macos_version.sh",
                                  live_stream: Omnibus.logger.live_stream(:info),

--- a/omnibus/scripts/check_macos_version.sh
+++ b/omnibus/scripts/check_macos_version.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/env bash
+# Check that all binaries are compatible with the minimum macOS version we support
+# https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
+# The script will return an error code and print information on the violations or errors found
+# Inputs (via environment):
+# INSTALL_DIR: directory with binaries to check for compatibility
+# ARCH: arm64 / x86_64
+# MIN_ACCEPTABLE_VERSION: minimum version that we accept
+
+set -euo pipefail
+
+satisfies_min_version() {
+    local min_acceptable_version="$MIN_ACCEPTABLE_VERSION"
+    local arch="$ARCH"
+
+    local vtool_output="$(vtool -arch "${arch}" -show-build "$1")"
+    local cmd=$(echo "$vtool_output" | awk '/cmd / {print $2}')
+
+    case $cmd in
+        "LC_VERSION_MIN_MACOSX")
+            local min_version=$(echo "$vtool_output" | awk '/version / {print $2}')
+            ;;
+        "LC_BUILD_VERSION")
+            local min_version=$(echo "$vtool_output" | awk '/minos / {print $2}')
+            ;;
+    esac
+
+    if [ -z "${min_version:-}" ]; then
+        echo "ERROR: failed to detect minimum version of $1" >&2
+        echo "vtool output: $(vtool -show-build "$1")"
+        return 1
+    fi
+    local highest_version=$(printf '%s\n%s\n' "$min_version" "$min_acceptable_version" | sort -V | tail -1)
+    if [[ "$highest_version" != "$min_acceptable_version" ]]; then
+        echo "ERROR: minimum version for $1 (${min_version}) is higher than the minimimum acceptable (${min_acceptable_version})" >&2
+        return 1
+    fi
+}
+
+export -f satisfies_min_version
+
+echo "Checking $INSTALL_DIR for compatibility with version >= $MIN_ACCEPTABLE_VERSION and architecture $ARCH..."
+
+find "$INSTALL_DIR" -type f -print0 |
+    xargs -0 -n1000 -P9 file -n --mime-type |
+    awk -F: '/[^)]:[[:space:]]*application\/x-mach-binary/ { printf "%s%c", $1, 0 }' |
+    xargs -0 -n1 -P9 -I {} bash -euo pipefail -c 'satisfies_min_version "$@"' _ {}


### PR DESCRIPTION
### What does this PR do?

Adds a check to macOS builds (inside Omnibus) to ensure we don't ship binaries that don't support the minimum OS version that we advertise.

### Motivation

With all the recent build changes, we need to be careful with not regressing in compatibility.

### Describe how you validated your changes

In its final state, with allowed patterns, we see ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1209246108)):

```
[Builder: datadog-agent-finalize] I | 2025-10-31T14:32:01+00:00 | $ ./omnibus/scripts/check_macos_version.sh
                          I | 2025-10-31T14:32:01+00:00 | Checking /tmp/gitlabci/datadog-agent-build/bin for compatibility with version >= 11.0 and architecture x86_64...
                          I | 2025-10-31T14:32:12+00:00 | WARNING: minimum version for /tmp/gitlabci/datadog-agent-build/bin/embedded/lib/python3.13/site-packages/ddtrace/appsec/_ddwaf/libddwaf/x86_64/lib/libddwaf.dylib (12.7) is higher than the minimimum acceptable (11.0) (explicitly allowed)
                          I | 2025-10-31T14:32:12+00:00 | WARNING: minimum version for /tmp/gitlabci/datadog-agent-build/bin/embedded/bin/secret-generic-connector (12.0) is higher than the minimimum acceptable (11.0) (explicitly allowed)
```
which matches expected behavior.

On a test commit with secret-generic-connector removed from the "allow_list" [we get](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1209581720#L2139):

```
                          I | 2025-10-31T15:44:41+00:00 | ERROR: minimum version for /tmp/gitlabci/datadog-agent-build/bin/embedded/bin/secret-generic-connector (12.0) is higher than the minimimum acceptable (11.0)
```

### Additional Notes

Added explicit exceptions:
- libddwaf: known issue with ddtrace library
- secret-generic-connector: this is caused by it being built with go 1.25, which is known to bump minimum required macos version to 12.
