### PR TITLE
Sort package diff output by size change

### DIFF
--- a/tasks/libs/common/diff.py
+++ b/tasks/libs/common/diff.py
@@ -1,12 +1,15 @@
 import os
 
 
-def diff(dir1: str, dir2: str):
+def diff(dir1: str, dir2: str, sort_by_size: bool = False):
     from binary import convert_units
 
     seen = set()
-    dir1not2 = []
+    dir1not2 = []  # Files in dir1 but not in dir2 (removed files)
+    dir2not1 = []  # Files in dir2 but not in dir1 (new files)
+    size_mismatches = []  # Files with size differences
 
+    # First pass: walk dir1 and collect differences
     for dirpath, _, filenames in os.walk(dir1):
         for filename in filenames:
             dir1filepath = os.path.join(dirpath, filename)
@@ -14,35 +17,57 @@ def diff(dir1: str, dir2: str):
             dir2filepath = dir2 + relfilepath
 
             if not os.path.exists(dir2filepath) and not os.path.islink(dir2filepath):
-                dir1not2.append(relfilepath)
+                s1 = os.stat(dir1filepath, follow_symlinks=False)
+                dir1not2.append((relfilepath, s1.st_size))
                 continue
 
             seen.add(relfilepath)
             s1 = os.stat(dir1filepath, follow_symlinks=False)
             s2 = os.stat(dir2filepath, follow_symlinks=False)
             if s1.st_size != s2.st_size:
-                diff = s2.st_size - s1.st_size
-                sign = "+" if diff > 0 else "-"
-                amount, unit = convert_units(abs(diff))
-                amount = round(amount, 2)
-                print(f"Size mismatch: {relfilepath} {s1.st_size} vs {s2.st_size} ({sign}{amount}{unit})")
+                size_mismatches.append((relfilepath, s1.st_size, s2.st_size))
 
-    print()
-
-    if dir1not2:
-        print(f"Files in {dir1} but not in {dir2}:")
-        for filepath in dir1not2:
-            print(filepath)
-
-        print()
-
-    header = False
+    # Second pass: walk dir2 to find new files
     for dirpath, _, filenames in os.walk(dir2):
         for filename in filenames:
             dir2filepath = os.path.join(dirpath, filename)
             relfilepath = dir2filepath.removeprefix(dir2)
             if relfilepath not in seen:
-                if not header:
-                    print(f"Files in {dir2} but not in {dir1}:")
-                    header = True
-                print(relfilepath)
+                s2 = os.stat(dir2filepath, follow_symlinks=False)
+                dir2not1.append((relfilepath, s2.st_size))
+
+    # Sort if requested
+    if sort_by_size:
+        # Sort size mismatches by decreasing absolute change
+        size_mismatches.sort(key=lambda x: x[2] - x[1], reverse=True)
+        # Sort removed and new files by decreasing size
+        dir1not2.sort(key=lambda x: x[1], reverse=True)
+        dir2not1.sort(key=lambda x: x[1], reverse=True)
+
+    # Print size mismatches
+    for relfilepath, s1_size, s2_size in size_mismatches:
+        diff_bytes = s2_size - s1_size
+        sign = "+" if diff_bytes > 0 else "-"
+        amount, unit = convert_units(abs(diff_bytes))
+        amount = round(amount, 2)
+        print(f"Size mismatch: {relfilepath} {s1_size} vs {s2_size} ({sign}{amount}{unit})")
+
+    print()
+
+    # Print removed files
+    if dir1not2:
+        print(f"Files in {dir1} but not in {dir2}:")
+        for filepath, size in dir1not2:
+            amount, unit = convert_units(size)
+            amount = round(amount, 2)
+            print(f"{filepath} (-{amount}{unit})")
+
+        print()
+
+    # Print new files
+    if dir2not1:
+        print(f"Files in {dir2} but not in {dir1}:")
+        for filepath, size in dir2not1:
+            amount, unit = convert_units(size)
+            amount = round(amount, 2)
+            print(f"{filepath} (+{amount}{unit})")

