### PR TITLE
Give @xz//:gen_pkgconfig public visibility

### DIFF
--- a/deps/xz.BUILD.bazel
+++ b/deps/xz.BUILD.bazel
@@ -211,6 +211,7 @@ expand_template(
     substitutions = {
         "{{VERSION}}": VERSION,
     },
+    visibility = ["//visibility:public"],
 )
 
 pkg_files(


### PR DESCRIPTION
Any configure based package depending on xz needs to have a data dependency on the pc file.

The use case motivating this is //deps/openssl.BUILD.bazel.