### PR TITLE
chore(devcontainer): use localWorkspaceFolderBasename for worspace path

### DIFF
--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -15,7 +15,7 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from tasks.build_tags import build_tags, filter_incompatible_tags, get_build_tags, get_default_build_tags
-from tasks.commands.docker import AGENT_REPOSITORY_PATH, DockerCLI
+from tasks.commands.docker import DockerCLI
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.utils import is_installed
@@ -88,7 +88,7 @@ def setup(
         "--security-opt",
         "seccomp=unconfined",
         "-w",
-        "/workspaces/datadog-agent",
+        "/workspaces/${localWorkspaceFolderBasename}",
         "--name",
         "datadog-agent-devcontainer",
     ]
@@ -122,10 +122,10 @@ def setup(
         }
     }
 
-    # onCreateCommond runs the install-tools and deps tasks only when the devcontainer is created and not each time
+    # onCreateCommand runs the install-tools and deps tasks only when the devcontainer is created and not each time
     # the container is started
     devcontainer["onCreateCommand"] = (
-        f"git config --global --add safe.directory {AGENT_REPOSITORY_PATH} && dda inv -- -e install-tools && dda inv -- -e deps"
+        "git config --global --add safe.directory /workspaces/${localWorkspaceFolderBasename} && dda inv -- -e install-tools && dda inv -- -e deps"
     )
 
     devcontainer["containerEnv"] = {


### PR DESCRIPTION
### What does this PR do?
Replaces hardcoded `/workspaces/datadog-agent` with `${localWorkspaceFolderBasename}` in the Docker run command and `onCreateCommand`, so the setup works with any workspace name.

### Motivation
Allows dynamic workspace directory names.

### Describe how you validated your changes
Changes were validated by creating the devcontainer manually:
```
➜  datadog-agent-primary git:(dev/wassim.dhif/devcontainer-variable-directory) devcontainer up --workspace-folder .
[1 ms] @devcontainers/cli 0.80.1. Node.js v24.10.0. darwin 24.6.0 arm64.
[...]
Container started
[...]
{"outcome":"success","containerId":"210be79a340003d61117d22223cfc3f19b869385d6a672eb32c7b15a0ade176e","remoteUser":"datadog","remoteWorkspaceFolder":"/workspaces/datadog-agent-primary"}
```

Exec in the devcontainer:
```➜  datadog-agent-primary git:(dev/wassim.dhif/devcontainer-variable-directory) ddae
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

datadog@210be79a3400:/workspaces/datadog-agent-primary$ ls
AGENTS.md                    Dockerfiles           bazel              devenv             go.work.sum     releasenotes                 tasks
BUILD.bazel                  LICENSE               bin                docs               internal        releasenotes-dca             test
CHANGELOG-DCA.rst            LICENSE-3rdparty.csv  chocolatey         examples           mkdocs.yml      renovate.json                test_output.json
CHANGELOG-INSTALLSCRIPT.rst  MODULE.bazel          cmd                flakes.yaml        modules.yml     repository.datadog.yml       third_party
CHANGELOG.rst                MODULE.bazel.lock     comp               generate_tools.go  omnibus         rtloader                     tools
CLAUDE.md                    NOTICE                datadog-agent.map  go.mod             pkg             service.datadog.yaml
CLAUDE_PERSONAL.md           README.md             deps               go.sum             pyproject.toml  skaffold.yaml
CONTRIBUTING.md              SUPPORT.md            dev                go.work            release.json    static-analysis.datadog.yml
```

Using Visual Studio code:

<img width="1436" height="855" alt="image" src="https://github.com/user-attachments/assets/1cb3f7d1-a911-48b4-ae1e-7cac06d315e3" />

### Additional Notes
N/A