### PR TITLE
AGTMETRICS-385 Remove unused MarshalSplitCompress for sketches

### DIFF
--- a/pkg/serializer/internal/metrics/sketch_benchmark_test.go
+++ b/pkg/serializer/internal/metrics/sketch_benchmark_test.go
@@ -16,7 +16,6 @@ import (
 	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/impl"
 	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
 
 func benchmarkSplitPayloadsSketchesNew(b *testing.B, numPoints int) {
@@ -32,7 +31,7 @@ func benchmarkSplitPayloadsSketchesNew(b *testing.B, numPoints int) {
 	logger := logmock.New(b)
 
 	for n := 0; n < b.N; n++ {
-		payloads, err := serializer.MarshalSplitCompress(marshaler.NewBufferContext(), mockConfig, compressor, logger)
+		payloads, err := serializer.MarshalSplitCompressPipelines(mockConfig, compressor, testPipelines(), logger)
 		require.NoError(b, err)
 		var pb int
 		for _, p := range payloads {


### PR DESCRIPTION
### What does this PR do?

Remove unused MarshalSplitCompress for sketches

### Motivation

Cleanup

### Describe how you validated your changes

### Additional Notes
