### PR TITLE
[CWS] Add support for legacy fields in eval command

### DIFF
--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -52,6 +52,21 @@ type EvalRuleParams struct {
 func evalRule(provider rules.PolicyProvider, decoder *json.Decoder, evalArgs EvalRuleParams) (EvalReport, error) {
 	var report EvalReport
 
+	// we need to initialize the model early on to handle legacy field when setting field values in dataFromJSON
+	var m eval.Model
+	var eventCtor func() eval.Event
+	if evalArgs.UseWindowsModel {
+		wmodel := &winmodel.Model{}
+		wmodel.SetLegacyFields(winmodel.SECLLegacyFields)
+		m = wmodel
+		eventCtor = newFakeWindowsEvent
+	} else {
+		lmodel := &model.Model{}
+		lmodel.SetLegacyFields(model.SECLLegacyFields)
+		m = lmodel
+		eventCtor = newFakeEvent
+	}
+
 	event, variables, err := dataFromJSON(decoder)
 	if err != nil {
 		return report, err
@@ -84,13 +99,7 @@ func evalRule(provider rules.PolicyProvider, decoder *json.Decoder, evalArgs Eva
 
 	loader := rules.NewPolicyLoader(provider)
 
-	var ruleSet *rules.RuleSet
-	if evalArgs.UseWindowsModel {
-		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
-	} else {
-		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
-	}
-
+	ruleSet := rules.NewRuleSet(m, eventCtor, ruleOpts, evalOpts)
 	if _, err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
 		return report, err
 	}


### PR DESCRIPTION
### What does this PR do?

Add support for legacy fields in `system-probe runtime policy eval` command.

### Motivation

### Describe how you validated your changes

### Additional Notes
