### PR TITLE
Add members read permissions on deps update workflow

### DIFF
--- a/.github/chainguard/self.update-dependencies.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-dependencies.create-pr.sts.yaml
@@ -12,3 +12,4 @@ claim_pattern:
 permissions:
   contents: write
   pull_requests: write
+  members: read


### PR DESCRIPTION
### What does this PR do?
Add `members: read` permissions on `golang.org/x/...` deps update workflow.

### Motivation
The workflow fails to add Agent Runtimes team to reviewers, this should fix it.

### Describe how you validated your changes
I can't run the workflow from this branch so I can't check if it works with the change.

### Additional Notes
