### PR TITLE
Handle dot separated keys in config yaml

### DIFF
--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -616,3 +616,33 @@ fruit:
 	assert.Equal(t, 5, ntmConf.GetInt("fruit.cherry.seed.num"))
 	assert.Equal(t, 12, ntmConf.GetInt("fruit.donut.dozen"))
 }
+
+func TestCompareConfigUsesDotSeparatedFields(t *testing.T) {
+	configData := `
+my_feature.info.enabled: true
+second_feature:
+  info.enabled: true
+additional_endpoints:
+  https://url1.com:
+    - my_api_key
+`
+	viperConf, ntmConf := constructBothConfigs(configData, false, func(cfg model.Setup) {
+		cfg.BindEnvAndSetDefault("my_feature.info.name", "feat")
+		cfg.BindEnvAndSetDefault("my_feature.info.enabled", false)
+		cfg.BindEnvAndSetDefault("my_feature.info.version", "v2")
+		cfg.BindEnvAndSetDefault("second_feature.info.enabled", false)
+		cfg.BindEnvAndSetDefault("additional_endpoints", map[string][]string{})
+	})
+
+	assert.Equal(t, true, viperConf.Get("my_feature.info.enabled"))
+	assert.Equal(t, true, ntmConf.Get("my_feature.info.enabled"))
+
+	assert.Equal(t, true, viperConf.Get("second_feature.info.enabled"))
+	assert.Equal(t, true, ntmConf.Get("second_feature.info.enabled"))
+
+	expectEndpoints := map[string][]string{
+		"https://url1.com": {"my_api_key"},
+	}
+	assert.Equal(t, expectEndpoints, viperConf.GetStringMapStringSlice("additional_endpoints"))
+	assert.Equal(t, expectEndpoints, ntmConf.GetStringMapStringSlice("additional_endpoints"))
+}

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -330,3 +330,15 @@ func TestReadConfigInvalidYaml(t *testing.T) {
 	err := cfg.ReadConfig(strings.NewReader("123"))
 	require.Error(t, err)
 }
+
+func TestBuildNestedMap(t *testing.T) {
+	m := buildNestedMap([]string{"a", "b", "c"}, 123)
+	expect := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": map[string]interface{}{
+				"c": 123,
+			},
+		},
+	}
+	require.Equal(t, expect, m)
+}


### PR DESCRIPTION
### What does this PR do?

When the config yaml has a key like `my_feature.info.enabled` viper treats this like a nested config `{"my_feature": {"info": {"enabled": ...}}}`. Nodetreemodel should do the same.

When run with `DD_CONF_NODETREEMODEL=enable`, this fixes the tests in `pkg/config/utils`.

### Motivation

Remove our dependency on viper.

### Describe how you validated your changes

Unit tests.

### Additional Notes
