### PR TITLE
[ABLD-158] Switch @openssl// to depend on @xz//:liblzma instead of :lzma

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -65,7 +65,7 @@ configure_make(
     }),
     deps = [
         "@bzip2//:bz2",
-        "@xz//:lzma",
+        "@xz//:liblzma",
         "@zlib",
     ],
 )


### PR DESCRIPTION
It turns out the things that depend on openssl can not build with the :lzma usege.

It needs more investigation, but I think the culprit is using the output_shared_library feature of rules-foreign-cc. We probably should just build a regulary library and then add a cc_shared_library on top of that.

Doing this now, even without complete understanding, allows us to add curl on top of openssl, and then test a real dependency stack to a binary.

Needed by #42546 