### PR TITLE
Only build payloads we intend to send

### DIFF
--- a/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer.go
@@ -266,13 +266,13 @@ func fromTransactionPriorityProto(priority TransactionPriorityProto) (transactio
 func fromTransactionDestinationProto(destination TransactionDestinationProto) (transaction.Destination, error) {
 	switch destination {
 	case TransactionDestinationProto_ALL_REGIONS:
-		return transaction.AllRegions, nil
+		return transaction.PrimaryOnly, nil
 	case TransactionDestinationProto_PRIMARY_ONLY:
 		return transaction.PrimaryOnly, nil
 	case TransactionDestinationProto_SECONDARY_ONLY:
 		return transaction.SecondaryOnly, nil
 	default:
-		return transaction.AllRegions, fmt.Errorf("Unsupported destination %v", destination)
+		return transaction.PrimaryOnly, fmt.Errorf("Unsupported destination %v", destination)
 	}
 }
 
@@ -298,8 +298,6 @@ func toTransactionPriorityProto(priority transaction.Priority) (TransactionPrior
 
 func toTransactionDestinationProto(destination transaction.Destination) (TransactionDestinationProto, error) {
 	switch destination {
-	case transaction.AllRegions:
-		return TransactionDestinationProto_ALL_REGIONS, nil
 	case transaction.PrimaryOnly:
 		return TransactionDestinationProto_PRIMARY_ONLY, nil
 	case transaction.SecondaryOnly:

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -198,30 +198,13 @@ const (
 type Destination int
 
 const (
-	// AllRegions indicates the transaction should be sent to all regions (default behavior)
-	AllRegions = iota
-	// PrimaryOnly indicates the transaction should be sent to the primary region during MRF
-	PrimaryOnly
-	// SecondaryOnly indicates the transaction should be sent to the secondary region during MRF
+	// PrimaryOnly indicates the transaction should be sent to the primary region when MRF is not active.
+	PrimaryOnly = iota
+	// SecondaryOnly indicates the transaction should be sent to the secondary region when MRF is active.
 	SecondaryOnly
 	// LocalOnly indicates the transaction should be sent to the local endpoint (cluster-agent) only
 	LocalOnly
 )
-
-func (d Destination) String() string {
-	switch d {
-	case AllRegions:
-		return "AllRegions"
-	case PrimaryOnly:
-		return "PrimaryOnly"
-	case SecondaryOnly:
-		return "SecondaryOnly"
-	case LocalOnly:
-		return "LocalOnly"
-	default:
-		return "Unknown"
-	}
-}
 
 // HTTPTransaction represents one Payload for one Endpoint on one Domain.
 type HTTPTransaction struct {

--- a/pkg/serializer/series_benchmark_test.go
+++ b/pkg/serializer/series_benchmark_test.go
@@ -83,7 +83,7 @@ func BenchmarkSeries(b *testing.B) {
 			FilterFunc: func(_ metricsserializer.Filterable) bool {
 				return true
 			},
-			Destination: transaction.AllRegions,
+			Destination: transaction.PrimaryOnly,
 		}}
 		return iterableSeries.MarshalSplitCompressPipelines(mockConfig, compressor, pipeline)
 	}


### PR DESCRIPTION
### What does this PR do?

If in MRF failover mode, there is no need to build PrimaryOnly payload, as it would be dropped just later by the domain forwarder.

Same applies to SecondaryOnly payload, but in reverse.

Do not use AllRegions at all. Domain forwarder does not check for this value during MRF checks and would forward such payload to MRF destination, even though it wasn't filtered correctly.

See DomainForwarder.sendHTTPTransactions for details on how these destinations are handled.

If autoscaling failover is enabled, but MRF isn't then there is similarly no need to build a fail-over MRF payload.

### Motivation

Simplify code, avoid costly serialization when possible, avoid sending unfiltered payloads to secondary destination when switching to MRF.

### Describe how you validated your changes

### Additional Notes
