### PR TITLE
fix test panic during udp server shutdown

### DIFF
--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -963,7 +963,7 @@ func (s *UDPServer) Run(payloadSize int) error {
 			}
 			ret := s.onMessage(buf, n)
 			if ret != nil {
-				_, err = s.ln.WriteTo(ret, addr)
+				_, err = ln.WriteTo(ret, addr)
 				if err != nil {
 					if !errors.Is(err, net.ErrClosed) {
 						fmt.Printf("writeto: %s\n", err)


### PR DESCRIPTION
### What does this PR do?

Fixes a test panic during test UDP server shutdown. It was accessing a variable that could have been set to `nil`. Use the captured variable instead.

### Motivation

```
=== RUN   TestTracerSuite/prebuilt/TestUDPIncomingDirectionFix
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x193f5b7]
goroutine 14567 [running]:
github.com/DataDog/datadog-agent/pkg/network/tracer.(*UDPServer).Run.func1()
	/go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer_test.go:966 +0xb7
created by github.com/DataDog/datadog-agent/pkg/network/tracer.(*UDPServer).Run in goroutine 14535
	/go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer_test.go:954 +0x185
```

### Describe how you validated your changes

### Additional Notes
