### PR TITLE
Add language detection to USM sysinfo command

### DIFF
--- a/cmd/system-probe/subcommands/usm/sysinfo_linux.go
+++ b/cmd/system-probe/subcommands/usm/sysinfo_linux.go
@@ -157,12 +157,11 @@ func outputSysinfoHumanReadable(info *SystemInfo, maxCmdlineLength, maxNameLengt
 		}
 
 		// Get language for this process (Languages array matches Processes array order)
-		var langStr string
+		lang := languagemodels.Language{}
 		if i < len(info.Languages) {
-			langStr = formatLanguage(info.Languages[i])
-		} else {
-			langStr = "-"
+			lang = info.Languages[i]
 		}
+		langStr := formatLanguage(lang)
 
 		// Truncate language to max 12 chars to keep table aligned
 		if len(langStr) > 12 {

--- a/cmd/system-probe/subcommands/usm/sysinfo_linux_test.go
+++ b/cmd/system-probe/subcommands/usm/sysinfo_linux_test.go
@@ -8,11 +8,17 @@
 package usm
 
 import (
+	"os"
+	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/privileged"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
 func TestSysinfoCommand(t *testing.T) {
@@ -32,4 +38,27 @@ func TestSysinfoCommand(t *testing.T) {
 	maxNameFlag := cmd.Flags().Lookup("max-name-length")
 	require.NotNil(t, maxNameFlag, "--max-name-length flag should exist")
 	require.Equal(t, "25", maxNameFlag.DefValue, "--max-name-length should default to 25")
+}
+
+func TestLanguageDetectionGo(t *testing.T) {
+	// Create a process wrapper for the current test process (which is a Go binary)
+	proc := &procutil.Process{
+		Pid:     int32(os.Getpid()),
+		Name:    "test",
+		Cmdline: []string{"test"},
+	}
+
+	// Create language detector and detect language
+	detector := privileged.NewLanguageDetector()
+	languages := detector.DetectWithPrivileges([]languagemodels.Process{proc})
+
+	// Verify we got one result
+	require.Len(t, languages, 1)
+
+	// Verify the language is Go
+	assert.Equal(t, languagemodels.Go, languages[0].Name)
+
+	// Verify the version is detected and matches the runtime version
+	assert.NotEmpty(t, languages[0].Version)
+	assert.Equal(t, runtime.Version(), languages[0].Version)
 }


### PR DESCRIPTION
### What does this PR do?
This commit adds language detection capability to the system-probe USM sysinfo command, displaying the detected programming language for each running process.

Changes:
- Add language detection integration using privileged detector
- Display language and version in new "Language" column
- Add formatLanguage() helper to format language output
- Add unit test for Go binary language detection

The language detector chain runs: TracerDetector -> InjectorDetector ->
GoDetector -> DotnetDetector, stopping at the first successful detection.

Example output:
PID     | PPID    | Name                      | Language     | Command
--------|---------|---------------------------|--------------|----------
25583   | 1       | dockerd                   | go/go1.24.7  | /usr/bin/dockerd
172855  | 172833  | java                      | java         | java -jar app.jar

### Motivation
Identifying the process language will enable more effective debugging and troubleshooting.

### Describe how you validated your changes
#### Unit Tests:
- Added TestLanguageDetectionGo that verifies language detection works by detecting the test binary itself (a Go binary)
- Test validates both language name (go) and version detection (runtime.Version())
- All existing tests continue to pass

#### Manual Testing on Vagrant VM:
- Built system-probe and ran sudo ./bin/system-probe/system-probe usm sysinfo
- Verified Language column appears in output
- Confirmed detection works for real processes:
  - dockerd: go/go1.24.7
  - containerd: go/go1.23.7
  - system-probe: go/go1.24.9
- Verified unknown languages show as -

#### Why only Go binary test:
The unit test focuses on Go binary detection because:
1. Simplicity - The test binary itself is Go, so no external binaries or test fixtures needed
2. Reliability - Go detector works on any Go binary through binary analysis
3. Consistency with existing tests - The privileged detector tests (pkg/languagedetection/internal/detectors/privileged/*_test.go) also only test Go with real binaries. Other
languages (Python, Node, Java, Ruby, PHP, .NET) are tested with mock memfd files since they require either:
    - Datadog tracer installed in the process (TracerDetector)
    - APM auto-injection active (InjectorDetector)
    - Actual language runtime binaries

### Additional Notes
