### PR TITLE
[CWS] set CLOEXEC on netns handles

### DIFF
--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -133,7 +133,7 @@ func (nn *NetworkNamespace) getNamespaceHandleDup() (*os.File, error) {
 	}
 
 	// duplicate the file descriptor to avoid race conditions with the resync
-	dup, err := unix.Dup(int(nn.handle.Fd()))
+	dup, err := unix.FcntlInt(uintptr(nn.handle.Fd()), unix.F_DUPFD_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

This PR makes sure the fds used by network namespace dup handles have the CLOEXEC flag set, making sure they won't be inherited by any spawned process.

### Motivation

### Describe how you validated your changes

### Additional Notes
