### PR TITLE
[CWS] set O_CLOEXEC on erpc fd

### DIFF
--- a/pkg/security/probe/erpc/erpc.go
+++ b/pkg/security/probe/erpc/erpc.go
@@ -13,6 +13,8 @@ import (
 	"runtime"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -92,7 +94,7 @@ func (k *ERPC) Close() error {
 
 // NewERPC returns a new ERPC object
 func NewERPC() (*ERPC, error) {
-	fd, err := syscall.Dup(syscall.Stdout)
+	fd, err := unix.FcntlInt(uintptr(syscall.Stdout), unix.F_DUPFD_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

This PR makes sure the fd used by eRPC has the CLOEXEC flag set, making sure it won't be inherited by any spawned process.

### Motivation

### Describe how you validated your changes

### Additional Notes
