### PR TITLE
Add FIPS-compliant DDOT packages

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -155,6 +155,7 @@ trigger_distribution*         @DataDog/agent-delivery
 integration_tests_windows*    @DataDog/windows-products
 integration_tests_otel        @DataDog/opentelemetry-agent
 docker_image_build_otel       @DataDog/opentelemetry-agent
+build_otel_agent_*            @DataDog/opentelemetry-agent
 ddot_byoc_*                   @DataDog/opentelemetry-agent
 datadog_otel_components_ocb_build  @DataDog/opentelemetry-agent
 docker_integration_tests      @DataDog/container-integrations

--- a/.gitlab/binary_build/otel_agent.yml
+++ b/.gitlab/binary_build/otel_agent.yml
@@ -7,7 +7,7 @@
     - when: on_success
   script:
     - !reference [.retrieve_linux_go_deps]
-    - dda inv -- -e otel-agent.build
+    - dda inv -- -e otel-agent.build --flavor "$FLAVOR"
   needs: ["go_deps"]
   variables:
     KUBERNETES_MEMORY_REQUEST: "16Gi"
@@ -18,11 +18,9 @@
       - $CI_PROJECT_DIR/bin/otel-agent/otel-agent
 
 build_otel_agent_binary_x64:
-  extends: .build_otel_agent_binary_common
+  extends: [.build_otel_agent_binary_common, .agent_base_flavor]
   tags: ["arch:amd64", "specific:true"]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
 
 build_otel_agent_binary_arm64:
-  extends: .build_otel_agent_binary_common
+  extends: [.build_otel_agent_binary_common, .agent_base_flavor]
   tags: ["arch:arm64", "specific:true"]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -295,6 +295,24 @@ docker_build_agent7_full_arm64:
     TAG_SUFFIX: -7-full
     BUILD_ARG: --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-*-7*-arm64.tar.xz
 
+docker_build_agent7_fips_full:
+  extends: [.docker_build_amd64, .docker_build_agent7]
+  needs:
+    - job: datadog-agent-7-x64-fips
+    - job: datadog-otel-agent-x64-fips
+  variables:
+    TAG_SUFFIX: -7-fips-full
+    BUILD_ARG: --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-*-7*-amd64.tar.xz
+
+docker_build_agent7_fips_full_arm64:
+  extends: [.docker_build_arm64, .docker_build_agent7]
+  needs:
+    - job: datadog-agent-7-arm64-fips
+    - job: datadog-otel-agent-arm64-fips
+  variables:
+    TAG_SUFFIX: -7-fips-full
+    BUILD_ARG: --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-*-7*-arm64.tar.xz
+
 # build the cluster-agent image
 .docker_build_cluster_agent:
   extends: .docker_build_job_definition

--- a/.gitlab/package_build/linux.yml
+++ b/.gitlab/package_build/linux.yml
@@ -54,29 +54,46 @@
     DD_CXX: "aarch64-unknown-linux-gnu-g++"
     DD_CMAKE_TOOLCHAIN: "/opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake"
 
-.agent_7_build:
+.agent_base_flavor:
   variables:
     FLAVOR: base
 
-.agent_fips_build:
+.agent_fips_flavor:
   variables:
     FLAVOR: fips
 
 # build Agent 7 binaries for x86_64
 datadog-agent-7-x64:
-  extends: [.agent_build_common, .agent_build_x86, .agent_7_build]
+  extends: [.agent_build_common, .agent_build_x86, .agent_base_flavor]
 
 # build Agent 7 binaries for arm64
 datadog-agent-7-arm64:
-  extends: [.agent_build_common, .agent_build_arm64, .agent_7_build]
+  extends: [.agent_build_common, .agent_build_arm64, .agent_base_flavor]
 
 # build Agent 7 binaries for x86_64 with FIPS
 datadog-agent-7-x64-fips:
-  extends: [.agent_build_common, .agent_build_x86, .agent_fips_build]
+  extends: [.agent_build_common, .agent_build_x86, .agent_fips_flavor]
 
 # build Agent 7 binaries for arm64 with FIPS
 datadog-agent-7-arm64-fips:
-  extends: [.agent_build_common, .agent_build_arm64, .agent_fips_build]
+  extends: [.agent_build_common, .agent_build_arm64, .agent_fips_flavor]
+
+# Common to IoT, DDOT and dogstatsd
+.toolchain-common-x64:
+  tags: ["arch:amd64", "specific:true"]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  variables:
+    DD_CC: "x86_64-unknown-linux-gnu-gcc"
+    DD_CXX: "x86_64-unknown-linux-gnu-g++"
+
+.toolchain-common-arm64:
+  tags: ["arch:arm64", "specific:true"]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  variables:
+    DD_CC: "aarch64-unknown-linux-gnu-gcc"
+    DD_CXX: "aarch64-unknown-linux-gnu-g++"
+
+# ----- IoT -----
 
 .iot-agent-common:
   extends: .agent_build_common
