### PR TITLE
fix(otel-agent): Obfuscate db.statement and db.query.text

### DIFF
--- a/pkg/trace/transform/obfuscate_test.go
+++ b/pkg/trace/transform/obfuscate_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	semconv126 "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.6.1"
+
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+)
+
+func TestObfuscateSQLSpan(t *testing.T) {
+	o := obfuscate.NewObfuscator(obfuscate.Config{})
+	defer o.Stop()
+
+	t.Run("empty resource", func(t *testing.T) {
+		span := &pb.Span{
+			Resource: "",
+			Meta:     map[string]string{},
+		}
+		oq, err := ObfuscateSQLSpan(o, span)
+		assert.Nil(t, oq)
+		assert.NoError(t, err)
+		assert.Equal(t, "", span.Resource)
+	})
+
+	t.Run("non-parsable SQL query", func(t *testing.T) {
+		span := &pb.Span{
+			Resource: "This is completely invalid SQL that cannot be parsed at all",
+			Meta:     map[string]string{},
+		}
+		oq, err := ObfuscateSQLSpan(o, span)
+		if err != nil {
+			// If obfuscation fails, resource should be set to TextNonParsable
+			assert.Nil(t, oq)
+			assert.Equal(t, TextNonParsable, span.Resource)
+			assert.Equal(t, TextNonParsable, span.Meta[TagSQLQuery])
+		} else {
+			// If obfuscator can handle it, that's also valid
+			require.NotNil(t, oq)
+			assert.NotEmpty(t, span.Resource)
+		}
+	})
+
+	t.Run("OTel db.statement matching resource", func(t *testing.T) {
+		query := "SELECT * FROM orders WHERE status = 'pending'"
+		span := &pb.Span{
+			Resource: query,
+			Meta: map[string]string{
+				string(semconv.DBStatementKey): query,
+			},
+		}
+		oq, err := ObfuscateSQLSpan(o, span)
+		require.NoError(t, err)
+		require.NotNil(t, oq)
+		// Both resource and db.statement should be obfuscated the same way
+		assert.Equal(t, span.Resource, span.Meta[string(semconv.DBStatementKey)])
+		assert.Equal(t, "SELECT * FROM orders WHERE status = ?", span.Resource)
+		assert.Equal(t, "SELECT * FROM orders WHERE status = ?", span.Meta[string(semconv.DBStatementKey)])
+	})
+
+	t.Run("with OTel db.statement different from resource", func(t *testing.T) {
+		span := &pb.Span{
+			Resource: "SELECT name FROM orders WHERE id = 1",
+			Meta: map[string]string{
+				string(semconv.DBStatementKey): "SELECT email FROM users WHERE id = 2",
+			},
+		}
+		oq, err := ObfuscateSQLSpan(o, span)
+		require.NoError(t, err)
+		require.NotNil(t, oq)
+		// Resource and db.statement should be obfuscated independently
+		assert.Equal(t, "SELECT name FROM orders WHERE id = ?", span.Resource)
+		assert.Equal(t, "SELECT email FROM users WHERE id = ?", span.Meta[string(semconv.DBStatementKey)])
+	})
+
+	t.Run("with OTel db.query.text matching resource", func(t *testing.T) {
+		query := "SELECT * FROM products WHERE price > 100"
+		span := &pb.Span{
+			Resource: query,
+			Meta: map[string]string{
+				string(semconv126.DBQueryTextKey): query,
+			},
+		}
+		oq, err := ObfuscateSQLSpan(o, span)
+		require.NoError(t, err)
+		require.NotNil(t, oq)
+		// Both resource and db.query.text should be obfuscated the same way
+		assert.Equal(t, span.Resource, span.Meta[string(semconv126.DBQueryTextKey)])
+		assert.Equal(t, "SELECT * FROM products WHERE price > ?", span.Resource)
+		assert.Equal(t, "SELECT * FROM products WHERE price > ?", span.Meta[string(semconv126.DBQueryTextKey)])
+	})
+
+	t.Run("with OTel db.query.text different from resource", func(t *testing.T) {
+		span := &pb.Span{
+			Resource: "SELECT name FROM orders WHERE id = 1",
+			Meta: map[string]string{
+				string(semconv126.DBQueryTextKey): "SELECT title FROM products WHERE id = 2",
+			},
+		}
+		oq, err := ObfuscateSQLSpan(o, span)
+		require.NoError(t, err)
+		require.NotNil(t, oq)
+		// Resource and db.query.text should be obfuscated independently
+		assert.Equal(t, "SELECT name FROM orders WHERE id = ?", span.Resource)
+		assert.Equal(t, "SELECT title FROM products WHERE id = ?", span.Meta[string(semconv126.DBQueryTextKey)])
+	})
+
+}

--- a/releasenotes/notes/otel-db-attrs-obfuscation-28293a2f26a2be80.yaml
+++ b/releasenotes/notes/otel-db-attrs-obfuscation-28293a2f26a2be80.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    When OTel db spans contain a db.statement or db.query.text that
+    differ from the resource name, perform a separate obfuscation,
+    to avoid overriding their contents.

--- a/releasenotes/notes/otel-db-attrs-obfuscation-28293a2f26a2be80.yaml
+++ b/releasenotes/notes/otel-db-attrs-obfuscation-28293a2f26a2be80.yaml
@@ -8,6 +8,6 @@
 ---
 fixes:
   - |
-    When OTel db spans contain a db.statement or db.query.text that
-    differ from the resource name, perform a separate obfuscation,
+    When OTel db spans contain a `db.statement` or `db.query.text` that
+    differ from the resource name, perform a separate obfuscation
     to avoid overriding their contents.


### PR DESCRIPTION
### What does this PR do?
These fields _should_ match the contents of the span resource name, but this semantic recommendation is not guaranteed. 

For libraries that do not follow it, this commit checks whether the values match, before assigning the value of the obfuscated resource name in the OTel db fields. If they do not match, a separate obfuscation is performed.

### Motivation

A recent investigation on a customer escalation showed that `spanner` library does not follow this convention, which results on the trace-agent overriding the contents of `db.statement`.

### Describe how you validated your changes
Added unit tests

### Additional Notes
