### PR TITLE
use posix paths for comparisons

### DIFF
--- a/tasks/components.py
+++ b/tasks/components.py
@@ -4,14 +4,15 @@ Invoke entrypoint, import here all the tasks we want to make available
 
 import os
 import pathlib
-from collections import namedtuple
 from collections.abc import Iterable
+from dataclasses import dataclass
 from string import Template
 
 from invoke import task
 from invoke.exceptions import Exit
 
 from tasks.libs.types.copyright import COPYRIGHT_HEADER
+
 
 # Component represents a directory defining a component
 #  version=1 is the classic style using:
@@ -21,10 +22,32 @@ from tasks.libs.types.copyright import COPYRIGHT_HEADER
 #    comp/<name>/def/component.go
 #    comp/<name>/fx/fx.go
 #    comp/<name>/impl/*
-Component = namedtuple('Component', ['name', 'def_file', 'path', 'doc', 'team', 'version'])
+@dataclass
+class Component:
+    name: str
+    def_file: str
+    path: str
+    doc: str
+    team: str | None
+    version: int
+
+    def __post_init__(self):
+        self.def_file = pathlib.Path(self.def_file).as_posix()
+        self.path = pathlib.Path(self.path).as_posix()
+
+
 # Bundle represents a bundle of components, defined using:
 #    comp/<group>/bundle.go
-Bundle = namedtuple('Bundle', ['path', 'doc', 'team', 'content', 'components'])
+@dataclass
+class Bundle:
+    path: str
+    doc: str
+    team: str | None
+    content: list
+    components: list
+
+    def __post_init__(self):
+        self.path = pathlib.Path(self.path).as_posix()
 
 
 def find_team(content: Iterable[str]) -> str | None:
@@ -197,7 +220,7 @@ def check_component_contents_and_file_hiearchy(comp):
         return f"** {comp.def_file} does not define a Component interface"
 
     # Skip components that need to migrate
-    if str(comp.def_file) in components_to_migrate:
+    if comp.def_file in components_to_migrate:
         return
 
     # Special case for api
@@ -283,7 +306,7 @@ def locate_implementation_folders(comp):
         if entry.is_file():
             continue
 
-        if str(entry) in components_missing_implementation_folder:
+        if to_posix_path(entry) in components_missing_implementation_folder:
             return 'skip'
 
         if comp.version == 2:
@@ -293,7 +316,7 @@ def locate_implementation_folders(comp):
 
         if comp.version == 1:
             # Check for component implementation using the classic style: comp/<component>/<component>impl
-            if str(entry) in components_classic_style:
+            if to_posix_path(entry) in components_classic_style:
                 folders.append(entry)
 
     return folders
@@ -308,7 +331,7 @@ def locate_nontest_source_files(folder_list):
         for entry in folder.iterdir():
             if not entry.is_file():
                 continue
-            filename = str(entry)
+            filename = to_posix_path(entry)
             if filename.endswith('.go') and not filename.endswith('_test.go'):
                 results.append(entry)
     return results
@@ -371,7 +394,7 @@ def get_components_and_bundles():
             if direntry.is_file() and direntry.name == "bundle.go":
                 # Found bundle definition
                 content = read_file_content(direntry).split('\n')
-                path = str(direntry)[: -len('/bundle.go')]
+                path = to_posix_path(direntry).removesuffix('/bundle.go')
                 team = find_team(content)
                 doc = find_doc(content)
                 bundles.append(Bundle(path, doc, team, content, []))
@@ -389,9 +412,9 @@ def get_components_and_bundles():
         for c in components:
             if c.path.startswith(b.path):
                 bundle_components.append(c)
-        sorted_bundles.append(Bundle(b.path, b.doc, b.team, b.content, sorted(bundle_components)))
+        sorted_bundles.append(Bundle(b.path, b.doc, b.team, b.content, sorted(bundle_components, key=lambda c: c.name)))
 
-    return sorted(components, key=lambda c: c.path), sorted(sorted_bundles)
+    return sorted(components, key=lambda c: c.path), sorted(sorted_bundles, key=lambda b: b.path)
 
 
 def locate_component_def(dir):
