### PR TITLE
dyninst: give integration test a longer timeout

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -214,7 +214,7 @@ func testDyninst(
 		assert.Equal(c, allProbeIDs, installedProbeIDs)
 	}
 	require.EventuallyWithT(
-		t, assertProbesInstalled, 60*time.Second, 100*time.Millisecond,
+		t, assertProbesInstalled, 180*time.Second, 100*time.Millisecond,
 		"diagnostics should indicate that the probes are installed",
 	)
 


### PR DESCRIPTION
### What does this PR do?

We see this sometimes time out. These machines must be quite overloaded. Nothing else in the test output looked amiss.

### Motivation

[CI Dashboard](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdatadog-agent%20%40test.suite%3Apkg%2Fdyninst%20%40test.name%3ATestDyninst%20%40test.status%3Afail%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZo16UKAnIP_3gAAABhBWm8xNlVLQUFBQTZNaVhjZnBnRjZOSkoAAAAkZjE5YTM1ZTktNjZiMy00Y2E4LTk5NDEtNjQ5MWUwMzYyZmM4AAA40Q&fromUser=false&graphType=flamegraph&index=citest&testId=AwAAAZo16UKAnIP_3gAAABhBWm8xNlVLQUFBQTZNaVhjZnBnRjZOSkoAAAAkZjE5YTM1ZTktNjZiMy00Y2E4LTk5NDEtNjQ5MWUwMzYyZmM4AAA40Q&trace=AwAAAZo16UKAnIP_3gAAABhBWm8xNlVLQUFBQTZNaVhjZnBnRjZOSkoAAAAkZjE5YTM1ZTktNjZiMy00Y2E4LTk5NDEtNjQ5MWUwMzYyZmM4AAA40Q&start=1761248862040&end=1761853662040&paused=false)
