### PR TITLE
[DDOT][OTAGENT-559] COAT: Add GW usage metric 

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -372,6 +372,11 @@ var defaultProfiles = `
             - version
             - command
             - host
+        - name: runtime.datadog_agent_ddot_gateway_usage
+          aggregate_tags:
+            - version
+            - command
+            - host
     schedule:
       start_after: 30
       iterations: 0

--- a/comp/otelcol/collector/impl/collector.go
+++ b/comp/otelcol/collector/impl/collector.go
@@ -153,6 +153,12 @@ func addFactories(reqs Requires, factories otelcol.Factories, gatewayUsage otel.
 			[]string{"version", "command", "host", "task_arn"},
 			"Usage metric of OTLP metrics in DDOT",
 		)
+		store.DDOTGWUsage = reqs.Telemetry.NewGauge(
+			"runtime",
+			"datadog_agent_ddot_gateway_usage",
+			[]string{"version", "command", "host", "task_arn"},
+			"Usage metric for GW deployments with DDOT",
+		)
 	}
 	if v, ok := reqs.LogsAgent.Get(); ok {
 		factories.Exporters[datadogexporter.Type] = datadogexporter.NewFactory(reqs.TraceAgent, reqs.Serializer, v, reqs.SourceProvider, reqs.StatsdClientWrapper, gatewayUsage, store)

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer.go
@@ -84,8 +84,8 @@ type SerializerConsumer interface {
 	otlpmetrics.Consumer
 	Send(s serializer.MetricSerializer) error
 	addRuntimeTelemetryMetric(hostname string, languageTags []string)
-	addTelemetryMetric(hostname string, params exporter.Settings, usageMetric telemetry.Gauge)
-	addGatewayUsage(hostname string, gatewayUsage otel.GatewayUsage)
+	addTelemetryMetric(hostname string, params exporter.Settings, coatUsageMetric telemetry.Gauge)
+	addGatewayUsage(hostname string, params exporter.Settings, gatewayUsage otel.GatewayUsage, coatUsageMetric telemetry.Gauge)
 }
 
 type serializerConsumer struct {
@@ -173,7 +173,7 @@ func (c *serializerConsumer) ConsumeTimeSeries(_ context.Context, dimensions *ot
 }
 
 // addTelemetryMetric to know if an Agent is using OTLP metrics.
-func (c *serializerConsumer) addTelemetryMetric(agentHostname string, params exporter.Settings, usageMetric telemetry.Gauge) {
+func (c *serializerConsumer) addTelemetryMetric(agentHostname string, params exporter.Settings, coatUsageMetric telemetry.Gauge) {
 	timestamp := float64(time.Now().Unix())
 	c.series = append(c.series, &metrics.Serie{
 		Name:           "datadog.agent.otlp.metrics",
@@ -184,7 +184,7 @@ func (c *serializerConsumer) addTelemetryMetric(agentHostname string, params exp
 		SourceTypeName: "System",
 	})
 
-	if usageMetric == nil {
+	if coatUsageMetric == nil {
 		return
 	}
 
@@ -192,14 +192,14 @@ func (c *serializerConsumer) addTelemetryMetric(agentHostname string, params exp
 	switch c.ipath {
 	case ddot:
 		for host := range c.hosts {
-			usageMetric.Set(1.0, buildInfo.Version, buildInfo.Command, host, "")
+			coatUsageMetric.Set(1.0, buildInfo.Version, buildInfo.Command, host, "")
 		}
 		for ecsFargateTag := range c.ecsFargateTags {
 			taskArn := strings.Split(ecsFargateTag, ":")[1]
-			usageMetric.Set(1.0, buildInfo.Version, buildInfo.Command, "", taskArn)
+			coatUsageMetric.Set(1.0, buildInfo.Version, buildInfo.Command, "", taskArn)
 		}
 	case agentOTLPIngest:
-		usageMetric.Set(1.0, buildInfo.Version, buildInfo.Command, agentHostname)
+		coatUsageMetric.Set(1.0, buildInfo.Version, buildInfo.Command, agentHostname)
 	case ossCollector:
 		params.Logger.Fatal("wrong consumer implementation used in OSS datadog exporter, should use collectorConsumer")
 	default:
@@ -221,7 +221,9 @@ func (c *serializerConsumer) addRuntimeTelemetryMetric(hostname string, language
 	}
 }
 
-func (c *serializerConsumer) addGatewayUsage(hostname string, gatewayUsage otel.GatewayUsage) {
+func (c *serializerConsumer) addGatewayUsage(hostname string, params exporter.Settings,
+	gatewayUsage otel.GatewayUsage, coatUsageMetric telemetry.Gauge) {
+	buildInfo := params.BuildInfo
 	value, enabled := gatewayUsage.Gauge()
 	if enabled {
 		c.series = append(c.series, &metrics.Serie{
@@ -232,6 +234,45 @@ func (c *serializerConsumer) addGatewayUsage(hostname string, gatewayUsage otel.
 			MType:          metrics.APIGaugeType,
 			SourceTypeName: "System",
 		})
+
+		if coatUsageMetric == nil {
+			return
+		}
+
+		switch c.ipath {
+		case ddot:
+			for host := range c.hosts {
+				coatUsageMetric.Set(value, buildInfo.Version, buildInfo.Command, host, "")
+			}
+			for ecsFargateTag := range c.ecsFargateTags {
+				taskArn := strings.Split(ecsFargateTag, ":")[1]
+				coatUsageMetric.Set(value, buildInfo.Version, buildInfo.Command, "", taskArn)
+			}
+		case agentOTLPIngest:
+		case ossCollector:
+			params.Logger.Fatal("wrong consumer implementation used in OSS datadog exporter, should use collectorConsumer")
+		default:
+			params.Logger.Fatal("ingestion path unset or unknown", zap.Int("ingestion path enum", int(c.ipath)))
+		}
+	} else {
+		if coatUsageMetric == nil {
+			return
+		}
+		switch c.ipath {
+		case ddot:
+			for host := range c.hosts {
+				coatUsageMetric.Set(0, buildInfo.Version, buildInfo.Command, host, "")
+			}
+			for ecsFargateTag := range c.ecsFargateTags {
+				taskArn := strings.Split(ecsFargateTag, ":")[1]
+				coatUsageMetric.Set(0, buildInfo.Version, buildInfo.Command, "", taskArn)
+			}
+		case agentOTLPIngest:
+		case ossCollector:
+			params.Logger.Fatal("wrong consumer implementation used in OSS datadog exporter, should use collectorConsumer")
+		default:
+			params.Logger.Fatal("ingestion path unset or unknown", zap.Int("ingestion path enum", int(c.ipath)))
+		}
 	}
 }
 

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
@@ -74,17 +74,18 @@ func (f SourceProviderFunc) Source(ctx context.Context) (source.Source, error) {
 // Exporter translate OTLP metrics into the Datadog format and sends
 // them to the agent serializer.
 type Exporter struct {
-	tr              *metrics.Translator
-	s               serializer.MetricSerializer
-	hostGetter      SourceProviderFunc
-	extraTags       []string
-	apmReceiverAddr string
-	createConsumer  createConsumerFunc
-	params          exporter.Settings
-	hostmetadata    datadogconfig.HostMetadataConfig
-	reporter        *inframetadata.Reporter
-	gatewayUsage    otel.GatewayUsage
-	usageMetric     telemetry.Gauge
+	tr                *metrics.Translator
+	s                 serializer.MetricSerializer
+	hostGetter        SourceProviderFunc
+	extraTags         []string
+	apmReceiverAddr   string
+	createConsumer    createConsumerFunc
+	params            exporter.Settings
+	hostmetadata      datadogconfig.HostMetadataConfig
+	reporter          *inframetadata.Reporter
+	gatewayUsage      otel.GatewayUsage
+	coatUsageMetric   telemetry.Gauge
+	coatGWUsageMetric telemetry.Gauge
 }
 
 // TODO: expose the same function in OSS exporter and remove this
@@ -151,7 +152,8 @@ func NewExporter(
 	params exporter.Settings,
 	reporter *inframetadata.Reporter,
 	gatewayUsage otel.GatewayUsage,
-	usageMetric telemetry.Gauge,
+	coatUsageMetric telemetry.Gauge,
+	coatGWUsageMetric telemetry.Gauge,
 ) (*Exporter, error) {
 	var extraTags []string
 	if cfg.Metrics.Tags != "" {
@@ -162,17 +164,18 @@ func NewExporter(
 		zap.String("apm_receiver_url", cfg.Metrics.APMStatsReceiverAddr),
 		zap.String("histogram_mode", fmt.Sprintf("%v", cfg.Metrics.Metrics.HistConfig.Mode)))
 	return &Exporter{
-		tr:              tr,
-		s:               s,
-		hostGetter:      hostGetter,
-		apmReceiverAddr: cfg.Metrics.APMStatsReceiverAddr,
-		extraTags:       extraTags,
-		createConsumer:  createConsumer,
-		params:          params,
-		hostmetadata:    cfg.HostMetadata,
-		reporter:        reporter,
-		gatewayUsage:    gatewayUsage,
-		usageMetric:     usageMetric,
+		tr:                tr,
+		s:                 s,
+		hostGetter:        hostGetter,
+		apmReceiverAddr:   cfg.Metrics.APMStatsReceiverAddr,
+		extraTags:         extraTags,
+		createConsumer:    createConsumer,
+		params:            params,
+		hostmetadata:      cfg.HostMetadata,
+		reporter:          reporter,
+		gatewayUsage:      gatewayUsage,
+		coatUsageMetric:   coatUsageMetric,
+		coatGWUsageMetric: coatGWUsageMetric,
 	}, nil
 }
 
@@ -195,9 +198,9 @@ func (e *Exporter) ConsumeMetrics(ctx context.Context, ld pmetric.Metrics) error
 		return err
 	}
 
-	consumer.addTelemetryMetric(hostname, e.params, e.usageMetric)
+	consumer.addTelemetryMetric(hostname, e.params, e.coatUsageMetric)
 	consumer.addRuntimeTelemetryMetric(hostname, rmt.Languages)
-	consumer.addGatewayUsage(hostname, e.gatewayUsage)
+	consumer.addGatewayUsage(hostname, e.params, e.gatewayUsage, e.coatGWUsageMetric)
 	if err := consumer.Send(e.s); err != nil {
 		return fmt.Errorf("failed to flush metrics: %w", err)
 	}

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -512,7 +512,13 @@ func TestUsageMetric_DDOT(t *testing.T) {
 			"runtime",
 			"datadog_agent_ddot_metrics",
 			[]string{"version", "command", "host", "task_arn"},
-			"Usage metric of OTLP metrics in OTLP ingestion",
+			"Usage metric of OTLP metrics in DDOT",
+		),
+		DDOTGWUsage: telemetryComp.NewGauge(
+			"runtime",
+			"datadog_agent_ddot_gateway_usage",
+			[]string{"version", "command", "host", "task_arn"},
+			"Usage metric for GW deployments with DDOT",
 		),
 	}
 	f := NewFactoryForOTelAgent(rec, func(context.Context) (string, error) {
@@ -544,7 +550,73 @@ func TestUsageMetric_DDOT(t *testing.T) {
 	require.NoError(t, exp.ConsumeMetrics(ctx, md))
 	require.NoError(t, exp.Shutdown(ctx))
 
+	// DDOT usage metric should be 1
 	usageMetric, err := telemetryComp.GetGaugeMetric("runtime", "datadog_agent_ddot_metrics")
+	require.NoError(t, err)
+	require.Len(t, usageMetric, 1)
+	assert.Equal(t, map[string]string{"host": "test-host", "command": "otelcol", "version": "latest", "task_arn": ""}, usageMetric[0].Tags())
+	assert.Equal(t, 1.0, usageMetric[0].Value())
+
+	// GW usage metric should be zero
+	usageMetric, err = telemetryComp.GetGaugeMetric("runtime", "datadog_agent_ddot_gateway_usage")
+	require.NoError(t, err)
+	require.Len(t, usageMetric, 1)
+	assert.Equal(t, map[string]string{"host": "test-host", "command": "otelcol", "version": "latest", "task_arn": ""}, usageMetric[0].Tags())
+	assert.Equal(t, float64(0), usageMetric[0].Value())
+
+	_, err = telemetryComp.GetGaugeMetric("runtime", "datadog_agent_otlp_ingest_metrics")
+	assert.ErrorContains(t, err, "runtime__datadog_agent_otlp_ingest_metrics not found")
+}
+
+func TestUsageMetric_GW(t *testing.T) {
+	rec := &metricRecorder{}
+	ctx := context.Background()
+	telemetryComp := fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
+	store := TelemetryStore{
+		DDOTGWUsage: telemetryComp.NewGauge(
+			"runtime",
+			"datadog_agent_ddot_gateway_usage",
+			[]string{"version", "command", "host", "task_arn"},
+			"Usage metric for GW deployments with DDOT",
+		),
+	}
+	gwUsage := otel.NewGatewayUsage()
+	f := NewFactoryForOTelAgent(rec, func(context.Context) (string, error) {
+		return "agent-host", nil
+	}, nil, gwUsage, store, nil)
+
+	// Force gw usage attribute to detect GW; two different host attributes will trigger that.
+	attr := gwUsage.GetHostFromAttributesHandler()
+	attr.OnHost("foo")
+	attr.OnHost("bar")
+
+	cfg := f.CreateDefaultConfig().(*ExporterConfig)
+	exp, err := f.CreateMetrics(
+		ctx,
+		exportertest.NewNopSettings(component.MustNewType("datadog")),
+		cfg,
+	)
+	require.NoError(t, err)
+	require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+
+	md := pmetric.NewMetrics()
+	rms := md.ResourceMetrics()
+	rm := rms.AppendEmpty()
+	rm.Resource().Attributes().PutStr("datadog.host.name", "test-host")
+	ilms := rm.ScopeMetrics()
+	ilm := ilms.AppendEmpty()
+	metricsArray := ilm.Metrics()
+	met := metricsArray.AppendEmpty()
+	met.SetName("test-metric")
+	met.SetEmptySum()
+	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dp := met.Sum().DataPoints().AppendEmpty()
+	dp.SetIntValue(100)
+
+	require.NoError(t, exp.ConsumeMetrics(ctx, md))
+	require.NoError(t, exp.Shutdown(ctx))
+
+	usageMetric, err := telemetryComp.GetGaugeMetric("runtime", "datadog_agent_ddot_gateway_usage")
 	require.NoError(t, err)
 	require.Len(t, usageMetric, 1)
 	assert.Equal(t, map[string]string{"host": "test-host", "command": "otelcol", "version": "latest", "task_arn": ""}, usageMetric[0].Tags())

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
@@ -61,6 +61,8 @@ type TelemetryStore struct {
 	DDOTMetrics telemetry.Gauge
 	// DDOTTraces tracks hosts running DDOT and ingest traces
 	DDOTTraces telemetry.Gauge
+	// DDOTGWUsage tracks hosts running DDOT in GW mode
+	DDOTGWUsage telemetry.Gauge
 }
 
 type createConsumerFunc func(extraTags []string, apmReceiverAddr string, buildInfo component.BuildInfo) SerializerConsumer
@@ -249,7 +251,7 @@ func (f *factory) createMetricExporter(ctx context.Context, params exp.Settings,
 		usageMetric = f.store.DDOTMetrics
 	}
 
-	newExp, err := NewExporter(f.s, cfg, hostGetter, f.createConsumer, tr, params, reporter, f.gatewayUsage, usageMetric)
+	newExp, err := NewExporter(f.s, cfg, hostGetter, f.createConsumer, tr, params, reporter, f.gatewayUsage, usageMetric, f.store.DDOTGWUsage)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?
This PR adds COAT GW usage metric to DDOT.

It relies on the previous non-COAT metric to determine if a Collector is acting as a GW, processing traffic from multiple hosts in the same collector.

### Motivation
The motivation for this feature is to be able to more closely track GW usage adoption and deployments. 

### Describe how you validated your changes
These changes can be easily validated; COAT metric should be reported to the corresponding org for running collectors.

Also added the relevant unit tests to validate the COAT metric values were expected.

### Additional Notes

The current pattern to do/add COAT metrics is not the cleanest, we probably want to work a little bit on the interfaces and abstractions so that it becomes easier and more ergonomic to add new metrics, and, in particular, to report effectively telemetry as both COAT and non-COAT when required. We can tackle that in a separate effort. 
