### PR TITLE
[SBOM] compute and include dependencies in sbomgen

### DIFF
--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -236,7 +236,8 @@ func NewCollector(cfg config.Component, wmeta option.Option[workloadmeta.Compone
 func NewCollectorForCLI() *Collector {
 	return &Collector{
 		config: collectorConfig{
-			maxCacheSize: math.MaxInt,
+			maxCacheSize:        math.MaxInt,
+			computeDependencies: true,
 		},
 		marshaler: cyclonedx.NewMarshaler(""),
 


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/42183 introduced a new config to include dependencies in the SBOM, but this option is not set in SBOMgen, let's include it. N.B.: sbomgen is a debug tool only for now, it's not included in any package.

### Motivation

### Describe how you validated your changes

### Additional Notes
