### PR TITLE
Use fips flavor to add fips tags to all binaries

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -529,12 +529,3 @@ def compute_config_build_tags(targets="all", build_include=None, build_exclude=N
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     use_tags = get_build_tags(build_include, build_exclude)
     return use_tags
-
-
-def add_fips_tags(tags: list[str], fips_mode: bool) -> list[str]:
-    is_windows_build = sys.platform == 'win32' or os.getenv("GOOS") == "windows"
-    if fips_mode:
-        tags.append("goexperiment.systemcrypto")
-    if fips_mode and not is_windows_build:
-        tags.append("requirefips")
-    return tags

--- a/tasks/cws_instrumentation.py
+++ b/tasks/cws_instrumentation.py
@@ -7,7 +7,8 @@ import shutil
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.build_tags import add_fips_tags, get_default_build_tags
+from tasks.build_tags import get_default_build_tags
+from tasks.flavor import AgentFlavor
 from tasks.libs.common.git import get_commit_sha, get_current_branch
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import (
@@ -55,8 +56,9 @@ def build(
     }
 
     ldflags += ' '.join([f"-X '{main + key}={value}'" for key, value in ld_vars.items()])
-    build_tags += get_default_build_tags(build="cws-instrumentation")
-    build_tags = add_fips_tags(build_tags, fips_mode)
+    build_tags += get_default_build_tags(
+        build="cws-instrumentation", flavor=AgentFlavor.fips if fips_mode else AgentFlavor.base
+    )
 
     if injector_only:
         build_tags.append("cws_instrumentation_injector_only")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -18,7 +18,8 @@ from invoke.tasks import task
 import tasks.libs.cws.backend_doc_gen as backend_doc_gen
 import tasks.libs.cws.secl_doc_gen as secl_doc_gen
 from tasks.agent import generate_config
-from tasks.build_tags import add_fips_tags, get_default_build_tags
+from tasks.build_tags import get_default_build_tags
+from tasks.flavor import AgentFlavor
 from tasks.go import run_golangci_lint
 from tasks.libs.build.ninja import NinjaWriter
 from tasks.libs.common.git import get_commit_sha, get_common_ancestor, get_current_branch
@@ -92,8 +93,9 @@ def build(
         )
 
     ldflags += ' '.join([f"-X '{main + key}={value}'" for key, value in ld_vars.items()])
-    build_tags += get_default_build_tags(build="security-agent")
-    build_tags = add_fips_tags(build_tags, fips_mode)
+    build_tags += get_default_build_tags(
+        build="security-agent", flavor=AgentFlavor.fips if fips_mode else AgentFlavor.base
+    )
 
     if os.path.exists(BIN_PATH):
         os.remove(BIN_PATH)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -20,7 +20,8 @@ from invoke.context import Context
 from invoke.exceptions import Exit
 from invoke.tasks import task
 
-from tasks.build_tags import UNIT_TEST_TAGS, add_fips_tags, get_default_build_tags
+from tasks.build_tags import UNIT_TEST_TAGS, get_default_build_tags
+from tasks.flavor import AgentFlavor
 from tasks.libs.build.ninja import NinjaWriter
 from tasks.libs.ciproviders.gitlab_api import ReferenceTag
 from tasks.libs.common.color import color_message
@@ -838,8 +839,9 @@ def build_sysprobe_binary(
         static=static,
     )
 
-    build_tags = get_default_build_tags(build="system-probe")
-    build_tags = add_fips_tags(build_tags, fips_mode)
+    build_tags = get_default_build_tags(
+        build="system-probe", flavor=AgentFlavor.fips if fips_mode else AgentFlavor.base
+    )
     if bundle_ebpf:
         build_tags.append(BUNDLE_TAG)
     if strip_binary:


### PR DESCRIPTION
### What does this PR do?
Update `security-agent`, `system-probe`, and `cws-instrumentation` build tasks to use `fips` flavor in order to add fips build tags, rather than adding them manually separately.

### Motivation
Unify and simplify logic.

### Describe how you validated your changes
CI.

### Additional Notes
