### PR TITLE
omit empty api_key

### DIFF
--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -71,7 +71,7 @@ type Config struct {
 
 // DatadogConfig represents the configuration to write in /etc/datadog-agent/datadog.yaml
 type DatadogConfig struct {
-	APIKey               string                     `yaml:"api_key"`
+	APIKey               string                     `yaml:"api_key,omitempty"`
 	Hostname             string                     `yaml:"hostname,omitempty"`
 	Site                 string                     `yaml:"site,omitempty"`
 	Proxy                DatadogConfigProxy         `yaml:"proxy,omitempty"`


### PR DESCRIPTION
### What does this PR do?
when running fleet installer setup, do not write `api_key` to config if it is empty

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2007
don't want to erase existing `api_key` if setup is re-run without setting `DD_API_KEY` environment variable
