### PR TITLE
[USMON-1363] usm: events: Prevent malformed batch from ruining batch state

### DIFF
--- a/pkg/network/protocols/events/batch_offsets.go
+++ b/pkg/network/protocols/events/batch_offsets.go
@@ -66,6 +66,9 @@ func (o *offsetManager) Get(cpu int, batch *Batch, syncing bool) (begin, end int
 	// usually this is the full batch size but it can be less
 	// in the context of a forced (partial) read
 	end = int(batch.Len)
+	if end == 0 {
+		return 0, 0
+	}
 
 	// if this is part of a forced read (that is, we're reading a batch before
 	// it's complete) we need to keep track of which entries we're reading


### PR DESCRIPTION
### What does this PR do?

This PR fixes a race condition in the batch offset manager that can cause malformed batch states. When syncing batches from user mode, empty batches (with `Len == 0`) are now properly handled by returning early, preventing them from overriding the batch state.

### Motivation

Due to races between user mode and the kernel, we might get an empty batch while syncing batches from the user mode, as the kernel may have already sent the event and emptied the batch. These empty batches were previously processed and could corrupt the batch state, leading to flaky test behavior.

### Describe how you validated your changes

The fix adds a simple guard to check if `batch.Len` is 0 and returns early with `(0, 0)` in the offset manager's `Get` method at pkg/network/protocols/events/batch_offsets.go:69.

### Additional Notes

This change addresses flakiness observed in USM event handling tests by preventing empty batches from interfering with the batch state tracking.