### PR TITLE
write bool when false

### DIFF
--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -78,11 +78,11 @@ type DatadogConfig struct {
 	Env                  string                     `yaml:"env,omitempty"`
 	Tags                 []string                   `yaml:"tags,omitempty"`
 	ExtraTags            []string                   `yaml:"extra_tags,omitempty"`
-	LogsEnabled          bool                       `yaml:"logs_enabled,omitempty"`
+	LogsEnabled          *bool                      `yaml:"logs_enabled,omitempty"`
 	DJM                  DatadogConfigDJM           `yaml:"djm_config,omitempty"`
 	ProcessConfig        DatadogConfigProcessConfig `yaml:"process_config,omitempty"`
 	ExpectedTagsDuration string                     `yaml:"expected_tags_duration,omitempty"`
-	RemoteUpdates        bool                       `yaml:"remote_updates,omitempty"`
+	RemoteUpdates        *bool                      `yaml:"remote_updates,omitempty"`
 	Installer            DatadogConfigInstaller     `yaml:"installer,omitempty"`
 	DDURL                string                     `yaml:"dd_url,omitempty"`
 	LogsConfig           LogsConfig                 `yaml:"logs_config,omitempty"`
@@ -93,7 +93,7 @@ type DatadogConfig struct {
 
 // GPUCheckConfig represents the configuration for the GPU check
 type GPUCheckConfig struct {
-	Enabled     bool   `yaml:"enabled,omitempty"`
+	Enabled     *bool  `yaml:"enabled,omitempty"`
 	NvmlLibPath string `yaml:"nvml_lib_path,omitempty"`
 }
 
@@ -106,7 +106,7 @@ type DatadogConfigProxy struct {
 
 // DatadogConfigDJM represents the configuration for the Data Jobs Monitoring
 type DatadogConfigDJM struct {
-	Enabled bool `yaml:"enabled,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // DatadogConfigProcessConfig represents the configuration for the process agent
@@ -139,7 +139,7 @@ type IntegrationConfigLogs struct {
 	Service                string              `yaml:"service,omitempty"`
 	Source                 string              `yaml:"source,omitempty"`
 	Tags                   string              `yaml:"tags,omitempty"`
-	AutoMultiLineDetection bool                `yaml:"auto_multi_line_detection,omitempty"`
+	AutoMultiLineDetection *bool               `yaml:"auto_multi_line_detection,omitempty"`
 	LogProcessingRules     []LogProcessingRule `yaml:"log_processing_rules,omitempty"`
 }
 
@@ -178,30 +178,30 @@ type SystemProbeConfig struct {
 
 // RuntimeSecurityConfig represents the configuration for the runtime security
 type RuntimeSecurityConfig struct {
-	Enabled bool       `yaml:"enabled,omitempty"`
+	Enabled *bool      `yaml:"enabled,omitempty"`
 	SBOM    SBOMConfig `yaml:"sbom,omitempty"`
 }
 
 // SBOMConfig represents the configuration for the SBOM
 type SBOMConfig struct {
-	Enabled        bool                     `yaml:"enabled,omitempty"`
+	Enabled        *bool                    `yaml:"enabled,omitempty"`
 	ContainerImage SBOMContainerImageConfig `yaml:"container_image,omitempty"`
 	Host           SBOMHostConfig           `yaml:"host,omitempty"`
 }
 
 // SBOMContainerImageConfig represents the configuration for the SBOM container image
 type SBOMContainerImageConfig struct {
-	Enabled bool `yaml:"enabled,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // SBOMHostConfig represents the configuration for the SBOM host
 type SBOMHostConfig struct {
-	Enabled bool `yaml:"enabled,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // GPUMonitoringConfig represents the configuration for GPU monitoring
 type GPUMonitoringConfig struct {
-	Enabled bool `yaml:"enabled,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // SecurityAgentConfig represents the configuration to write in /etc/datadog-agent/security-agent.yaml
@@ -212,7 +212,7 @@ type SecurityAgentConfig struct {
 
 // SecurityAgentComplianceConfig represents the configuration for the compliance
 type SecurityAgentComplianceConfig struct {
-	Enabled bool `yaml:"enabled,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // LogsConfig represents the configuration for global log processing rules

--- a/pkg/fleet/installer/setup/config/config_test.go
+++ b/pkg/fleet/installer/setup/config/config_test.go
@@ -77,7 +77,7 @@ env: "old_env"
 	config := Config{}
 	config.DatadogYAML.APIKey = "1234567890" // Required field
 	config.DatadogYAML.Hostname = "new_hostname"
-	config.DatadogYAML.LogsEnabled = true
+	config.DatadogYAML.LogsEnabled = BoolToPtr(true)
 
 	err := WriteConfigs(config, tempDir)
 	assert.NoError(t, err)
@@ -153,7 +153,7 @@ func TestDoubleWriteConfig(t *testing.T) {
 	config := Config{}
 	config.DatadogYAML.APIKey = "1234567890" // Required field
 	config.DatadogYAML.Hostname = "new_hostname"
-	config.DatadogYAML.LogsEnabled = true
+	config.DatadogYAML.LogsEnabled = BoolToPtr(true)
 
 	err := WriteConfigs(config, tempDir)
 	assert.NoError(t, err)
@@ -205,7 +205,7 @@ remote_updates: false
 
 	cfg := Config{}
 	cfg.DatadogYAML.APIKey = "key"
-	cfg.DatadogYAML.RemoteUpdates = true
+	cfg.DatadogYAML.RemoteUpdates = BoolToPtr(true)
 
 	err := WriteConfigs(cfg, tempDir)
 	assert.NoError(t, err)
@@ -218,10 +218,6 @@ remote_updates: false
 }
 
 func TestRemoteUpdatesFalse(t *testing.T) {
-	// TODO: fix this test
-	// With omitempty on bool fields, setting false omits the key in the override,
-	// so merge keeps existing true value.
-	t.Skip("Test fails")
 	tempDir := t.TempDir()
 	existing := `---
 api_key: "key"
@@ -231,7 +227,7 @@ remote_updates: true
 
 	cfg := Config{}
 	cfg.DatadogYAML.APIKey = "key"
-	cfg.DatadogYAML.RemoteUpdates = false
+	cfg.DatadogYAML.RemoteUpdates = BoolToPtr(false)
 
 	err := WriteConfigs(cfg, tempDir)
 	assert.NoError(t, err)
@@ -241,6 +237,28 @@ remote_updates: true
 	assert.Equal(t, map[string]interface{}{
 		"api_key":        "key",
 		"remote_updates": false,
+	}, datadog)
+}
+
+func TestLogsEnabledFalse(t *testing.T) {
+	tempDir := t.TempDir()
+	existing := `---
+api_key: "key"
+logs_enabled: true
+`
+	writeInitialDatadogConfig(t, tempDir, existing)
+
+	cfg := Config{}
+	cfg.DatadogYAML.APIKey = "key"
+	cfg.DatadogYAML.LogsEnabled = BoolToPtr(false)
+
+	err := WriteConfigs(cfg, tempDir)
+	assert.NoError(t, err)
+
+	datadog := readDatadogYAML(t, tempDir)
+	assert.Equal(t, map[string]interface{}{
+		"api_key":      "key",
+		"logs_enabled": false,
 	}, datadog)
 }
 
@@ -255,7 +273,7 @@ api_key: "old_key"
 	cfg.DatadogYAML.APIKey = "full_test_key"
 	cfg.DatadogYAML.Site = "datadoghq.com"
 	cfg.DatadogYAML.DDURL = "https://app.datadoghq.com"
-	cfg.DatadogYAML.RemoteUpdates = true
+	cfg.DatadogYAML.RemoteUpdates = BoolToPtr(true)
 
 	err := WriteConfigs(cfg, tempDir)
 	assert.NoError(t, err)
@@ -457,7 +475,7 @@ func TestWriteConfigWithEOLAtEnd(t *testing.T) {
 
 	cfg := Config{}
 	cfg.DatadogYAML.APIKey = "key"
-	cfg.DatadogYAML.LogsEnabled = true
+	cfg.DatadogYAML.LogsEnabled = BoolToPtr(true)
 
 	err := WriteConfigs(cfg, tempDir)
 	assert.NoError(t, err)

--- a/pkg/fleet/installer/setup/defaultscript/default_script.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script.go
@@ -121,44 +121,34 @@ func setConfigSecurityProducts(s *common.Setup) {
 	}
 
 	if complianceConfigEnabledOk && strings.ToLower(complianceConfigEnabled) != "false" {
-		s.Config.SecurityAgentYAML.ComplianceConfig.Enabled = true
+		s.Config.SecurityAgentYAML.ComplianceConfig.Enabled = config.BoolToPtr(true)
 	}
 	if runtimeSecurityConfigEnabledOk && strings.ToLower(runtimeSecurityConfigEnabled) != "false" {
-		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.Enabled = true
-		s.Config.SystemProbeYAML.RuntimeSecurityConfig.Enabled = true
+		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.Enabled = config.BoolToPtr(true)
+		s.Config.SystemProbeYAML.RuntimeSecurityConfig.Enabled = config.BoolToPtr(true)
 	}
 	if sbomContainerImageEnabledOk && strings.ToLower(sbomContainerImageEnabled) != "false" {
-		s.Config.DatadogYAML.SBOM.Enabled = true
-		s.Config.DatadogYAML.SBOM.ContainerImage.Enabled = true
-		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.SBOM.Enabled = true
-		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.SBOM.ContainerImage.Enabled = true
-		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.Enabled = true
-		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.ContainerImage.Enabled = true
+		s.Config.DatadogYAML.SBOM.Enabled = config.BoolToPtr(true)
+		s.Config.DatadogYAML.SBOM.ContainerImage.Enabled = config.BoolToPtr(true)
+		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.SBOM.Enabled = config.BoolToPtr(true)
+		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.SBOM.ContainerImage.Enabled = config.BoolToPtr(true)
+		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.Enabled = config.BoolToPtr(true)
+		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.ContainerImage.Enabled = config.BoolToPtr(true)
 	}
 	if sbomHostEnabledOk && strings.ToLower(sbomHostEnabled) != "false" {
-		s.Config.DatadogYAML.SBOM.Enabled = true
-		s.Config.DatadogYAML.SBOM.Host.Enabled = true
-		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.SBOM.Enabled = true
-		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.SBOM.Host.Enabled = true
-		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.Enabled = true
-		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.Host.Enabled = true
+		s.Config.DatadogYAML.SBOM.Enabled = config.BoolToPtr(true)
+		s.Config.DatadogYAML.SBOM.Host.Enabled = config.BoolToPtr(true)
+		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.SBOM.Enabled = config.BoolToPtr(true)
+		s.Config.SecurityAgentYAML.RuntimeSecurityConfig.SBOM.Host.Enabled = config.BoolToPtr(true)
+		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.Enabled = config.BoolToPtr(true)
+		s.Config.SystemProbeYAML.RuntimeSecurityConfig.SBOM.Host.Enabled = config.BoolToPtr(true)
 	}
 }
 
 // setConfigInstallerDaemon sets the daemon in the configuration
 func setConfigInstallerDaemon(s *common.Setup) {
-	if runtime.GOOS == "windows" {
-		// on windows this needs to default to false
-		// as setup is the entry point for FIPS installations as well
-		s.Config.DatadogYAML.RemoteUpdates = false
-		if val, ok := os.LookupEnv("DD_REMOTE_UPDATES"); ok && strings.ToLower(val) == "true" {
-			s.Config.DatadogYAML.RemoteUpdates = true
-		}
-	} else {
-		s.Config.DatadogYAML.RemoteUpdates = true
-		if val, ok := os.LookupEnv("DD_REMOTE_UPDATES"); ok && strings.ToLower(val) == "false" {
-			s.Config.DatadogYAML.RemoteUpdates = false
-		}
+	if val, ok := os.LookupEnv("DD_REMOTE_UPDATES"); ok {
+		s.Config.DatadogYAML.RemoteUpdates = config.BoolToPtr(strings.ToLower(val) == "true")
 	}
 }
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -37,14 +37,14 @@ var (
 			Path:                   "/databricks/driver/logs/*.log",
 			Source:                 "driver_logs",
 			Service:                "databricks",
-			AutoMultiLineDetection: true,
+			AutoMultiLineDetection: config.BoolToPtr(true),
 		},
 		{
 			Type:                   "file",
 			Path:                   "/databricks/driver/logs/stderr",
 			Source:                 "driver_stderr",
 			Service:                "databricks",
-			AutoMultiLineDetection: true,
+			AutoMultiLineDetection: config.BoolToPtr(true),
 		},
 		{
 			Type:    "file",
@@ -54,7 +54,7 @@ var (
 			LogProcessingRules: []config.LogProcessingRule{
 				{Type: "multi_line", Name: "logger_multiline", Pattern: "(^\\+[-+]+\\n(\\|.*\\n)+\\+[-+]+$)|^(ERROR|INFO|DEBUG|WARN|CRITICAL|NOTSET|Traceback)"},
 			},
-			AutoMultiLineDetection: true,
+			AutoMultiLineDetection: config.BoolToPtr(true),
 		},
 	}
 	workerLogs = []config.IntegrationConfigLogs{
@@ -63,21 +63,21 @@ var (
 			Path:                   "/databricks/spark/work/*/*/*.log",
 			Source:                 "worker_logs",
 			Service:                "databricks",
-			AutoMultiLineDetection: true,
+			AutoMultiLineDetection: config.BoolToPtr(true),
 		},
 		{
 			Type:                   "file",
 			Path:                   "/databricks/spark/work/*/*/stderr",
 			Source:                 "worker_stderr",
 			Service:                "databricks",
-			AutoMultiLineDetection: true,
+			AutoMultiLineDetection: config.BoolToPtr(true),
 		},
 		{
 			Type:                   "file",
 			Path:                   "/databricks/spark/work/*/*/stdout",
 			Source:                 "worker_stdout",
 			Service:                "databricks",
-			AutoMultiLineDetection: true,
+			AutoMultiLineDetection: config.BoolToPtr(true),
 		},
 	}
 	tracerConfigDatabricks = config.APMConfigurationDefault{
@@ -100,7 +100,7 @@ func SetupDatabricks(s *common.Setup) error {
 		return fmt.Errorf("failed to get hostname: %w", err)
 	}
 	s.Config.DatadogYAML.Hostname = hostname
-	s.Config.DatadogYAML.DJM.Enabled = true
+	s.Config.DatadogYAML.DJM.Enabled = config.BoolToPtr(true)
 	s.Config.DatadogYAML.ExpectedTagsDuration = "10m"
 	s.Config.DatadogYAML.ProcessConfig.ExpvarPort = 6063 // avoid port conflict on 6062
 
@@ -129,7 +129,7 @@ func SetupDatabricks(s *common.Setup) error {
 	default:
 		setupDatabricksWorker(s)
 	}
-	if s.Config.DatadogYAML.LogsEnabled {
+	if s.Config.DatadogYAML.LogsEnabled != nil && *s.Config.DatadogYAML.LogsEnabled {
 		loadLogProcessingRules(s)
 	}
 	return nil
@@ -243,7 +243,7 @@ func setupGPUIntegration(s *common.Setup) {
 	s.Out.WriteString("Setting up GPU monitoring based on env variable GPU_MONITORING_ENABLED=true\n")
 	s.Span.SetTag("host_tag_set.gpu_monitoring_enabled", "true")
 
-	s.Config.DatadogYAML.GPUCheck.Enabled = true
+	s.Config.DatadogYAML.GPUCheck.Enabled = config.BoolToPtr(true)
 
 	// Agent must be restarted after NVML initialization, which occurs after init script execution
 	s.DelayedAgentRestartConfig.Scheduled = true
@@ -257,7 +257,7 @@ func setupDatabricksDriver(s *common.Setup) {
 
 	var sparkIntegration config.IntegrationConfig
 	if os.Getenv("DRIVER_LOGS_ENABLED") == "true" {
-		s.Config.DatadogYAML.LogsEnabled = true
+		s.Config.DatadogYAML.LogsEnabled = config.BoolToPtr(true)
 		sparkIntegration.Logs = driverLogs
 		s.Span.SetTag("host_tag_set.driver_logs_enabled", "true")
 	}
@@ -281,7 +281,7 @@ func setupDatabricksWorker(s *common.Setup) {
 	var sparkIntegration config.IntegrationConfig
 
 	if os.Getenv("WORKER_LOGS_ENABLED") == "true" {
-		s.Config.DatadogYAML.LogsEnabled = true
+		s.Config.DatadogYAML.LogsEnabled = config.BoolToPtr(true)
 		sparkIntegration.Logs = workerLogs
 		s.Span.SetTag("host_tag_set.worker_logs_enabled", "true")
 	}

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -344,7 +344,7 @@ func TestSetupGPUIntegration(t *testing.T) {
 	tests := []struct {
 		name                   string
 		env                    map[string]string
-		expectedEnableGPUM     bool
+		expectedEnableGPUM     *bool
 		expectedSystemProbeGPU bool
 	}{
 		{
@@ -352,7 +352,7 @@ func TestSetupGPUIntegration(t *testing.T) {
 			env: map[string]string{
 				"DD_GPU_ENABLED": "true",
 			},
-			expectedEnableGPUM:     true,
+			expectedEnableGPUM:     config.BoolToPtr(true),
 			expectedSystemProbeGPU: true,
 		},
 		{
@@ -360,13 +360,13 @@ func TestSetupGPUIntegration(t *testing.T) {
 			env: map[string]string{
 				"DD_GPU_ENABLED": "",
 			},
-			expectedEnableGPUM:     false,
+			expectedEnableGPUM:     nil,
 			expectedSystemProbeGPU: false,
 		},
 		{
 			name:                   "GPU monitoring not set",
 			env:                    map[string]string{},
-			expectedEnableGPUM:     false,
+			expectedEnableGPUM:     nil,
 			expectedSystemProbeGPU: false,
 		},
 	}

--- a/pkg/fleet/installer/setup/djm/dataproc.go
+++ b/pkg/fleet/installer/setup/djm/dataproc.go
@@ -51,7 +51,7 @@ func SetupDataproc(s *common.Setup) error {
 		return fmt.Errorf("failed to get hostname: %w", err)
 	}
 	s.Config.DatadogYAML.Hostname = hostname
-	s.Config.DatadogYAML.DJM.Enabled = true
+	s.Config.DatadogYAML.DJM.Enabled = config.BoolToPtr(true)
 	if os.Getenv("DD_TRACE_DEBUG") == "true" {
 		s.Out.WriteString("Enabling Datadog Java Tracer DEBUG logs on DD_TRACE_DEBUG=true\n")
 		tracerConfigDataproc.TraceDebug = config.BoolToPtr(true)

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -71,7 +71,7 @@ func SetupEmr(s *common.Setup) error {
 		return fmt.Errorf("failed to get hostname: %w", err)
 	}
 	s.Config.DatadogYAML.Hostname = hostname
-	s.Config.DatadogYAML.DJM.Enabled = true
+	s.Config.DatadogYAML.DJM.Enabled = config.BoolToPtr(true)
 
 	if os.Getenv("DD_DATA_STREAMS_ENABLED") == "true" {
 		s.Out.WriteString("Propagating variable DD_DATA_STREAMS_ENABLED=true to tracer configuration\n")
@@ -193,7 +193,7 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 }
 
 func enableEmrLogs(s *common.Setup, collectFromDriver bool) {
-	s.Config.DatadogYAML.LogsEnabled = true
+	s.Config.DatadogYAML.LogsEnabled = config.BoolToPtr(true)
 	loadLogProcessingRules(s)
 	// Load the existing integration config and add logs section to it
 	sparkIntegration := s.Config.IntegrationConfigs["spark.d/conf.yaml"]


### PR DESCRIPTION
### What does this PR do?
ensure options explicitly set to `false` are written to the config

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2008
yaml marshaller does not write false bools tagged with `omitempty`, must use `*bool` instead.

`remote_updates` defaults to `true` as of https://github.com/DataDog/datadog-agent/pull/42500, so we need a way to disable it

### Additional Notes
removed explicit `RemoteUpdates` value set in `setConfigInstallerDaemon`, it is now only written to config when explicitly provided. Updating the default to `false` for FIPS installs will have to be handled another way.