@@ -91,20 +108,10 @@ datadog-agent-7-arm64-fips:
     - !reference [.upload_sbom_artifacts]
 
 iot-agent-x64:
-  extends: .iot-agent-common
-  tags: ["arch:amd64", "specific:true"]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  variables:
-    DD_CC: "x86_64-unknown-linux-gnu-gcc"
-    DD_CXX: "x86_64-unknown-linux-gnu-g++"
+  extends: [.iot-agent-common, .toolchain-common-x64]
 
 iot-agent-arm64:
-  extends: .iot-agent-common
-  tags: ["arch:arm64", "specific:true"]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  variables:
-    DD_CC: "aarch64-unknown-linux-gnu-gcc"
-    DD_CXX: "aarch64-unknown-linux-gnu-g++"
+  extends: [.iot-agent-common, .toolchain-common-arm64]
 
 iot-agent-armhf:
   extends: .iot-agent-common
@@ -116,6 +123,8 @@ iot-agent-armhf:
     # we can only address 32 bits of memory, which is likely to OOM
     # if we use too many compression threads or a too agressive level
     FORCED_PACKAGE_COMPRESSION_LEVEL: 5
+
+# ----- Dogstatsd -----
 
 .dogstatsd_build_common:
   needs: ["go_mod_tidy_check", "go_deps"]
@@ -143,20 +152,12 @@ iot-agent-armhf:
     - !reference [.cache_omnibus_ruby_deps, cache]
 
 dogstatsd-x64:
-  extends: .dogstatsd_build_common
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64", "specific:true"]
-  variables:
-    DD_CC: "x86_64-unknown-linux-gnu-gcc"
-    DD_CXX: "x86_64-unknown-linux-gnu-g++"
+  extends: [.dogstatsd_build_common, .toolchain-common-x64]
 
 dogstatsd-arm64:
-  extends: .dogstatsd_build_common
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:arm64", "specific:true"]
-  variables:
-    DD_CC: "aarch64-unknown-linux-gnu-gcc"
-    DD_CXX: "aarch64-unknown-linux-gnu-g++"
+  extends: [.dogstatsd_build_common, .toolchain-common-arm64]
+
+# ----- DDOT -----
 
 .otel_build_common:
   needs: ["go_mod_tidy_check", "go_deps"]
@@ -169,7 +170,7 @@ dogstatsd-arm64:
     - !reference [.cache_omnibus_ruby_deps, setup]
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
-    - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --target-project ddot
+    - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --target-project ddot --flavor "$FLAVOR"
     - ls -la $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts]
   variables:
@@ -184,17 +185,13 @@ dogstatsd-arm64:
     - !reference [.cache_omnibus_ruby_deps, cache]
 
 datadog-otel-agent-x64:
-  extends: .otel_build_common
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64", "specific:true"]
-  variables:
-    DD_CC: "x86_64-unknown-linux-gnu-gcc"
-    DD_CXX: "x86_64-unknown-linux-gnu-g++"
+  extends: [.otel_build_common, .toolchain-common-x64, .agent_base_flavor]
 
 datadog-otel-agent-arm64:
-  extends: .otel_build_common
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:arm64", "specific:true"]
-  variables:
-    DD_CC: "aarch64-unknown-linux-gnu-gcc"
-    DD_CXX: "aarch64-unknown-linux-gnu-g++"
+  extends: [.otel_build_common, .toolchain-common-arm64, .agent_base_flavor]
+
+datadog-otel-agent-x64-fips:
+  extends: [.otel_build_common, .toolchain-common-x64, .agent_fips_flavor]
+
+datadog-otel-agent-arm64-fips:
+  extends: [.otel_build_common, .toolchain-common-arm64, .agent_fips_flavor]

--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -78,29 +78,36 @@ agent_deb-arm64-a7-fips:
     OMNIBUS_EXTRA_ARGS: "--flavor fips"
     DD_PROJECT: "agent"
 
