### PR TITLE
usm: http: Use AddBoolConst rather re-implementing it

### DIFF
--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -181,18 +181,7 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 	}
 
 	utils.EnableOption(opts, "http_monitoring_enabled")
-
-	// Set eBPF constant based on consumer type
-	var constantValue uint64
-	if p.useDirectConsumer {
-		constantValue = 1
-	} else {
-		constantValue = 0
-	}
-	opts.ConstantEditors = append(opts.ConstantEditors, manager.ConstantEditor{
-		Name:  "use_direct_consumer",
-		Value: constantValue,
-	})
+	utils.AddBoolConst(opts, p.useDirectConsumer, "use_direct_consumer")
 
 	// Configure event stream
 	events.Configure(p.cfg, eventStream, p.mgr, opts)


### PR DESCRIPTION
### What does this PR do?

This PR refactors the HTTP protocol configuration to use the existing `utils.AddBoolConst` utility function instead of manually implementing boolean-to-constant conversion logic.

### Motivation

The codebase already has a utility function `utils.AddBoolConst` that handles converting boolean values to eBPF constants. The HTTP protocol configuration was re-implementing this same logic, which is redundant and less maintainable. Using the utility function improves code consistency and reduces duplication.

### Describe how you validated your changes

### Additional Notes

---

*This PR was opened by [Claude Code](https://claude.com/claude-code), an AI coding assistant.*