### PR TITLE
discovery: Fix cleanup race in test

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -169,13 +169,16 @@ func disableCloseOnExec(t *testing.T, f *os.File) {
 
 func startProcessWithFile(t *testing.T, f *os.File) *exec.Cmd {
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(func() { cancel() })
 
 	// Disable close-on-exec so that the process gets it
 	t.Cleanup(func() { f.Close() })
 	disableCloseOnExec(t, f)
 
 	cmd := exec.CommandContext(ctx, "sleep", "1000")
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
 	err := cmd.Start()
 	require.NoError(t, err)
 	f.Close()


### PR DESCRIPTION
### What does this PR do?

Fix this kind of error which happens since we don't wait for the process
holding the port to exit.

```
 PASS pkg/collector/corechecks/servicediscovery/module.TestServicesBasic (0.02s)
 === RUN   TestServicesPorts
     impl_linux_test.go:143:
         	Error Trace:	impl_linux_test.go:143
         	            	impl_services_test.go:136
         	            	impl_services_test.go:151
         	Error:      	Received unexpected error:
         	            	listen udp4 :8083: bind: address already in use
         	Test:       	TestServicesPorts
 --- FAIL: TestServicesPorts (0.00s)
```

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-238

### Describe how you validated your changes

Ran 'TestServices(Basic|Ports)' 1000 times.  Before the change it fails after a
dozen or so times.
