### PR TITLE
[autodiscovery/prometheus] Fix case where no container matches annotation port

### DIFF
--- a/comp/core/autodiscovery/common/utils/prometheus_pods_test.go
+++ b/comp/core/autodiscovery/common/utils/prometheus_pods_test.go
@@ -514,7 +514,24 @@ func TestConfigsForPod(t *testing.T) {
 					},
 				},
 			},
-			expectError: true, // No container matches port in annotation
+			want: []integration.Config{
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data(`{"namespace":"","metrics":[".*"],"openmetrics_endpoint":"http://%%host%%:9999/metrics"}`)},
+					Provider:      names.PrometheusPods,
+					Source:        "prometheus_pods:containerd://cont-id-1",
+					ADIdentifiers: []string{"containerd://cont-id-1"},
+				},
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data(`{"namespace":"","metrics":[".*"],"openmetrics_endpoint":"http://%%host%%:9999/metrics"}`)},
+					Provider:      names.PrometheusPods,
+					Source:        "prometheus_pods:containerd://cont-id-2",
+					ADIdentifiers: []string{"containerd://cont-id-2"},
+				},
+			},
 		},
 		{
 			name:    "invalid port in annotation",

--- a/comp/core/autodiscovery/providers/prometheus_pods_test.go
+++ b/comp/core/autodiscovery/providers/prometheus_pods_test.go
@@ -259,7 +259,7 @@ func TestGetConfigErrors(t *testing.T) {
 			wantErrs: true,
 		},
 		{
-			name: "pod with port annotation but no matching container",
+			name: "pod with port annotation but no matching container should not generate errors",
 			events: []workloadmeta.Event{
 				{
 					Type: workloadmeta.EventTypeSet,
@@ -302,7 +302,7 @@ func TestGetConfigErrors(t *testing.T) {
 					},
 				},
 			},
-			wantErrs: true,
+			wantErrs: false,
 		},
 		{
 			name: "valid pod should not generate errors",

--- a/releasenotes/notes/ad-prometheus-fix-no-matching-cont-case-211baf7128bc32bb.yaml
+++ b/releasenotes/notes/ad-prometheus-fix-no-matching-cont-case-211baf7128bc32bb.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a regression with Prometheus scraping for Istio-injected containers
+    introduced in version 7.70.


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in the Prometheus autodiscovery provider.

A PR merged in 7.70 (#39264￼) broke Prometheus scraping for Istio-injected containers. This PR restores the expected behavior.

### Describe how you validated your changes

- I deployed Istio and enabled injection in a test namespace using `kubectl label namespace test istio-injection=enabled`.
- I deployed the Agent with the helm chart setting `datadog.prometheusScrape.enabled` to true.
- I deployed a pod in the test namespace and confirmed that with the current version, a Prometheus check was not scheduled, but it worked correctly with 7.69.0 and with this PR.