### PR TITLE
Ra/diagnose proxy mvp

### DIFF
--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -91,7 +91,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		GlobalParams: globalParams,
 	}
 
-	// From the CLI standpoint most of the changes are covered by the “agent diagnose all” sub-command.
+	// From the CLI standpoint most of the changes are covered by the "agent diagnose all" sub-command.
 	// Other, previous sub-commands left AS IS for now for compatibility reasons. But further changes
 	// are possible, e.g. removal of all sub-commands and using command-line options to fine-tune
 	// diagnose depth, breadth and output format. Suggestions are welcome.
@@ -379,6 +379,7 @@ This command print the security-agent metadata payload. This payload is used by 
 	showPayloadCommand.AddCommand(agentTelemetryCmd)
 	showPayloadCommand.AddCommand(agentFullTelemetryCmd)
 	diagnoseCommand.AddCommand(showPayloadCommand)
+	diagnoseCommand.AddCommand(newProxyCommand())
 
 	return []*cobra.Command{diagnoseCommand}
 }

--- a/cmd/agent/subcommands/diagnose/proxy_cmd.go
+++ b/cmd/agent/subcommands/diagnose/proxy_cmd.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package diagnose
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	dproxy "github.com/DataDog/datadog-agent/pkg/diagnose/proxy"
+	"github.com/spf13/cobra"
+)
+
+func newProxyCommand() *cobra.Command {
+	var jsonOut bool
+	var noNetwork bool
+	var summaryOut bool
+	var includeSensitive bool // reserved for future probes/TLS details
+
+	cmd := &cobra.Command{
+		Use:   "proxy",
+		Short: "Diagnose proxy/TLS configuration and common pitfalls",
+		Long:  "Shows effective proxy settings with source precedence and lints common no_proxy and conflict issues.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = includeSensitive // MVP: unused
+
+			// NOTE: configsetup.Datadog() is used inside ComputeEffective().
+			// Ensure you run with DD_CONF_DIR or via `-c` at the root agent level
+			// so datadog.yaml is loaded. We don't call any extra loader here to
+			// avoid linking on symbols that differ by agent versions.
+
+			res := dproxy.Run(noNetwork)
+
+			if jsonOut {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(res)
+			}
+
+			if summaryOut {
+				writeProxySummary(res)
+				return nil
+			}
+
+			// Default human output
+			fmt.Printf("Proxy/TLS Diagnose: %s\n\n", res.Summary)
+			fmt.Printf("Effective proxy (with sources):\n")
+			fmt.Printf("  HTTPS    : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTPS.Value), res.Effective.HTTPS.Source)
+			fmt.Printf("  HTTP     : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTP.Value), res.Effective.HTTP.Source)
+			fmt.Printf("  NO_PROXY : %q [%s]\n\n", res.Effective.NoProxy.Value, res.Effective.NoProxy.Source)
+
+			fmt.Println("NO_PROXY evaluation:")
+			if len(res.EndpointMatrix) == 0 {
+				fmt.Println("  (no endpoints discovered)")
+			} else {
+				for _, row := range res.EndpointMatrix {
+					b := "no"
+					if row.Bypassed {
+						b = "YES"
+					}
+					fmt.Printf("  - %-7s host=%s port=%s bypassed=%s token=%q\n",
+						row.Endpoint.Name, row.Host, row.Port, b, row.Matched)
+				}
+			}
+			fmt.Println()
+
+			if len(res.Findings) == 0 {
+				fmt.Println("Findings: none. Looks good ✅")
+				return nil
+			}
+			fmt.Println("Findings:")
+			for _, f := range res.Findings {
+				fmt.Printf("  - [%s] %s\n    → %s\n", f.Severity, f.Description, f.Action)
+			}
+			return nil
+		},
+	}
+
+	// Flags
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output JSON")
+	cmd.Flags().BoolVar(&noNetwork, "no-network", true, "Do not run active network probes. Set to false to run DNS/TCP/TLS/HTTP checks.")
+	cmd.Flags().BoolVar(&summaryOut, "summary", false, "Print a compact, privacy-safe summary block.")
+	cmd.Flags().BoolVar(&includeSensitive, "include-sensitive", false, "Include sensitive details (reserved)")
+
+	return cmd
+}
+
+func writeProxySummary(res dproxy.Result) {
+	utc := time.Now().UTC().Format(time.RFC3339)
+	fmt.Printf("=== Proxy/TLS Diagnose (privacy-safe, %s) ===\n", utc)
+	fmt.Printf("Summary: %s\n", res.Summary)
+	fmt.Printf("HTTPS: %q [%s]\n", dproxy.RedactURL(res.Effective.HTTPS.Value), res.Effective.HTTPS.Source)
+	fmt.Printf("HTTP : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTP.Value), res.Effective.HTTP.Source)
+	if res.Effective.NoProxy.Value != "" {
+		fmt.Printf("NO_PROXY: %q [%s]\n", res.Effective.NoProxy.Value, res.Effective.NoProxy.Source)
+	}
+
+	printed := 0
+	for _, f := range res.Findings {
+		if printed >= 6 {
+			fmt.Println("…")
+			break
+		}
+		fmt.Printf("- [%s] %s\n", f.Severity, f.Description)
+		printed++
+	}
+
+	byp := 0
+	for _, row := range res.EndpointMatrix {
+		if row.Bypassed {
+			byp++
+		}
+	}
+	if byp > 0 {
+		fmt.Printf("Bypass: %d intake(s) bypass proxy due to NO_PROXY.\n", byp)
+	}
+	fmt.Println()
+}

--- a/cmd/agent/subcommands/diagnose/proxy_cmd.go
+++ b/cmd/agent/subcommands/diagnose/proxy_cmd.go
@@ -1,129 +1,125 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-
-package diagnose
+package proxy
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
-	"time"
+	"path/filepath"
+	"strings"
 
-	dproxy "github.com/DataDog/datadog-agent/pkg/diagnose/proxy"
-	"github.com/spf13/cobra"
+	configsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	yaml "gopkg.in/yaml.v2"
 )
 
-func newProxyCommand() *cobra.Command {
-	var jsonOut bool
-	var noNetwork bool
-	var summaryOut bool
-	var includeSensitive bool // reserved (for probe/TLS chain output later)
-
-	cmd := &cobra.Command{
-		Use:   "proxy",
-		Short: "Diagnose proxy/TLS configuration and common pitfalls",
-		Long:  "Shows effective proxy settings with source precedence and lints common no_proxy and conflict issues.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			_ = includeSensitive // not used in MVP
-
-			// --- IMPORTANT: honor -c/--cfgpath by exporting DD_CONF_DIR ---
-			// Our config reader (pkg/config/setup) already respects DD_CONF_DIR.
-			// The diagnose root may not preload config in --local/-o mode, so
-			// we set the env ourselves before calling into the proxy code.
-			if f := cmd.InheritedFlags().Lookup("cfgpath"); f != nil {
-				if v := f.Value.String(); v != "" {
-					_ = os.Setenv("DD_CONF_DIR", v)
-				}
-			}
-			// --------------------------------------------------------------
-
-			res := dproxy.Run(noNetwork)
-
-			if jsonOut {
-				enc := json.NewEncoder(os.Stdout)
-				enc.SetIndent("", "  ")
-				return enc.Encode(res)
-			}
-
-			if summaryOut {
-				fmt.Print(dproxy.FormatSummary(res))
-				return nil
-			}
-			fmt.Printf("Proxy/TLS Diagnose: %s\n\n", res.Summary)
-			fmt.Printf("Effective proxy (with sources):\n")
-			fmt.Printf("  HTTPS    : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTPS.Value), res.Effective.HTTPS.Source)
-			fmt.Printf("  HTTP     : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTP.Value), res.Effective.HTTP.Source)
-			fmt.Printf("  NO_PROXY : %q [%s]\n\n", res.Effective.NoProxy.Value, res.Effective.NoProxy.Source)
-			fmt.Println("NO_PROXY evaluation:")
-			if len(res.EndpointMatrix) == 0 {
-				fmt.Println("  (no endpoints discovered)")
-			} else {
-				for _, row := range res.EndpointMatrix {
-					b := "no"
-					if row.Bypassed {
-						b = "YES"
-					}
-					fmt.Printf("  - %-12s host=%s port=%s bypassed=%s token=%q\n",
-						row.Endpoint.Name, row.Host, row.Port, b, row.Matched)
-				}
-			}
-			fmt.Println()
-
-			if len(res.Findings) == 0 {
-				fmt.Println("Findings: none. Looks good ✅")
-				return nil
-			}
-			fmt.Println("Findings:")
-			for _, f := range res.Findings {
-				fmt.Printf("  - [%s] %s\n    → %s\n", f.Severity, f.Description, f.Action)
-			}
-			return nil
-		},
+func pick(val string, best *ValueWithSource, source Source) {
+	v := strings.TrimSpace(val)
+	if v == "" {
+		return
 	}
-
-	// Flags
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output JSON")
-	cmd.Flags().BoolVar(&noNetwork, "no-network", true, "Do not run active network probes. Set to false to run DNS/TCP/TLS/HTTP checks.")
-	cmd.Flags().BoolVar(&summaryOut, "summary", false, "Print a compact, privacy-safe summary block.")
-	cmd.Flags().BoolVar(&includeSensitive, "include-sensitive", false, "Include sensitive details (reserved)")
-
-	return cmd
+	// Only take the value if we haven't set one yet or we're still at "default".
+	if best.Source == "" || best.Source == SourceDefault {
+		best.Value = v
+		best.Source = source
+	}
 }
 
-func writeProxySummary(res dproxy.Result) {
-	// header
-	utc := time.Now().UTC().Format(time.RFC3339)
-	fmt.Printf("=== Proxy/TLS Diagnose (privacy-safe, %s) ===\n", utc)
-	fmt.Printf("Summary: %s\n", res.Summary)
-
-	// effective (scrubbed via RedactURL in CLI; JSON already redacts via MarshalJSON)
-	fmt.Printf("HTTPS: %q [%s]\n", dproxy.RedactURL(res.Effective.HTTPS.Value), res.Effective.HTTPS.Source)
-	fmt.Printf("HTTP : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTP.Value), res.Effective.HTTP.Source)
-	if res.Effective.NoProxy.Value != "" {
-		fmt.Printf("NO_PROXY: %q [%s]\n", res.Effective.NoProxy.Value, res.Effective.NoProxy.Source)
+func joinNoProxySlice(slice []string) string {
+	if len(slice) == 0 {
+		return ""
 	}
+	return strings.Join(slice, ",")
+}
 
-	// key findings (keep it short)
-	printed := 0
-	for _, f := range res.Findings {
-		if printed >= 6 {
-			fmt.Println("…")
-			break
+// minimal YAML shape to read proxy.* from datadog.yaml directly when needed
+type ddYAML struct {
+	Proxy struct {
+		HTTP    string   `yaml:"http"`
+		HTTPS   string   `yaml:"https"`
+		NoProxy []string `yaml:"no_proxy"`
+	} `yaml:"proxy"`
+}
+
+func tryLoadProxyFromYAML(confDir string) (http, https string, np []string, ok bool) {
+	if strings.TrimSpace(confDir) == "" {
+		return "", "", nil, false
+	}
+	path := filepath.Join(confDir, "datadog.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", nil, false
+	}
+	var doc ddYAML
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", "", nil, false
+	}
+	return doc.Proxy.HTTP, doc.Proxy.HTTPS, doc.Proxy.NoProxy, true
+}
+
+// ComputeEffective returns the chosen HTTP/HTTPS/NO_PROXY values with their sources.
+// Precedence (highest→lowest):
+//   DD_PROXY_*  → datadog.yaml proxy.*  → HTTPS_PROXY/HTTP_PROXY/NO_PROXY (incl. lowercase variants)
+func ComputeEffective() Effective {
+	var http, https, noProxy ValueWithSource
+	http.Source, https.Source, noProxy.Source = SourceDefault, SourceDefault, SourceDefault
+
+	// 1) Highest: DD_* (explicit Datadog env)
+	pick(os.Getenv("DD_PROXY_HTTP"), &http, SourceDDEnv)
+	pick(os.Getenv("DD_PROXY_HTTPS"), &https, SourceDDEnv)
+	pick(os.Getenv("DD_NO_PROXY"), &noProxy, SourceDDEnv)
+
+	// 2) Next: in-process datadog config (if already loaded)
+	cfg := configsetup.Datadog()
+	if cfg != nil {
+		pick(cfg.GetString("proxy.http"), &http, SourceConfig)
+		pick(cfg.GetString("proxy.https"), &https, SourceConfig)
+		if v := cfg.GetStringSlice("proxy.no_proxy"); len(v) > 0 {
+			pick(joinNoProxySlice(v), &noProxy, SourceConfig)
 		}
-		fmt.Printf("- [%s] %s\n", f.Severity, f.Description)
-		printed++
 	}
 
-	// endpoint bypass hint
-	byp := 0
-	for _, row := range res.EndpointMatrix {
-		if row.Bypassed {
-			byp++
+	// 2b) Fallback: if nothing (or partial) came from the in-process config, read datadog.yaml directly.
+	// We honor DD_CONF_DIR (subcommand sets it from -c). This makes -c work even when the parent
+	// command didn't initialize the global config.
+	if ddConf := os.Getenv("DD_CONF_DIR"); ddConf != "" {
+		if http.Value == "" || https.Value == "" || noProxy.Value == "" {
+			if h, s, np, ok := tryLoadProxyFromYAML(ddConf); ok {
+				if http.Value == "" {
+					pick(h, &http, SourceConfig)
+				}
+				if https.Value == "" {
+					pick(s, &https, SourceConfig)
+				}
+				if noProxy.Value == "" && len(np) > 0 {
+					pick(joinNoProxySlice(np), &noProxy, SourceConfig)
+				}
+			}
 		}
 	}
-	if byp > 0 {
-		fmt.Printf("Bypass: %d intake(s) bypass proxy due to NO_PROXY.\n", byp)
+
+	// 3) Lowest: standard env (upper then lower)
+	pick(os.Getenv("HTTPS_PROXY"), &https, SourceStdEnv)
+	pick(os.Getenv("HTTP_PROXY"), &http, SourceStdEnv)
+	pick(os.Getenv("NO_PROXY"), &noProxy, SourceStdEnv)
+	if https.Value == "" {
+		pick(os.Getenv("https_proxy"), &https, SourceStdEnv)
 	}
-	fmt.Println()
+	if http.Value == "" {
+		pick(os.Getenv("http_proxy"), &http, SourceStdEnv)
+	}
+	if noProxy.Value == "" {
+		pick(os.Getenv("no_proxy"), &noProxy, SourceStdEnv)
+	}
+
+	eff := Effective{
+		HTTP:    http,
+		HTTPS:   https,
+		NoProxy: noProxy,
+	}
+
+	// Non-exact NO_PROXY toggle (env preferred; allow config if exposed).
+	if v := os.Getenv("DD_NO_PROXY_NONEXACT_MATCH"); strings.EqualFold(v, "true") {
+		eff.NonExactNoProxy = true
+	} else if cfg != nil && cfg.IsSet("DD_NO_PROXY_NONEXACT_MATCH") {
+		eff.NonExactNoProxy = strings.EqualFold(cfg.GetString("DD_NO_PROXY_NONEXACT_MATCH"), "true")
+	}
+
+	return eff
 }

--- a/cmd/agent/subcommands/diagnose/proxy_cmd.go
+++ b/cmd/agent/subcommands/diagnose/proxy_cmd.go
@@ -1,125 +1,129 @@
-package proxy
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package diagnose
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
+	"time"
 
-	configsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	yaml "gopkg.in/yaml.v2"
+	dproxy "github.com/DataDog/datadog-agent/pkg/diagnose/proxy"
+	"github.com/spf13/cobra"
 )
 
-func pick(val string, best *ValueWithSource, source Source) {
-	v := strings.TrimSpace(val)
-	if v == "" {
-		return
-	}
-	// Only take the value if we haven't set one yet or we're still at "default".
-	if best.Source == "" || best.Source == SourceDefault {
-		best.Value = v
-		best.Source = source
-	}
-}
+func newProxyCommand() *cobra.Command {
+	var jsonOut bool
+	var noNetwork bool
+	var summaryOut bool
+	var includeSensitive bool // reserved (for probe/TLS chain output later)
 
-func joinNoProxySlice(slice []string) string {
-	if len(slice) == 0 {
-		return ""
-	}
-	return strings.Join(slice, ",")
-}
+	cmd := &cobra.Command{
+		Use:   "proxy",
+		Short: "Diagnose proxy/TLS configuration and common pitfalls",
+		Long:  "Shows effective proxy settings with source precedence and lints common no_proxy and conflict issues.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = includeSensitive // not used in MVP
 
-// minimal YAML shape to read proxy.* from datadog.yaml directly when needed
-type ddYAML struct {
-	Proxy struct {
-		HTTP    string   `yaml:"http"`
-		HTTPS   string   `yaml:"https"`
-		NoProxy []string `yaml:"no_proxy"`
-	} `yaml:"proxy"`
-}
-
-func tryLoadProxyFromYAML(confDir string) (http, https string, np []string, ok bool) {
-	if strings.TrimSpace(confDir) == "" {
-		return "", "", nil, false
-	}
-	path := filepath.Join(confDir, "datadog.yaml")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", "", nil, false
-	}
-	var doc ddYAML
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return "", "", nil, false
-	}
-	return doc.Proxy.HTTP, doc.Proxy.HTTPS, doc.Proxy.NoProxy, true
-}
-
-// ComputeEffective returns the chosen HTTP/HTTPS/NO_PROXY values with their sources.
-// Precedence (highest→lowest):
-//   DD_PROXY_*  → datadog.yaml proxy.*  → HTTPS_PROXY/HTTP_PROXY/NO_PROXY (incl. lowercase variants)
-func ComputeEffective() Effective {
-	var http, https, noProxy ValueWithSource
-	http.Source, https.Source, noProxy.Source = SourceDefault, SourceDefault, SourceDefault
-
-	// 1) Highest: DD_* (explicit Datadog env)
-	pick(os.Getenv("DD_PROXY_HTTP"), &http, SourceDDEnv)
-	pick(os.Getenv("DD_PROXY_HTTPS"), &https, SourceDDEnv)
-	pick(os.Getenv("DD_NO_PROXY"), &noProxy, SourceDDEnv)
-
-	// 2) Next: in-process datadog config (if already loaded)
-	cfg := configsetup.Datadog()
-	if cfg != nil {
-		pick(cfg.GetString("proxy.http"), &http, SourceConfig)
-		pick(cfg.GetString("proxy.https"), &https, SourceConfig)
-		if v := cfg.GetStringSlice("proxy.no_proxy"); len(v) > 0 {
-			pick(joinNoProxySlice(v), &noProxy, SourceConfig)
-		}
-	}
-
-	// 2b) Fallback: if nothing (or partial) came from the in-process config, read datadog.yaml directly.
-	// We honor DD_CONF_DIR (subcommand sets it from -c). This makes -c work even when the parent
-	// command didn't initialize the global config.
-	if ddConf := os.Getenv("DD_CONF_DIR"); ddConf != "" {
-		if http.Value == "" || https.Value == "" || noProxy.Value == "" {
-			if h, s, np, ok := tryLoadProxyFromYAML(ddConf); ok {
-				if http.Value == "" {
-					pick(h, &http, SourceConfig)
-				}
-				if https.Value == "" {
-					pick(s, &https, SourceConfig)
-				}
-				if noProxy.Value == "" && len(np) > 0 {
-					pick(joinNoProxySlice(np), &noProxy, SourceConfig)
+			// --- IMPORTANT: honor -c/--cfgpath by exporting DD_CONF_DIR ---
+			// Our config reader (pkg/config/setup) already respects DD_CONF_DIR.
+			// The diagnose root may not preload config in --local/-o mode, so
+			// we set the env ourselves before calling into the proxy code.
+			if f := cmd.InheritedFlags().Lookup("cfgpath"); f != nil {
+				if v := f.Value.String(); v != "" {
+					_ = os.Setenv("DD_CONF_DIR", v)
 				}
 			}
+			// --------------------------------------------------------------
+
+			res := dproxy.Run(noNetwork)
+
+			if jsonOut {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(res)
+			}
+
+			if summaryOut {
+				fmt.Print(dproxy.FormatSummary(res))
+				return nil
+			}
+			fmt.Printf("Proxy/TLS Diagnose: %s\n\n", res.Summary)
+			fmt.Printf("Effective proxy (with sources):\n")
+			fmt.Printf("  HTTPS    : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTPS.Value), res.Effective.HTTPS.Source)
+			fmt.Printf("  HTTP     : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTP.Value), res.Effective.HTTP.Source)
+			fmt.Printf("  NO_PROXY : %q [%s]\n\n", res.Effective.NoProxy.Value, res.Effective.NoProxy.Source)
+			fmt.Println("NO_PROXY evaluation:")
+			if len(res.EndpointMatrix) == 0 {
+				fmt.Println("  (no endpoints discovered)")
+			} else {
+				for _, row := range res.EndpointMatrix {
+					b := "no"
+					if row.Bypassed {
+						b = "YES"
+					}
+					fmt.Printf("  - %-12s host=%s port=%s bypassed=%s token=%q\n",
+						row.Endpoint.Name, row.Host, row.Port, b, row.Matched)
+				}
+			}
+			fmt.Println()
+
+			if len(res.Findings) == 0 {
+				fmt.Println("Findings: none. Looks good ✅")
+				return nil
+			}
+			fmt.Println("Findings:")
+			for _, f := range res.Findings {
+				fmt.Printf("  - [%s] %s\n    → %s\n", f.Severity, f.Description, f.Action)
+			}
+			return nil
+		},
+	}
+
+	// Flags
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output JSON")
+	cmd.Flags().BoolVar(&noNetwork, "no-network", true, "Do not run active network probes. Set to false to run DNS/TCP/TLS/HTTP checks.")
+	cmd.Flags().BoolVar(&summaryOut, "summary", false, "Print a compact, privacy-safe summary block.")
+	cmd.Flags().BoolVar(&includeSensitive, "include-sensitive", false, "Include sensitive details (reserved)")
+
+	return cmd
+}
+
+func writeProxySummary(res dproxy.Result) {
+	// header
+	utc := time.Now().UTC().Format(time.RFC3339)
+	fmt.Printf("=== Proxy/TLS Diagnose (privacy-safe, %s) ===\n", utc)
+	fmt.Printf("Summary: %s\n", res.Summary)
+
+	// effective (scrubbed via RedactURL in CLI; JSON already redacts via MarshalJSON)
+	fmt.Printf("HTTPS: %q [%s]\n", dproxy.RedactURL(res.Effective.HTTPS.Value), res.Effective.HTTPS.Source)
+	fmt.Printf("HTTP : %q [%s]\n", dproxy.RedactURL(res.Effective.HTTP.Value), res.Effective.HTTP.Source)
+	if res.Effective.NoProxy.Value != "" {
+		fmt.Printf("NO_PROXY: %q [%s]\n", res.Effective.NoProxy.Value, res.Effective.NoProxy.Source)
+	}
+
+	// key findings (keep it short)
+	printed := 0
+	for _, f := range res.Findings {
+		if printed >= 6 {
+			fmt.Println("…")
+			break
+		}
+		fmt.Printf("- [%s] %s\n", f.Severity, f.Description)
+		printed++
+	}
+
+	// endpoint bypass hint
+	byp := 0
+	for _, row := range res.EndpointMatrix {
+		if row.Bypassed {
+			byp++
 		}
 	}
-
-	// 3) Lowest: standard env (upper then lower)
-	pick(os.Getenv("HTTPS_PROXY"), &https, SourceStdEnv)
-	pick(os.Getenv("HTTP_PROXY"), &http, SourceStdEnv)
-	pick(os.Getenv("NO_PROXY"), &noProxy, SourceStdEnv)
-	if https.Value == "" {
-		pick(os.Getenv("https_proxy"), &https, SourceStdEnv)
+	if byp > 0 {
+		fmt.Printf("Bypass: %d intake(s) bypass proxy due to NO_PROXY.\n", byp)
 	}
-	if http.Value == "" {
-		pick(os.Getenv("http_proxy"), &http, SourceStdEnv)
-	}
-	if noProxy.Value == "" {
-		pick(os.Getenv("no_proxy"), &noProxy, SourceStdEnv)
-	}
-
-	eff := Effective{
-		HTTP:    http,
-		HTTPS:   https,
-		NoProxy: noProxy,
-	}
-
-	// Non-exact NO_PROXY toggle (env preferred; allow config if exposed).
-	if v := os.Getenv("DD_NO_PROXY_NONEXACT_MATCH"); strings.EqualFold(v, "true") {
-		eff.NonExactNoProxy = true
-	} else if cfg != nil && cfg.IsSet("DD_NO_PROXY_NONEXACT_MATCH") {
-		eff.NonExactNoProxy = strings.EqualFold(cfg.GetString("DD_NO_PROXY_NONEXACT_MATCH"), "true")
-	}
-
-	return eff
+	fmt.Println()
 }

--- a/pkg/diagnose/proxy/conflicts.go
+++ b/pkg/diagnose/proxy/conflicts.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"os"
+	"strings"
+
+	configsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// lintConflicts detects conflicting proxy values across dd_env / config / std_env.
+func lintConflicts(eff Effective) []Finding {
+	var out []Finding
+
+	cfg := configsetup.Datadog()
+
+	collect := func(key string) []ValueWithSource {
+		values := []ValueWithSource{}
+
+		// dd env
+		if key == "https" {
+			if v := strings.TrimSpace(os.Getenv("DD_PROXY_HTTPS")); v != "" {
+				values = append(values, ValueWithSource{Value: v, Source: SourceDDEnv})
+			}
+		} else {
+			if v := strings.TrimSpace(os.Getenv("DD_PROXY_HTTP")); v != "" {
+				values = append(values, ValueWithSource{Value: v, Source: SourceDDEnv})
+			}
+		}
+
+		// config
+		if cfg != nil {
+			if key == "https" {
+				if v := strings.TrimSpace(cfg.GetString("proxy.https")); v != "" {
+					values = append(values, ValueWithSource{Value: v, Source: SourceConfig})
+				}
+			} else {
+				if v := strings.TrimSpace(cfg.GetString("proxy.http")); v != "" {
+					values = append(values, ValueWithSource{Value: v, Source: SourceConfig})
+				}
+			}
+		}
+
+		// std env
+		if key == "https" {
+			if v := strings.TrimSpace(os.Getenv("HTTPS_PROXY")); v != "" {
+				values = append(values, ValueWithSource{Value: v, Source: SourceStdEnv})
+			}
+		} else {
+			if v := strings.TrimSpace(os.Getenv("HTTP_PROXY")); v != "" {
+				values = append(values, ValueWithSource{Value: v, Source: SourceStdEnv})
+			}
+		}
+
+		// Lowercase variants (last resort)
+		if key == "https" && len(values) == 0 {
+			if v := strings.TrimSpace(os.Getenv("https_proxy")); v != "" {
+				values = append(values, ValueWithSource{Value: v, Source: SourceStdEnv})
+			}
+		}
+		if key == "http" && len(values) == 0 {
+			if v := strings.TrimSpace(os.Getenv("http_proxy")); v != "" {
+				values = append(values, ValueWithSource{Value: v, Source: SourceStdEnv})
+			}
+		}
+
+		// de-dup by value
+		uniq := make(map[string]Source)
+		out := []ValueWithSource{}
+		for _, vv := range values {
+			if _, seen := uniq[vv.Value]; !seen {
+				uniq[vv.Value] = vv.Source
+				out = append(out, vv)
+			}
+		}
+		return out
+	}
+
+	// HTTPS
+	if vals := collect("https"); len(vals) > 1 {
+		out = append(out, Finding{
+			Code:        "proxy.https.conflict",
+			Severity:    SeverityYellow,
+			Description: "HTTPS proxy is defined by multiple sources with different values.",
+			Action:      "Use a single source or align the values across sources.",
+			Evidence:    vals,
+		})
+	}
+
+	// HTTP
+	if vals := collect("http"); len(vals) > 1 {
+		out = append(out, Finding{
+			Code:        "proxy.http.conflict",
+			Severity:    SeverityYellow,
+			Description: "HTTP proxy is defined by multiple sources with different values.",
+			Action:      "Use a single source or align the values across sources.",
+			Evidence:    vals,
+		})
+	}
+
+	return out
+}

--- a/pkg/diagnose/proxy/conflicts.go
+++ b/pkg/diagnose/proxy/conflicts.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import (

--- a/pkg/diagnose/proxy/effective_config.go
+++ b/pkg/diagnose/proxy/effective_config.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	"os"
+	"strings"
+
+	configsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+func pick(val string, best *ValueWithSource, source Source) {
+	if strings.TrimSpace(val) == "" {
+		return
+	}
+	if best.Source == "" || best.Source == SourceDefault {
+		best.Value = strings.TrimSpace(val)
+		best.Source = source
+	}
+}
+
+func joinNoProxySlice(slice []string) string {
+	if len(slice) == 0 {
+		return ""
+	}
+	return strings.Join(slice, ",")
+}
+
+// Precedence (highest→lowest):
+//   DD_PROXY_*  →  datadog.yaml (proxy.*)  →  HTTPS_PROXY/HTTP_PROXY/NO_PROXY (+ lowercase)
+func ComputeEffective() Effective {
+	var http, https, noProxy ValueWithSource
+	http.Source, https.Source, noProxy.Source = SourceDefault, SourceDefault, SourceDefault
+
+	// Highest: DD_* (Datadog env)
+	pick(os.Getenv("DD_PROXY_HTTP"), &http, SourceDDEnv)
+	pick(os.Getenv("DD_PROXY_HTTPS"), &https, SourceDDEnv)
+	pick(os.Getenv("DD_NO_PROXY"), &noProxy, SourceDDEnv)
+
+	// Next: datadog.yaml via setup.Datadog() – assumes config was loaded by the Agent
+	// (or by setting DD_CONF_DIR / passing -c at CLI).
+	cfg := configsetup.Datadog()
+	if cfg != nil {
+		pick(cfg.GetString("proxy.http"), &http, SourceConfig)
+		pick(cfg.GetString("proxy.https"), &https, SourceConfig)
+		if v := cfg.GetStringSlice("proxy.no_proxy"); len(v) > 0 {
+			pick(joinNoProxySlice(v), &noProxy, SourceConfig)
+		}
+	}
+
+	// Lowest: standard env
+	pick(os.Getenv("HTTPS_PROXY"), &https, SourceStdEnv)
+	pick(os.Getenv("HTTP_PROXY"), &http, SourceStdEnv)
+	pick(os.Getenv("NO_PROXY"), &noProxy, SourceStdEnv)
+	if https.Value == "" {
+		pick(os.Getenv("https_proxy"), &https, SourceStdEnv)
+	}
+	if http.Value == "" {
+		pick(os.Getenv("http_proxy"), &http, SourceStdEnv)
+	}
+	if noProxy.Value == "" {
+		pick(os.Getenv("no_proxy"), &noProxy, SourceStdEnv)
+	}
+
+	eff := Effective{
+		HTTP:    http,
+		HTTPS:   https,
+		NoProxy: noProxy,
+	}
+
+	// Non-exact no_proxy (env preferred; allow config fallback if present)
+	if v := os.Getenv("DD_NO_PROXY_NONEXACT_MATCH"); strings.EqualFold(v, "true") {
+		eff.NonExactNoProxy = true
+	} else if cfg != nil && cfg.IsSet("DD_NO_PROXY_NONEXACT_MATCH") {
+		eff.NonExactNoProxy = strings.EqualFold(cfg.GetString("DD_NO_PROXY_NONEXACT_MATCH"), "true")
+	}
+
+	return eff
+}

--- a/pkg/diagnose/proxy/effective_config.go
+++ b/pkg/diagnose/proxy/effective_config.go
@@ -2,17 +2,21 @@ package proxy
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	configsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func pick(val string, best *ValueWithSource, source Source) {
-	if strings.TrimSpace(val) == "" {
+	v := strings.TrimSpace(val)
+	if v == "" {
 		return
 	}
+	// Only take the value if we haven't set one yet or we're still at "default".
 	if best.Source == "" || best.Source == SourceDefault {
-		best.Value = strings.TrimSpace(val)
+		best.Value = v
 		best.Source = source
 	}
 }
@@ -24,19 +28,44 @@ func joinNoProxySlice(slice []string) string {
 	return strings.Join(slice, ",")
 }
 
+// minimal YAML shape to read proxy.* from datadog.yaml directly when needed
+type ddYAML struct {
+	Proxy struct {
+		HTTP    string   `yaml:"http"`
+		HTTPS   string   `yaml:"https"`
+		NoProxy []string `yaml:"no_proxy"`
+	} `yaml:"proxy"`
+}
+
+func tryLoadProxyFromYAML(confDir string) (http, https string, np []string, ok bool) {
+	if strings.TrimSpace(confDir) == "" {
+		return "", "", nil, false
+	}
+	path := filepath.Join(confDir, "datadog.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", nil, false
+	}
+	var doc ddYAML
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", "", nil, false
+	}
+	return doc.Proxy.HTTP, doc.Proxy.HTTPS, doc.Proxy.NoProxy, true
+}
+
+// ComputeEffective returns the chosen HTTP/HTTPS/NO_PROXY values with their sources.
 // Precedence (highest→lowest):
-//   DD_PROXY_*  →  datadog.yaml (proxy.*)  →  HTTPS_PROXY/HTTP_PROXY/NO_PROXY (+ lowercase)
+//   DD_PROXY_*  → datadog.yaml proxy.*  → HTTPS_PROXY/HTTP_PROXY/NO_PROXY (incl. lowercase variants)
 func ComputeEffective() Effective {
 	var http, https, noProxy ValueWithSource
 	http.Source, https.Source, noProxy.Source = SourceDefault, SourceDefault, SourceDefault
 
-	// Highest: DD_* (Datadog env)
+	// 1) Highest: DD_* (explicit Datadog env)
 	pick(os.Getenv("DD_PROXY_HTTP"), &http, SourceDDEnv)
 	pick(os.Getenv("DD_PROXY_HTTPS"), &https, SourceDDEnv)
 	pick(os.Getenv("DD_NO_PROXY"), &noProxy, SourceDDEnv)
 
-	// Next: datadog.yaml via setup.Datadog() – assumes config was loaded by the Agent
-	// (or by setting DD_CONF_DIR / passing -c at CLI).
+	// 2) Next: in-process datadog config (if already loaded)
 	cfg := configsetup.Datadog()
 	if cfg != nil {
 		pick(cfg.GetString("proxy.http"), &http, SourceConfig)
@@ -46,7 +75,26 @@ func ComputeEffective() Effective {
 		}
 	}
 
-	// Lowest: standard env
+	// 2b) Fallback: if nothing (or partial) came from the in-process config, read datadog.yaml directly.
+	// We honor DD_CONF_DIR (subcommand sets it from -c). This makes -c work even when the parent
+	// command didn't initialize the global config.
+	if ddConf := os.Getenv("DD_CONF_DIR"); ddConf != "" {
+		if http.Value == "" || https.Value == "" || noProxy.Value == "" {
+			if h, s, np, ok := tryLoadProxyFromYAML(ddConf); ok {
+				if http.Value == "" {
+					pick(h, &http, SourceConfig)
+				}
+				if https.Value == "" {
+					pick(s, &https, SourceConfig)
+				}
+				if noProxy.Value == "" && len(np) > 0 {
+					pick(joinNoProxySlice(np), &noProxy, SourceConfig)
+				}
+			}
+		}
+	}
+
+	// 3) Lowest: standard env (upper then lower)
 	pick(os.Getenv("HTTPS_PROXY"), &https, SourceStdEnv)
 	pick(os.Getenv("HTTP_PROXY"), &http, SourceStdEnv)
 	pick(os.Getenv("NO_PROXY"), &noProxy, SourceStdEnv)
@@ -66,7 +114,7 @@ func ComputeEffective() Effective {
 		NoProxy: noProxy,
 	}
 
-	// Non-exact no_proxy (env preferred; allow config fallback if present)
+	// Non-exact NO_PROXY toggle (env preferred; allow config if exposed).
 	if v := os.Getenv("DD_NO_PROXY_NONEXACT_MATCH"); strings.EqualFold(v, "true") {
 		eff.NonExactNoProxy = true
 	} else if cfg != nil && cfg.IsSet("DD_NO_PROXY_NONEXACT_MATCH") {

--- a/pkg/diagnose/proxy/effective_config.go
+++ b/pkg/diagnose/proxy/effective_config.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import (

--- a/pkg/diagnose/proxy/endpoints.go
+++ b/pkg/diagnose/proxy/endpoints.go
@@ -1,0 +1,132 @@
+package proxy
+
+import (
+	"net/url"
+	"strings"
+
+	configsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// EffectiveEndpoints returns a privacy-safe list of "well-known" endpoints
+// we can evaluate against NO_PROXY rules. Only the host/port are important;
+// URLs are used as convenient carriers.
+func EffectiveEndpoints() []Endpoint {
+	var eps []Endpoint
+
+	cfg := configsetup.Datadog()
+
+	// Resolve site
+	site := "datadoghq.com"
+	if cfg != nil {
+		if s := strings.TrimSpace(cfg.GetString("site")); s != "" {
+			site = s
+		}
+	}
+
+	// Resolve dd_url (control plane)
+	ddURL := "https://app." + site
+	if cfg != nil {
+		if s := strings.TrimSpace(cfg.GetString("dd_url")); s != "" {
+			ddURL = s
+		}
+	}
+	eps = append(eps, Endpoint{Name: "core", URL: ddURL})
+
+	// A small curated set of product intakes (hostnames only matter for NO_PROXY).
+	host := func(h string) string { return "https://" + h + "." + site }
+	eps = append(eps,
+		Endpoint{Name: "dbm-metrics", URL: host("dbm-metrics-intake")},
+		Endpoint{Name: "ndm", URL: host("ndm-intake")},
+		Endpoint{Name: "snmp-traps", URL: host("snmp-traps-intake")},
+		Endpoint{Name: "netpath", URL: host("netpath-intake")},
+		Endpoint{Name: "container-life", URL: host("contlcycle-intake")},
+		Endpoint{Name: "container-image", URL: host("contimage-intake")},
+		Endpoint{Name: "sbom", URL: host("sbom-intake")},
+	)
+
+	// Flare support (generic hostname; versioned alias also exists in prod)
+	eps = append(eps, Endpoint{Name: "flare", URL: "https://flare.agent." + site})
+
+	return eps
+}
+
+func splitNoProxyList(s string) []string {
+	// Support comma and/or whitespace separated tokens.
+	out := []string{}
+	f := func(r rune) bool { return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r' }
+	for _, tok := range strings.FieldsFunc(s, f) {
+		tok = strings.TrimSpace(tok)
+		if tok != "" {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+func domainMatches(host, suffix string) bool {
+	// exact match or label-boundary suffix match
+	if strings.EqualFold(host, suffix) {
+		return true
+	}
+	return strings.HasSuffix(strings.ToLower(host), "."+strings.ToLower(suffix))
+}
+
+// EvaluateNoProxy computes a matrix describing which endpoints are bypassed by NO_PROXY.
+func EvaluateNoProxy(eff Effective, eps []Endpoint) []EndpointCheck {
+	matrix := make([]EndpointCheck, 0, len(eps))
+
+	noProxy := strings.TrimSpace(eff.NoProxy.Value)
+	tokens := splitNoProxyList(noProxy)
+
+	for _, ep := range eps {
+		u, err := url.Parse(ep.URL)
+		if err != nil || u.Host == "" {
+			continue
+		}
+		host := u.Hostname()
+		port := u.Port()
+
+		check := EndpointCheck{
+			Endpoint: ep,
+			Host:     host,
+			Port:     port,
+			Bypassed: false,
+			Matched:  "",
+		}
+
+		for _, t := range tokens {
+			t = strings.TrimSpace(t)
+			if t == "" {
+				continue
+			}
+			if t == "*" {
+				check.Bypassed = true
+				check.Matched = t
+				break
+			}
+			if strings.HasPrefix(t, ".") {
+				if domainMatches(host, strings.TrimPrefix(t, ".")) {
+					check.Bypassed = true
+					check.Matched = t
+					break
+				}
+			} else {
+				// exact hostname or (if allowed) substring fallback
+				if strings.EqualFold(host, t) {
+					check.Bypassed = true
+					check.Matched = t
+					break
+				}
+				if eff.NonExactNoProxy && strings.Contains(strings.ToLower(host), strings.ToLower(t)) {
+					check.Bypassed = true
+					check.Matched = t
+					break
+				}
+			}
+		}
+
+		matrix = append(matrix, check)
+	}
+
+	return matrix
+}

--- a/pkg/diagnose/proxy/endpoints.go
+++ b/pkg/diagnose/proxy/endpoints.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import (

--- a/pkg/diagnose/proxy/json_redact.go
+++ b/pkg/diagnose/proxy/json_redact.go
@@ -1,0 +1,13 @@
+package proxy
+
+// Optional helpers for callers who want redacted JSON.
+// The CLI prints redacted values already via RedactURL; JSON output
+// currently returns the raw values (common Agent behavior).
+
+func RedactEffectiveForJSON(e Effective) Effective {
+	out := e
+	out.HTTP.Value = RedactURL(e.HTTP.Value)
+	out.HTTPS.Value = RedactURL(e.HTTPS.Value)
+	// NO_PROXY is not redacted (doesn't carry credentials)
+	return out
+}

--- a/pkg/diagnose/proxy/json_redact.go
+++ b/pkg/diagnose/proxy/json_redact.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import (

--- a/pkg/diagnose/proxy/lint_shapes.go
+++ b/pkg/diagnose/proxy/lint_shapes.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"net/url"
+	"strings"
+)
+
+func lintURLShapes(eff Effective) []Finding {
+	var out []Finding
+
+	// HTTPS proxy
+	if v := strings.TrimSpace(eff.HTTPS.Value); v != "" {
+		u, err := url.Parse(v)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			out = append(out, Finding{
+				Code:        "proxy.https.invalid_url",
+				Severity:    SeverityYellow,
+				Description: "Proxy https is not a valid URL (missing scheme/host or parse failed).",
+				Action:      "Provide a full URL, e.g. http://proxy.company:3128",
+				Evidence:    v,
+			})
+		} else if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
+			out = append(out, Finding{
+				Code:        "proxy.https.unknown_scheme",
+				Severity:    SeverityYellow,
+				Description: "Proxy https uses a non-standard scheme.",
+				Action:      "Use http:// or https:// unless you explicitly support the scheme.",
+				Evidence:    v,
+			})
+		}
+	}
+
+	// HTTP proxy
+	if v := strings.TrimSpace(eff.HTTP.Value); v != "" {
+		u, err := url.Parse(v)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			out = append(out, Finding{
+				Code:        "proxy.http.invalid_url",
+				Severity:    SeverityYellow,
+				Description: "Proxy http is not a valid URL (missing scheme/host or parse failed).",
+				Action:      "Provide a full URL, e.g. http://proxy.company:3128",
+				Evidence:    v,
+			})
+		} else if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
+			out = append(out, Finding{
+				Code:        "proxy.http.unknown_scheme",
+				Severity:    SeverityYellow,
+				Description: "Proxy http uses a non-standard scheme.",
+				Action:      "Use http:// or https:// unless you explicitly support the scheme.",
+				Evidence:    v,
+			})
+		}
+	}
+
+	return out
+}

--- a/pkg/diagnose/proxy/lint_shapes.go
+++ b/pkg/diagnose/proxy/lint_shapes.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import (

--- a/pkg/diagnose/proxy/lints.go
+++ b/pkg/diagnose/proxy/lints.go
@@ -1,0 +1,26 @@
+package proxy
+
+import "strings"
+
+// LintAll holds simple config-only lints that don't hit the network.
+func LintAll(eff Effective) []Finding {
+	var out []Finding
+
+	// NO_PROXY leading dot can be surprising in some envs.
+	if np := strings.TrimSpace(eff.NoProxy.Value); np != "" {
+		for _, tok := range splitNoProxyList(np) {
+			if strings.HasPrefix(tok, ".") {
+				out = append(out, Finding{
+					Code:        "no_proxy.leading_dot",
+					Severity:    SeverityYellow,
+					Description: "no_proxy entry starts with a dot (e.g., .example.com). Behavior may differ across environments.",
+					Action:      "Prefer explicit hosts or bare domains (example.com) to avoid ambiguity.",
+					Evidence:    tok,
+				})
+				break
+			}
+		}
+	}
+
+	return out
+}

--- a/pkg/diagnose/proxy/lints.go
+++ b/pkg/diagnose/proxy/lints.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import "strings"

--- a/pkg/diagnose/proxy/probes.go
+++ b/pkg/diagnose/proxy/probes.go
@@ -1,0 +1,12 @@
+package proxy
+
+// Network probes are intentionally stubbed for the MVP.
+// They can be extended to perform DNS/TCP/TLS/HTTP checks when --no-network=false.
+
+func ProbeProxyConnectivity(_ Effective) []Finding {
+	return nil
+}
+
+func ProbeEndpointsConnectivity(_ Effective, _ []Endpoint) []Finding {
+	return nil
+}

--- a/pkg/diagnose/proxy/probes.go
+++ b/pkg/diagnose/proxy/probes.go
@@ -1,12 +1,69 @@
 package proxy
 
-// Network probes are intentionally stubbed for the MVP.
-// They can be extended to perform DNS/TCP/TLS/HTTP checks when --no-network=false.
+import (
+	"context"
+	"net"
+	"net/url"
+	"time"
+)
 
-func ProbeProxyConnectivity(_ Effective) []Finding {
-	return nil
+// ProbeProxyConnectivity performs a minimal active probe when network checks are enabled.
+// It attempts a TCP connection to the configured HTTPS proxy. If this fails, we report a red finding.
+// This intentionally avoids sending any HTTP CONNECT or TLS handshake in the MVP.
+func ProbeProxyConnectivity(eff Effective) []Finding {
+	var out []Finding
+
+	// Nothing to probe if no HTTPS proxy is set.
+	if eff.HTTPS.Value == "" {
+		return out
+	}
+
+	u, err := url.Parse(eff.HTTPS.Value)
+	if err != nil || u.Host == "" {
+		// Shape/parse problems are already covered by config lints.
+		return out
+	}
+
+	// Determine host:port; default ports if missing.
+	target := u.Host
+	if _, _, err := net.SplitHostPort(target); err != nil {
+		switch u.Scheme {
+		case "http":
+			target = net.JoinHostPort(u.Host, "80")
+		case "https":
+			target = net.JoinHostPort(u.Host, "443")
+		default:
+			// Non-standard/unknown schemes are flagged by lints; skip active probe.
+			return out
+		}
+	}
+
+	// Fast TCP dial to the proxy.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	d := net.Dialer{}
+	conn, err := d.DialContext(ctx, "tcp", target)
+	if err != nil {
+		out = append(out, Finding{
+			Code:        "proxy.https.connect_failed",
+			Severity:    SeverityRed,
+			Description: "Failed to connect to the configured HTTPS proxy.",
+			Action:      "Verify host/port, firewall, routing, and that the proxy is reachable.",
+			Evidence: map[string]string{
+				"target": target,
+				"error":  err.Error(),
+			},
+		})
+		return out
+	}
+	_ = conn.Close()
+
+	return out
 }
 
+// ProbeEndpointsConnectivity remains a stub in the MVP.
+// (Future: DNS/TCP/TLS/HTTP probes to each intake when --no-network=false.)
 func ProbeEndpointsConnectivity(_ Effective, _ []Endpoint) []Finding {
 	return nil
 }

--- a/pkg/diagnose/proxy/probes.go
+++ b/pkg/diagnose/proxy/probes.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import (

--- a/pkg/diagnose/proxy/proxy_diagnose_test.go
+++ b/pkg/diagnose/proxy/proxy_diagnose_test.go
@@ -1,0 +1,103 @@
+package proxy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- helpers ---
+
+func useEmptyConfig(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "datadog.yaml"), []byte(""), 0644); err != nil {
+		t.Fatalf("write empty datadog.yaml: %v", err)
+	}
+	t.Setenv("DD_CONF_DIR", dir)
+}
+
+func hasFinding(code string, findings []Finding) bool {
+	for _, f := range findings {
+		if f.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+// --- tests ---
+
+func TestRun_JSON_EndpointMatrixPresentEvenWhenEmpty(t *testing.T) {
+	useEmptyConfig(t)
+	t.Setenv("DD_PROXY_HTTP", "")
+	t.Setenv("DD_PROXY_HTTPS", "")
+	t.Setenv("DD_NO_PROXY", "")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("NO_PROXY", "")
+
+	res := Run(true)
+
+	raw, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("json.Marshal(Result): %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("json.Unmarshal(Result): %v", err)
+	}
+	v, ok := m["endpoint_matrix"]
+	if !ok {
+		t.Fatalf("endpoint_matrix key missing in JSON: %s", string(raw))
+	}
+	if _, ok := v.([]any); !ok {
+		t.Fatalf("endpoint_matrix is not a JSON array (got %T): %v", v, v)
+	}
+}
+
+func TestComputeEffective_Precedence_StdEnvThenDDEnv(t *testing.T) {
+	useEmptyConfig(t)
+
+	// std env only → chosen with SourceStdEnv
+	t.Setenv("HTTPS_PROXY", "http://std:8443")
+	t.Setenv("DD_PROXY_HTTPS", "")
+	eff := ComputeEffective()
+	if eff.HTTPS.Value != "http://std:8443" || eff.HTTPS.Source != SourceStdEnv {
+		t.Fatalf("std_env precedence failed: got %+v", eff.HTTPS)
+	}
+
+	// dd env overrides std env
+	t.Setenv("DD_PROXY_HTTPS", "http://dd:443")
+	eff = ComputeEffective()
+	if eff.HTTPS.Value != "http://dd:443" || eff.HTTPS.Source != SourceDDEnv {
+		t.Fatalf("dd_env precedence failed: got %+v", eff.HTTPS)
+	}
+}
+
+func TestRun_Lints_UnknownScheme(t *testing.T) {
+	useEmptyConfig(t)
+	t.Setenv("DD_PROXY_HTTPS", "socks5://corp-proxy:1080")
+
+	res := Run(true) // config-only
+	if !hasFinding("proxy.https.unknown_scheme", res.Findings) {
+		raw, _ := json.MarshalIndent(res, "", "  ")
+		t.Fatalf("expected finding proxy.https.unknown_scheme; got:\n%s", string(raw))
+	}
+	if res.Summary != SeverityYellow && res.Summary != SeverityRed {
+		t.Fatalf("expected summary yellow/red due to lint; got %s", res.Summary)
+	}
+}
+
+func TestRun_Lints_ConflictDDvsStd(t *testing.T) {
+	useEmptyConfig(t)
+	t.Setenv("DD_PROXY_HTTPS", "http://dd:443")
+	t.Setenv("HTTPS_PROXY", "http://std:8443")
+
+	res := Run(true)
+	if !hasFinding("proxy.https.conflict", res.Findings) {
+		raw, _ := json.MarshalIndent(res, "", "  ")
+		t.Fatalf("expected finding proxy.https.conflict; got:\n%s", string(raw))
+	}
+}

--- a/pkg/diagnose/proxy/proxy_diagnose_test.go
+++ b/pkg/diagnose/proxy/proxy_diagnose_test.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import (

--- a/pkg/diagnose/proxy/reporter.go
+++ b/pkg/diagnose/proxy/reporter.go
@@ -1,6 +1,8 @@
 package proxy
 
-// Run executes config-only lints. Probes remain off unless noNetwork=false.
+// Run executes config lints and, if enabled, minimal network probes.
+// - Config lints always run.
+// - When noNetwork == false, we also attempt a TCP dial to the HTTPS proxy.
 func Run(noNetwork bool) Result {
 	eff := ComputeEffective()
 	findings := []Finding{}
@@ -34,6 +36,7 @@ func Run(noNetwork bool) Result {
 		}
 	}
 
+	// Minimal active probe path (off by default)
 	if !noNetwork {
 		findings = append(findings, ProbeProxyConnectivity(eff)...)
 		findings = append(findings, ProbeEndpointsConnectivity(eff, eps)...)

--- a/pkg/diagnose/proxy/reporter.go
+++ b/pkg/diagnose/proxy/reporter.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 // Run executes config lints and, if enabled, minimal network probes.

--- a/pkg/diagnose/proxy/scrub.go
+++ b/pkg/diagnose/proxy/scrub.go
@@ -1,0 +1,19 @@
+package proxy
+
+import "net/url"
+
+// RedactURL removes user:pass@ from URLs for display purposes.
+// If parsing fails, returns the input unchanged.
+func RedactURL(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if u.User != nil {
+		u.User = url.User("****")
+	}
+	return u.String()
+}

--- a/pkg/diagnose/proxy/scrub.go
+++ b/pkg/diagnose/proxy/scrub.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import "net/url"

--- a/pkg/diagnose/proxy/summary.go
+++ b/pkg/diagnose/proxy/summary.go
@@ -1,0 +1,29 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatSummary renders a short privacy-safe block.
+// (CLI has its own writer, but this is available for other callers.)
+func FormatSummary(res Result) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Summary: %s\n", res.Summary)
+	fmt.Fprintf(&b, "HTTPS: %q [%s]\n", RedactURL(res.Effective.HTTPS.Value), res.Effective.HTTPS.Source)
+	fmt.Fprintf(&b, "HTTP : %q [%s]\n", RedactURL(res.Effective.HTTP.Value), res.Effective.HTTP.Source)
+	if res.Effective.NoProxy.Value != "" {
+		fmt.Fprintf(&b, "NO_PROXY: %q [%s]\n", res.Effective.NoProxy.Value, res.Effective.NoProxy.Source)
+	}
+	// Key findings (trim to keep it short)
+	count := 0
+	for _, f := range res.Findings {
+		if count >= 3 {
+			b.WriteString("…\n")
+			break
+		}
+		fmt.Fprintf(&b, "- [%s] %s\n", f.Severity, f.Description)
+		count++
+	}
+	return b.String()
+}

--- a/pkg/diagnose/proxy/summary.go
+++ b/pkg/diagnose/proxy/summary.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 import (

--- a/pkg/diagnose/proxy/types.go
+++ b/pkg/diagnose/proxy/types.go
@@ -1,0 +1,64 @@
+package proxy
+
+type Source string
+
+const (
+	SourceDefault Source = "default"
+	SourceStdEnv  Source = "std_env"
+	SourceConfig  Source = "config"
+	SourceDDEnv   Source = "dd_env"
+)
+
+type ValueWithSource struct {
+	Value  string `json:"value"`
+	Source Source `json:"source"`
+}
+
+type Effective struct {
+	HTTP            ValueWithSource `json:"http"`
+	HTTPS           ValueWithSource `json:"https"`
+	NoProxy         ValueWithSource `json:"no_proxy"`
+	NonExactNoProxy bool            `json:"non_exact_no_proxy"`
+}
+
+type Severity string
+
+const (
+	SeverityGreen  Severity = "green"
+	SeverityYellow Severity = "yellow"
+	SeverityRed    Severity = "red"
+)
+
+type Finding struct {
+	Code        string   `json:"code"`
+	Severity    Severity `json:"severity"`
+	Description string   `json:"description"`
+	Action      string   `json:"action"`
+	Evidence    any      `json:"evidence,omitempty"`
+}
+
+type Endpoint struct {
+	Name string `json:"name"` // control, logs, apm, process, rc, etc.
+	URL  string `json:"url"`
+}
+
+type EndpointCheck struct {
+	Endpoint Endpoint `json:"endpoint"`
+	Host     string   `json:"host"`
+	Port     string   `json:"port"`
+	Bypassed bool     `json:"bypassed"`
+	Matched  string   `json:"matched_token,omitempty"`
+}
+
+type Conflict struct {
+	Key    string            `json:"key"`
+	Values []ValueWithSource `json:"values"`
+}
+
+type Result struct {
+	Summary        Severity        `json:"summary"`
+	Effective      Effective       `json:"effective"`
+	Findings       []Finding       `json:"findings"`
+	EndpointMatrix []EndpointCheck `json:"endpoint_matrix"` // always present (possibly [])
+	Conflicts      []Conflict      `json:"conflicts,omitempty"`
+}

--- a/pkg/diagnose/proxy/types.go
+++ b/pkg/diagnose/proxy/types.go
@@ -1,3 +1,6 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
 package proxy
 
 type Source string


### PR DESCRIPTION
### What does this PR do?

Adds a new CLI subcommand: `agent diagnose proxy`.

**Capabilities**
- **Effective config with source precedence**: resolves and displays `HTTP(S)_PROXY` / `NO_PROXY` from `DD_PROXY_*` (dd_env) → `datadog.yaml` (config) → standard env (std_env).  
- **NO_PROXY evaluation**: privacy-safe matrix showing which Datadog endpoints would bypass the proxy and exactly which token matched.  
- **Config lints**: invalid/missing scheme, unknown scheme, leading-dot `NO_PROXY`, and conflicting values across sources.  
- **Redaction**: credentials in proxy URLs are redacted in human and JSON output.  
- **Output modes**: human, `--summary`, and `--json`.  
- **Network probes (opt-in)**: `--no-network=false` performs a fast TCP connect to the configured HTTPS proxy.

**Key code paths**
- `cmd/agent/subcommands/diagnose/proxy_cmd.go` (new command + flags; honors `-c/--cfgpath` via `DD_CONF_DIR`)
- `pkg/diagnose/proxy/*` (effective config, endpoint list, lints, conflicts, probes, JSON redaction, summary, tests)
- `cmd/agent/subcommands/diagnose/command.go` (wires `newProxyCommand()`)

Flags:
- `--json`, `--summary`, `--no-network` (default: true), `--include-sensitive` (reserved placeholder)

---

### Motivation

Proxy/TLS misconfiguration is a frequent source of hard-to-diagnose connectivity issues. Today it’s unclear **which** proxy value wins and **why** traffic is (or isn’t) proxied. This command makes the precedence, conflicts, and `NO_PROXY` effects explicit and safe to share (redacted), reducing time-to-fix for customers and support.

---

### Describe how you validated your changes

**Unit tests**
- `pkg/diagnose/proxy/proxy_diagnose_test.go`
  - Ensures JSON always contains `endpoint_matrix` (never null)
  - Verifies precedence: std_env < dd_env; config honored via `DD_CONF_DIR`
  - Lints: unknown scheme (`socks5://`), conflicting sources
- Additional helpers cover redaction and shape checks across files in `pkg/diagnose/proxy/*`.

**Manual checks**
- Clean env → summary green; effective values `[default]`.
- Set `HTTPS_PROXY` → source shows `[std_env]`.
- Set `DD_PROXY_HTTPS` alongside `HTTPS_PROXY` → conflict finding; effective uses `[dd_env]`.
- `-c <tmpdir>` with `datadog.yaml` (`proxy.https`) → config beats std_env when `DD_*` unset.
- `NO_PROXY=.datadoghq.com` → `no_proxy.leading_dot` finding; multiple endpoints bypassed with matched token shown.
- Redaction: credentials in proxy URL appear as `****`.
- Probes: with `--no-network=false` and a closed port proxy (e.g. `127.0.0.1:9`) → red finding `proxy.https.connect_failed`.

**Build/test**
```bash
go build ./cmd/agent
go test ./pkg/diagnose/proxy/...
```

### Additional Notes

- Default behavior is privacy-safe: **no** network dials unless `--no-network=false`.
    
- Non-breaking: adds a subcommand; existing diagnose commands unchanged.
    
- `-c/--cfgpath` is respected by exporting `DD_CONF_DIR` before reading config.
    
- Credentials are redacted in all display paths (human + JSON).
    
- Reno release note included under `releasenotes/notes/` (feature).
    
- Follow-ups (separate PRs): expand active probes (DNS/TLS/HTTP), expose additional endpoints via flag, optional TLS chain diagnostics.
    