### PR TITLE
[CNM-4884][network] Use kernel.RootNSPID instead of os.Getpid

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -241,10 +241,15 @@ func writeConnections(w http.ResponseWriter, marshaler marshal.Marshaler, cs *ne
 
 	w.Header().Set("Content-type", marshaler.ContentType())
 
-	connectionsModeler := marshal.NewConnectionsModeler(cs)
+	connectionsModeler, err := marshal.NewConnectionsModeler(cs)
+	if err != nil {
+		log.Errorf("unable to create new connections modeler: %s", err)
+		w.WriteHeader(500)
+		return
+	}
 	defer connectionsModeler.Close()
 
-	err := marshaler.Marshal(cs, w, connectionsModeler)
+	err = marshaler.Marshal(cs, w, connectionsModeler)
 	if err != nil {
 		log.Errorf("unable to marshall connections with type %s: %s", marshaler.ContentType(), err)
 		w.WriteHeader(500)

--- a/cmd/system-probe/modules/network_tracer_test.go
+++ b/cmd/system-probe/modules/network_tracer_test.go
@@ -69,7 +69,7 @@ func TestDecode(t *testing.T) {
 	marshaller := marshal.GetMarshaler(encoding.ContentTypeJSON)
 	ostream := bytes.NewBuffer(nil)
 
-	connectionsModeler := marshal.NewConnectionsModeler(in)
+	connectionsModeler, _ := marshal.NewConnectionsModeler(in)
 	defer connectionsModeler.Close()
 
 	err := marshaller.Marshal(in, ostream, connectionsModeler)

--- a/cmd/system-probe/modules/network_tracer_test.go
+++ b/cmd/system-probe/modules/network_tracer_test.go
@@ -69,10 +69,11 @@ func TestDecode(t *testing.T) {
 	marshaller := marshal.GetMarshaler(encoding.ContentTypeJSON)
 	ostream := bytes.NewBuffer(nil)
 
-	connectionsModeler, _ := marshal.NewConnectionsModeler(in)
+	connectionsModeler, err := marshal.NewConnectionsModeler(in)
+	require.NoError(t, err)
 	defer connectionsModeler.Close()
 
-	err := marshaller.Marshal(in, ostream, connectionsModeler)
+	err = marshaller.Marshal(in, ostream, connectionsModeler)
 	require.NoError(t, err)
 
 	writeConnections(rec, marshaller, in)

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -45,7 +45,7 @@ func getBlobWriter(t *testing.T, assert *assert.Assertions, in *network.Connecti
 	marshaler := marshal.GetMarshaler(marshalerType)
 	assert.Equal(marshalerType, marshaler.ContentType())
 	blobWriter := bytes.NewBuffer(nil)
-	connectionsModeler := marshal.NewConnectionsModeler(in)
+	connectionsModeler, _ := marshal.NewConnectionsModeler(in)
 	defer connectionsModeler.Close()
 	err := marshaler.Marshal(in, blobWriter, connectionsModeler)
 	require.NoError(t, err)
@@ -377,7 +377,7 @@ func TestSerialization(t *testing.T) {
 		assert.Equal("application/json", marshaler.ContentType())
 
 		blobWriter := bytes.NewBuffer(nil)
-		connectionsModeler := marshal.NewConnectionsModeler(in)
+		connectionsModeler, _ := marshal.NewConnectionsModeler(in)
 		defer connectionsModeler.Close()
 		err := marshaler.Marshal(in, blobWriter, connectionsModeler)
 		require.NoError(t, err)
@@ -409,7 +409,7 @@ func TestSerialization(t *testing.T) {
 		assert.Equal("application/json", marshaler.ContentType())
 
 		blobWriter := bytes.NewBuffer(nil)
-		connectionsModeler := marshal.NewConnectionsModeler(in)
+		connectionsModeler, _ := marshal.NewConnectionsModeler(in)
 		defer connectionsModeler.Close()
 		err := marshaler.Marshal(in, blobWriter, connectionsModeler)
 		require.NoError(t, err)

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -45,9 +45,10 @@ func getBlobWriter(t *testing.T, assert *assert.Assertions, in *network.Connecti
 	marshaler := marshal.GetMarshaler(marshalerType)
 	assert.Equal(marshalerType, marshaler.ContentType())
 	blobWriter := bytes.NewBuffer(nil)
-	connectionsModeler, _ := marshal.NewConnectionsModeler(in)
+	connectionsModeler, err := marshal.NewConnectionsModeler(in)
+	require.NoError(t, err)
 	defer connectionsModeler.Close()
-	err := marshaler.Marshal(in, blobWriter, connectionsModeler)
+	err = marshaler.Marshal(in, blobWriter, connectionsModeler)
 	require.NoError(t, err)
 
 	return blobWriter
@@ -377,9 +378,10 @@ func TestSerialization(t *testing.T) {
 		assert.Equal("application/json", marshaler.ContentType())
 
 		blobWriter := bytes.NewBuffer(nil)
-		connectionsModeler, _ := marshal.NewConnectionsModeler(in)
+		connectionsModeler, err := marshal.NewConnectionsModeler(in)
+		require.NoError(t, err)
 		defer connectionsModeler.Close()
-		err := marshaler.Marshal(in, blobWriter, connectionsModeler)
+		err = marshaler.Marshal(in, blobWriter, connectionsModeler)
 		require.NoError(t, err)
 
 		unmarshaler := unmarshal.GetUnmarshaler("")
@@ -409,9 +411,10 @@ func TestSerialization(t *testing.T) {
 		assert.Equal("application/json", marshaler.ContentType())
 
 		blobWriter := bytes.NewBuffer(nil)
-		connectionsModeler, _ := marshal.NewConnectionsModeler(in)
+		connectionsModeler, err := marshal.NewConnectionsModeler(in)
+		require.NoError(t, err)
 		defer connectionsModeler.Close()
-		err := marshaler.Marshal(in, blobWriter, connectionsModeler)
+		err = marshaler.Marshal(in, blobWriter, connectionsModeler)
 		require.NoError(t, err)
 
 		unmarshaler := unmarshal.GetUnmarshaler("application/json")

--- a/pkg/network/encoding/marshal/modeler.go
+++ b/pkg/network/encoding/marshal/modeler.go
@@ -7,7 +7,6 @@ package marshal
 
 import (
 	"fmt"
-	"os"
 	"sync"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -20,10 +19,6 @@ import (
 var (
 	cfgOnce  = sync.Once{}
 	agentCfg *model.AgentConfiguration
-
-	getSysProbePid = sync.OnceValue(func() uint32 {
-		return uint32(os.Getpid())
-	})
 )
 
 // ConnectionsModeler contains all the necessary structs for modeling a connection.

--- a/pkg/network/encoding/marshal/modeler.go
+++ b/pkg/network/encoding/marshal/modeler.go
@@ -6,10 +6,12 @@
 package marshal
 
 import (
+	"fmt"
 	"os"
 	"sync"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -39,16 +41,20 @@ type ConnectionsModeler struct {
 // It also includes formatted connection telemetry related to all batches, not specific batches.
 // Furthermore, it stores the current agent configuration which applies to all instances related to the entire set of connections,
 // rather than just individual batches.
-func NewConnectionsModeler(conns *network.Connections) *ConnectionsModeler {
+func NewConnectionsModeler(conns *network.Connections) (*ConnectionsModeler, error) {
 	ipc := make(ipCache, len(conns.Conns)/2)
+	nspid, err := kernel.RootNSPID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get root namespace PID: %w", err)
+	}
 	return &ConnectionsModeler{
 		usmEncoders:  initializeUSMEncoders(conns),
 		ipc:          ipc,
 		dnsFormatter: newDNSFormatter(conns, ipc),
 		routeIndex:   make(map[network.Via]RouteIdx),
 		tagsSet:      network.NewTagsSet(),
-		sysProbePid:  getSysProbePid(),
-	}
+		sysProbePid:  uint32(nspid),
+	}, nil
 }
 
 // Close cleans all encoders resources.

--- a/pkg/network/encoding/marshal/modeler_test.go
+++ b/pkg/network/encoding/marshal/modeler_test.go
@@ -48,7 +48,7 @@ func TestConnectionModelerAgentConfiguration(t *testing.T) {
 			mock.NewSystemProbe(t)
 			cfgOnce = sync.Once{}
 			conns := &network.Connections{}
-			mod := NewConnectionsModeler(conns)
+			mod, _ := NewConnectionsModeler(conns)
 			streamer := NewProtoTestStreamer[*model.Connections]()
 			builder := model.NewConnectionsBuilder(streamer)
 			expected := &model.AgentConfiguration{

--- a/pkg/network/encoding/marshal/modeler_test.go
+++ b/pkg/network/encoding/marshal/modeler_test.go
@@ -12,6 +12,7 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -48,7 +49,8 @@ func TestConnectionModelerAgentConfiguration(t *testing.T) {
 			mock.NewSystemProbe(t)
 			cfgOnce = sync.Once{}
 			conns := &network.Connections{}
-			mod, _ := NewConnectionsModeler(conns)
+			mod, err := NewConnectionsModeler(conns)
+			require.NoError(t, err)
 			streamer := NewProtoTestStreamer[*model.Connections]()
 			builder := model.NewConnectionsBuilder(streamer)
 			expected := &model.AgentConfiguration{

--- a/pkg/util/kernel/fs_nolinux.go
+++ b/pkg/util/kernel/fs_nolinux.go
@@ -7,7 +7,11 @@
 
 package kernel
 
-import "github.com/DataDog/datadog-agent/pkg/util/funcs"
+import (
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/util/funcs"
+)
 
 // ProcFSRoot is the path to procfs
 var ProcFSRoot = funcs.MemoizeNoError(func() string {
@@ -17,4 +21,9 @@ var ProcFSRoot = funcs.MemoizeNoError(func() string {
 // SysFSRoot is the path to sysfs
 var SysFSRoot = funcs.MemoizeNoError(func() string {
 	return ""
+})
+
+// RootNSPID returns the current PID for non-linux platforms
+var RootNSPID = funcs.Memoize(func() (int, error) {
+	return os.Getpid(), nil
 })


### PR DESCRIPTION
### What does this PR do?

[network] Use kernel.RootNSPID instead of os.Getpid

Bug fix for https://github.com/DataDog/datadog-agent/pull/42462

### Motivation

> pids are namespaced so if you ran os.Getpid  inside a container, you will get a different pid than the network tracer. Like for example, when you start a container the init process is pid 1, for every single container

### Describe how you validated your changes

### Additional Notes
