### PR TITLE
[SBOM] do not include host sbom in flare, when host sbom is disabled

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -388,8 +388,11 @@ func getSharedFxOption() fx.Option {
 		)),
 		core.Bundle(),
 		flareprofiler.Module(),
-		fx.Provide(func() flaretypes.Provider {
-			return flaretypes.NewProvider(hostSbom.FlareProvider)
+		fx.Provide(func(cfg config.Component) flaretypes.Provider {
+			provider := &hostSbom.FlareProvider{
+				Config: cfg,
+			}
+			return flaretypes.NewProvider(provider.ProvideFlare)
 		}),
 		lsof.Module(),
 		// Enable core agent specific features like persistence-to-disk

--- a/pkg/sbom/collectors/host/flare_provider.go
+++ b/pkg/sbom/collectors/host/flare_provider.go
@@ -10,13 +10,22 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
-
 	"github.com/DataDog/datadog-agent/pkg/sbom/scanner"
 )
 
 // FlareProvider generates a host SBOM and adds it to the flare.
-func FlareProvider(fb flaretypes.FlareBuilder) error {
+type FlareProvider struct {
+	Config config.Component
+}
+
+// ProvideFlare generates a host SBOM and adds it to the flare.
+func (p *FlareProvider) ProvideFlare(fb flaretypes.FlareBuilder) error {
+	if !p.Config.GetBool("sbom.host.enabled") {
+		return nil
+	}
+
 	globalScanner := scanner.GetGlobalScanner()
 	if globalScanner == nil {
 		return nil


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/CWS-5432

We currently trigger a host SBOM scan during flare building, even if host is disabled (you still need another sbom feature to be enabled, it's not true in the general case). This PR fixes that.

### Motivation

### Describe how you validated your changes

### Additional Notes
