### PR TITLE
Allow nghttp2 to build on macos.

### DIFF
--- a/deps/nghttp2.BUILD.bazel
+++ b/deps/nghttp2.BUILD.bazel
@@ -43,7 +43,8 @@ cc_library(
     copts = [
         "-DHAVE_CONFIG_H",
     ],
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )


### PR DESCRIPTION
- It is unused at this time on macos
- But allowing it helps test the curl build portability.
