### PR TITLE
[AGENTRUN-861] Enable dead code elimination for the systray binary

### DIFF
--- a/tasks/systray.py
+++ b/tasks/systray.py
@@ -59,7 +59,8 @@ def build(ctx, debug=False, console=False, rebuild=False, race=False, go_mod="re
         bin_path=os.path.join(BIN_PATH, bin_name("ddtray")),
         ldflags=ldflags,
         env=env,
-        check_deadcode=os.getenv("DEPLOY_AGENT") == "true",
+        check_deadcode=True,
+        build_tags=["grpcnotrace"],
     )
 
 


### PR DESCRIPTION
### What does this PR do?
Add `grpcnotrace` build tag on `systray` binary, in order to enable dead code elimination.

### Motivation
Reduce artifact size.

### Describe how you validated your changes
CI

### Additional Notes
