### PR TITLE
dyninst: move temporary files from /var/tmp to /tmp

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -45,9 +45,9 @@ const (
 	defaultBTFOutputDir = "/var/tmp/datadog-agent/system-probe/btf"
 
 	// defaultDynamicInstrumentationDebugInfoDir is the default path for debug
-	// info for dynamic instrumentation this is the directory where the debug
-	// info is decompressed into during processing.
-	defaultDynamicInstrumentationDebugInfoDir = "/var/tmp/datadog-agent/system-probe/dynamic-instrumentation/decompressed-debug-info"
+	// info for Dynamic Instrumentation. This is the directory where the DWARF
+	// data from analyzed binaries is decompressed into during processing.
+	defaultDynamicInstrumentationDebugInfoDir = "/tmp/datadog-agent/system-probe/dynamic-instrumentation/decompressed-debug-info"
 
 	// defaultAptConfigDirSuffix is the default path under `/etc` to the apt config directory
 	defaultAptConfigDirSuffix = "/apt"

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -85,8 +85,8 @@ func NewConfig(_ *sysconfigtypes.Config) (*Config, error) {
 		DiagsUploaderURL:       withPath(traceAgentURL, diagsUploaderPath),
 		SymDBUploadEnabled:     pkgconfigsetup.SystemProbe().GetBool("dynamic_instrumentation.symdb_upload_enabled"),
 		SymDBUploaderURL:       withPath(traceAgentURL, symdbUploaderPath),
-		SymDBCacheDir:          "/var/tmp/datadog-agent/system-probe/dynamic-instrumentation/symdb_uploads",
-		ProbeTombstoneFilePath: "/var/tmp/datadog-agent/system-probe/dynamic-instrumentation/debugger_probes_tombstone.json",
+		SymDBCacheDir:          "/tmp/datadog-agent/system-probe/dynamic-instrumentation/symdb-uploads",
+		ProbeTombstoneFilePath: "/tmp/datadog-agent/system-probe/dynamic-instrumentation/debugger-probes-tombstone.json",
 		DiskCacheEnabled:       cacheEnabled,
 		DiskCacheConfig:        cacheConfig,
 	}


### PR DESCRIPTION
In our k8s Helm charts we mount some dirs under
`/var/tmp/datadog-agent/system-probe/...`, but we mount them as host dirs.
That's not what we want for the
`/var/tmp/datadog-agent/system-probe/dynamic-instrumentation` (we want
this dir to be an emptyDir mount so that it does not survive pod
restarts). So, let's move our caches out of `/var/tmp`, to make the
distinction more apparent.

Also replace underscores with dashes in some of the paths, for
consistency with other files.