### PR TITLE
Shift the logs decoder to utilize an interface for better mocking/testability

### DIFF
--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -42,9 +42,19 @@ func NewInput(content []byte) *message.Message {
 // The LineHandler processes the messages it as necessary (as single lines,
 // multiple lines, or auto-detecting the two), and sends the result to the
 // Decoder's output channel.
-type Decoder struct {
-	InputChan  chan *message.Message
-	OutputChan chan *message.Message
+type Decoder interface {
+	Start()
+	Stop()
+	GetLineCount() int64
+	GetDetectedPattern() *regexp.Regexp
+	InputChan() chan *message.Message
+	OutputChan() chan *message.Message
+}
+
+// decoderImpl is the default implementation of the Decoder interface
+type decoderImpl struct {
+	inputChan  chan *message.Message
+	outputChan chan *message.Message
 
 	framer      *framer.Framer
 	lineParser  LineParser
@@ -56,8 +66,16 @@ type Decoder struct {
 	detectedPattern *DetectedPattern
 }
 
+func (d *decoderImpl) InputChan() chan *message.Message {
+	return d.inputChan
+}
+
+func (d *decoderImpl) OutputChan() chan *message.Message {
+	return d.outputChan
+}
+
 // InitializeDecoder returns a properly initialized Decoder
-func InitializeDecoder(source *sources.ReplaceableSource, parser parsers.Parser, tailerInfo *status.InfoRegistry) *Decoder {
+func InitializeDecoder(source *sources.ReplaceableSource, parser parsers.Parser, tailerInfo *status.InfoRegistry) Decoder {
 	return NewDecoderWithFraming(source, parser, framer.UTF8Newline, nil, tailerInfo)
 }
 
@@ -80,7 +98,7 @@ func syncSourceInfo(source *sources.ReplaceableSource, lh *MultiLineHandler) {
 }
 
 // NewNoopDecoder initializes a decoder with all dependent components in passthrough mode.
-func NewNoopDecoder() *Decoder {
+func NewNoopDecoder() Decoder {
 	inputChan := make(chan *message.Message)
 	outputChan := make(chan *message.Message)
 	detectedPattern := &DetectedPattern{}
@@ -94,7 +112,7 @@ func NewNoopDecoder() *Decoder {
 }
 
 // NewDecoderWithFraming initialize a decoder with given endline strategy.
-func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Parser, framing framer.Framing, multiLinePattern *regexp.Regexp, tailerInfo *status.InfoRegistry) *Decoder {
+func NewDecoderWithFraming(source *sources.ReplaceableSource, parser parsers.Parser, framing framer.Framing, multiLinePattern *regexp.Regexp, tailerInfo *status.InfoRegistry) Decoder {
 	maxMessageSize := config.MaxMessageSizeBytes(pkgconfigsetup.Datadog())
 	inputChan := make(chan *message.Message)
 	outputChan := make(chan *message.Message)
@@ -192,10 +210,10 @@ func buildLegacyAutoMultilineHandlerFromConfig(outputFn func(*message.Message), 
 }
 
 // New returns an initialized Decoder
-func New(InputChan chan *message.Message, OutputChan chan *message.Message, framer *framer.Framer, lineParser LineParser, lineHandler LineHandler, detectedPattern *DetectedPattern) *Decoder {
-	return &Decoder{
-		InputChan:       InputChan,
-		OutputChan:      OutputChan,
+func New(InputChan chan *message.Message, OutputChan chan *message.Message, framer *framer.Framer, lineParser LineParser, lineHandler LineHandler, detectedPattern *DetectedPattern) Decoder {
+	return &decoderImpl{
+		inputChan:       InputChan,
+		outputChan:      OutputChan,
 		framer:          framer,
 		lineParser:      lineParser,
 		lineHandler:     lineHandler,
@@ -204,28 +222,28 @@ func New(InputChan chan *message.Message, OutputChan chan *message.Message, fram
 }
 
 // Start starts the Decoder
-func (d *Decoder) Start() {
+func (d *decoderImpl) Start() {
 	go d.run()
 }
 
 // Stop stops the Decoder
-func (d *Decoder) Stop() {
+func (d *decoderImpl) Stop() {
 	// stop the entire decoder by closing the input.  This will "bubble" through the
 	// components and eventually cause run() to finish, closing OutputChan.
-	close(d.InputChan)
+	close(d.InputChan())
 }
 
-func (d *Decoder) run() {
+func (d *decoderImpl) run() {
 	defer func() {
 		// flush any remaining output in component order, and then close the
 		// output channel
 		d.lineParser.flush()
 		d.lineHandler.flush()
-		close(d.OutputChan)
+		close(d.outputChan)
 	}()
 	for {
 		select {
-		case msg, isOpen := <-d.InputChan:
+		case msg, isOpen := <-d.InputChan():
 			if !isOpen {
 				// InputChan has been closed, no more lines are expected
 				return
@@ -245,14 +263,14 @@ func (d *Decoder) run() {
 }
 
 // GetLineCount returns the number of decoded lines
-func (d *Decoder) GetLineCount() int64 {
+func (d *decoderImpl) GetLineCount() int64 {
 	// for the moment, this counts _frames_, which aren't quite the same but
 	// close enough for logging purposes
 	return d.framer.GetFrameCount()
 }
 
 // GetDetectedPattern returns a detected pattern (if any)
-func (d *Decoder) GetDetectedPattern() *regexp.Regexp {
+func (d *decoderImpl) GetDetectedPattern() *regexp.Regexp {
 	if d.detectedPattern == nil {
 		return nil
 	}

--- a/pkg/logs/internal/decoder/decoder_mock.go
+++ b/pkg/logs/internal/decoder/decoder_mock.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package decoder
+
+import (
+	"regexp"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// MockDecoder is a mock decoder that can be used to test the decoder
+type MockDecoder struct {
+	inputChan  chan *message.Message
+	outputChan chan *message.Message
+}
+
+// InputChan returns the input channel
+func (d *MockDecoder) InputChan() chan *message.Message {
+	return d.inputChan
+}
+
+// OutputChan returns the output channel
+func (d *MockDecoder) OutputChan() chan *message.Message {
+	return d.outputChan
+}
+
+// Start starts the mock decoder
+func (d *MockDecoder) Start() {
+	go d.run()
+}
+
+// Stop stops the mock decoder
+func (d *MockDecoder) Stop() {
+	close(d.inputChan)
+}
+
+func (d *MockDecoder) run() {
+	for msg := range d.inputChan {
+		d.outputChan <- msg
+	}
+}
+
+// GetDetectedPattern returns the detected pattern (if any)
+func (d *MockDecoder) GetDetectedPattern() *regexp.Regexp {
+	return nil
+}
+
+// GetLineCount returns the number of decoded lines
+func (d *MockDecoder) GetLineCount() int64 {
+	return 0
+}
+
+// NewMockDecoder creates a new mock decoder
+func NewMockDecoder() *MockDecoder {
+	return &MockDecoder{
+		inputChan:  make(chan *message.Message),
+		outputChan: make(chan *message.Message),
+	}
+}

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func InitializeDecoderForTest(source *sources.LogSource, parser parsers.Parser) *Decoder {
+func InitializeDecoderForTest(source *sources.LogSource, parser parsers.Parser) Decoder {
 	info := status.NewInfoRegistry()
 	return InitializeDecoder(sources.NewReplaceableSource(source), parser, info)
 }
@@ -37,19 +37,19 @@ func TestDecoderWithDockerHeader(t *testing.T) {
 	input := []byte("hello\n")
 	input = append(input, []byte{1, 0, 0, 0, 0, 10, 0, 0}...) // docker header
 	input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
-	d.InputChan <- NewInput(input)
+	d.InputChan() <- NewInput(input)
 
 	var output *message.Message
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, "hello", string(output.GetContent()))
 	assert.Equal(t, len("hello")+1, output.RawDataLen)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	expected := []byte{1, 0, 0, 0, 0}
 	assert.Equal(t, expected, output.GetContent())
 	assert.Equal(t, 6, output.RawDataLen)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	expected = append([]byte{0, 0}, []byte("2018-06-14T18:27:03.246999277Z app logs")...)
 	assert.Equal(t, expected, output.GetContent())
 	assert.Equal(t, len(expected)+1, output.RawDataLen)
@@ -68,9 +68,9 @@ func TestDecoderWithDockerHeaderSingleline(t *testing.T) {
 
 	line = append([]byte{2, 0, 0, 0, 0, 0, 0, 0}, []byte("2019-06-06T16:35:55.930852911Z message\n")...)
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("message"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)
@@ -78,7 +78,7 @@ func TestDecoderWithDockerHeaderSingleline(t *testing.T) {
 
 	line = []byte("wrong message\n")
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	// As we have no validation on the header, the parsing is incorrect
 	// and this test fails.
@@ -92,7 +92,7 @@ func TestDecoderWithDockerHeaderSingleline(t *testing.T) {
 	// assert.Equal(t, message.StatusInfo, output.Status)
 	// assert.Equal(t, "", output.Timestamp)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("message"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
@@ -120,16 +120,16 @@ func TestDecoderWithDockerHeaderMultiline(t *testing.T) {
 
 	line = append([]byte{1, 0, 0, 0, 0, 0, 0, 0}, []byte("2019-06-06T16:35:55.930852911Z 1234 hello\n")...)
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	line = append([]byte{1, 0, 0, 0, 0, 0, 0, 0}, []byte("2019-06-06T16:35:55.930852912Z world\n")...)
 	lineLen += len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	line = append([]byte{2, 0, 0, 0, 0, 0, 0, 0}, []byte("2019-06-06T16:35:55.930852913Z 1234 bye\n")...)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("1234 hello\\nworld"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
@@ -137,7 +137,7 @@ func TestDecoderWithDockerHeaderMultiline(t *testing.T) {
 
 	lineLen = len(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("1234 bye"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)
@@ -155,9 +155,9 @@ func TestDecoderWithDockerJSONSingleline(t *testing.T) {
 
 	line = []byte(`{"log":"message\n","stream":"stdout","time":"2019-06-06T16:35:55.930852911Z"}` + "\n")
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("message"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
@@ -165,9 +165,9 @@ func TestDecoderWithDockerJSONSingleline(t *testing.T) {
 
 	line = []byte("wrong message\n")
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("wrong message"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
@@ -194,16 +194,16 @@ func TestDecoderWithDockerJSONMultiline(t *testing.T) {
 
 	line = []byte(`{"log":"1234 hello\n","stream":"stdout","time":"2019-06-06T16:35:55.930852911Z"}` + "\n")
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	line = []byte(`{"log":"world\n","stream":"stdout","time":"2019-06-06T16:35:55.930852912Z"}` + "\n")
 	lineLen += len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	line = []byte(`{"log":"1234 bye\n","stream":"stderr","time":"2019-06-06T16:35:55.930852913Z"}` + "\n")
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("1234 hello\\nworld"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
@@ -211,7 +211,7 @@ func TestDecoderWithDockerJSONMultiline(t *testing.T) {
 
 	lineLen = len(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("1234 bye"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)
@@ -228,15 +228,15 @@ func TestDecoderWithDockerJSONSplittedByDocker(t *testing.T) {
 
 	line = []byte(`{"log":"part1","stream":"stdout","time":"2019-06-06T16:35:55.930852911Z"}` + "\n")
 	rawLen := len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	line = []byte(`{"log":"part2\n","stream":"stdout","time":"2019-06-06T16:35:55.930852912Z"}` + "\n")
 	rawLen += len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	// We don't reaggregate partial messages but we expect content of line not finishing with a '\n' character to be reconciliated
 	// with the next line.
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("part1part2"), output.GetContent())
 	assert.Equal(t, rawLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
@@ -251,18 +251,18 @@ func TestDecoderWithDecodingParser(t *testing.T) {
 	d.Start()
 
 	input := []byte{'h', 0x0, 'e', 0x0, 'l', 0x0, 'l', 0x0, 'o', 0x0, '\n', 0x0}
-	d.InputChan <- NewInput(input)
+	d.InputChan() <- NewInput(input)
 
 	var output *message.Message
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, "hello", string(output.GetContent()))
 	assert.Equal(t, len(input), output.RawDataLen)
 
 	// Test with BOM
 	input = []byte{0xFF, 0xFE, 'h', 0x0, 'e', 0x0, 'l', 0x0, 'l', 0x0, 'o', 0x0, '\n', 0x0}
-	d.InputChan <- NewInput(input)
+	d.InputChan() <- NewInput(input)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, "hello", string(output.GetContent()))
 	assert.Equal(t, len(input), output.RawDataLen)
 
@@ -280,9 +280,9 @@ func TestDecoderWithSinglelineKubernetes(t *testing.T) {
 
 	line = []byte("2019-06-06T16:35:55.930852911Z stderr F message\n")
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("message"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)
@@ -290,9 +290,9 @@ func TestDecoderWithSinglelineKubernetes(t *testing.T) {
 
 	line = []byte("wrong message\n")
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("wrong message"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
@@ -318,16 +318,16 @@ func TestDecoderWithMultilineKubernetes(t *testing.T) {
 
 	line = []byte("2019-06-06T16:35:55.930852911Z stdout F 1234 hello\n")
 	lineLen = len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	line = []byte("2019-06-06T16:35:55.930852912Z stdout F world\n")
 	lineLen += len(line)
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
 	line = []byte("2019-06-06T16:35:55.930852913Z stderr F 1234 bye\n")
-	d.InputChan <- NewInput(line)
+	d.InputChan() <- NewInput(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("1234 hello\\nworld"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
@@ -335,7 +335,7 @@ func TestDecoderWithMultilineKubernetes(t *testing.T) {
 
 	lineLen = len(line)
 
-	output = <-d.OutputChan
+	output = <-d.OutputChan()
 	assert.Equal(t, []byte("1234 bye"), output.GetContent())
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)

--- a/pkg/logs/internal/decoder/file_decoder.go
+++ b/pkg/logs/internal/decoder/file_decoder.go
@@ -22,12 +22,12 @@ import (
 )
 
 // NewDecoderFromSource creates a new decoder from a log source
-func NewDecoderFromSource(source *sources.ReplaceableSource, tailerInfo *status.InfoRegistry) *Decoder {
+func NewDecoderFromSource(source *sources.ReplaceableSource, tailerInfo *status.InfoRegistry) Decoder {
 	return NewDecoderFromSourceWithPattern(source, nil, tailerInfo)
 }
 
 // NewDecoderFromSourceWithPattern creates a new decoder from a log source with a multiline pattern
-func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLinePattern *regexp.Regexp, tailerInfo *status.InfoRegistry) *Decoder {
+func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLinePattern *regexp.Regexp, tailerInfo *status.InfoRegistry) Decoder {
 
 	// TODO: remove those checks and add to source a reference to a tagProvider and a lineParser.
 	var lineParser parsers.Parser

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -450,7 +450,7 @@ func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.Tail
 	}
 
 	// Create decoder with stored pattern if available
-	var decoderInstance *decoder.Decoder
+	var decoderInstance decoder.Decoder
 	if oldInfo.Pattern != nil {
 		decoderInstance = decoder.NewDecoderFromSourceWithPattern(file.Source, oldInfo.Pattern, tailerInfo)
 	} else {

--- a/pkg/logs/tailers/container/tailer.go
+++ b/pkg/logs/tailers/container/tailer.go
@@ -80,7 +80,7 @@ type Tailer struct {
 	ContainerID string
 
 	outputChan      chan *message.Message
-	decoder         *decoder.Decoder
+	decoder         decoder.Decoder
 	unsafeLogReader func(context.Context, time.Time) (io.ReadCloser, error)
 	Source          *sources.LogSource
 	tagProvider     tag.Provider
@@ -357,7 +357,7 @@ func (t *Tailer) readForever() {
 				t.wait()
 				continue
 			}
-			t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
+			t.decoder.InputChan() <- decoder.NewInput(inBuf[:n])
 		}
 	}
 }
@@ -415,7 +415,7 @@ func (d *dockerMessageForwarder) forward() {
 		// the decoder has successfully been flushed
 		d.tailer.done <- struct{}{}
 	}()
-	for output := range d.tailer.decoder.OutputChan {
+	for output := range d.tailer.decoder.OutputChan() {
 		if len(output.GetContent()) > 0 {
 			msg := buildMessage(d.tailer, output)
 			d.tailer.outputChan <- msg
@@ -455,7 +455,7 @@ func (k *kubeletMessageForwarder) forward() {
 		// the decoder has successfully been flushed
 		k.tailer.done <- struct{}{}
 	}()
-	for output := range k.tailer.decoder.OutputChan {
+	for output := range k.tailer.decoder.OutputChan() {
 		if len(output.GetContent()) > 0 {
 			// Because the kubelet API does not support sub-second granularity we run the risk of logging duplicates
 			// we check the timestamp to drop logs that have already been processed

--- a/pkg/logs/tailers/container/tailer_test.go
+++ b/pkg/logs/tailers/container/tailer_test.go
@@ -77,19 +77,13 @@ func (m *mockReaderSleep) Close() error {
 	return nil
 }
 
-func NewTestDecoder() *decoder.Decoder {
-	return &decoder.Decoder{
-		InputChan: make(chan *message.Message),
-	}
-}
-
 func NewTestTailer(reader io.ReadCloser, unsafeReader io.ReadCloser, cancelFunc context.CancelFunc) *Tailer {
 	containerID := "1234567890abcdef"
 	source := sources.NewLogSource("foo", nil)
 	tailer := &Tailer{
 		ContainerID: containerID,
 		outputChan:  make(chan *message.Message, 100),
-		decoder:     NewTestDecoder(),
+		decoder:     decoder.NewMockDecoder(),
 		unsafeLogReader: func(ctx context.Context, t time.Time) (io.ReadCloser, error) { //nolint
 			return unsafeReader, nil
 		},

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -75,7 +75,7 @@ type Tailer struct {
 	outputChan chan *message.Message
 
 	// decoder handles decoding the raw bytes read from the file into log messages.
-	decoder *decoder.Decoder
+	decoder decoder.Decoder
 
 	// sleepDuration is the time between polls of the underlying file.
 	sleepDuration time.Duration
@@ -130,7 +130,7 @@ type TailerOptions struct {
 	OutputChan      chan *message.Message    // Required
 	File            *File                    // Required
 	SleepDuration   time.Duration            // Required
-	Decoder         *decoder.Decoder         // Required
+	Decoder         decoder.Decoder          // Required
 	Info            *status.InfoRegistry     // Required
 	Rotated         bool                     // Optional
 	TagAdder        tag.EntityTagAdder       // Required
@@ -213,7 +213,7 @@ func (t *Tailer) NewRotatedTailer(
 	file *File,
 	outputChan chan *message.Message,
 	capacityMonitor *metrics.CapacityMonitor,
-	decoder *decoder.Decoder,
+	decoder decoder.Decoder,
 	info *status.InfoRegistry,
 	tagAdder tag.EntityTagAdder,
 	fingerprint *logstypes.Fingerprint,
@@ -369,7 +369,7 @@ func (t *Tailer) forwardMessages() {
 		t.isFinished.Store(true)
 		close(t.done)
 	}()
-	for output := range t.decoder.OutputChan {
+	for output := range t.decoder.OutputChan() {
 		offset := t.decodedOffset.Load() + int64(output.RawDataLen)
 		identifier := t.Identifier()
 		if t.didFileRotate.Load() {

--- a/pkg/logs/tailers/file/tailer_nix.go
+++ b/pkg/logs/tailers/file/tailer_nix.go
@@ -57,6 +57,6 @@ func (t *Tailer) read() (int, error) {
 	}
 	t.lastReadOffset.Add(int64(n))
 	msg := decoder.NewInput(inBuf[:n])
-	t.decoder.InputChan <- msg
+	t.decoder.InputChan() <- msg
 	return n, nil
 }

--- a/pkg/logs/tailers/file/tailer_windows.go
+++ b/pkg/logs/tailers/file/tailer_windows.go
@@ -101,7 +101,7 @@ func (t *Tailer) readAvailable() (int, error) {
 		// logs pipeline.
 		timer := time.NewTimer(t.windowsOpenFileTimeout)
 		select {
-		case t.decoder.InputChan <- decoder.NewInput(inBuf[:n]):
+		case t.decoder.InputChan() <- decoder.NewInput(inBuf[:n]):
 			timer.Stop()
 		case <-timer.C:
 			// The windowsOpenFileTimeout expired, and we want to avoid
@@ -114,7 +114,7 @@ func (t *Tailer) readAvailable() (int, error) {
 			f = nil
 
 			// blocking send to the decoder
-			t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
+			t.decoder.InputChan() <- decoder.NewInput(inBuf[:n])
 		}
 	}
 }

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -36,7 +36,7 @@ const (
 
 // Tailer collects logs from a journal.
 type Tailer struct {
-	decoder    *decoder.Decoder
+	decoder    decoder.Decoder
 	source     *sources.LogSource
 	outputChan chan *message.Message
 	journal    Journal
@@ -201,7 +201,7 @@ func (t *Tailer) forwardMessages() {
 		close(t.done)
 	}()
 
-	for decodedMessage := range t.decoder.OutputChan {
+	for decodedMessage := range t.decoder.OutputChan() {
 		if len(decodedMessage.GetContent()) > 0 {
 			// Preserve the original message structure and ParsingExtra information (including IsTruncated)
 			// The decodedMessage already has the proper origin with tags set
@@ -309,7 +309,7 @@ func (t *Tailer) tail() {
 			select {
 			case <-t.stop:
 				return
-			case t.decoder.InputChan <- msg:
+			case t.decoder.InputChan() <- msg:
 			}
 		}
 	}

--- a/pkg/logs/tailers/socket/tailer.go
+++ b/pkg/logs/tailers/socket/tailer.go
@@ -28,7 +28,7 @@ type Tailer struct {
 	Conn       net.Conn
 	outputChan chan *message.Message
 	read       func(*Tailer) ([]byte, string, error)
-	decoder    *decoder.Decoder
+	decoder    decoder.Decoder
 	stop       chan struct{}
 	done       chan struct{}
 }
@@ -67,7 +67,7 @@ func (t *Tailer) forwardMessages() {
 		// the decoder has successfully been flushed
 		t.done <- struct{}{}
 	}()
-	for output := range t.decoder.OutputChan {
+	for output := range t.decoder.OutputChan() {
 		if len(output.GetContent()) > 0 {
 			origin := message.NewOrigin(t.source)
 			origin.SetTags(output.ParsingExtra.Tags)
@@ -113,7 +113,7 @@ func (t *Tailer) readForever() {
 				sourceHostTag := fmt.Sprintf("source_host:%s", ipAddressWithoutPort)
 				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, sourceHostTag)
 			}
-			t.decoder.InputChan <- msg
+			t.decoder.InputChan() <- msg
 		}
 	}
 }

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -66,7 +66,7 @@ type Tailer struct {
 	evtapi     evtapi.API
 	source     *sources.LogSource
 	config     *Config
-	decoder    *decoder.Decoder
+	decoder    decoder.Decoder
 	outputChan chan *message.Message
 
 	cancelTail context.CancelFunc
@@ -148,7 +148,7 @@ func (t *Tailer) forwardMessages() {
 		close(t.done)
 	}()
 
-	for decodedMessage := range t.decoder.OutputChan {
+	for decodedMessage := range t.decoder.OutputChan() {
 		if len(decodedMessage.GetContent()) > 0 {
 			// Leverage the existing message instead of creating a new one
 			// This preserves all bookmark information and is more efficient
@@ -325,7 +325,7 @@ func (t *Tailer) handleEvent(eventRecordHandle evtapi.EventRecordHandle) {
 	}
 
 	t.source.RecordBytes(int64(len(msg.GetContent())))
-	t.decoder.InputChan <- msg
+	t.decoder.InputChan() <- msg
 }
 
 // enrichEvent renders event record fields using EvtFormatMessage and adds them to the map.


### PR DESCRIPTION
### What does this PR do?
Shift references to the decoder over to utilizing an interface rather than a concrete struct. This will allow for enhanced mockability/testability moving forward.

### Motivation

### Describe how you validated your changes
Automated tests were relied on for change correctness, as the vast majority of potential issues this change could introduce would be compile-time errors.

### Additional Notes