-ddot_deb-x64:
-  extends: [.package_deb_common, .package_deb_x86]
+.ddot_deb_common:
+  extends: .package_deb_common
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-  needs: ["datadog-otel-agent-x64"]
   variables:
     DD_PROJECT: "ddot"
     PACKAGE_REQUIRED_FILES_LIST: "test/required_files/ddot.txt"
     # TODO(agent-devx): Re-enable VPA by removing this when it will be possible to configure memory lower bound to avoid OOMs
     DD_DISABLE_VPA: true
 
+ddot_deb-x64:
+  extends: [.ddot_deb_common, .package_deb_x86]
+  needs: ["datadog-otel-agent-x64"]
+
 ddot_deb-arm64:
-  extends: [.package_deb_common, .package_deb_arm64]
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
+  extends: [.ddot_deb_common, .package_deb_arm64]
   needs: ["datadog-otel-agent-arm64"]
+
+ddot_deb-x64-fips:
+  extends: [.ddot_deb_common, .package_deb_x86]
+  needs: ["datadog-otel-agent-x64-fips"]
   variables:
-    DD_PROJECT: "ddot"
-    PACKAGE_REQUIRED_FILES_LIST: "test/required_files/ddot.txt"
-    # TODO(agent-devx): Re-enable VPA by removing this when it will be possible to configure memory lower bound to avoid OOMs
-    DD_DISABLE_VPA: true
+    OMNIBUS_EXTRA_ARGS: "--flavor fips"
+
+ddot_deb-arm64-fips:
+  extends: [.ddot_deb_common, .package_deb_arm64]
+  needs: ["datadog-otel-agent-arm64-fips"]
+  variables:
+    OMNIBUS_EXTRA_ARGS: "--flavor fips"
 
 installer_deb-amd64:
   extends: [.package_deb_common, .package_deb_x86]

--- a/.gitlab/packaging/rpm.yml
+++ b/.gitlab/packaging/rpm.yml
@@ -130,23 +130,33 @@ agent_suse-arm64-a7-fips:
     OMNIBUS_EXTRA_ARGS: "--host-distribution=suse --flavor fips"
     DD_PROJECT: agent
 
-ddot_rpm-x64:
-  extends: [.package_rpm_common, .package_rpm_x86]
-  needs: ["datadog-otel-agent-x64"]
+.ddot_rpm_common:
+  extends: .package_rpm_common
   variables:
     DD_PROJECT: ddot
     PACKAGE_REQUIRED_FILES_LIST: "test/required_files/ddot.txt"
     # TODO(agent-devx): Re-enable VPA by removing this when it will be possible to configure memory lower bound to avoid OOMs
     DD_DISABLE_VPA: true
 
+ddot_rpm-x64:
+  extends: [.ddot_rpm_common, .package_rpm_x86]
+  needs: ["datadog-otel-agent-x64"]
+
 ddot_rpm-arm64:
-  extends: [.package_rpm_common, .package_rpm_arm64]
+  extends: [.ddot_rpm_common, .package_rpm_arm64]
   needs: ["datadog-otel-agent-arm64"]
+
+ddot_rpm-x64-fips:
+  extends: [.ddot_rpm_common, .package_rpm_x86]
+  needs: ["datadog-otel-agent-x64-fips"]
   variables:
-    DD_PROJECT: ddot
-    PACKAGE_REQUIRED_FILES_LIST: "test/required_files/ddot.txt"
-    # TODO(agent-devx): Re-enable VPA by removing this when it will be possible to configure memory lower bound to avoid OOMs
-    DD_DISABLE_VPA: true
+    OMNIBUS_EXTRA_ARGS: "--flavor fips"
+
+ddot_rpm-arm64-fips:
+  extends: [.ddot_rpm_common, .package_rpm_arm64]
+  needs: ["datadog-otel-agent-arm64-fips"]
+  variables:
+    OMNIBUS_EXTRA_ARGS: "--flavor fips"
 
 ddot_suse_rpm-x64:
   extends: [.package_suse_rpm_common, .package_rpm_x86]

--- a/omnibus/config/projects/ddot.rb
+++ b/omnibus/config/projects/ddot.rb
@@ -6,7 +6,11 @@ require "./lib/ostools.rb"
 require "./lib/project_helpers.rb"
 
 name 'ddot'
-package_name 'datadog-agent-ddot'
+if fips_mode?
+  package_name 'datadog-fips-agent-ddot'
+else
+  package_name 'datadog-agent-ddot'
+end
 
 license "Apache-2.0"
 license_file "../LICENSE"

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -24,6 +24,7 @@ build do
 
     # set GOPATH on the omnibus source dir for this software
     gopath = Pathname.new(project_dir) + '../../../..'
+    flavor_arg = ENV['AGENT_FLAVOR']
 
     # include embedded path (mostly for `pkg-config` binary)
     #