--- a/tasks/package.py
+++ b/tasks/package.py
@@ -132,6 +132,7 @@ def diff(
     base_pipeline: str | None = None,
     target_ref: str | None = None,
     target_pipeline: str | None = None,
+    sort_by_size: bool = True,
 ):
     """
     Diff the content of the given package.
@@ -153,7 +154,7 @@ def diff(
     target_extract_dir = os.path.join(tmpdir, "target")
     download(ctx, target_pipeline_id, binary, _type, flavor, arch, tmpdir, extract_dir=target_extract_dir)
 
-    _diff(base_extract_dir, target_extract_dir)
+    _diff(base_extract_dir, target_extract_dir, sort_by_size=sort_by_size)
 
 
 @task(

--- a/tasks/unit_tests/diff_tests.py
+++ b/tasks/unit_tests/diff_tests.py
@@ -120,8 +120,8 @@ class TestDiff(unittest.TestCase):
 
         # Verify output includes files in dir1 but not in dir2
         mock_print.assert_any_call("Files in /dir1 but not in /dir2:")
-        mock_print.assert_any_call("/file2.txt")
-        mock_print.assert_any_call("/file3.txt")
+        mock_print.assert_any_call("/file2.txt (-1000B)")
+        mock_print.assert_any_call("/file3.txt (-1000B)")
 
     @patch('os.stat')
     @patch('os.path.islink')
@@ -156,8 +156,8 @@ class TestDiff(unittest.TestCase):
 
         # Verify output includes files in dir2 but not in dir1
         mock_print.assert_any_call("Files in /dir2 but not in /dir1:")
-        mock_print.assert_any_call("/file2.txt")
-        mock_print.assert_any_call("/file3.txt")
+        mock_print.assert_any_call("/file2.txt (+1000B)")
+        mock_print.assert_any_call("/file3.txt (+1000B)")
 
     @patch('os.stat')
     @patch('os.path.islink')
@@ -213,14 +213,14 @@ class TestDiff(unittest.TestCase):
 
         # Files in dir1 but not in dir2
         mock_print.assert_any_call("Files in /dir1 but not in /dir2:")
-        mock_print.assert_any_call("/file2.txt")
-        mock_print.assert_any_call("/subdir/file3.txt")
-        mock_print.assert_any_call("/subdir/file4.txt")
+        mock_print.assert_any_call("/file2.txt (-500B)")
+        mock_print.assert_any_call("/subdir/file3.txt (-500B)")
+        mock_print.assert_any_call("/subdir/file4.txt (-500B)")
 
         # Files in dir2 but not in dir1
         mock_print.assert_any_call("Files in /dir2 but not in /dir1:")
-        mock_print.assert_any_call("/unique.txt")
-        mock_print.assert_any_call("/other/file5.txt")
+        mock_print.assert_any_call("/unique.txt (+500B)")
+        mock_print.assert_any_call("/other/file5.txt (+500B)")
 
     @patch('os.stat')
     @patch('os.path.islink')
@@ -264,3 +264,105 @@ class TestDiff(unittest.TestCase):
 
         # Verify symlinks were properly skipped
         self.assertEqual(mock_print.call_count, 1)  # Only the newline should be printed
+
+    @patch('os.stat')
+    @patch('os.path.islink')
+    @patch('os.path.exists')
+    @patch('os.walk')
+    @patch('builtins.print')
+    def test_sort_by_size(self, mock_print, mock_walk, mock_exists, mock_islink, mock_stat):
+        """Test case where results are sorted by size when sort_by_size=True."""
+        # Setup directory structure with various files
+        mock_walk.side_effect = [
+            # Files in dir1
+            [('/dir1', [], ['file1.txt', 'file2.txt', 'file3.txt', 'removed1.txt', 'removed2.txt'])],
+            # Files in dir2
+            [('/dir2', [], ['file1.txt', 'file2.txt', 'file3.txt', 'new1.txt', 'new2.txt'])],
+        ]
+
+        # Control which files exist in which directories
+        def exists_side_effect(path):
+            return 'removed' not in path
+
+        mock_exists.side_effect = exists_side_effect
+        mock_islink.return_value = False
+
+        # Different file sizes to test sorting
+        size_map = {
+            '/dir1/file1.txt': 1000,  # file1: increase by 500 bytes
+            '/dir2/file1.txt': 1500,
+            '/dir1/file2.txt': 3000,  # file2: increase by 2000 bytes (larger change)
+            '/dir2/file2.txt': 5000,
+            '/dir1/file3.txt': 1300,  # file3: decrease by 300 bytes
+            '/dir2/file3.txt': 1000,
+            '/dir1/removed1.txt': 800,  # Smaller removed file
+            '/dir1/removed2.txt': 1500,  # Larger removed file
+            '/dir2/new1.txt': 600,  # Smaller new file
+            '/dir2/new2.txt': 1200,  # Larger new file
+        }
+
+        def stat_side_effect(path, follow_symlinks=None):
+            self.assertEqual(follow_symlinks, False)
+            stat_result = MagicMock()
+            stat_result.st_size = size_map.get(path, 0)
+            return stat_result
+
+        mock_stat.side_effect = stat_side_effect
+
+        # Call the function with sort_by_size=True
+        diff('/dir1', '/dir2', sort_by_size=True)
+
+        # Get all print calls
+        print_calls = [call[0][0] if call[0] else '' for call in mock_print.call_args_list]
+
+        # Find the indices of size mismatches in the output
+        size_mismatch_indices = [i for i, call in enumerate(print_calls) if 'Size mismatch:' in str(call)]
+
+        # Verify size mismatches are sorted by decreasing absolute change
+        # file2 (+2000), file1 (+500), file3 (-300)
+        self.assertIn('file2.txt', str(print_calls[size_mismatch_indices[0]]))
+        self.assertIn('+1.95KiB', str(print_calls[size_mismatch_indices[0]]))
+        self.assertIn('file1.txt', str(print_calls[size_mismatch_indices[1]]))
+        self.assertIn('+500B', str(print_calls[size_mismatch_indices[1]]))
+        self.assertIn('file3.txt', str(print_calls[size_mismatch_indices[2]]))
+        self.assertIn('-300B', str(print_calls[size_mismatch_indices[2]]))
+
+        # Find the section for removed files
+        removed_section_start = None
+        for i, call in enumerate(print_calls):
+            if 'Files in /dir1 but not in /dir2:' in str(call):
+                removed_section_start = i
+                break
+
+        # Verify removed files are sorted by size (removed2: 1500, removed1: 800)
+        self.assertIsNotNone(removed_section_start, "Could not find removed files section")
+        if removed_section_start is not None:
+            removed_files = []
+            for i in range(removed_section_start + 1, len(print_calls)):
+                if print_calls[i] and '/removed' in str(print_calls[i]):
+                    removed_files.append(str(print_calls[i]))
+                elif print_calls[i] and 'Files in' in str(print_calls[i]):
+                    break
+
+        self.assertEqual(len(removed_files), 2)
+        self.assertIn('removed2.txt', removed_files[0])
+        self.assertIn('removed1.txt', removed_files[1])
+
+        # Find the section for new files
+        new_section_start = None
+        for i, call in enumerate(print_calls):
+            if 'Files in /dir2 but not in /dir1:' in str(call):
+                new_section_start = i
+                break
+
+        # Verify new files are sorted by size (new2: 1200, new1: 600)
+        self.assertIsNotNone(new_section_start, "Could not find new files section")
+        if new_section_start is not None:
+            new_files = []
+            for i in range(new_section_start + 1, len(print_calls)):
+                if print_calls[i] and '/new' in str(print_calls[i]):
+                    new_files.append(str(print_calls[i]))
+
+            self.assertEqual(len(new_files), 2)
+            self.assertIn('new2.txt', new_files[0])
+            self.assertIn('new1.txt', new_files[1])


### PR DESCRIPTION
### What does this PR do?
Sort package diff output by size change by default.
Also printed the size of added/removed files.

### Motivation
The task is mostly used to find the reason for a size change, this change helps find the cause for an increase or a decrease at a glance.

### Describe how you validated your changes
Updated unit tests, manual tests.

### Additional Notes
