### PR TITLE
[NCM] Add check / extracted metadata metrics

### DIFF
--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement.go
@@ -189,13 +189,13 @@ func (c *Check) FindMatchingProfile() (*profile.NCMProfile, error) {
 }
 
 func (c *Check) getDeviceTags() []string {
-	// TODO: confirm what tags should be associated for a device config and/or its metrics
 	deviceID := fmt.Sprintf("%s:%s", c.checkContext.Namespace, c.checkContext.Device.IPAddress)
 	deviceTags := []string{
 		"device_namespace:" + c.checkContext.Namespace,
 		"device_ip:" + c.checkContext.Device.IPAddress,
 		"device_id:" + deviceID,
-		// TODO: device_hostname..?
+		// TODO: device_hostname - may need to be extracted from config / output to be retrieved in NCM core check
+		"config_source:cli",
 		"profile:" + c.checkContext.ProfileCache.ProfileName,
 	}
 	return slices.Clone(deviceTags)

--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement.go
@@ -10,6 +10,7 @@ package networkconfigmanagement
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
@@ -34,17 +35,19 @@ const CheckName = "network_config_management"
 // Check is the main struct for the network configuration management check
 type Check struct {
 	core.CheckBase
-	checkContext *ncmconfig.NcmCheckContext
-	sender       *ncmsender.NCMSender
-	agentConfig  config.Component
-	remoteClient ncmremote.Client
-	clock        clock.Clock
+	checkContext  *ncmconfig.NcmCheckContext
+	sender        *ncmsender.NCMSender
+	agentConfig   config.Component
+	remoteClient  ncmremote.Client
+	clock         clock.Clock
+	lastCheckTime time.Time
 }
 
 // Run executes the check to retrieve network device configurations from a device
 func (c *Check) Run() error {
 	var checkErr error
 	var configs []ncmreport.NetworkDeviceConfig
+	checkStartTime := c.clock.Now()
 
 	checkErr = c.remoteClient.Connect()
 	if checkErr != nil {
@@ -71,15 +74,13 @@ func (c *Check) Run() error {
 	// Update the remote client's device profile to access the correct commands
 	c.remoteClient.SetProfile(c.checkContext.ProfileCache.Profile)
 
+	deviceID := fmt.Sprintf("%s:%s", c.checkContext.Namespace, c.checkContext.Device.IPAddress)
+	deviceTags := c.getDeviceTags()
+	c.sender.SetDeviceTags(deviceTags)
+
 	rawRunningConfig, checkErr := c.remoteClient.RetrieveRunningConfig()
 	if checkErr != nil {
 		return checkErr
-	}
-
-	// TODO: confirm what tags should be associated for a device config and/or its metrics
-	deviceID := fmt.Sprintf("%s:%s", c.checkContext.Namespace, c.checkContext.Device.IPAddress)
-	tags := []string{
-		"device_ip:" + c.checkContext.Device.IPAddress,
 	}
 
 	runningConfig, metadata, checkErr := c.checkContext.ProfileCache.Profile.ProcessCommandOutput(profile.Running, rawRunningConfig)
@@ -87,7 +88,7 @@ func (c *Check) Run() error {
 		log.Warnf("unable to process rules for running config for device %s, using agent collection ts: %s", deviceID, checkErr)
 	}
 	// TODO: helper fn to take metadata that needs to be emitted as metrics + emit them
-	configs = append(configs, ncmreport.ToNetworkDeviceConfig(deviceID, c.checkContext.Device.IPAddress, ncmreport.RUNNING, metadata, tags, runningConfig))
+	configs = append(configs, ncmreport.ToNetworkDeviceConfig(deviceID, c.checkContext.Device.IPAddress, ncmreport.RUNNING, metadata, deviceTags, runningConfig))
 
 	rawStartupConfig, checkErr := c.remoteClient.RetrieveStartupConfig()
 	if checkErr != nil {
@@ -99,7 +100,7 @@ func (c *Check) Run() error {
 			log.Warnf("unable to process rules for startup config for device %s, using agent collection ts: %s", deviceID, checkErr)
 		}
 		// add the startup config to the payload if it was retrieved successfully
-		configs = append(configs, ncmreport.ToNetworkDeviceConfig(deviceID, c.checkContext.Device.IPAddress, ncmreport.STARTUP, metadata, tags, startupConfig))
+		configs = append(configs, ncmreport.ToNetworkDeviceConfig(deviceID, c.checkContext.Device.IPAddress, ncmreport.STARTUP, metadata, deviceTags, startupConfig))
 	}
 
 	checkErr = c.sender.SendNCMConfig(ncmreport.ToNCMPayload(c.checkContext.Namespace, "", configs, c.clock.Now().Unix()))
@@ -107,8 +108,8 @@ func (c *Check) Run() error {
 		return checkErr
 	}
 
-	// TODO: Send any metrics as well
-	//c.sender.SendNCMMetrics()
+	c.sender.SendNCMCheckMetrics(checkStartTime, c.lastCheckTime)
+	c.lastCheckTime = checkStartTime
 
 	c.sender.Commit()
 	return nil
@@ -131,19 +132,19 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 		return fmt.Errorf("common configure failed: %s", err)
 	}
 
+	// Initialize the clock
+	c.clock = clock.New()
+
 	// Initialize the Sender
 	s, err := c.GetSender()
 	if err != nil {
 		return err
 	}
-	ncmSender := ncmsender.NewNCMSender(s, c.checkContext.Namespace)
+	ncmSender := ncmsender.NewNCMSender(s, c.checkContext.Namespace, c.clock)
 	c.sender = ncmSender
 
 	// TODO: add check to see the device's credentials type (SSH/Telnet) and create appropriate client factory
 	c.remoteClient = ncmremote.NewSSHClient(c.checkContext.Device)
-
-	// Initialize the clock
-	c.clock = clock.New()
 
 	return nil
 }
@@ -185,4 +186,17 @@ func (c *Check) FindMatchingProfile() (*profile.NCMProfile, error) {
 		return prof, nil
 	}
 	return nil, fmt.Errorf("unable to find matching profile for device %s", c.checkContext.Device.IPAddress)
+}
+
+func (c *Check) getDeviceTags() []string {
+	// TODO: confirm what tags should be associated for a device config and/or its metrics
+	deviceID := fmt.Sprintf("%s:%s", c.checkContext.Namespace, c.checkContext.Device.IPAddress)
+	deviceTags := []string{
+		"device_namespace:" + c.checkContext.Namespace,
+		"device_ip:" + c.checkContext.Device.IPAddress,
+		"device_id:" + deviceID,
+		// TODO: device_hostname..?
+		"profile:" + c.checkContext.ProfileCache.ProfileName,
+	}
+	return slices.Clone(deviceTags)
 }

--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
@@ -249,6 +249,7 @@ func TestCheck_Run_Success(t *testing.T) {
 		"device_namespace:default",
 		"device_ip:10.0.0.1",
 		"device_id:default:10.0.0.1",
+		"config_source:cli",
 		"profile:p2",
 	}
 	expectedTagsBytes, _ := json.Marshal(expectedTags)

--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
@@ -220,6 +220,7 @@ func TestCheck_Run_Success(t *testing.T) {
 
 	// Set up mock sender expectations
 	mockSender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return().Once()
+	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockSender.On("Commit").Return()
 
 	// Configure the check
@@ -244,6 +245,13 @@ func TestCheck_Run_Success(t *testing.T) {
 
 	runningBytes, _ := json.Marshal([]byte(runningOutput))
 	startupBytes, _ := json.Marshal([]byte(startupOutput))
+	expectedTags := []string{
+		"device_namespace:default",
+		"device_ip:10.0.0.1",
+		"device_id:default:10.0.0.1",
+		"profile:p2",
+	}
+	expectedTagsBytes, _ := json.Marshal(expectedTags)
 
 	var expectedEvent = []byte(fmt.Sprintf(`
 {
@@ -255,7 +263,7 @@ func TestCheck_Run_Success(t *testing.T) {
       "device_ip": "10.0.0.1",
       "config_type": "running",
       "timestamp": 1754043600,
-      "tags": ["device_ip:10.0.0.1"],
+      "tags": %s,
       "content": %s
     },
     {
@@ -263,19 +271,20 @@ func TestCheck_Run_Success(t *testing.T) {
       "device_ip": "10.0.0.1",
       "config_type": "startup",
       "timestamp": 0,
-      "tags": ["device_ip:10.0.0.1"],
+      "tags": %s,
       "content": %s
     }
   ],
   "collect_timestamp": 1754043600
 }
-`, runningBytes, startupBytes))
+`, expectedTagsBytes, runningBytes, expectedTagsBytes, startupBytes))
 
 	compactEvent := new(bytes.Buffer)
 	err = json.Compact(compactEvent, expectedEvent)
 	assert.NoError(t, err)
 	mockSender.AssertNumberOfCalls(t, "EventPlatformEvent", 1)
 	mockSender.AssertEventPlatformEvent(t, compactEvent.Bytes(), "ndmconfig")
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "datadog.ncm.check_duration", expectedTags)
 	mockSender.AssertExpectations(t)
 }
 

--- a/pkg/networkconfigmanagement/sender/sender.go
+++ b/pkg/networkconfigmanagement/sender/sender.go
@@ -70,7 +70,7 @@ func (s *NCMSender) SendNCMCheckMetrics(startTime time.Time, lastCheckTime time.
 
 // SendMetricsFromExtractedMetadata sends metrics from data extracted from the device config after processing
 func (s *NCMSender) SendMetricsFromExtractedMetadata(metadata profile.ExtractedMetadata, configType ncmreport.ConfigType) {
-	tags := s.getDeviceTags()
+	tags := append(s.getDeviceTags(), utils.GetCommonAgentTags()...)
 	switch configType {
 	case ncmreport.RUNNING:
 		tags = append(s.getDeviceTags(), ncmRunningConfigTypeTag)

--- a/pkg/networkconfigmanagement/sender/sender.go
+++ b/pkg/networkconfigmanagement/sender/sender.go
@@ -11,31 +11,76 @@ package sender
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
 	ncmreport "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/report"
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/utils"
+	"github.com/benbjohnson/clock"
+)
+
+const (
+	ncmCheckDurationMetric  = "datadog.ncm.check_duration"
+	ncmCheckIntervalMetric  = "datadog.ncm.check_interval"
+	ncmConfigSizeMetric     = "ncm.config_size"
+	ncmRunningConfigTypeTag = "config_type:running"
+	ncmStartupConfigTypeTag = "config_type:startup"
 )
 
 // NCMSender is a wrapper around the sender.Sender to send network device configuration data
 type NCMSender struct {
-	Sender    sender.Sender
-	namespace string
+	Sender     sender.Sender
+	namespace  string
+	hostname   string // TODO: get the hostname to use
+	deviceTags []string
+	clock      clock.Clock
 }
 
 // NewNCMSender creates a new NCMSender
-func NewNCMSender(sender sender.Sender, namespace string) *NCMSender {
+func NewNCMSender(sender sender.Sender, namespace string, clock clock.Clock) *NCMSender {
 	return &NCMSender{
 		Sender:    sender,
 		namespace: namespace,
+		clock:     clock,
 	}
 }
 
-// SendNCMMetrics sends the network device configuration metrics to Datadog
-func (s *NCMSender) SendNCMMetrics() error {
-	// Implement the logic to send the network device configuration
-	// This is a placeholder implementation
-	//s.GaugeWithTimestamp()
-	return nil
+// SetDeviceTags sets the device tags for the sender to use for metrics submission
+func (s *NCMSender) SetDeviceTags(deviceTags []string) {
+	s.deviceTags = deviceTags
+}
+
+func (s *NCMSender) getDeviceTags() []string {
+	return utils.CopyStrings(s.deviceTags)
+}
+
+// SendNCMCheckMetrics sends metrics about the check itself to Datadog
+func (s *NCMSender) SendNCMCheckMetrics(startTime time.Time, lastCheckTime time.Time) {
+	tags := append(s.getDeviceTags(), utils.GetCommonAgentTags()...)
+	duration := s.clock.Since(startTime).Seconds()
+	s.Sender.Gauge(ncmCheckDurationMetric, duration, s.hostname, tags)
+
+	if !lastCheckTime.IsZero() {
+		interval := startTime.Sub(lastCheckTime).Seconds()
+		s.Sender.Gauge(ncmCheckIntervalMetric, interval, s.hostname, tags)
+	}
+}
+
+// SendMetricsFromExtractedMetadata sends metrics from data extracted from the device config after processing
+func (s *NCMSender) SendMetricsFromExtractedMetadata(metadata profile.ExtractedMetadata, configType ncmreport.ConfigType) {
+	tags := s.getDeviceTags()
+	switch configType {
+	case ncmreport.RUNNING:
+		tags = append(s.getDeviceTags(), ncmRunningConfigTypeTag)
+	case ncmreport.STARTUP:
+		tags = append(s.getDeviceTags(), ncmStartupConfigTypeTag)
+	}
+	// if config size was extracted, submit the metric
+	if metadata.ConfigSize != 0 {
+		s.Sender.Gauge(ncmConfigSizeMetric, float64(metadata.ConfigSize), s.hostname, tags)
+	}
 }
 
 // SendNCMConfig sends the network device configuration payload to event platform

--- a/pkg/networkconfigmanagement/sender/sender_test.go
+++ b/pkg/networkconfigmanagement/sender/sender_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
+	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/mock"
 
@@ -26,10 +28,10 @@ import (
 func TestNCMSender_SendNCMConfig_Success(t *testing.T) {
 	mockSender := &mocksender.MockSender{}
 	namespace := "default"
-	ncmSender := NewNCMSender(mockSender, namespace)
-
 	mockClock := clock.NewMock()
 	mockClock.Set(time.Date(2025, 8, 1, 10, 20, 0, 0, time.UTC))
+
+	ncmSender := NewNCMSender(mockSender, namespace, mockClock)
 
 	// Create test payload
 	configs := []ncmreport.NetworkDeviceConfig{
@@ -79,4 +81,119 @@ func TestNCMSender_SendNCMConfig_Success(t *testing.T) {
 	mockSender.AssertNumberOfCalls(t, "EventPlatformEvent", 1)
 	mockSender.AssertEventPlatformEvent(t, compactEvent.Bytes(), eventplatform.EventTypeNetworkConfigManagement)
 	mockSender.AssertExpectations(t)
+}
+
+type expectedMetric struct {
+	submissionType string
+	name           string
+	value          float64
+	tags           []string
+}
+
+func TestNCMSender_SendNCMCheckMetrics(t *testing.T) {
+	tests := []struct {
+		name            string
+		startTime       time.Time
+		lastCheckTime   time.Time
+		tags            []string
+		expectedMetrics []expectedMetric
+	}{
+		{
+			name:          "Submit NCM check metrics successfully",
+			startTime:     time.Date(2025, 8, 1, 10, 20, 0, 0, time.UTC),
+			lastCheckTime: time.Date(2025, 8, 1, 10, 05, 0, 0, time.UTC), // 15 minutes before
+			tags:          []string{"device_ip:10.0.0.1"},
+			expectedMetrics: []expectedMetric{
+				{
+					submissionType: "Gauge",
+					name:           ncmCheckDurationMetric,
+					value:          5,
+					tags:           []string{"device_ip:10.0.0.1", "agent_version:" + version.AgentVersion},
+				},
+				{
+					submissionType: "Gauge",
+					name:           ncmCheckIntervalMetric,
+					value:          900, // 15 minutes in seconds
+					tags:           []string{"device_ip:10.0.0.1", "agent_version:" + version.AgentVersion},
+				},
+			},
+		},
+		{
+			name:      "Last check time is zero (first run), no interval metric sent",
+			startTime: time.Date(2025, 8, 1, 10, 20, 0, 0, time.UTC),
+			tags:      []string{"device_ip:10.0.0.1"},
+			expectedMetrics: []expectedMetric{
+				{
+					submissionType: "Gauge",
+					name:           ncmCheckDurationMetric,
+					value:          5,
+					tags:           []string{"device_ip:10.0.0.1", "agent_version:" + version.AgentVersion},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSender := mocksender.NewMockSender("test")
+			mockSender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+			mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+			mockClock := clock.NewMock()
+			mockClock.Set(tt.startTime)
+			mockClock.Add(5 * time.Second)
+
+			sender := NewNCMSender(mockSender, "test-namespace", mockClock)
+			sender.SetDeviceTags(tt.tags)
+
+			sender.SendNCMCheckMetrics(tt.startTime, tt.lastCheckTime)
+
+			for _, metric := range tt.expectedMetrics {
+				mockSender.AssertMetric(t, metric.submissionType, metric.name, metric.value, "", metric.tags)
+			}
+		})
+	}
+}
+
+func TestNCMSender_SendMetricsFromExtractedMetadata(t *testing.T) {
+	tests := []struct {
+		name              string
+		extractedMetadata profile.ExtractedMetadata
+		configType        ncmreport.ConfigType
+		tags              []string
+		expectedMetrics   []expectedMetric
+	}{
+		{
+			name: "Config size metric submitted if present",
+			extractedMetadata: profile.ExtractedMetadata{
+				ConfigSize: 300,
+			},
+			configType: ncmRunningConfigTypeTag,
+			tags:       []string{"device_id:10.0.0.1", "config_type:running"},
+			expectedMetrics: []expectedMetric{
+				{
+					submissionType: "Gauge",
+					name:           ncmConfigSizeMetric,
+					value:          300,
+				},
+			},
+		},
+		{
+			name:            "Nothing extracted - no metrics expected",
+			expectedMetrics: []expectedMetric{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSender := mocksender.NewMockSender("test")
+			mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+			sender := NewNCMSender(mockSender, "test-namespace", clock.NewMock())
+			sender.SetDeviceTags(tt.tags)
+			sender.SendMetricsFromExtractedMetadata(tt.extractedMetadata, tt.configType)
+
+			for _, metric := range tt.expectedMetrics {
+				mockSender.AssertMetric(t, metric.submissionType, metric.name, metric.value, "", tt.tags)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR is adding metrics to be emitted by the agent during an NCM check run by these changes:
* Added metrics:
  * Check metrics
    * `datadog.ncm.check_duration` from the start of `Run()` until submission
    * `datadog.ncm.check_interval` if another check has run, it will emit the interval between the two runs
  * Extracted metadata metrics
    * `ncm.config_size` if extracted via metadata parsing during processing rules
* Clean up device tags that should be emitted as part of the device's config metadata + metrics

More metrics to emit but starting here :-D 

**Other metric ideas**
* Profile matching metric results (success, failures)
* Config command retrieval (success, failures)
* Payload submission (num of configs for submission)
* Devices using NCM? (can be similar to one above)
* Metrics related to SSH client
* Processing rules errors, etc.

### Motivation

### Describe how you validated your changes

### Additional Notes
