### PR TITLE
trace/api: fix forwardingTransport with multiple targets

### DIFF
--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -15,8 +15,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
 // measuringTransport is a transport that emits count and timing metrics
@@ -56,6 +57,7 @@ type forwardingTransport struct {
 	rt      http.RoundTripper
 	targets []*url.URL
 	keys    []string
+	logger  *log.ThrottledLogger
 }
 
 // newForwardingTransport creates a new forwardingTransport, wrapping another
@@ -80,12 +82,12 @@ func newForwardingTransport(
 			apiKeys = append(apiKeys, strings.TrimSpace(key))
 		}
 	}
-	return &forwardingTransport{rt, targets, apiKeys}
+	return &forwardingTransport{rt, targets, apiKeys, log.NewThrottled(10, 10*time.Second)}
 }
 
 // RoundTrip makes an HTTP round trip forwarding one request to multiple
 // additional endpoints.
-func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response, rerr error) {
+func (m *forwardingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	setTarget := func(r *http.Request, u *url.URL, apiKey string) {
 		q := r.URL.Query()
 		u.RawQuery = q.Encode()
@@ -98,46 +100,50 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 		return m.rt.RoundTrip(req)
 	}
 
-	slurp, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
+	var body []byte
+	if req.Body != nil {
+		slurp, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		body = slurp
 	}
 
+	roundTripAdditional := func(req *http.Request) {
+		resp, err := m.rt.RoundTrip(req)
+		if err == nil {
+			// we discard responses for all subsequent requests
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		} else {
+			m.logger.Error("error forwarding request to %s: %v", req.URL, err)
+		}
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}
 	var wg sync.WaitGroup
-	wg.Add(len(m.targets))
 	for i, u := range m.targets {
-		go func(i int, u *url.URL) {
+		if i == 0 {
+			continue
+		}
+		newreq := req.Clone(req.Context())
+		if body != nil {
+			newreq.Body = io.NopCloser(bytes.NewReader(body))
+		}
+		setTarget(newreq, u, m.keys[i])
+		wg.Add(1)
+		go func() {
 			defer wg.Done()
-			newreq := req.Clone(req.Context())
-			newreq.Body = io.NopCloser(bytes.NewReader(slurp))
-			setTarget(newreq, u, m.keys[i])
-			if i == 0 {
-				// Given the way we construct the list of targets the main endpoint
-				// will be the first one called, we return its response and error.
-				// Ignoring bodyclose lint here because of a bug in the linter:
-				// https://github.com/timakin/bodyclose/issues/30.
-				rres, rerr = m.rt.RoundTrip(newreq) //nolint:bodyclose
-				if rres != nil && rres.Body != nil {
-					rres.Body.Close()
-				}
-				return
-			}
-			resp, err := m.rt.RoundTrip(newreq)
-			if err == nil {
-				// we discard responses for all subsequent requests
-				io.Copy(io.Discard, resp.Body) //nolint:errcheck
-			} else {
-				log.Error(err)
-			}
-			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
-			}
-
-		}(i, u)
+			roundTripAdditional(newreq)
+		}()
 	}
+	setTarget(req, m.targets[0], m.keys[0])
+	if body != nil {
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	res, err := m.rt.RoundTrip(req)
 	wg.Wait()
-
-	return rres, rerr
+	return res, err
 }
 
 // newMeasuringForwardingTransport creates a forwardingTransport wrapped in a measuringTransport.

--- a/pkg/trace/api/transports_test.go
+++ b/pkg/trace/api/transports_test.go
@@ -9,34 +9,25 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 )
 
-// mockTransport is a simple mock that returns a nil response and an error
-type mockTransport struct {
-	returnNilResponse bool
-}
+// nilResponseTransport is a simple mock that returns a nil response and an
+// error.
+type nilResponseTransport struct{}
 
