### PR TITLE
fix: remove major version argument

### DIFF
--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -32,7 +32,7 @@
   before_script:
     - OS=$(echo $OS_LTSC_MAPPING | cut -d ':' -f 1)
     - LTSC_VERSION=$(echo $OS_LTSC_MAPPING | cut -d ':' -f 2)
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv -- agent.version --major-version 7 --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
     - IMG_BASE_SRC="${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_SOURCES="${IMG_BASE_SRC}-7${JMX}-win${OS}${FLAVOR}-amd64"
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${FLAVOR}-ltsc${LTSC_VERSION}${JMX}"

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -58,7 +58,7 @@ $outputDirectory = "$repoRoot\build-out"
 if (![string]::IsNullOrEmpty($VersionOverride)) {
     $rawAgentVersion = $VersionOverride
 } else {
-    $rawAgentVersion = (dda inv -- agent.version --url-safe --major-version 7)
+    $rawAgentVersion = (dda inv -- agent.version --url-safe)
 }
 $copyright = "Datadog {0}" -f (Get-Date).Year
 


### PR DESCRIPTION
### What does this PR do?

Remove major version argument from agent.release task since it was removed in a [previous pr](https://github.com/DataDog/datadog-agent/pull/41815).

### Motivation

windows choco job failed in 7.73.0-rc.1 pipeline

https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1210090962

### Describe how you validated your changes

locally ran invoke task and confirmed fix.

### Additional Notes