@@ -46,6 +47,24 @@ build do
 
     env = with_standard_compiler_flags(env)
 
+    if fips_mode?
+      if windows_target?
+        msgoroot = ENV['MSGO_ROOT']
+        if msgoroot.nil? || msgoroot.empty?
+          raise "MSGO_ROOT not set"
+        end
+        if !File.exist?("#{msgoroot}\\bin\\go.exe")
+          raise "msgo go.exe not found at #{msgoroot}\\bin\\go.exe"
+        end
+        env["GOROOT"] = msgoroot
+        env["PATH"] = "#{msgoroot}\\bin;#{env['PATH']}"
+      else
+        msgoroot = "/usr/local/msgo"
+        env["GOROOT"] = msgoroot
+        env["PATH"] = "#{msgoroot}/bin:#{env['PATH']}"
+      end
+    end
+
     if windows_target?
       conf_dir = "#{install_dir}/etc/datadog-agent"
     else
@@ -56,7 +75,7 @@ build do
     mkdir conf_dir
     mkdir embedded_bin_dir
 
-    command "dda inv -- -e otel-agent.build", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "dda inv -- -e otel-agent.build --flavor #{flavor_arg}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
 
     if windows_target?
       copy 'bin/otel-agent/otel-agent.exe', embedded_bin_dir

--- a/omnibus/config/software/package-artifact.rb
+++ b/omnibus/config/software/package-artifact.rb
@@ -64,4 +64,3 @@ build do
        vars: { uninstall_command: uninstall_command}
   end
 end
-

--- a/releasenotes/notes/add-fips-buils-for-ddot-2297d0ec27149e14.yaml
+++ b/releasenotes/notes/add-fips-buils-for-ddot-2297d0ec27149e14.yaml
@@ -1,0 +1,2 @@
+enhancements:
+  - 'Provide FIPS-compliant builds for the Datadog distribution of OpenTelemetry (DDOT).'

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -328,6 +328,7 @@ build_tags = {
         # Test setups
         "lint": AGENT_TAGS.union(FIPS_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
         "unit-tests": AGENT_TAGS.union(FIPS_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+        "otel-agent": OTEL_AGENT_TAGS.union(FIPS_TAGS),
     },
     AgentFlavor.heroku: {
         "agent": AGENT_HEROKU_TAGS,

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -242,8 +242,9 @@ def build(
 
     if not target_project:
         target_project = "agent"
-    if target_project != "agent" and flavor != AgentFlavor.base:
-        print("flavors only make sense when building the agent")
+
+    if flavor != AgentFlavor.base and target_project not in ["agent", "ddot"]:
+        print("flavors only make sense when building the agent or ddot")
         raise Exit(code=1)
     if flavor.is_iot():
         target_project = "iot-agent"

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -7,6 +7,7 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from tasks.build_tags import get_default_build_tags
+from tasks.flavor import AgentFlavor
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_version_ldflags
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
@@ -43,7 +44,7 @@ def byoc_release(ctx, image=DDOT_DEV_AGENT_TAG, branch=DDOT_DEV_AGENT_BRANCH, re
 
 
 @task
-def build(ctx, byoc=False):
+def build(ctx, byoc=False, flavor=AgentFlavor.base.name):
     """
     Build the otel agent
     """
@@ -51,8 +52,9 @@ def build(ctx, byoc=False):
     if os.path.exists(BIN_PATH):
         os.remove(BIN_PATH)
 
+    flavor = AgentFlavor[flavor]
     env = {"GO111MODULE": "on"}
-    build_tags = get_default_build_tags(build="otel-agent")
+    build_tags = get_default_build_tags(build="otel-agent", flavor=flavor)
     ldflags = get_version_ldflags(ctx)
     ldflags += f' -X github.com/DataDog/datadog-agent/cmd/otel-agent/command.BYOC={byoc}'
     if os.environ.get("DELVE"):


### PR DESCRIPTION
### What does this PR do?

Add additional CI pipeline jobs to package FIPS-compliant variants of the DDOT .rpm and .deb packages,
as well as a `-fips-full` docker image

### Motivation

Closes [OTAGENT-640](https://datadoghq.atlassian.net/browse/OTAGENT-640?atlOrigin=eyJpIjoiOWRhNzU1ZDYyZjViNDk4NzkxZGZhZjcwODhlZjMxMWYiLCJwIjoiaiJ9)

### Describe how you validated your changes

By having the gitlab CI run and the added jobs succeeded

[OTAGENT-640]: https://datadoghq.atlassian.net/browse/OTAGENT-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