### PR TITLE
Move logs fingerprinter to a mock-able interface

### DIFF
--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -61,7 +61,7 @@ type Launcher struct {
 	filesTailedBetweenScans []*tailer.File
 	// Stores pertinent information about old tailer when rotation occurs and fingerprinting isn't possible
 	oldInfoMap    map[string]*oldTailerInfo
-	fingerprinter *tailer.Fingerprinter
+	fingerprinter tailer.Fingerprinter
 }
 
 type oldTailerInfo struct {
@@ -415,7 +415,7 @@ func (s *Launcher) startNewTailer(file *tailer.File, m config.TailingMode, finge
 	var whence int
 	mode := s.handleTailingModeChange(tailer.Identifier(), m)
 
-	offset, whence, err := Position(s.registry, tailer.Identifier(), mode, *s.fingerprinter)
+	offset, whence, err := Position(s.registry, tailer.Identifier(), mode, s.fingerprinter)
 	if err != nil {
 		log.Warnf("Could not recover offset for file with path %v: %v", file.Path, err)
 	}
@@ -475,7 +475,7 @@ func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.Tail
 	var whence int
 	mode := s.handleTailingModeChange(tailer.Identifier(), m)
 
-	offset, whence, err := Position(s.registry, tailer.Identifier(), mode, *s.fingerprinter)
+	offset, whence, err := Position(s.registry, tailer.Identifier(), mode, s.fingerprinter)
 	if err != nil {
 		log.Warnf("Could not recover offset for file with path %v: %v", file.Path, err)
 	}

--- a/pkg/logs/launchers/file/position_test.go
+++ b/pkg/logs/launchers/file/position_test.go
@@ -26,65 +26,66 @@ func TestPosition(t *testing.T) {
 	maxLines := 1
 	maxBytes := 2048
 	toSkip := 0
-	fingerprintConfig := &types.FingerprintConfig{
-		MaxBytes:            maxBytes,
-		Count:               maxLines,
-		CountToSkip:         toSkip,
-		FingerprintStrategy: types.FingerprintStrategyLineChecksum,
-	}
 
 	// Create a mock fingerprinter
-	mockFingerprinter := file.NewFingerprinter(*fingerprintConfig)
+	mockFingerprinter := file.NewFingerprinterMock()
 
 	// Set a fingerprint in the registry
 	fingerprint := &types.Fingerprint{
-		Value:  12345,
-		Config: fingerprintConfig,
+		Value: 12345,
+		Config: &types.FingerprintConfig{
+			MaxBytes:            maxBytes,
+			Count:               maxLines,
+			CountToSkip:         toSkip,
+			FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+		},
 	}
 	registry.SetFingerprint(fingerprint)
+	mockFingerprinter.SetFingerprint("test", fingerprint)
+	mockFingerprinter.SetInvalidFingerprint("")
 
-	offset, whence, err = Position(registry, "", config.End, *mockFingerprinter)
+	offset, whence, err = Position(registry, "", config.End, mockFingerprinter)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekEnd, whence)
 
-	offset, whence, err = Position(registry, "", config.Beginning, *mockFingerprinter)
+	offset, whence, err = Position(registry, "", config.Beginning, mockFingerprinter)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekStart, whence)
 
 	registry.SetOffset("test", "123456789")
-	offset, whence, err = Position(registry, "test", config.End, *mockFingerprinter)
+	offset, whence, err = Position(registry, "test", config.End, mockFingerprinter)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(123456789), offset)
 	assert.Equal(t, io.SeekStart, whence)
 
 	registry.SetOffset("test", "987654321")
-	offset, whence, err = Position(registry, "test", config.Beginning, *mockFingerprinter)
+	offset, whence, err = Position(registry, "test", config.Beginning, mockFingerprinter)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(987654321), offset)
 	assert.Equal(t, io.SeekStart, whence)
 
 	registry.SetOffset("test", "foo")
-	offset, whence, err = Position(registry, "test", config.End, *mockFingerprinter)
+	offset, whence, err = Position(registry, "test", config.End, mockFingerprinter)
 	assert.NotNil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekEnd, whence)
 
 	registry.SetOffset("test", "bar")
-	offset, whence, err = Position(registry, "test", config.Beginning, *mockFingerprinter)
+	offset, whence, err = Position(registry, "test", config.Beginning, mockFingerprinter)
 	assert.NotNil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekStart, whence)
 
 	registry.SetOffset("test", "123456789")
-	offset, whence, err = Position(registry, "test", config.ForceBeginning, *mockFingerprinter)
+	offset, whence, err = Position(registry, "test", config.ForceBeginning, mockFingerprinter)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekStart, whence)
 
 	registry.SetOffset("test", "987654321")
