### PR TITLE
ci(serverless-init): run serverless-init logs tests against correct directory

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -168,7 +168,7 @@ tests_serverless-init-logs:
     - when: on_success
   script:
     - !reference [.retrieve_linux_go_deps]
-    - go test -tags "serverless otlp test" ./cmd/serverless-init/.
+    - go test -tags "serverless otlp test" ./comp/logs/agent/agentimpl/.
 
 # Check consistency of go.mod file with project imports
 go_mod_tidy_check:


### PR DESCRIPTION
### What does this PR do?

Runs serverless-init log tests against the correct logs directory.

### Motivation

Tests not running in CI.

### Describe how you validated your changes

Confirm test runs on `./comp/logs/agent/agentimpl/.` in Gitlab job.

### Additional Notes
