### PR TITLE
chore(devcontainer): harmonize devcontainer name to RFC1123

### DIFF
--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -128,7 +128,7 @@ jobs:
 
     - name: Grant the datadog user access to host Docker socket
       run: |
-        docker exec -u root datadog_agent_devcontainer sh -lc '
+        docker exec -u root datadog-agent-devcontainer sh -lc '
           set -e
           sock=/var/run/docker.sock
           gid=$(stat -c %g "$sock")

--- a/.run/docker/Run development container for AMD64.run.xml
+++ b/.run/docker/Run development container for AMD64.run.xml
@@ -4,7 +4,7 @@
       <settings>
         <option name="imageTag" value="registry.ddbuild.io/ci/datadog-agent-devenv:1-amd64" />
         <option name="command" value="sleep infinity" />
-        <option name="containerName" value="datadog-agent-devenv" />
+        <option name="containerName" value="datadog-agent-devcontainer" />
         <option name="commandLineOptions" value="--platform linux/amd64 -w /home/datadog/go/src/github.com/DataDog/datadog-agent" />
         <option name="showCommandPreview" value="true" />
         <option name="volumeBindings">

--- a/.run/docker/Run development container.run.xml
+++ b/.run/docker/Run development container.run.xml
@@ -4,7 +4,7 @@
       <settings>
         <option name="imageTag" value="registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64" />
         <option name="command" value="sleep infinity" />
-        <option name="containerName" value="datadog-agent-devenv" />
+        <option name="containerName" value="datadog-agent-devcontainer" />
         <option name="commandLineOptions" value="-w /home/datadog/go/src/github.com/DataDog/datadog-agent" />
         <option name="showCommandPreview" value="true" />
         <option name="volumeBindings">

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -57,9 +57,9 @@ profiles:
       artifacts:
       - image: agent
         custom:
-          buildCommand: "docker exec datadog_agent_devcontainer bash -c \"
+          buildCommand: "docker exec datadog-agent-devcontainer bash -c \"
             dda inv agent.hacky-dev-image-build --target-image=$IMAGE\""
       - image: clusteragent
         custom:
-          buildCommand: "docker exec datadog_agent_devcontainer bash -c \"
+          buildCommand: "docker exec datadog-agent-devcontainer bash -c \"
             dda inv cluster-agent.hacky-dev-image-build --target-image=$IMAGE\""

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -22,7 +22,7 @@ from tasks.libs.common.utils import is_installed
 
 DEVCONTAINER_DIR = ".devcontainer"
 DEVCONTAINER_FILE = "devcontainer.json"
-DEVCONTAINER_NAME = "datadog_agent_devcontainer"
+DEVCONTAINER_NAME = "datadog-agent-devcontainer"
 DEVCONTAINER_IMAGE = "registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64"
 
 
@@ -71,7 +71,7 @@ def setup(
 
     local_build_tags = ",".join(use_tags)
 
-    devcontainer["name"] = "Datadog-Agent-DevEnv"
+    devcontainer["name"] = "Datadog Agent Development Container"
     if image:
         devcontainer["image"] = image
         if devcontainer.get("build"):
@@ -90,7 +90,7 @@ def setup(
         "-w",
         "/workspaces/datadog-agent",
         "--name",
-        "datadog_agent_devcontainer",
+        "datadog-agent-devcontainer",
     ]
     devcontainer["features"] = {}
     devcontainer["remoteUser"] = "datadog"


### PR DESCRIPTION
### What does this PR do?
Standardizes the devcontainer name to an [RFC 1123](https://www.rfc-editor.org/rfc/rfc1123)–compliant value: **`datadog-agent-devcontainer`**.

### Motivation
- Align naming across Agent devcontainer configs.
- Ensure compatibility with Kubernetes/Skaffold and any tooling that expects [DNS-1123](https://www.rfc-editor.org/rfc/rfc1123)–compliant identifiers.

### Changes
- Rename:
  - `datadog_agent_devcontainer` → `datadog-agent-devcontainer`
  - `datadog-agent-devenv` → `datadog-agent-devcontainer`
- Update references in configs, scripts, and docs.

### How did you validate it?
- Built and launched the devcontainer locally.
- Ran Skaffold/K8s workflow to confirm the name is accepted.
- Grepped the repo to ensure no remaining references to old names (other than the image name).
```
➜  datadog-agent-primary git:(dev/wassim.dhif/rename-devcontainer-rfc-1123) grep -R datadog_agent_devcontainer .
➜  datadog-agent-primary git:(dev/wassim.dhif/rename-devcontainer-rfc-1123) grep -R datadog-agent-devenv .
./tasks/devcontainer.py:DEVCONTAINER_IMAGE = "registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64"
./.run/docker/Run development container for AMD64.run.xml:        <option name="imageTag" value="registry.ddbuild.io/ci/datadog-agent-devenv:1-amd64" />
./.run/docker/Run linter.run.xml:        <option name="imageTag" value="486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-devenv:1-arm64" />
./.run/docker/Run development container.run.xml:        <option name="imageTag" value="registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64" />
./.run/docker/Run unit tests.run.xml:        <option name="imageTag" value="486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-devenv:1-arm64" />
```

### Additional Notes
- No production impact; dev-only change.
- If local scripts relied on the old name, they’ll need to be updated.