-func (m *mockTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
-	if m.returnNilResponse {
-		return nil, errors.New("mock error with nil response")
-	}
-	return &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader("ok")),
-	}, nil
+func (m *nilResponseTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, errors.New("mock error with nil response")
 }
 
 // TestForwardingTransport_NilResponse verifies that RoundTrip doesn't panic
 // when the underlying transport returns a nil response with an error.
 func TestForwardingTransport_NilResponse(t *testing.T) {
-	mockRT := &mockTransport{returnNilResponse: true}
 	mainEndpoint, _ := url.Parse("http://localhost:8080")
-
-	ft := newForwardingTransport(mockRT, mainEndpoint, "test-key", nil)
-
+	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", nil)
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/traces", strings.NewReader("test body"))
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
@@ -60,14 +51,12 @@ func TestForwardingTransport_NilResponse(t *testing.T) {
 // TestForwardingTransport_MultipleTargetsNilResponse verifies that RoundTrip doesn't panic
 // when forwarding to multiple targets and the underlying transport returns a nil response.
 func TestForwardingTransport_MultipleTargetsNilResponse(t *testing.T) {
-	mockRT := &mockTransport{returnNilResponse: true}
 	mainEndpoint, _ := url.Parse("http://localhost:8080")
 	additionalEndpoints := map[string][]string{
 		"http://localhost:8081": {"key1"},
 	}
 
-	ft := newForwardingTransport(mockRT, mainEndpoint, "test-key", additionalEndpoints)
-
+	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", additionalEndpoints)
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/traces", strings.NewReader("test body"))
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
@@ -85,5 +74,69 @@ func TestForwardingTransport_MultipleTargetsNilResponse(t *testing.T) {
 
 	if resp != nil {
 		t.Error("expected nil response")
+	}
+}
+
+// TestForwardingTransport_MultipleTargets verifies that the transport forwards
+// the request to multiple targets correctly. It explicitly ensures that the
+// response body is not closed when forwarding to multiple targets. Furthermore,
+// it tests explicitly that the transport works when the request body is nil.
+func TestForwardingTransport_MultipleTargets(t *testing.T) {
+	const responseBody = "ok"
+	setupTransport := func(t *testing.T) http.RoundTripper {
+		h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(responseBody))
+		})
+		s := httptest.NewServer(h)
+		t.Cleanup(s.Close)
+		s2 := httptest.NewServer(h)
+		t.Cleanup(s2.Close)
+		mainEndpoint, _ := url.Parse(s.URL)
+		additionalEndpoint, _ := url.Parse(s2.URL)
+		additionalEndpoints := map[string][]string{
+			additionalEndpoint.String(): {"key1"},
+		}
+		return newForwardingTransport(http.DefaultTransport, mainEndpoint, "test-key", additionalEndpoints)
+	}
+	validateResponse := func(t *testing.T, rt http.RoundTripper, req *http.Request) {
+		resp, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Errorf("failed to round trip: %v", err)
+		}
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
+		read, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("failed to read response body: %v", err)
+		}
+		if read := string(read); read != responseBody {
+			t.Fatalf("expected response body to be %q, got %q", responseBody, read)
+		}
+	}
+	newRequest := func(t *testing.T, method, url string, body io.Reader) *http.Request {
+		req, err := http.NewRequest(method, url, body)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+		return req
+	}
+	for _, c := range []struct {
+		name string
+		req  *http.Request
+	}{
+		{
+			name: "nil request body",
+			req:  newRequest(t, "POST", "http://localhost:8080/v1/traces", nil /* body */),
+		},
+		{
+			name: "non-nil request body",
+			req:  newRequest(t, "POST", "http://localhost:8080/v1/traces", strings.NewReader("request body")),
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			rt := setupTransport(t)
+			validateResponse(t, rt, c.req)
+		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Before this change we'd close the response body for the request that we RoundTrip which violates the contract of the RoundTripper used by the ReverseProxy. The result was that all the proxied requests looked like they had failed. In practice they hadn't, but it lead to quite a bit of scary logging, and it prevented the client of the proxy from actually getting the response.

Also, limit the rate of error logging when sending to secondary endpoints.

### Motivation

We recently started using multiple endpoints in some clusters and observed a lot of these logs (this code used to never be exercised). Worse yet, this had caused panics (https://github.com/DataDog/datadog-agent/pull/42339). 

### Describe how you validated your changes

Testing.

