### PR TITLE
(fleet) remove noisy telemetry spans

### DIFF
--- a/pkg/fleet/installer/telemetry/tracer.go
+++ b/pkg/fleet/installer/telemetry/tracer.go
@@ -25,9 +25,9 @@ var (
 		"garbage_collect":           0.05,
 		"HTTPClient":                0.05,
 		"agent.startup":             0.0,
-		"get_states":                0.0,
-		"installer.get_states":      0.0,
-		"installer.get-states":      0.0,
+		"get_states":                0.01,
+		"installer.get_states":      0.01,
+		"installer.get-states":      0.01,
 	}
 )
 

--- a/pkg/fleet/installer/telemetry/tracer.go
+++ b/pkg/fleet/installer/telemetry/tracer.go
@@ -25,8 +25,9 @@ var (
 		"garbage_collect":           0.05,
 		"HTTPClient":                0.05,
 		"agent.startup":             0.0,
-		"get_states":                0.01,
-		"installer.get_states":      0.01,
+		"get_states":                0.0,
+		"installer.get_states":      0.0,
+		"installer.get-states":      0.0,
 	}
 )
 


### PR DESCRIPTION
This PR cuts down on the noise from datadog-installer spans, removing any sampling for the worse offender.
