### PR TITLE
AGTMETRICS-385 Move domain versioning into GetMultipleEndpoints

### DIFF
--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -148,10 +148,17 @@ func getObsPipelineURLForPrefix(log log.Component, datatype string, prefix strin
 	return "", nil
 }
 
-// NewOptions creates new Options with default values
+// NewOptions creates a configuration for the forwarder with OPW enabled.
+//
+// Deprecated, use NewOptionsWithOPW instead.
 func NewOptions(config config.Component, log log.Component, keysPerDomain map[string][]utils.APIKeys) (*Options, error) {
 
-	resolvers, err := pkgresolver.NewSingleDomainResolvers(keysPerDomain)
+	return NewOptionsWithOPW(config, log, utils.EndpointDescriptorSetFromKeysPerDomain(keysPerDomain))
+}
+
+// NewOptionsWithOPW creates a configuration for the forwarder with OPW enabled.
+func NewOptionsWithOPW(config config.Component, log log.Component, eds utils.EndpointDescriptorSet) (*Options, error) {
+	resolvers, err := pkgresolver.NewSingleDomainResolvers2(eds)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -343,10 +343,8 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 	domainForwarderSort := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}
 	transactionContainerSort := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: false}
 
-	for domain, resolver := range options.DomainResolvers {
-		domain, _ := utils.AddAgentVersionToDomain(domain, "app")
-		resolver.SetBaseDomain(domain)
-
+	for _, resolver := range options.DomainResolvers {
+		domain := resolver.GetBaseDomain()
 		if !resolver.IsUsable() {
 			log.Errorf("No API keys for domain '%s', dropping domain ", domain)
 		} else {
@@ -377,7 +375,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 			fwd := newDomainForwarder(
 				config,
 				log,
-				domain,
+				resolver.GetBaseDomain(),
 				resolver.IsMRF(),
 				resolver.IsLocal(),
 				transactionContainer,

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -344,19 +344,6 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 	transactionContainerSort := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: false}
 
 	for domain, resolver := range options.DomainResolvers {
-		isMRF := false
-		if config.GetBool("multi_region_failover.enabled") {
-			log.Infof("MRF is enabled, checking site: %v ", domain)
-			siteURL, err := utils.GetMRFInfraEndpoint(config)
-			if err != nil {
-				log.Error("Error building MRF infra endpoint: ", err)
-			}
-			if domain == siteURL {
-				log.Infof("MRF domain '%s', configured ", domain)
-				isMRF = true
-			}
-
-		}
 		domain, _ := utils.AddAgentVersionToDomain(domain, "app")
 		resolver.SetBaseDomain(domain)
 
@@ -391,7 +378,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 				config,
 				log,
 				domain,
-				isMRF,
+				resolver.IsMRF(),
 				resolver.IsLocal(),
 				transactionContainer,
 				numberOfWorkers,

--- a/comp/forwarder/defaultforwarder/forwarder.go
+++ b/comp/forwarder/defaultforwarder/forwarder.go
@@ -46,20 +46,20 @@ func newForwarder(dep dependencies) (provides, error) {
 
 func createOptions(params Params, config config.Component, log log.Component) (*Options, error) {
 	var options *Options
-	keysPerDomain, err := utils.GetMultipleEndpoints(config)
+	endpoints, err := utils.GetMultipleEndpoints(config)
 	if err != nil {
 		log.Error("Misconfiguration of agent endpoints: ", err)
 		return nil, fmt.Errorf("Misconfiguration of agent endpoints: %s", err)
 	}
 
 	if !params.withResolver {
-		options, err = NewOptions(config, log, keysPerDomain)
+		options, err = NewOptionsWithOPW(config, log, endpoints)
 		if err != nil {
 			log.Error("Error creating forwarder options: ", err)
 			return nil, fmt.Errorf("Error creating forwarder options: %s", err)
 		}
 	} else {
-		r, err := resolver.NewSingleDomainResolvers(keysPerDomain)
+		r, err := resolver.NewSingleDomainResolvers2(endpoints)
 		if err != nil {
 			log.Error("Error creating resolver: ", err)
 			return nil, fmt.Errorf("Error creating resolver: %s", err)

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -172,10 +172,15 @@ func NewSingleDomainResolver(domain string, apiKeys []utils.APIKeys) (DomainReso
 
 // NewSingleDomainResolvers converts a map of domain/api keys into a map of SingleDomainResolver
 func NewSingleDomainResolvers(keysPerDomain map[string][]utils.APIKeys) (map[string]DomainResolver, error) {
+	return NewSingleDomainResolvers2(utils.EndpointDescriptorSetFromKeysPerDomain(keysPerDomain))
+}
+
+// NewSingleDomainResolvers2 creates a set of domain resolvers from an EndpointDescriptorSet.
+func NewSingleDomainResolvers2(eds utils.EndpointDescriptorSet) (map[string]DomainResolver, error) {
 	resolvers := make(map[string]DomainResolver)
-	for domain, keys := range keysPerDomain {
+	for _, ed := range eds {
 		var err error
-		resolvers[domain], err = NewSingleDomainResolver(domain, keys)
+		resolvers[ed.BaseURL], err = NewSingleDomainResolver(ed.BaseURL, ed.APIKeys)
 		if err != nil {
 			return nil, err
 		}

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -153,24 +153,24 @@ func updateAdditionalEndpoints(resolver DomainResolver, setting string, config c
 
 // NewSingleDomainResolver creates a DomainResolver with its destination domain & API keys
 func NewSingleDomainResolver(domain string, apiKeys []utils.APIKeys) (DomainResolver, error) {
-	return NewSingleDomainResolver2(utils.EndpointDescriptor{BaseURL: domain, APIKeys: apiKeys})
+	return NewSingleDomainResolver2(utils.EndpointDescriptor{BaseURL: domain, APIKeySet: apiKeys})
 }
 
 // NewSingleDomainResolver2 creates a DomainResolver from an endpoint configuration object.
 func NewSingleDomainResolver2(descriptor utils.EndpointDescriptor) (DomainResolver, error) {
 	// Ensure all API keys have a config setting path so we can keep track to ensure they are updated
 	// when the config changes.
-	for _, keys := range descriptor.APIKeys {
+	for _, keys := range descriptor.APIKeySet {
 		if keys.ConfigSettingPath == "" {
 			return nil, fmt.Errorf("API key for %v does not specify a config setting path", descriptor.BaseURL)
 		}
 	}
 
-	deduped := utils.DedupAPIKeys(descriptor.APIKeys)
+	deduped := utils.DedupAPIKeys(descriptor.APIKeySet)
 
 	return &domainResolver{
 		domain:         descriptor.BaseURL,
-		apiKeys:        descriptor.APIKeys,
+		apiKeys:        descriptor.APIKeySet,
 		keyVersion:     0,
 		dedupedAPIKeys: deduped,
 		mu:             sync.Mutex{},

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -186,9 +186,9 @@ func NewSingleDomainResolvers(keysPerDomain map[string][]utils.APIKeys) (map[str
 // NewSingleDomainResolvers2 creates a set of domain resolvers from an EndpointDescriptorSet.
 func NewSingleDomainResolvers2(eds utils.EndpointDescriptorSet) (map[string]DomainResolver, error) {
 	resolvers := make(map[string]DomainResolver)
-	for _, ed := range eds {
+	for domain, ed := range eds {
 		var err error
-		resolvers[ed.BaseURL], err = NewSingleDomainResolver2(ed)
+		resolvers[domain], err = NewSingleDomainResolver2(ed)
 		if err != nil {
 			return nil, err
 		}
@@ -244,11 +244,6 @@ func (r *domainResolver) GetAPIKeysInfo() ([]utils.APIKeys, int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.apiKeys, r.keyVersion
-}
-
-// SetBaseDomain sets the only destination available for a SingleDomainResolver
-func (r *domainResolver) SetBaseDomain(domain string) {
-	r.domain = domain
 }
 
 // UpdateAPIKeys updates the api keys at the given config path and sets the deduped keys to the new list.
@@ -355,6 +350,10 @@ func (r *domainResolver) GetAlternateDomains() []string {
 // The resolver will match transaction.Endpoint.Name against forwarderName to check if the request shall
 // be diverted.
 func (r *domainResolver) RegisterAlternateDestination(domain string, forwarderName string, dType DestinationType) {
+	if r.overrides == nil {
+		r.overrides = map[string]destination{}
+	}
+
 	d := destination{
 		domain: domain,
 		dType:  dType,

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -178,7 +178,7 @@ func NewSingleDomainResolver2(descriptor utils.EndpointDescriptor) (DomainResolv
 	}, nil
 }
 
-// NewSingleDomainResolvers converts a map of domain/api keys into a map of SingleDomainResolver
+// NewSingleDomainResolvers converts a map of domain/api keys into a map of DomainResolver
 func NewSingleDomainResolvers(keysPerDomain map[string][]utils.APIKeys) (map[string]DomainResolver, error) {
 	return NewSingleDomainResolvers2(utils.EndpointDescriptorSetFromKeysPerDomain(keysPerDomain))
 }

--- a/comp/forwarder/defaultforwarder/sync_forwarder.go
+++ b/comp/forwarder/defaultforwarder/sync_forwarder.go
@@ -28,8 +28,8 @@ type SyncForwarder struct {
 }
 
 // NewSyncForwarder returns a new synchronous forwarder.
-func NewSyncForwarder(config config.Component, log log.Component, keysPerDomain utils.EndpointDescriptorSet, timeout time.Duration) (*SyncForwarder, error) {
-	options, err := NewOptionsWithOPW(config, log, keysPerDomain)
+func NewSyncForwarder(config config.Component, log log.Component, endpoints utils.EndpointDescriptorSet, timeout time.Duration) (*SyncForwarder, error) {
+	options, err := NewOptionsWithOPW(config, log, endpoints)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/forwarder/defaultforwarder/sync_forwarder.go
+++ b/comp/forwarder/defaultforwarder/sync_forwarder.go
@@ -28,8 +28,8 @@ type SyncForwarder struct {
 }
 
 // NewSyncForwarder returns a new synchronous forwarder.
-func NewSyncForwarder(config config.Component, log log.Component, keysPerDomain map[string][]utils.APIKeys, timeout time.Duration) (*SyncForwarder, error) {
-	options, err := NewOptions(config, log, keysPerDomain)
+func NewSyncForwarder(config config.Component, log log.Component, keysPerDomain utils.EndpointDescriptorSet, timeout time.Duration) (*SyncForwarder, error) {
+	options, err := NewOptionsWithOPW(config, log, keysPerDomain)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -50,10 +50,10 @@ type ServerlessDemultiplexer struct {
 }
 
 // InitAndStartServerlessDemultiplexer creates and starts new Demultiplexer for the serverless agent.
-func InitAndStartServerlessDemultiplexer(keysPerDomain utils.EndpointDescriptorSet, forwarderTimeout time.Duration, tagger tagger.Component, shouldForceFlushAllOnForceFlushToSerializer bool) (*ServerlessDemultiplexer, error) {
+func InitAndStartServerlessDemultiplexer(endpoints utils.EndpointDescriptorSet, forwarderTimeout time.Duration, tagger tagger.Component, shouldForceFlushAllOnForceFlushToSerializer bool) (*ServerlessDemultiplexer, error) {
 	bufferSize := pkgconfigsetup.Datadog().GetInt("aggregator_buffer_size")
 	logger := logimpl.NewTemporaryLoggerWithoutInit()
-	forwarder, err := forwarder.NewSyncForwarder(pkgconfigsetup.Datadog(), logger, keysPerDomain, forwarderTimeout)
+	forwarder, err := forwarder.NewSyncForwarder(pkgconfigsetup.Datadog(), logger, endpoints, forwarderTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -50,7 +50,7 @@ type ServerlessDemultiplexer struct {
 }
 
 // InitAndStartServerlessDemultiplexer creates and starts new Demultiplexer for the serverless agent.
-func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]utils.APIKeys, forwarderTimeout time.Duration, tagger tagger.Component, shouldForceFlushAllOnForceFlushToSerializer bool) (*ServerlessDemultiplexer, error) {
+func InitAndStartServerlessDemultiplexer(keysPerDomain utils.EndpointDescriptorSet, forwarderTimeout time.Duration, tagger tagger.Component, shouldForceFlushAllOnForceFlushToSerializer bool) (*ServerlessDemultiplexer, error) {
 	bufferSize := pkgconfigsetup.Datadog().GetInt("aggregator_buffer_size")
 	logger := logimpl.NewTemporaryLoggerWithoutInit()
 	forwarder, err := forwarder.NewSyncForwarder(pkgconfigsetup.Datadog(), logger, keysPerDomain, forwarderTimeout)

--- a/pkg/config/utils/endpoints.go
+++ b/pkg/config/utils/endpoints.go
@@ -173,8 +173,8 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (EndpointDescriptorSet, error
 			return nil, fmt.Errorf("could not parse url from 'additional_endpoints' %s: %s", domain, err)
 		}
 
-		if _, ok := keysPerDomain[domain]; ok {
-			keysPerDomain[domain] = append(keysPerDomain[domain], apiKeys...)
+		if oldAPIKeys, ok := keysPerDomain[domain]; ok {
+			keysPerDomain[domain] = append(oldAPIKeys, apiKeys...)
 		} else {
 			keysPerDomain[domain] = apiKeys
 		}

--- a/pkg/config/utils/endpoints.go
+++ b/pkg/config/utils/endpoints.go
@@ -126,6 +126,7 @@ func DedupAPIKeys(endpoints []APIKeys) []string {
 type EndpointDescriptor struct {
 	BaseURL string
 	APIKeys []APIKeys
+	IsMRF   bool
 }
 
 func newEndpointDescriptor(baseURL, configKey string, apiKeys ...string) EndpointDescriptor {
@@ -190,6 +191,7 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (EndpointDescriptorSet, error
 		eds[haURL] = EndpointDescriptor{
 			BaseURL: haURL,
 			APIKeys: newAPIKeyset("multi_region_failover.api_key", c.GetString("multi_region_failover.api_key")),
+			IsMRF:   true,
 		}
 	}
 

--- a/pkg/config/utils/endpoints.go
+++ b/pkg/config/utils/endpoints.go
@@ -124,14 +124,14 @@ func DedupAPIKeys(endpoints []APIKeys) []string {
 
 // EndpointDescriptor holds configuration about a single endpoint (aka domain) for infra pipelines.
 type EndpointDescriptor struct {
-	BaseURL    string
-	APIKeySet  []APIKeys
-	IsMRF      bool
+	BaseURL   string
+	APIKeySet []APIKeys
+	IsMRF     bool
 }
 
 func newEndpointDescriptor(baseURL string, apiKeySet []APIKeys) EndpointDescriptor {
 	return EndpointDescriptor{
-		BaseURL: baseURL,
+		BaseURL:   baseURL,
 		APIKeySet: apiKeySet,
 	}
 }

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -24,13 +24,10 @@ func TestSecretBackendWithMultipleEndpoints(t *testing.T) {
 	conf := mock.NewFromFile(t, "./tests/datadog_secrets.yaml")
 
 	expectedKeysPerDomain := EndpointDescriptorSet{
-		"https://app.datadoghq.com.": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com.",
-			APIKeys: []APIKeys{
-				NewAPIKeys("api_key", "someapikey"),
-				NewAPIKeys("additional_endpoints", "someotherapikey"),
-			},
-		},
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", []APIKeys{
+			NewAPIKeys("api_key", "someapikey"),
+			NewAPIKeys("additional_endpoints", "someotherapikey"),
+		}),
 	}
 	keysPerDomain, err := GetMultipleEndpoints(conf)
 	assert.NoError(t, err)
@@ -54,14 +51,11 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
-		"https://app.datadoghq.com.": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com.",
-			APIKeys: []APIKeys{
-				NewAPIKeys("api_key", "fakeapikey"),
-				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
-			},
-		},
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", []APIKeys{
+			NewAPIKeys("api_key", "fakeapikey"),
+			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
+		}),
 	}
 
 	assert.NoError(t, err)
@@ -86,14 +80,11 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey"),
-		"https://app.datadoghq.com": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com",
-			APIKeys: []APIKeys{
-				NewAPIKeys("api_key", "fakeapikey"),
-				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
-			},
-		},
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
+			NewAPIKeys("api_key", "fakeapikey"),
+			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
+		}),
 	}
 
 	assert.NoError(t, err)
@@ -109,8 +100,8 @@ func TestGetMultipleEndpointsEnvVar(t *testing.T) {
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "api_key", "fakeapikey"),
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -135,9 +126,9 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu.":  newEndpointDescriptor("https://app.datadoghq.eu.", "api_key", "fakeapikey"),
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "additional_endpoints", "fakeapikey2", "fakeapikey3"),
+		"https://app.datadoghq.eu.":  newEndpointDescriptor("https://app.datadoghq.eu.", newAPIKeyset("api_key", "fakeapikey")),
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("additional_endpoints", "fakeapikey2", "fakeapikey3")),
 	}
 
 	assert.NoError(t, err)
@@ -155,7 +146,7 @@ api_key: fakeapikey
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", "api_key", "fakeapikey"),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -181,13 +172,11 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com",
-			APIKeys: []APIKeys{
-				NewAPIKeys("api_key", "fakeapikey"),
-				NewAPIKeys("additional_endpoints", "fakeapikey2"),
-			}},
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey"),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
+			NewAPIKeys("api_key", "fakeapikey"),
+			NewAPIKeys("additional_endpoints", "fakeapikey2"),
+		}),
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -214,14 +203,11 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com",
-			APIKeys: []APIKeys{
-				NewAPIKeys("api_key", "fakeapikey"),
-				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey"),
-			},
-		},
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey", "someotherapikey", "someapikey"),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
+			NewAPIKeys("api_key", "fakeapikey"),
+			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey"),
+		}),
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey", "someotherapikey", "someapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -253,7 +239,7 @@ func TestSiteEnvVar(t *testing.T) {
 			externalAgentURL := GetMainEndpoint(testConfig, tc.prefix, "external_config.external_agent_dd_url")
 
 			expectedMultipleEndpoints := EndpointDescriptorSet{
-				tc.expectedSiteURL: newEndpointDescriptor(tc.expectedSiteURL, "api_key", "fakeapikey"),
+				tc.expectedSiteURL: newEndpointDescriptor(tc.expectedSiteURL, newAPIKeyset("api_key", "fakeapikey")),
 			}
 
 			assert.NoError(t, err)
@@ -274,7 +260,7 @@ api_key: fakeapikey
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "api_key", "fakeapikey"),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -321,7 +307,7 @@ convert_dd_site_fqdn.enabled: false
 			externalAgentURL := GetMainEndpoint(testConfig, tc.externalPrefix, tc.externalConfig)
 
 			expectedMultipleEndpoints := EndpointDescriptorSet{
-				tc.expectedSite: newEndpointDescriptor(tc.expectedSite, "api_key", "fakeapikey"),
+				tc.expectedSite: newEndpointDescriptor(tc.expectedSite, newAPIKeyset("api_key", "fakeapikey")),
 			}
 
 			assert.NoError(t, err)
@@ -343,7 +329,7 @@ func TestDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -363,7 +349,7 @@ func TestDDDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -387,7 +373,7 @@ func TestDDURLAndDDDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.dd_dd_url.eu": newEndpointDescriptor("https://app.datadoghq.dd_dd_url.eu", "api_key", "fakeapikey"),
+		"https://app.datadoghq.dd_dd_url.eu": newEndpointDescriptor("https://app.datadoghq.dd_dd_url.eu", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -410,7 +396,7 @@ external_config:
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", "api_key", "fakeapikey"),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -432,7 +418,7 @@ external_config:
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -23,10 +23,13 @@ import (
 func TestSecretBackendWithMultipleEndpoints(t *testing.T) {
 	conf := mock.NewFromFile(t, "./tests/datadog_secrets.yaml")
 
-	expectedKeysPerDomain := map[string][]APIKeys{
-		"https://app.datadoghq.com.": {
-			NewAPIKeys("api_key", "someapikey"),
-			NewAPIKeys("additional_endpoints", "someotherapikey"),
+	expectedKeysPerDomain := EndpointDescriptorSet{
+		"https://app.datadoghq.com.": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com.",
+			APIKeys: []APIKeys{
+				NewAPIKeys("api_key", "someapikey"),
+				NewAPIKeys("additional_endpoints", "someotherapikey"),
+			},
 		},
 	}
 	keysPerDomain, err := GetMultipleEndpoints(conf)
@@ -50,13 +53,14 @@ additional_endpoints:
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://foo.datadoghq.com.": {
-			NewAPIKeys("additional_endpoints", "someapikey"),
-		},
-		"https://app.datadoghq.com.": {
-			NewAPIKeys("api_key", "fakeapikey"),
-			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
+		"https://app.datadoghq.com.": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com.",
+			APIKeys: []APIKeys{
+				NewAPIKeys("api_key", "fakeapikey"),
+				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
+			},
 		},
 	}
 
@@ -81,13 +85,14 @@ additional_endpoints:
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://foo.datadoghq.com": {
-			NewAPIKeys("additional_endpoints", "someapikey"),
-		},
-		"https://app.datadoghq.com": {
-			NewAPIKeys("api_key", "fakeapikey"),
-			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey"),
+		"https://app.datadoghq.com": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com",
+			APIKeys: []APIKeys{
+				NewAPIKeys("api_key", "fakeapikey"),
+				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
+			},
 		},
 	}
 
@@ -103,13 +108,9 @@ func TestGetMultipleEndpointsEnvVar(t *testing.T) {
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://foo.datadoghq.com.": {
-			NewAPIKeys("additional_endpoints", "someapikey"),
-		},
-		"https://app.datadoghq.com.": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "api_key", "fakeapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -133,16 +134,10 @@ additional_endpoints:
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.eu.": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
-		"https://foo.datadoghq.com.": {
-			NewAPIKeys("additional_endpoints", "someapikey"),
-		},
-		"https://app.datadoghq.com.": {
-			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.eu.":  newEndpointDescriptor("https://app.datadoghq.eu.", "api_key", "fakeapikey"),
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "additional_endpoints", "fakeapikey2", "fakeapikey3"),
 	}
 
 	assert.NoError(t, err)
@@ -159,10 +154,8 @@ api_key: fakeapikey
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.com": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", "api_key", "fakeapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -187,14 +180,14 @@ additional_endpoints:
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.com": {
-			NewAPIKeys("api_key", "fakeapikey"),
-			NewAPIKeys("additional_endpoints", "fakeapikey2"),
-		},
-		"https://foo.datadoghq.com": {
-			NewAPIKeys("additional_endpoints", "someapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.com": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com",
+			APIKeys: []APIKeys{
+				NewAPIKeys("api_key", "fakeapikey"),
+				NewAPIKeys("additional_endpoints", "fakeapikey2"),
+			}},
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -220,14 +213,15 @@ additional_endpoints:
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.com": {
-			NewAPIKeys("api_key", "fakeapikey"),
-			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey"),
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.com": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com",
+			APIKeys: []APIKeys{
+				NewAPIKeys("api_key", "fakeapikey"),
+				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey"),
+			},
 		},
-		"https://foo.datadoghq.com": {
-			NewAPIKeys("additional_endpoints", "someapikey", "someotherapikey", "someapikey"),
-		},
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey", "someotherapikey", "someapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -258,10 +252,8 @@ func TestSiteEnvVar(t *testing.T) {
 			multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 			externalAgentURL := GetMainEndpoint(testConfig, tc.prefix, "external_config.external_agent_dd_url")
 
-			expectedMultipleEndpoints := map[string][]APIKeys{
-				tc.expectedSiteURL: {
-					NewAPIKeys("api_key", "fakeapikey"),
-				},
+			expectedMultipleEndpoints := EndpointDescriptorSet{
+				tc.expectedSiteURL: newEndpointDescriptor(tc.expectedSiteURL, "api_key", "fakeapikey"),
 			}
 
 			assert.NoError(t, err)
@@ -281,10 +273,8 @@ api_key: fakeapikey
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.com.": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "api_key", "fakeapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -330,10 +320,8 @@ convert_dd_site_fqdn.enabled: false
 			multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 			externalAgentURL := GetMainEndpoint(testConfig, tc.externalPrefix, tc.externalConfig)
 
-			expectedMultipleEndpoints := map[string][]APIKeys{
-				tc.expectedSite: {
-					NewAPIKeys("api_key", "fakeapikey"),
-				},
+			expectedMultipleEndpoints := EndpointDescriptorSet{
+				tc.expectedSite: newEndpointDescriptor(tc.expectedSite, "api_key", "fakeapikey"),
 			}
 
 			assert.NoError(t, err)
@@ -354,10 +342,8 @@ func TestDDURLEnvVar(t *testing.T) {
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.eu": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -376,10 +362,8 @@ func TestDDDDURLEnvVar(t *testing.T) {
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.eu": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -402,10 +386,8 @@ func TestDDURLAndDDDDURLEnvVar(t *testing.T) {
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.dd_dd_url.eu": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.dd_dd_url.eu": newEndpointDescriptor("https://app.datadoghq.dd_dd_url.eu", "api_key", "fakeapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -427,10 +409,8 @@ external_config:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.com": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", "api_key", "fakeapikey"),
 	}
 
 	assert.NoError(t, err)
@@ -451,10 +431,8 @@ external_config:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
-	expectedMultipleEndpoints := map[string][]APIKeys{
-		"https://app.datadoghq.eu": {
-			NewAPIKeys("api_key", "fakeapikey"),
-		},
+	expectedMultipleEndpoints := EndpointDescriptorSet{
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
 	}
 
 	assert.NoError(t, err)

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -205,9 +205,9 @@ additional_endpoints:
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
 		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
-				NewAPIKeys("api_key", "fakeapikey"),
-				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey"),
-			}),
+			NewAPIKeys("api_key", "fakeapikey"),
+			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey"),
+		}),
 		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey", "someotherapikey", "someapikey")),
 	}
 

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -24,13 +24,11 @@ func TestSecretBackendWithMultipleEndpoints(t *testing.T) {
 	conf := mock.NewFromFile(t, "./tests/datadog_secrets.yaml")
 
 	expectedKeysPerDomain := EndpointDescriptorSet{
-		"https://app.datadoghq.com.": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com.",
-			APIKeys: []APIKeys{
+		"https://app.datadoghq.com.": newEndpointDescriptor(
+			"https://app.datadoghq.com.", []APIKeys{
 				NewAPIKeys("api_key", "someapikey"),
 				NewAPIKeys("additional_endpoints", "someotherapikey"),
-			},
-		},
+			}),
 	}
 	keysPerDomain, err := GetMultipleEndpoints(conf)
 	assert.NoError(t, err)
@@ -54,14 +52,11 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
-		"https://app.datadoghq.com.": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com.",
-			APIKeys: []APIKeys{
-				NewAPIKeys("api_key", "fakeapikey"),
-				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
-			},
-		},
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", []APIKeys{
+			NewAPIKeys("api_key", "fakeapikey"),
+			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
+		}),
 	}
 
 	assert.NoError(t, err)
@@ -86,14 +81,11 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey"),
-		"https://app.datadoghq.com": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com",
-			APIKeys: []APIKeys{
-				NewAPIKeys("api_key", "fakeapikey"),
-				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
-			},
-		},
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
+			NewAPIKeys("api_key", "fakeapikey"),
+			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
+		}),
 	}
 
 	assert.NoError(t, err)
@@ -109,8 +101,8 @@ func TestGetMultipleEndpointsEnvVar(t *testing.T) {
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "api_key", "fakeapikey"),
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -135,9 +127,9 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu.":  newEndpointDescriptor("https://app.datadoghq.eu.", "api_key", "fakeapikey"),
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", "additional_endpoints", "someapikey"),
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "additional_endpoints", "fakeapikey2", "fakeapikey3"),
+		"https://app.datadoghq.eu.":  newEndpointDescriptor("https://app.datadoghq.eu.", newAPIKeyset("api_key", "fakeapikey")),
+		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("additional_endpoints", "fakeapikey2", "fakeapikey3")),
 	}
 
 	assert.NoError(t, err)
@@ -155,7 +147,7 @@ api_key: fakeapikey
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", "api_key", "fakeapikey"),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -181,13 +173,11 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com",
-			APIKeys: []APIKeys{
-				NewAPIKeys("api_key", "fakeapikey"),
-				NewAPIKeys("additional_endpoints", "fakeapikey2"),
-			}},
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey"),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
+			NewAPIKeys("api_key", "fakeapikey"),
+			NewAPIKeys("additional_endpoints", "fakeapikey2"),
+		}),
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -214,14 +204,11 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": EndpointDescriptor{
-			BaseURL: "https://app.datadoghq.com",
-			APIKeys: []APIKeys{
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
 				NewAPIKeys("api_key", "fakeapikey"),
 				NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey"),
-			},
-		},
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", "additional_endpoints", "someapikey", "someotherapikey", "someapikey"),
+			}),
+		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey", "someotherapikey", "someapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -253,7 +240,7 @@ func TestSiteEnvVar(t *testing.T) {
 			externalAgentURL := GetMainEndpoint(testConfig, tc.prefix, "external_config.external_agent_dd_url")
 
 			expectedMultipleEndpoints := EndpointDescriptorSet{
-				tc.expectedSiteURL: newEndpointDescriptor(tc.expectedSiteURL, "api_key", "fakeapikey"),
+				tc.expectedSiteURL: newEndpointDescriptor(tc.expectedSiteURL, newAPIKeyset("api_key", "fakeapikey")),
 			}
 
 			assert.NoError(t, err)
@@ -274,7 +261,7 @@ api_key: fakeapikey
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", "api_key", "fakeapikey"),
+		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -321,7 +308,7 @@ convert_dd_site_fqdn.enabled: false
 			externalAgentURL := GetMainEndpoint(testConfig, tc.externalPrefix, tc.externalConfig)
 
 			expectedMultipleEndpoints := EndpointDescriptorSet{
-				tc.expectedSite: newEndpointDescriptor(tc.expectedSite, "api_key", "fakeapikey"),
+				tc.expectedSite: newEndpointDescriptor(tc.expectedSite, newAPIKeyset("api_key", "fakeapikey")),
 			}
 
 			assert.NoError(t, err)
@@ -343,7 +330,7 @@ func TestDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -363,7 +350,7 @@ func TestDDDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -387,7 +374,7 @@ func TestDDURLAndDDDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.dd_dd_url.eu": newEndpointDescriptor("https://app.datadoghq.dd_dd_url.eu", "api_key", "fakeapikey"),
+		"https://app.datadoghq.dd_dd_url.eu": newEndpointDescriptor("https://app.datadoghq.dd_dd_url.eu", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -410,7 +397,7 @@ external_config:
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", "api_key", "fakeapikey"),
+		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)
@@ -432,7 +419,7 @@ external_config:
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", "api_key", "fakeapikey"),
+		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
 	}
 
 	assert.NoError(t, err)

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -85,7 +85,7 @@ func Diagnose(diagCfg diagnose.Config, log log.Component) []diagnose.Diagnosis {
 	}
 
 	var diagnoses []diagnose.Diagnosis
