### PR TITLE
Re-enable Fleet Config e2e Tests for Windows

### DIFF
--- a/test/new-e2e/tests/installer/windows/installer.go
+++ b/test/new-e2e/tests/installer/windows/installer.go
@@ -562,8 +562,7 @@ func (d *DatadogInstaller) SetConfigExperiment(config ConfigExperiment) (string,
 // StartConfigExperiment starts a config experiment using the provided InstallerConfig through the daemon.
 // It first sets the config catalog and then starts the experiment.
 func (d *DatadogInstaller) StartConfigExperiment(packageName string, config ConfigExperiment) (string, error) {
-	// First set the config catalog
-	//_, err := d.SetConfigExperiment(config)
+	// Convert ConfigExperiment to installerConfig format
 	operations := map[string]interface{}{
 		"deployment_id":   config.ID,
 		"file_operations": convertFilesToOperations(config.Files),
@@ -573,10 +572,11 @@ func (d *DatadogInstaller) StartConfigExperiment(packageName string, config Conf
 	if err != nil {
 		return "", err
 	}
-	// Then start the config experiment
+	// Escape quotes in the JSON string to handle PowerShell quoting properly
 	opsStr := strings.ReplaceAll(string(serializedOps), `"`, `\"`)
+
+	// Then start the config experiment
 	return d.execute(fmt.Sprintf("daemon start-config-experiment %s '%s'", packageName, opsStr))
-	//return d.execute(fmt.Sprintf("daemon start-config-experiment %s %s", packageName, config.ID))
 }
 
 // PromoteConfigExperiment promotes a config experiment through the daemon.

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
@@ -30,10 +30,10 @@ type RemoteWindowsAgentConfigAssertions struct {
 //
 // The `config get` subcommand only supports a small set of keys, so this method
 // fetches the full config and unmarshals it into a map.
-func (r *RemoteWindowsAgentAssertions) RuntimeConfig() *RemoteWindowsAgentConfigAssertions {
+func (r *RemoteWindowsAgentAssertions) RuntimeConfig(commandArgs ...string) *RemoteWindowsAgentConfigAssertions {
 	r.context.T().Helper()
 	output, err := r.agentClient.ConfigWithError(
-		agentclient.WithArgs([]string{"--all"}),
+		agentclient.WithArgs(commandArgs),
 	)
 	r.require.NoError(err)
 

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
@@ -8,8 +8,9 @@ package assertions
 import (
 	"strings"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 )
 
 // RemoteWindowsAgentAssertions is a type that extends the SuiteAssertions to add assertions
@@ -31,7 +32,9 @@ type RemoteWindowsAgentConfigAssertions struct {
 // fetches the full config and unmarshals it into a map.
 func (r *RemoteWindowsAgentAssertions) RuntimeConfig() *RemoteWindowsAgentConfigAssertions {
 	r.context.T().Helper()
-	output, err := r.agentClient.ConfigWithError()
+	output, err := r.agentClient.ConfigWithError(
+		agentclient.WithArgs([]string{"--all"}),
+	)
 	r.require.NoError(err)
 
 	var config map[interface{}]interface{}

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
@@ -8,7 +8,10 @@ package assertions
 import (
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strings"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	e2ecommon "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
@@ -17,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsagent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -239,4 +241,82 @@ func (r *RemoteWindowsHostAssertions) HasDatadogInstaller() *RemoteWindowsInstal
 	return &RemoteWindowsInstallerAssertions{
 		RemoteWindowsBinaryAssertions: bin,
 	}
+}
+
+// HasDDAgentUserFileAccess verifies that ddagentuser has appropriate permissions
+// on key Agent files and directories. This is to verify that config updates
+// or upgrades haven't broken file permissions.
+func (r *RemoteWindowsHostAssertions) HasDDAgentUserFileAccess() *RemoteWindowsHostAssertions {
+	r.context.T().Helper()
+
+	// Get ddagentuser identity
+	ddAgentUser, err := common.GetIdentityForUser(r.remoteHost, windowsagent.DefaultAgentUserName)
+	r.require.NoError(err, "should get ddagentuser identity")
+
+	// Get config root from registry
+	configRoot, err := windowsagent.GetConfigRootFromRegistry(r.remoteHost)
+	r.require.NoError(err, "should get config root from registry")
+
+	// Test critical paths that ddagentuser needs access to
+	criticalPaths := []struct {
+		path        string
+		minRights   int
+		description string
+		fileType    string
+	}{
+		{
+			path:        filepath.Join(configRoot, "datadog.yaml"),
+			minRights:   common.FileFullControl,
+			description: "datadog.yaml must be readable by ddagentuser",
+			fileType:    "file",
+		},
+		{
+			path:        filepath.Join(configRoot, "conf.d"),
+			minRights:   common.FileFullControl,
+			description: "conf.d must be readable by ddagentuser",
+			fileType:    "directory",
+		},
+		{
+			path:        filepath.Join(configRoot, "logs"),
+			minRights:   common.FileFullControl,
+			description: "logs directory must be writable by ddagentuser",
+			fileType:    "directory",
+		},
+	}
+
+	for _, cp := range criticalPaths {
+		switch cp.fileType {
+		case "file":
+			exists, err := r.remoteHost.FileExists(cp.path)
+			r.require.NoError(err, "should check if file exists")
+			if !exists {
+				r.require.Failf("path %s does not exist", cp.path)
+			}
+		case "directory":
+			_, err := r.remoteHost.Lstat(cp.path)
+			r.require.NoError(err, "should check if directory exists")
+		}
+
+		security, err := common.GetSecurityInfoForPath(r.remoteHost, cp.path)
+		r.require.NoError(err, "should get security info for %s", cp.path)
+
+		// Filter to get ddagentuser rules
+		ddagentRules := common.FilterRulesForIdentity(security.Access, ddAgentUser)
+		r.require.NotEmpty(ddagentRules,
+			"ddagentuser should have access rules on %s", cp.path)
+
+		// Verify at least one rule grants the minimum required rights
+		hasRequiredRights := false
+		for _, rule := range ddagentRules {
+			if rule.IsAllow() && (rule.Rights&cp.minRights) == cp.minRights {
+				hasRequiredRights = true
+				break
+			}
+		}
+
+		r.require.True(hasRequiredRights,
+			"%s (path: %s)", cp.description, cp.path)
+	}
+
+	return r
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -35,7 +35,7 @@ func TestAgentConfig(t *testing.T) {
 // TestConfigUpgradeSuccessful tests that the Agent's config can be upgraded
 // through the experiment (start/promote) workflow.
 func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
-	s.T().Skip("Skipping test during migration to new config experiment")
+	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -75,7 +75,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 // TestConfigUpgradeFailure tests that the Agent's config can be rolled back
 // through the experiment (start/promote) workflow.
 func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
-	s.T().Skip("Skipping test during migration to new config experiment")
+	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -130,7 +130,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 // TestConfigUpgradeNewAgents tests that config experiments can enable security agent and system probe
 // on new agent installations.
 func (s *testAgentConfigSuite) TestConfigUpgradeNewAgents() {
-	s.T().Skip("Skipping test during migration to new config experiment")
+	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -196,7 +196,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeNewAgents() {
 // TestRevertsConfigExperimentWhenServiceDies tests that the watchdog will revert
 // to stable config when the service dies.
 func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
-	s.T().Skip("Skipping test during migration to new config experiment")
+	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -240,7 +240,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 // TestRevertsConfigExperimentWhenTimeout tests that the watchdog will revert
 // to stable config when the timeout expires.
 func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
-	s.T().Skip("Skipping test during migration to new config experiment")
+	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -288,7 +288,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 // Partial regression test for WINA-1556, making sure that installation does not
 // modify the managed config or its permissions, preventing the Agent from accessing it.
 func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
-	s.T().Skip("Skipping test during migration to new config experiment")
+	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange - Start with previous version and custom config
 	s.setAgentConfig()
 	s.installPreviousAgentVersion()

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -43,7 +43,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	// assert that setup was successful
 	s.AssertSuccessfulConfigPromoteExperiment("empty")
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", true)
 
 	// Act
@@ -61,14 +61,14 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	s.mustStartConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", false)
 
 	// Promote config experiment
 	s.mustPromoteConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", false)
 }
 
@@ -83,7 +83,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 	// assert that setup was successful
 	s.AssertSuccessfulConfigPromoteExperiment("empty")
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_level", "debug")
 
 	// Act
@@ -116,7 +116,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 
 	// Config should be reverted to the stable config
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_level", "debug")
 
 	// backend will send stop experiment now
@@ -216,7 +216,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 	s.mustStartConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", false)
 
 	// Stop the agent service to trigger watchdog rollback
@@ -226,7 +226,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 	s.AssertSuccessfulConfigStopExperiment()
 
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", true)
 
 	// backend will send stop experiment now
@@ -262,7 +262,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 	s.mustStartConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", false)
 
 	// wait for the timeout
@@ -272,7 +272,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 	s.AssertSuccessfulConfigStopExperiment()
 
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", true)
 
 	// backend will send stop experiment now
@@ -330,7 +330,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 
 	// Verify the runtime config values are still preserved after upgrade
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().RuntimeConfig().
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", false)
 }
 

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -120,11 +120,11 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 		WithValueEqual("log_level", "debug")
 
 	// backend will send stop experiment now
-	s.assertDaemonStaysRunning(func() {
+	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().StopConfigExperiment(consts.AgentPackage)
 		s.Require().NoError(err, "daemon should stop cleanly")
 		s.AssertSuccessfulConfigStopExperiment()
-	})
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
 }
 
 // TestConfigUpgradeNewAgents tests that config experiments can enable security agent and system probe
@@ -230,11 +230,11 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 		WithValueEqual("log_to_console", true)
 
 	// backend will send stop experiment now
-	s.assertDaemonStaysRunning(func() {
+	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().StopConfigExperiment(consts.AgentPackage)
 		s.Require().NoError(err, "daemon should respond to request")
 		s.AssertSuccessfulConfigStopExperiment()
-	})
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
 }
 
 // TestRevertsConfigExperimentWhenTimeout tests that the watchdog will revert
@@ -276,11 +276,11 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 		WithValueEqual("log_to_console", true)
 
 	// backend will send stop experiment now
-	s.assertDaemonStaysRunning(func() {
+	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().StopConfigExperiment(consts.AgentPackage)
 		s.Require().NoError(err, "daemon should respond to request")
 		s.AssertSuccessfulConfigStopExperiment()
-	})
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
 }
 
 // TestManagedConfigActiveAfterUpgrade tests that the Agent's config is preserved after a package update.

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -36,7 +36,6 @@ func TestAgentConfig(t *testing.T) {
 // TestConfigUpgradeSuccessful tests that the Agent's config can be upgraded
 // through the experiment (start/promote) workflow.
 func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
-	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -77,7 +76,6 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 // TestConfigUpgradeFailure tests that the Agent's config can be rolled back
 // through the experiment (start/promote) workflow.
 func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
-	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -133,7 +131,6 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 // TestConfigUpgradeNewAgents tests that config experiments can enable security agent and system probe
 // on new agent installations.
 func (s *testAgentConfigSuite) TestConfigUpgradeNewAgents() {
-	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -199,7 +196,6 @@ func (s *testAgentConfigSuite) TestConfigUpgradeNewAgents() {
 // TestRevertsConfigExperimentWhenServiceDies tests that the watchdog will revert
 // to stable config when the service dies.
 func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
-	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -244,7 +240,6 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 // TestRevertsConfigExperimentWhenTimeout tests that the watchdog will revert
 // to stable config when the timeout expires.
 func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
-	//s.T().Skip("Skipping test during migration to new config experiment")
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()


### PR DESCRIPTION
### What does this PR do?
This PR re-enables the fleet config e2e tests for Windows

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2005

### Describe how you validated your changes
Check results of windows `TestAgentConfig` tests

### Additional Notes
