### PR TITLE
Fix device scan printing "successful scan" when there is an error

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -291,10 +291,12 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 		ScanType: metadata.ManualScan,
 	})
 	if err != nil {
-		fmt.Printf("Unable to perform device scan for device %s : %e", deviceID, err)
+		fmt.Printf("Unable to perform device scan for device %s: %v\n", deviceID, err)
+		return err
 	}
+
 	fmt.Printf("Completed scan successfully for device: %s\n", deviceID)
-	return err
+	return nil
 }
 
 // snmpWalk prints every SNMP value, in the style of the unix snmpwalk command.


### PR DESCRIPTION
### What does this PR do?

This PR fixes the CLI device scan printing "successful scan" when the scan results in an error by returning early.

### Motivation

### Describe how you validated your changes

### Additional Notes
