### PR TITLE
Adjust AD Logs Collect All Override Order

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
@@ -40,6 +41,7 @@ import (
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/config/mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
@@ -473,6 +475,9 @@ func TestResolveTemplate(t *testing.T) {
 	})
 
 	t.Run("CEL Identifier on Container", func(t *testing.T) {
+		mockConfig := configmock.New(t)
+		mockConfig.SetWithoutSource("logs_config.container_collect_all", true)
+
 		// Setup container tied to a pod
 		wmetaPod := listeners.CreateDummyPod("pod-name", "pod-ns", nil)
 		wmetaCtn := listeners.CreateDummyContainer("container-name", "container-image")
@@ -503,14 +508,34 @@ func TestResolveTemplate(t *testing.T) {
 		ac.applyChanges(ac.processNewConfig(tpl))
 		assert.Equal(t, 2, countLoadedConfigs(ac))
 
+		// CCA
+		tpl = utils.AddContainerCollectAllConfigs([]integration.Config{}, "container-image")[0]
+		ac.applyChanges(ac.processNewConfig(tpl))
+		assert.Equal(t, 3, countLoadedConfigs(ac))
+		activeConfigs := ac.GetAllConfigs()
+		activeConfigNames := make([]string, 0, len(activeConfigs))
+		for _, cfg := range activeConfigs {
+			activeConfigNames = append(activeConfigNames, cfg.Name)
+		}
+		expectedConfigNames := []string{"container-check-1", "container-check-2", "container_collect_all"}
+		assert.ElementsMatch(t, expectedConfigNames, activeConfigNames)
+
 		// AD Identifier + CEL matching
 		tpl = integration.Config{
 			Name:          "container-check-3",
 			ADIdentifiers: []string{"container-image"},
+			LogsConfig:    []byte(`{"source":"test-source"}`),
 			CELSelector:   workloadfilter.Rules{Containers: []string{`container.pod.name.matches("pod-name")`}},
 		}
-		ac.applyChanges(ac.processNewConfig(tpl))
+		logsConfigChanges := ac.processNewConfig(tpl)
+		ac.applyChanges(logsConfigChanges)
 		assert.Equal(t, 3, countLoadedConfigs(ac))
+
+		// Should override the generic container_collect_all check config
+		activeConfigs = ac.GetAllConfigs()
+		for _, cfg := range activeConfigs {
+			assert.NotEqual(t, "container_collect_all", cfg.Name)
+		}
 
 		// Bad AD Identifier + CEL matching
 		tpl = integration.Config{
@@ -521,10 +546,11 @@ func TestResolveTemplate(t *testing.T) {
 		ac.applyChanges(ac.processNewConfig(tpl))
 		assert.Equal(t, 3, countLoadedConfigs(ac))
 
-		// Test service deletion
+		// Test config deletion
 		ac.processRemovedConfigs(changes.Schedule)
 		assert.Equal(t, 2, countLoadedConfigs(ac))
 
+		// Test service deletion
 		ac.processDelService(service)
 		assert.Equal(t, 0, countLoadedConfigs(ac))
 	})

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -40,7 +40,6 @@ import (
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -178,7 +177,7 @@ type AutoConfigTestSuite struct {
 
 // SetupSuite saves the original listener registry
 func (suite *AutoConfigTestSuite) SetupSuite() {
-	cfg := mock.New(suite.T())
+	cfg := configmock.New(suite.T())
 	pkglogsetup.SetupLogger(
 		pkglogsetup.LoggerName("test"),
 		"debug",

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -147,8 +147,10 @@ func (s *WorkloadService) FilterTemplates(configs map[string]integration.Config)
 	// comp/core/autodiscovery/configresolver/configresolver.go
 	s.filterTemplatesEmptyOverrides(configs)
 	s.filterTemplatesOverriddenChecks(configs)
-	s.filterTemplatesContainerCollectAll(configs)
 	filterTemplatesMatched(s, configs)
+
+	// Container Collect All filtering should always be last
+	s.filterTemplatesContainerCollectAll(configs)
 }
 
 // GetFilterableEntity returns the filterable entity of the service


### PR DESCRIPTION
### What does this PR do?

Flips the order between config filtering for CELSelector and ContainerCollectAll.

For context, when a check configuration is defined with a CELSelector, the check config is initially tied to the service as a candidate. Additionally, the ContainerCollectAll check configuration is also dropped from a workload if there exists some other associated check config with a LogsConfig.

We want to prioritize keeping a ContainerCollectAll check configuration on a service if there won't be an overridden unique LogsConfig for the service. This PR filters the order of filtering to prioritize this behavior.

Previously, there could be a service with a check log config with a CELSelector that would ultimately drop the check config from being scheduled because conditions didn't match. This could the same LogConfig that the ContainerCollectAll filtering assumed would be present on the service so it also dropped the `container_collect_all` config. Thus, no logs config would be scheduled for the service even though ContainerCollectAll was enabled.

### Motivation

Make log check configs backed by the new `cel_selector` compatible with containerCollectAll.

CONTP-984

### Describe how you validated your changes

Deploy the following 3 following workloads.

```
apiVersion: v1
kind: Pod
metadata:
  name: hello-service-a
  namespace: default
  annotations:
    collect-logs: "unfiltered"
  labels:
    app: hello-world
    service: service-a
spec:
  containers:
  - name: hello
    image: busybox
    command: ['sh', '-c', 'while true; do echo "Hello from service-a"; sleep 2; done']
---
apiVersion: v1
kind: Pod
metadata:
  name: hello-service-b
  namespace: default
  annotations:
    collect-logs: "filtered"
  labels:
    app: hello-world
    service: service-b
spec:
  containers:
  - name: hello
    image: busybox
    command: ['sh', '-c', 'while true; do echo "Hello from service-b"; sleep 2; done']
---
apiVersion: v1
kind: Pod
metadata:
  name: hello-service-c
  namespace: default
  annotations:
    collect-logs: "other"
  labels:
    app: hello-world
    service: service-c
spec:
  containers:
  - name: hello
    image: busybox
    command: ['sh', '-c', 'while true; do echo "Hello from service-c"; sleep 2; done']
```

Deploy the Agent with the following configuration:

```
datadog:
  kubelet:
    tlsVerify: false
  logs:
    enabled: true
    containerCollectAll: true
  envDict:
    # Help us only see the containerCollectAll options
    # on the default namespace where the dummy apps are deployed
    DD_CONTAINER_EXCLUDE: "kube_namespace:.*"
    DD_CONTAINER_INCLUDE: "kube_namespace:default"
  confd:
    # Should only target service-a
    busybox-logs-unfiltered.yaml: |
      ad_identifiers:
        - busybox
      cel_selector:
        containers:
          - container.pod.annotations["collect-logs"] == "unfiltered"
      logs:
        - source: busybox
          service: busybox-unfiltered
    busybox-logs-filtered.yaml: |
      # Should only target service-b
      cel_selector:
        containers:
          - container.pod.annotations["collect-logs"] == "filtered" && container.image.reference.matches("busybox")
      logs:
        - source: busybox
          service: busybox-filtered
          log_processing_rules:
            - type: exclude_at_match
              name: exclude_hello
              pattern: "Hello.*"
agents:
  image:
    tag: <INSERT_TAG>
```

Expected output from `agent configcheck`:

```
# Matched via the AD_Identifer and used CELSelector to further filter
=== busybox-logs-unfiltered check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/busybox-logs-unfiltered.yaml
Log Config:
logs:
  - service: busybox-unfiltered
    source: busybox
Auto-discovery IDs:
* busybox
===

# Matched via the CELSelector
=== busybox-logs-filtered check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/busybox-logs-filtered.yaml
Log Config:
logs:
  - log_processing_rules:
      - name: exclude_hello
        pattern: Hello.*
        type: exclude_at_match
    service: busybox-filtered
    source: busybox
Auto-discovery IDs:
* cel://container
===
...
=== container_collect_all check ===
Configuration provider: kubernetes-container-allinone
Configuration source: container:docker://c3dd330e74d9ca28d4b6fd0a8c293cd4aac02a7f4f7a060330b27e42fcd9c457
Log Config:
- {}
Auto-discovery IDs:
* docker://c3dd330e74d9ca28d4b6fd0a8c293cd4aac02a7f4f7a060330b27e42fcd9c457
===
```

To confirm additionally, you can first delete the pod `hello-service-b` and in the `agent configcheck` output you should see that the check `busybox-logs-unfiltered` is removed. Then delete `hello-service-a` and in the `agent configcheck` output you should see that the check `busybox-logs-filtered` is removed. One remaining `container_collect_all` config should remain which targets `hello-service-c`.
