### PR TITLE
dyninst/ebpf: fix buffer offset management bug

### DIFF
--- a/pkg/dyninst/output/event.go
+++ b/pkg/dyninst/output/event.go
@@ -170,8 +170,8 @@ func (e Event) DataItems() iter.Seq2[DataItem, error] {
 			dataLen := int(header.Length)
 			if idx+dataLen > len(e) {
 				yield(DataItem{}, fmt.Errorf(
-					"not enough bytes to read data item: %d < %d",
-					len(e), idx+int(header.Length),
+					"not enough bytes to read data item (%d bytes): %d < %d",
+					header.Length, len(e), idx+int(header.Length),
 				))
 				return
 			}

--- a/pkg/dyninst/output/event_test.go
+++ b/pkg/dyninst/output/event_test.go
@@ -224,7 +224,7 @@ func TestEventIterator(t *testing.T) {
 			}(),
 			expectedStack:      fullStack,
 			expectedDataItems:  []DataItem{fullItems[0]},
-			expectDataItemsErr: []string{"", "not enough bytes to read data item:"},
+			expectDataItemsErr: []string{"", `not enough bytes to read data item \(8 bytes\): 108 < 112`},
 		},
 		{
 			name: "one valid data item, one truncated data item header",


### PR DESCRIPTION
I've been reading the code to try to understand the source of our corrupt data items, and this is the only clear bug I could find. The bug here is that when we go to the fallback case, and then we run out of space (which is an odd case, see below), then our attempt to "restore" the buffer would not take into account the fact that we pad out data items. I'm pretty sure this can result in garbage in the output buffer around where a data item header would be.

Imagine: data item is 7 bytes and offset is originally 100. We write the header (16 bytes) and then we write out the 7 bytes and pad to a word, so the offset after would be 124. The code before would subtract 23, leaving a spare byte in the buffer. I've tried to rework that code to be more obviously correct.

This bug is clear enough, but it takes more subtlety to hit it! We'd only hit it if we thought we ran out of space in the fallback. This is however pretty plausible:

To explain the surrounding code more, when we fault trying to access a piece of data under a pointer in one `bpf_probe_read_user` call, then we go to "fallback" mode. In fallback mode, we attempt to break the data along page boundaries. We do this because for memory that Go was handed by the operating system it gets to assume it's zero'd. So, like, if you allocate a big slice it'll all be zero'd and the pages are likely to fault on access. If we don't fault reading the prefix of the data on the first page, proceed to read page-by-page, and assume faulting pages are 0.

However, this code is somewhat deficient compared to the more general code in that it doesn't do the fancy size-class binary search for its buffer space checking -- it only works if there's at least a whole page of space available in the buffer. Now the situation in which we get into trouble is when that first page fits but some subsequent page doesn't...

I don't have an easy test for this case, but the code as it was before was definitely buggy. Let's merge this and write a test as a follow-up.

https://datadoghq.atlassian.net/browse/DEBUG-4569