### PR TITLE
CAP-3054 apply RetrieveUnifiedServiceTags to pods

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
@@ -85,6 +85,7 @@ func ExtractPod(ctx processors.ProcessorContext, p *corev1.Pod) *model.Pod {
 	}
 
 	pctx := ctx.(*processors.K8sProcessorContext)
+	podModel.Tags = append(podModel.Tags, transformers.RetrieveUnifiedServiceTags(p.ObjectMeta.Labels)...)
 	podModel.Tags = append(podModel.Tags, transformers.RetrieveMetadataTags(p.ObjectMeta.Labels, p.ObjectMeta.Annotations, pctx.LabelsAsTags, pctx.AnnotationsAsTags)...)
 
 	return &podModel

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
@@ -565,6 +565,31 @@ func TestExtractPod(t *testing.T) {
 				},
 			},
 		},
+		"pod with unified tags": {
+			input: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"tags.datadoghq.com/env":     "production",
+						"tags.datadoghq.com/version": "7.70.0",
+						"tags.datadoghq.com/service": "my-service",
+					},
+				},
+			},
+			expected: model.Pod{
+				Metadata: &model.Metadata{
+					Labels: []string{
+						"tags.datadoghq.com/env:production",
+						"tags.datadoghq.com/version:7.70.0",
+						"tags.datadoghq.com/service:my-service",
+					},
+				},
+				Tags: []string{
+					"env:production",
+					"version:7.70.0",
+					"service:my-service",
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
@@ -600,6 +600,8 @@ func TestExtractPod(t *testing.T) {
 			actual := ExtractPod(pctx, &tc.input)
 			sort.Strings(actual.Tags)
 			sort.Strings(tc.expected.Tags)
+			sort.Strings(actual.Metadata.Labels)
+			sort.Strings(tc.expected.Metadata.Labels)
 			assert.Equal(t, &tc.expected, actual)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Previous PR got reverted due to flaky test https://github.com/DataDog/datadog-agent/pull/42528
This PR fixes it  [60f3dac](https://github.com/DataDog/datadog-agent/pull/42529/commits/60f3dac7778441811efddfa900cb5e33bc2db6a8)


