### PR TITLE
autoscaling: fix sync of Autoscaling values in some cases

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
@@ -10,6 +10,8 @@ package workload
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,14 +25,26 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
-	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+type valuesItem struct {
+	namespace         string
+	name              string
+	receivedTimestamp time.Time
+	receivedVersion   string
+	scalingValues     model.ScalingValues
+}
+
 type autoscalingValuesProcessor struct {
 	store *store
+	// State is kept nil until the first full config is processed
+	state map[string]valuesItem
+	// We are guaranteed to be called in a single thread for pre/process/post
+	// However, reconcile could be called in parallel
+	updateLock sync.Mutex
 
-	processed           map[string]struct{}
+	newState            map[string]valuesItem
 	lastProcessingError bool
 }
 
@@ -41,11 +55,12 @@ func newAutoscalingValuesProcessor(store *store) autoscalingValuesProcessor {
 }
 
 func (p *autoscalingValuesProcessor) preProcess() {
-	p.processed = make(map[string]struct{}, len(p.processed))
 	p.lastProcessingError = false
+	p.newState = make(map[string]valuesItem, len(p.state))
+	p.updateLock.Lock()
 }
 
-func (p *autoscalingValuesProcessor) process(receivedTimestamp time.Time, configKey string, rawConfig state.RawConfig) error {
+func (p *autoscalingValuesProcessor) processItem(receivedTimestamp time.Time, configKey string, rawConfig state.RawConfig) error {
 	valuesList := &kubeAutoscaling.WorkloadValuesList{}
 	err := json.Unmarshal(rawConfig.Config, &valuesList)
 	if err != nil {
@@ -54,9 +69,9 @@ func (p *autoscalingValuesProcessor) process(receivedTimestamp time.Time, config
 	}
 
 	for _, values := range valuesList.Values {
-		processErr := p.processValues(values, receivedTimestamp)
+		processErr := p.processValues(values, rawConfig.Metadata.Version, receivedTimestamp)
 		if processErr != nil {
-			err = multierror.Append(err, processErr)
+			err = multierror.Append(err, fmt.Errorf("received invalid Autoscaling Values from config id:%s, version: %d, config key: %s, discarding", rawConfig.Metadata.ID, rawConfig.Metadata.Version, configKey))
 		}
 	}
 
@@ -64,110 +79,91 @@ func (p *autoscalingValuesProcessor) process(receivedTimestamp time.Time, config
 	return err
 }
 
-func (p *autoscalingValuesProcessor) processValues(values *kubeAutoscaling.WorkloadValues, timestamp time.Time) error {
+func (p *autoscalingValuesProcessor) processValues(values *kubeAutoscaling.WorkloadValues, receivedVersion uint64, timestamp time.Time) error {
 	if values == nil || values.Namespace == "" || values.Name == "" {
 		// Should never happen, but protecting the code from invalid inputs
 		return nil
 	}
 
 	id := autoscaling.BuildObjectID(values.Namespace, values.Name)
-	podAutoscaler, podAutoscalerFound := p.store.LockRead(id, false)
-	// If the PodAutoscaler is not found, it must be created through the controller
-	// discarding the values received here.
-	// The store is not locked as we call LockRead with lockOnMissing = false
-	if !podAutoscalerFound {
-		return nil
-	}
-
-	// Update PodAutoscaler values with received values
-	// Even on error, the PodAutoscaler can be partially updated, always setting it
-	defer func() {
-		p.processed[id] = struct{}{}
-		p.store.UnlockSet(id, podAutoscaler, configRetrieverStoreID)
-	}()
-
-	// Ignore values if the PodAutoscaler has a custom recommender configuration
-	if podAutoscaler.CustomRecommenderConfiguration() != nil {
-		return nil
-	}
 
 	scalingValues, err := parseAutoscalingValues(timestamp, values)
 	if err != nil {
 		return fmt.Errorf("failed to parse scaling values for PodAutoscaler %s: %w", id, err)
 	}
 
-	podAutoscaler.UpdateFromMainValues(scalingValues)
-
-	// Emit telemetry for received values
-	// Target name cannot normally be empty, but we handle it just in case
-	var targetName string
-	if podAutoscaler.Spec() != nil {
-		targetName = podAutoscaler.Spec().TargetRef.Name
-	}
-
-	// Horizontal value
-	if scalingValues.Horizontal != nil {
-		telemetryHorizontalScaleReceivedRecommendations.Set(
-			float64(scalingValues.Horizontal.Replicas),
-			podAutoscaler.Namespace(),
-			targetName,
-			podAutoscaler.Name(),
-			string(scalingValues.Horizontal.Source),
-			le.JoinLeaderValue,
-		)
-	}
-
-	// Vertical values
-	if scalingValues.Vertical != nil {
-		for _, containerResources := range scalingValues.Vertical.ContainerResources {
-			for resource, value := range containerResources.Requests {
-				telemetryVerticalScaleReceivedRecommendationsRequests.Set(
-					value.AsApproximateFloat64(),
-					podAutoscaler.Namespace(),
-					targetName,
-					podAutoscaler.Name(),
-					string(scalingValues.Vertical.Source),
-					containerResources.Name,
-					string(resource),
-					le.JoinLeaderValue,
-				)
-			}
-
-			for resource, value := range containerResources.Limits {
-				telemetryVerticalScaleReceivedRecommendationsLimits.Set(
-					value.AsApproximateFloat64(),
-					podAutoscaler.Namespace(),
-					targetName,
-					podAutoscaler.Name(),
-					string(scalingValues.Vertical.Source),
-					containerResources.Name,
-					string(resource),
-					le.JoinLeaderValue,
-				)
-			}
-		}
+	// Buffer the values in newState instead of updating store directly
+	// Existence checks and custom recommender config checks will be done during reconcile
+	p.newState[id] = valuesItem{
+		namespace:         values.Namespace,
+		name:              values.Name,
+		receivedTimestamp: timestamp,
+		receivedVersion:   strconv.FormatUint(receivedVersion, 10),
+		scalingValues:     scalingValues,
 	}
 
 	return nil
 }
 
+// postProcess is used after all configs have been processed to update internal state
 func (p *autoscalingValuesProcessor) postProcess() {
-	// We don't want to delete configs if we received incorrect data
-	if p.lastProcessingError {
-		log.Debugf("Skipping autoscaling values clean up due to errors while processing new data")
+	// TODO: How to handle the case where the remote version is lower than the local version?
+	// It can happen in case of file split
+	p.state = p.newState
+	p.newState = nil
+	p.updateLock.Unlock()
+}
+
+func (p *autoscalingValuesProcessor) reconcile(isLeader bool) {
+	// We only reconcile if we are the leader and we have a state
+	if !isLeader || p.state == nil {
 		return
 	}
 
-	// Clear values for all configs that were removed
-	p.store.Update(func(podAutoscaler model.PodAutoscalerInternal) (model.PodAutoscalerInternal, bool) {
-		if _, found := p.processed[podAutoscaler.ID()]; !found {
-			log.Infof("Autoscaling not present from remote values, removing values for PodAutoscaler %s", podAutoscaler.ID())
-			podAutoscaler.RemoveMainValues()
-			return podAutoscaler, true
+	// If we cannot TryLock, it means an update is already running.
+	// It would be useless to reconcile right after as no new data would have been received
+	if !p.updateLock.TryLock() {
+		return
+	}
+	defer p.updateLock.Unlock()
+
+	// Update PodAutoscalers with buffered values
+	for paID, item := range p.state {
+		podAutoscaler, podAutoscalerFound := p.store.LockRead(paID, false)
+		// If the PodAutoscaler is not found, it must be created through the controller
+		// discarding the values received here.
+		// The store is not locked as we call LockRead with lockOnMissing = false
+		if !podAutoscalerFound {
+			continue
 		}
 
-		return podAutoscaler, false
-	}, configRetrieverStoreID)
+		// Ignore values if the PodAutoscaler has a custom recommender configuration
+		if podAutoscaler.CustomRecommenderConfiguration() != nil {
+			p.store.UnlockSet(paID, podAutoscaler, configRetrieverStoreID)
+			continue
+		}
+
+		// Update PodAutoscaler values with received values
+		podAutoscaler.UpdateFromMainValues(item.scalingValues)
+		trackPodAutoscalerReceivedValues(podAutoscaler, item.receivedVersion)
+
+		p.store.UnlockSet(paID, podAutoscaler, configRetrieverStoreID)
+	}
+
+	// Clear values for all configs that were removed (only if no error occurred while processing new data)
+	if !p.lastProcessingError {
+		p.store.Update(func(podAutoscaler model.PodAutoscalerInternal) (model.PodAutoscalerInternal, bool) {
+			if _, found := p.state[podAutoscaler.ID()]; !found {
+				log.Infof("Autoscaling not present from remote values, removing values for PodAutoscaler %s", podAutoscaler.ID())
+				podAutoscaler.RemoveMainValues()
+				return podAutoscaler, true
+			}
+
+			return podAutoscaler, false
+		}, configRetrieverStoreID)
+	} else {
+		log.Debugf("Skipping autoscaling values clean up due to errors while processing new data")
+	}
 }
 
 func parseAutoscalingValues(timestamp time.Time, values *kubeAutoscaling.WorkloadValues) (model.ScalingValues, error) {

--- a/pkg/clusteragent/autoscaling/workload/config_retriever_values_test.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_values_test.go
@@ -55,7 +55,7 @@ func TestConfigRetriverAutoscalingValuesFollower(t *testing.T) {
 		},
 	}
 
-	// New Autoscaling settings received, should do nothing
+	// New Autoscaling values received, should store values in state
 	stateCallbackCalled := 0
 	mockRCClient.triggerUpdate(
 		data.ProductContainerAutoscalingValues,
@@ -65,7 +65,7 @@ func TestConfigRetriverAutoscalingValuesFollower(t *testing.T) {
 		func(_ string, applyState state.ApplyStatus) {
 			stateCallbackCalled++
 			assert.Equal(t, applyState, state.ApplyStatus{
-				State: state.ApplyStateUnacknowledged,
+				State: state.ApplyStateAcknowledged,
 				Error: "",
 			})
 		},
@@ -462,6 +462,92 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 	}, podAutoscalers)
 }
 
+func TestConfigRetriverAutoscalingValuesReconcile(t *testing.T) {
+	testClock := clock.NewFakeClock(time.Now())
+	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
+	isLeader := false
+	isLeaderFunc := func() bool {
+		return isLeader
+	}
+
+	_, mockRCClient := newMockConfigRetriever(t, isLeaderFunc, store, testClock)
+
+	// Add a PodAutoscaler to the store
+	store.Set("ns/name1", model.FakePodAutoscalerInternal{
+		Namespace: "ns",
+		Name:      "name1",
+	}.Build(), "unittest")
+
+	// Object values
+	value1 := &kubeAutoscaling.WorkloadValues{
+		Namespace: "ns",
+		Name:      "name1",
+		Horizontal: &kubeAutoscaling.WorkloadHorizontalValues{
+			Auto: &kubeAutoscaling.WorkloadHorizontalData{
+				Replicas: pointer.Ptr[int32](3),
+			},
+		},
+	}
+
+	// New Autoscaling values received, should store values in state but not update the store
+	stateCallbackCalled := 0
+	mockRCClient.triggerUpdate(
+		data.ProductContainerAutoscalingValues,
+		map[string]state.RawConfig{
+			"foo1": buildAutoscalingValuesRawConfig(t, 1, value1),
+		},
+		func(_ string, applyState state.ApplyStatus) {
+			stateCallbackCalled++
+			assert.Equal(t, applyState, state.ApplyStatus{
+				State: state.ApplyStateAcknowledged,
+				Error: "",
+			})
+		},
+	)
+
+	// Nothing changed in the store as we are not the leader
+	assert.Equal(t, 1, stateCallbackCalled)
+	podAutoscalers := store.GetAll()
+	assert.Equal(t, 1, len(podAutoscalers))
+	// Verify the PodAutoscaler doesn't have values
+	podAutoscaler := podAutoscalers[0]
+	assert.Equal(t, model.ScalingValues{}, podAutoscaler.MainScalingValues())
+
+	// Become leader and receive values again - now they should be processed and reconciled immediately
+	isLeader = true
+	callbackTimestamp := testClock.Now()
+	stateCallbackCalled = 0
+	mockRCClient.triggerUpdate(
+		data.ProductContainerAutoscalingValues,
+		map[string]state.RawConfig{
+			"foo1": buildAutoscalingValuesRawConfig(t, 2, value1),
+		},
+		func(_ string, applyState state.ApplyStatus) {
+			stateCallbackCalled++
+			assert.Equal(t, applyState, state.ApplyStatus{
+				State: state.ApplyStateAcknowledged,
+				Error: "",
+			})
+		},
+	)
+
+	assert.Equal(t, 1, stateCallbackCalled)
+	podAutoscalers = store.GetAll()
+	model.AssertPodAutoscalersEqual(t, []model.FakePodAutoscalerInternal{
+		{
+			Namespace: "ns",
+			Name:      "name1",
+			MainScalingValues: model.ScalingValues{
+				Horizontal: &model.HorizontalScalingValues{
+					Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+					Replicas:  3,
+					Timestamp: callbackTimestamp,
+				},
+			},
+		},
+	}, podAutoscalers)
+}
+
 func buildAutoscalingValuesRawConfig(t *testing.T, version uint64, values ...*kubeAutoscaling.WorkloadValues) state.RawConfig {
 	t.Helper()
 
@@ -472,5 +558,5 @@ func buildAutoscalingValuesRawConfig(t *testing.T, version uint64, values ...*ku
 	content, err := json.Marshal(valuesList)
 	assert.NoError(t, err)
 
-	return buildRawConfig(t, data.ProductContainerAutoscalingSettings, version, content)
+	return buildRawConfig(t, data.ProductContainerAutoscalingValues, version, content)
 }

--- a/pkg/clusteragent/autoscaling/workload/telemetry.go
+++ b/pkg/clusteragent/autoscaling/workload/telemetry.go
@@ -45,7 +45,7 @@ var (
 	telemetryHorizontalScaleReceivedRecommendations = telemetry.NewGaugeWithOpts(
 		subsystem,
 		"horizontal_scaling_received_replicas",
-		[]string{"namespace", "target_name", "autoscaler_name", "source", le.JoinLeaderLabel},
+		[]string{"namespace", "target_name", "autoscaler_name", "source", "version", le.JoinLeaderLabel},
 		"Tracks the value of replicas applied by the horizontal scaling recommendation",
 		commonOpts,
 	)
@@ -66,20 +66,20 @@ var (
 		"Tracks the number of patch requests sent by the patcher to the kubernetes api server",
 		commonOpts,
 	)
-	// telemetryVerticalScaleReceivedRecommendationsLimits tracks the vertical scaling recommendation limits received
-	telemetryVerticalScaleReceivedRecommendationsLimits = telemetry.NewGaugeWithOpts(
-		subsystem,
-		"vertical_scaling_received_limits",
-		[]string{"namespace", "target_name", "autoscaler_name", "source", "container_name", "resource_name", le.JoinLeaderLabel},
-		"Tracks the value of limits received by the vertical scaling controller",
-		commonOpts,
-	)
 	// telemetryVerticalScaleReceivedRecommendationsRequests tracks the vertical scaling recommendation requests received
 	telemetryVerticalScaleReceivedRecommendationsRequests = telemetry.NewGaugeWithOpts(
 		subsystem,
 		"vertical_scaling_received_requests",
-		[]string{"namespace", "target_name", "autoscaler_name", "source", "container_name", "resource_name", le.JoinLeaderLabel},
+		[]string{"namespace", "target_name", "autoscaler_name", "source", "version", "container_name", "resource_name", le.JoinLeaderLabel},
 		"Tracks the value of requests received by the vertical scaling recommendation",
+		commonOpts,
+	)
+	// telemetryVerticalScaleReceivedRecommendationsLimits tracks the vertical scaling recommendation limits received
+	telemetryVerticalScaleReceivedRecommendationsLimits = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"vertical_scaling_received_limits",
+		[]string{"namespace", "target_name", "autoscaler_name", "source", "version", "container_name", "resource_name", le.JoinLeaderLabel},
+		"Tracks the value of limits received by the vertical scaling controller",
 		commonOpts,
 	)
 
@@ -110,6 +110,63 @@ var (
 		autoscalingStatusConditions,
 	}
 )
+
+func trackPodAutoscalerReceivedValues(podAutoscaler model.PodAutoscalerInternal, version string) {
+	// Emit telemetry for received values
+	// Target name cannot normally be empty, but we handle it just in case
+	var targetName string
+	if podAutoscaler.Spec() != nil {
+		targetName = podAutoscaler.Spec().TargetRef.Name
+	}
+
+	scalingValues := podAutoscaler.MainScalingValues()
+
+	// Horizontal value
+	if podAutoscaler.MainScalingValues().Horizontal != nil {
+		telemetryHorizontalScaleReceivedRecommendations.Set(
+			float64(scalingValues.Horizontal.Replicas),
+			podAutoscaler.Namespace(),
+			targetName,
+			podAutoscaler.Name(),
+			string(scalingValues.Horizontal.Source),
+			version,
+			le.JoinLeaderValue,
+		)
+	}
+
+	// Vertical values
+	if scalingValues.Vertical != nil {
+		for _, containerResources := range scalingValues.Vertical.ContainerResources {
+			for resource, value := range containerResources.Requests {
+				telemetryVerticalScaleReceivedRecommendationsRequests.Set(
+					value.AsApproximateFloat64(),
+					podAutoscaler.Namespace(),
+					targetName,
+					podAutoscaler.Name(),
+					string(scalingValues.Vertical.Source),
+					containerResources.Name,
+					string(resource),
+					version,
+					le.JoinLeaderValue,
+				)
+			}
+
+			for resource, value := range containerResources.Limits {
+				telemetryVerticalScaleReceivedRecommendationsLimits.Set(
+					value.AsApproximateFloat64(),
+					podAutoscaler.Namespace(),
+					targetName,
+					podAutoscaler.Name(),
+					string(scalingValues.Vertical.Source),
+					containerResources.Name,
+					string(resource),
+					version,
+					le.JoinLeaderValue,
+				)
+			}
+		}
+	}
+}
 
 func trackPodAutoscalerStatus(podAutoscaler *datadoghq.DatadogPodAutoscaler) {
 	for _, condition := range podAutoscaler.Status.Conditions {


### PR DESCRIPTION
### What does this PR do?

Also buffer the values from remote config to make sure they are apply as soon as possible on some edge cases (all vertical autoscalers, race with leader election, etc.)

### Motivation

Fix delays observed when starting autoscaling

### Describe how you validated your changes

Non regression testing as testing the case itself is difficult but can be done with a small that explicitly slows down leader election.

### Additional Notes
