### PR TITLE
bump `github.com/DataDog/ebpf-manager` to v0.7.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -181,7 +181,7 @@ require (
 	github.com/DataDog/datadog-traceroute v0.1.29
 	github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0
 	github.com/DataDog/dd-trace-go/v2 v2.2.2 // indirect
-	github.com/DataDog/ebpf-manager v0.7.14
+	github.com/DataDog/ebpf-manager v0.7.15
 	github.com/DataDog/go-libddwaf/v4 v4.3.2
 	github.com/DataDog/go-sqllexer v0.1.9
 	github.com/DataDog/gopsutil v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0 h1
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0/go.mod h1:KsvZuiis+8Ix3r+FEIew7LvryZeeIDrYyiTPMR14GOY=
 github.com/DataDog/dd-trace-go/v2 v2.2.2 h1:t7RCS6et5z+xrvM9dqUPtCGoNOWTj0pcApzbktMZi2k=
 github.com/DataDog/dd-trace-go/v2 v2.2.2/go.mod h1:xvdSukALA8/NnVfTAnxqkZfLLO/6Vi4y5ooxfVy6dfk=
-github.com/DataDog/ebpf-manager v0.7.14 h1:k08TW46xdUEHggumRmbs9y+ymcZIJ1LKrRcXEq7EgIM=
-github.com/DataDog/ebpf-manager v0.7.14/go.mod h1:1NxKtexXSqwQxa4YhNRHllla09PbSXeMfpRnwwz8IUk=
+github.com/DataDog/ebpf-manager v0.7.15 h1:14PbnvXFQccV3zexENfNuADAxCuwHNori7sK55CP0SU=
+github.com/DataDog/ebpf-manager v0.7.15/go.mod h1:aWM8s7mxjzC3iNZNBc4h0qjyQuhKeaU+ET92eB/0pRQ=
 github.com/DataDog/go-cmp v0.0.0-20250605161605-8f326bf2ab9d h1:ErpIQikDqtpE21afk2ExlJn0wg7gGWyUVu/RY4rBlMI=
 github.com/DataDog/go-cmp v0.0.0-20250605161605-8f326bf2ab9d/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/ebpf-manager/releases/tag/v0.7.15 especially this includes https://github.com/DataDog/ebpf-manager/pull/251

### Motivation

### Describe how you validated your changes

### Additional Notes