-	domainResolvers, err := resolver.NewSingleDomainResolvers(keysPerDomain)
+	domainResolvers, err := resolver.NewSingleDomainResolvers2(keysPerDomain)
 	if err != nil {
 		return []diagnose.Diagnosis{
 			{

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -39,7 +39,7 @@ type MetricDogStatsD struct {
 
 // MultipleEndpointConfig abstracts the config package
 type MultipleEndpointConfig interface {
-	GetMultipleEndpoints() (map[string][]utils.APIKeys, error)
+	GetMultipleEndpoints() (utils.EndpointDescriptorSet, error)
 }
 
 // DogStatsDFactory allows create a new DogStatsD server
@@ -53,7 +53,7 @@ const (
 )
 
 // GetMultipleEndpoints returns the api keys per domain specified in the main agent config
-func (m *MetricConfig) GetMultipleEndpoints() (map[string][]utils.APIKeys, error) {
+func (m *MetricConfig) GetMultipleEndpoints() (utils.EndpointDescriptorSet, error) {
 	return utils.GetMultipleEndpoints(pkgconfigsetup.Datadog())
 }
 

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -57,13 +57,18 @@ func TestStartDoesNotBlock(t *testing.T) {
 
 type ValidMetricConfigMocked struct{}
 
-func (m *ValidMetricConfigMocked) GetMultipleEndpoints() (map[string][]utils.APIKeys, error) {
-	return map[string][]utils.APIKeys{"http://localhost:8888": {utils.NewAPIKeys("api_key", "value")}}, nil
+func (m *ValidMetricConfigMocked) GetMultipleEndpoints() (utils.EndpointDescriptorSet, error) {
+	return utils.EndpointDescriptorSet{
+		"http://localhost:8888": utils.EndpointDescriptor{
+			BaseURL: "http://localhost:8888",
+			APIKeys: []utils.APIKeys{utils.NewAPIKeys("api_key", "value")},
+		},
+	}, nil
 }
 
 type InvalidMetricConfigMocked struct{}
 
-func (m *InvalidMetricConfigMocked) GetMultipleEndpoints() (map[string][]utils.APIKeys, error) {
+func (m *InvalidMetricConfigMocked) GetMultipleEndpoints() (utils.EndpointDescriptorSet, error) {
 	return nil, fmt.Errorf("error")
 }
 

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -61,7 +61,7 @@ func (m *ValidMetricConfigMocked) GetMultipleEndpoints() (utils.EndpointDescript
 	return utils.EndpointDescriptorSet{
 		"http://localhost:8888": utils.EndpointDescriptor{
 			BaseURL: "http://localhost:8888",
-			APIKeys: []utils.APIKeys{utils.NewAPIKeys("api_key", "value")},
+			APIKeySet: []utils.APIKeys{utils.NewAPIKeys("api_key", "value")},
 		},
 	}, nil
 }

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -60,7 +60,7 @@ type ValidMetricConfigMocked struct{}
 func (m *ValidMetricConfigMocked) GetMultipleEndpoints() (utils.EndpointDescriptorSet, error) {
 	return utils.EndpointDescriptorSet{
 		"http://localhost:8888": utils.EndpointDescriptor{
-			BaseURL: "http://localhost:8888",
+			BaseURL:   "http://localhost:8888",
 			APIKeySet: []utils.APIKeys{utils.NewAPIKeys("api_key", "value")},
 		},
 	}, nil

--- a/pkg/status/endpoints/status.go
+++ b/pkg/status/endpoints/status.go
@@ -27,7 +27,7 @@ func PopulateStatus(stats map[string]interface{}) {
 
 	// obfuscate the api keys
 	for endpoint, eps := range endpoints {
-		keys := utils.DedupAPIKeys(eps.APIKeys)
+		keys := utils.DedupAPIKeys(eps.APIKeySet)
 		for i, key := range keys {
 			if len(key) > 5 {
 				keys[i] = key[len(key)-5:]

--- a/pkg/status/endpoints/status.go
+++ b/pkg/status/endpoints/status.go
@@ -27,7 +27,7 @@ func PopulateStatus(stats map[string]interface{}) {
 
 	// obfuscate the api keys
 	for endpoint, eps := range endpoints {
-		keys := utils.DedupAPIKeys(eps)
+		keys := utils.DedupAPIKeys(eps.APIKeys)
 		for i, key := range keys {
 			if len(key) > 5 {
 				keys[i] = key[len(key)-5:]


### PR DESCRIPTION
### What does this PR do?

This removes the need for the default forwarder to modify the resolvers after they have been created, streamlining configuration.

### Motivation

Simplify forwarder initialization.

### Describe how you validated your changes

### Additional Notes