@@ -405,7 +428,7 @@ def locate_component_def(dir):
     if def_file.is_file():
         # comp/api/api/def/component.go is a special case, it's not a component using version 2
         # PLEASE DO NOT ADD MORE EXCEPTIONS
-        if str(def_file) == "comp/api/api/def/component.go":
+        if to_posix_path(def_file) == "comp/api/api/def/component.go":
             return construct_component(component_name, def_file, dir, 1)
         else:
             return construct_component(component_name, def_file, dir, 2)
@@ -413,15 +436,15 @@ def locate_component_def(dir):
     # v1 component: this folder is a component root if it contains '/component.go' but the path is not '/def/component.go'
     # in particular, the directory named 'def' should not be treated as a component root
     def_file = dir / 'component.go'
-    if def_file.is_file() and '/def/component.go' not in str(def_file):
+    if def_file.is_file() and '/def/component.go' not in to_posix_path(def_file):
         return construct_component(component_name, def_file, dir, 1)
 
 
 def construct_component(compname, def_file, path, version):
-    def_content = read_file_content(str(def_file)).split('\n')
+    def_content = read_file_content(def_file).split('\n')
     team = find_team(def_content)
     doc = find_doc(def_content)
-    return Component(compname, str(def_file), str(path), doc, team, version)
+    return Component(compname, def_file, path, doc, team, version)
 
 
 def make_components_md(bundles, components_without_bundle):
@@ -709,7 +732,7 @@ def lint_fxutil_oneshot_test(_):
         folder_path = pathlib.Path(folder)
         for file in folder_path.rglob("*.go"):
             # Don't lint test files
-            if str(file).endswith("_test.go"):
+            if to_posix_path(file).endswith("_test.go"):
                 continue
 
             one_shot_count = file.read_text().count("fxutil.OneShot(")
@@ -742,3 +765,8 @@ def lint_fxutil_oneshot_test(_):
     if len(errors) > 0:
         msg = '\n'.join(errors)
         raise Exit(f"Missings tests: {msg}")
+
+
+def to_posix_path(path):
+    """Convert a path (string or Path object) to posix-style string with forward slashes."""
+    return pathlib.Path(path).as_posix()

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -32,8 +32,8 @@ class Component:
     version: int
 
     def __post_init__(self):
-        self.def_file = pathlib.Path(self.def_file).as_posix()
-        self.path = pathlib.Path(self.path).as_posix()
+        self.def_file = to_posix_path(self.def_file)
+        self.path = to_posix_path(self.path)
 
 
 # Bundle represents a bundle of components, defined using:
@@ -47,7 +47,7 @@ class Bundle:
     components: list
 
     def __post_init__(self):
-        self.path = pathlib.Path(self.path).as_posix()
+        self.path = to_posix_path(self.path)
 
 
 def find_team(content: Iterable[str]) -> str | None:

--- a/tasks/unit_tests/components_tests.py
+++ b/tasks/unit_tests/components_tests.py
@@ -28,9 +28,9 @@ class TestComponents(unittest.TestCase):
         )
 
     def tearDown(self):
+        os.chdir(self.origDir)
         if self.tmpdir:
             shutil.rmtree(self.tmpdir)
-        os.chdir(self.origDir)
         classicComp = 'comp/classic/classicimpl'
         components.components_classic_style.remove(classicComp)
 


### PR DESCRIPTION
### What does this PR do?
Fix `dda inv lint-components` on Windows by ensuring we compare paths with forward slashes

Fix `components_test.py`, must leave dir before deleting it on Windows

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2012

### Describe how you validated your changes
unit tests
```
dda inv invoke-unit-tests.run --tests 'components'
```

remove entries from `.gitlab/CODEOWNERS` and `comp/README.md` and then run
```
dda inv lint-components --fix
```

add new comp and then fix lint
```
dda inv components.new-component comp/testcomp --team='windows-products'
dda inv lint-components --fix
```

### Additional Notes
the issue is caught by the unit tests, but don't think we're running them on Windows.
 