### PR TITLE
[SYNTH-22716] Fix typo in network hops.

### DIFF
--- a/comp/syntheticstestscheduler/common/data.go
+++ b/comp/syntheticstestscheduler/common/data.go
@@ -104,7 +104,7 @@ type AssertionType string
 
 const (
 	// AssertionTypeNetworkHops represents a network hops assertion.
-	AssertionTypeNetworkHops AssertionType = "networkHops"
+	AssertionTypeNetworkHops AssertionType = "multiNetworkHop"
 	// AssertionTypeLatency represents a latency assertion.
 	AssertionTypeLatency AssertionType = "latency"
 	// AssertionTypePacketLoss represents a packet loss percentage assertion.


### PR DESCRIPTION
### What does this PR do?

It fixes the name for networkHops so the UI can use it.

### Motivation

### Describe how you validated your changes

### Additional Notes