-	offset, whence, err = Position(registry, "test", config.ForceEnd, *mockFingerprinter)
+	offset, whence, err = Position(registry, "test", config.ForceEnd, mockFingerprinter)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekEnd, whence)

--- a/pkg/logs/tailers/file/fingerprint_mock.go
+++ b/pkg/logs/tailers/file/fingerprint_mock.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package file
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/types"
+)
+
+// FingerprinterMock is a mock implementation of the Fingerprinter interface
+type FingerprinterMock struct {
+	shouldFileFingerprint map[string]bool
+	fingerprints          map[string]*types.Fingerprint
+}
+
+// NewFingerprinterMock creates a new FingerprintMock
+func NewFingerprinterMock() *FingerprinterMock {
+	return &FingerprinterMock{
+		shouldFileFingerprint: make(map[string]bool),
+		fingerprints:          make(map[string]*types.Fingerprint),
+	}
+}
+
+// SetShouldFileFingerprint sets whether or not the given file should be fingerprinted
+func (f *FingerprinterMock) SetShouldFileFingerprint(file *File, shouldFileFingerprint bool) {
+	f.shouldFileFingerprint[file.Path] = shouldFileFingerprint
+}
+
+// ShouldFileFingerprint returns previously set value for the given file, or false if no value was set
+func (f *FingerprinterMock) ShouldFileFingerprint(file *File) bool {
+	return f.shouldFileFingerprint[file.Path]
+}
+
+// SetFingerprint sets the fingerprint for the given file
+func (f *FingerprinterMock) SetFingerprint(filepath string, fingerprint *types.Fingerprint) {
+	f.shouldFileFingerprint[filepath] = true
+	f.fingerprints[filepath] = fingerprint
+}
+
+// SetInvalidFingerprint sets an invalid fingerprint for the given file
+func (f *FingerprinterMock) SetInvalidFingerprint(filepath string) {
+	f.shouldFileFingerprint[filepath] = true
+	f.fingerprints[filepath] = &types.Fingerprint{Value: types.InvalidFingerprintValue, Config: nil}
+}
+
+// ComputeFingerprint returns previously set fingerprint for the given file, or an error if no fingerprint was set
+func (f *FingerprinterMock) ComputeFingerprint(file *File) (*types.Fingerprint, error) {
+	if fingerprint, ok := f.fingerprints[file.Path]; ok {
+		return fingerprint, nil
+	}
+	return nil, fmt.Errorf("no fingerprint set for file %s", file.Path)
+}
+
+// ComputeFingerprintFromConfig returns previously set fingerprint for the given file path, or an error if no fingerprint was set
+func (f *FingerprinterMock) ComputeFingerprintFromConfig(filepath string, _ *types.FingerprintConfig) (*types.Fingerprint, error) {
+	if fingerprint, ok := f.fingerprints[filepath]; ok {
+		return fingerprint, nil
+	}
+	return nil, fmt.Errorf("no fingerprint set for file %s", filepath)
+}

--- a/pkg/logs/tailers/file/rotate_nix.go
+++ b/pkg/logs/tailers/file/rotate_nix.go
@@ -59,7 +59,7 @@ func (t *Tailer) DidRotate() (bool, error) {
 // - renamed and recreated
 // - removed and recreated
 // - truncated
-func (t *Tailer) DidRotateViaFingerprint(fingerprinter *Fingerprinter) (bool, error) {
+func (t *Tailer) DidRotateViaFingerprint(fingerprinter Fingerprinter) (bool, error) {
 	newFingerprint, err := fingerprinter.ComputeFingerprint(t.file)
 
 	// If computing the fingerprint led to an error there was likely an IO issue, handle this appropriately below.

--- a/pkg/logs/tailers/file/rotate_windows.go
+++ b/pkg/logs/tailers/file/rotate_windows.go
@@ -52,7 +52,7 @@ func (t *Tailer) DidRotate() (bool, error) {
 // - renamed and recreated
 // - removed and recreated
 // - truncated
-func (t *Tailer) DidRotateViaFingerprint(fingerprinter *Fingerprinter) (bool, error) {
+func (t *Tailer) DidRotateViaFingerprint(fingerprinter Fingerprinter) (bool, error) {
 	newFingerprint, err := fingerprinter.ComputeFingerprint(t.file)
 
 	// If computing the fingerprint led to an error there was likely an IO issue, handle this appropriately below.


### PR DESCRIPTION
### What does this PR do?
Shift the fingerprinter over to an interface to support mocking/testability. This change is intended to be non-functional.

### Motivation

### Describe how you validated your changes
Automated test coverage should be sufficient for this change

### Additional Notes
