### PR TITLE
[FA] Fix cache read of files payload

### DIFF
--- a/comp/core/autodiscovery/providers/config_reader.go
+++ b/comp/core/autodiscovery/providers/config_reader.go
@@ -166,14 +166,13 @@ func ReadConfigFormats() []ConfigFormatWrapper {
 		return []ConfigFormatWrapper{}
 	}
 
-	cachedFormats, found := reader.cache.Get("configFormats")
+	_, found := reader.cache.Get("configFormats")
 	if !found {
 		reader.readAndCacheAll()
-	} else {
-		cachedFormats, found = reader.cache.Get("configFormats")
-		if !found {
-			return []ConfigFormatWrapper{}
-		}
+	}
+	cachedFormats, found := reader.cache.Get("configFormats")
+	if !found {
+		return []ConfigFormatWrapper{}
 	}
 
 	typedCachedFormats, ok := cachedFormats.([]ConfigFormatWrapper)


### PR DESCRIPTION
### What does this PR do?

Fix cache read after it expires.
Since the default cleanup is 5min (unless `autoconf_config_files_poll`) and the default interval collection is 10min (unless `inventories_max_interval`), the cache always expires before the next payload is sent

### Motivation

### Describe how you validated your changes

### Additional Notes
