### PR TITLE
add a patch to fix .S file compilation & reorganize gcc-toolchain patches

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -78,11 +78,12 @@ bazel_dep(name = "rules_m4", version = "0.3")
 bazel_dep(name = "gcc_toolchain", version = "0.9.0")
 git_override(
     module_name = "gcc_toolchain",
-    commit = "0e2242b07961107d2b05a6552d70b2ef4ef485fb",
+    commit = "e736410ced16744922c11762783b7c1fdddf620c",
     patch_args = ["-p1"],
     patches = [
-        "//bazel/patches:datadog_agent_toolchain.patch",
-        "//bazel/patches:0001-fix-c-x86_64-header-locations-with-our-ctng-toolchai.patch",
+        "//bazel/patches:gcc-toolchain/0001-Remove-fortran-related-actions-adapt-to-our-ctng-too.patch",
+        "//bazel/patches:gcc-toolchain/0002-fix-c-x86_64-header-locations-with-our-ctng-toolchai.patch",
+        "//bazel/patches:gcc-toolchain/0003-add-nostdinc-to-asmflags.patch",
     ],
     remote = "https://github.com/f0rmiga/gcc-toolchain.git",
 )

--- a/bazel/patches/gcc-toolchain/0001-Remove-fortran-related-actions-adapt-to-our-ctng-too.patch
+++ b/bazel/patches/gcc-toolchain/0001-Remove-fortran-related-actions-adapt-to-our-ctng-too.patch
@@ -1,11 +1,23 @@
+From a8916678b7545ba11107982bdde64340e6981e25 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hugo=20Beauz=C3=A9e-Luyssen?= <hugo.beauzee@datadoghq.com>
+Date: Wed, 15 Oct 2025 08:55:15 +0200
+Subject: [PATCH 1/3] Remove fortran related actions & adapt to our ctng
+ toolchain
+
+---
+ toolchain/cc_toolchain_config.bzl |  79 ++--------------
+ toolchain/defs.bzl                | 150 +++++-------------------------
+ toolchain/module_extensions.bzl   |   2 +-
+ 3 files changed, 32 insertions(+), 199 deletions(-)
+
 diff --git a/toolchain/cc_toolchain_config.bzl b/toolchain/cc_toolchain_config.bzl
-index 3ad569b..5e90d8f 100644
+index 76b547e..b8ae535 100644
 --- a/toolchain/cc_toolchain_config.bzl
 +++ b/toolchain/cc_toolchain_config.bzl
 @@ -29,7 +29,6 @@ load(
+     "tool_path",
      "with_feature_set",
  )
- load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 -load("//toolchain/fortran:action_names.bzl", FORTRAN_ACTION_NAMES = "ACTION_NAMES")
  
  all_compile_actions = [
@@ -24,9 +36,9 @@ index 3ad569b..5e90d8f 100644
      extra_cxxflags = ctx.attr.extra_cxxflags
 -    extra_fflags = ctx.attr.extra_fflags
      extra_ldflags = ctx.attr.extra_ldflags
+     extra_asmflags = ctx.attr.extra_asmflags
  
-     action_configs = []
-@@ -153,7 +150,7 @@ def _impl(ctx):
+@@ -154,7 +151,7 @@ def _impl(ctx):
          enabled = True,
          flag_sets = [
              flag_set(
@@ -35,7 +47,7 @@ index 3ad569b..5e90d8f 100644
                  flag_groups = [
                      flag_group(
                          flags = [
-@@ -172,57 +169,12 @@ def _impl(ctx):
+@@ -173,57 +170,12 @@ def _impl(ctx):
          enabled = True,
      )
  
@@ -94,7 +106,7 @@ index 3ad569b..5e90d8f 100644
                  flag_groups = [
                      flag_group(
                          flags = [
-@@ -236,7 +188,7 @@ def _impl(ctx):
+@@ -237,7 +189,7 @@ def _impl(ctx):
                  ],
              ),
              flag_set(
@@ -103,7 +115,7 @@ index 3ad569b..5e90d8f 100644
                  flag_groups = [
                      flag_group(
                          flags = [
-@@ -248,12 +200,12 @@ def _impl(ctx):
+@@ -249,12 +201,12 @@ def _impl(ctx):
                  with_features = [with_feature_set(features = ["opt"])],
              ),
              flag_set(
@@ -118,7 +130,7 @@ index 3ad569b..5e90d8f 100644
                  flag_groups = [
                      flag_group(
                          flags = [
-@@ -405,7 +357,7 @@ def _impl(ctx):
+@@ -406,7 +358,7 @@ def _impl(ctx):
          enabled = True,
          flag_sets = [
              flag_set(
@@ -127,7 +139,7 @@ index 3ad569b..5e90d8f 100644
                  flag_groups = [
                      flag_group(
                          flags = ["%{user_compile_flags}"],
-@@ -439,17 +391,6 @@ def _impl(ctx):
+@@ -440,17 +392,6 @@ def _impl(ctx):
          ] if len(extra_cxxflags) > 0 else [],
      )
  
@@ -145,7 +157,7 @@ index 3ad569b..5e90d8f 100644
      extra_ldflags_feature = feature(
          name = "extra_ldflags",
          enabled = True,
-@@ -476,7 +417,6 @@ def _impl(ctx):
+@@ -488,7 +429,6 @@ def _impl(ctx):
                      ACTION_NAMES.cpp_module_codegen,
                      ACTION_NAMES.lto_backend,
                      ACTION_NAMES.clif_match,
@@ -153,7 +165,7 @@ index 3ad569b..5e90d8f 100644
                  ] + all_link_actions + lto_index_actions,
                  flag_groups = [
                      flag_group(
-@@ -489,9 +429,6 @@ def _impl(ctx):
+@@ -501,9 +441,6 @@ def _impl(ctx):
      )
  
      features = sanitizers_features + [
@@ -163,23 +175,23 @@ index 3ad569b..5e90d8f 100644
          default_compile_flags_feature,
          include_paths_feature,
          library_search_directories_feature,
-@@ -507,7 +444,6 @@ def _impl(ctx):
+@@ -519,7 +456,6 @@ def _impl(ctx):
          redacted_dates_feature,
          extra_cflags_feature,
          extra_cxxflags_feature,
 -        extra_fflags_feature,
          extra_ldflags_feature,
+         extra_asmflags_feature,
      ]
- 
-@@ -541,7 +477,6 @@ cc_toolchain_config = rule(
+@@ -554,7 +490,6 @@ cc_toolchain_config = rule(
          "cxx_builtin_include_directories": attr.string_list(mandatory = True),
          "extra_cflags": attr.string_list(mandatory = True),
          "extra_cxxflags": attr.string_list(mandatory = True),
 -        "extra_fflags": attr.string_list(mandatory = True),
          "extra_ldflags": attr.string_list(mandatory = True),
+         "extra_asmflags": attr.string_list(mandatory = True),
          "tool_paths": attr.string_dict(mandatory = True),
-     },
-@@ -557,7 +492,7 @@ def _sanitizer_feature(sanitizer):
+@@ -571,7 +506,7 @@ def _sanitizer_feature(sanitizer):
          name = sanitizer.name,
          flag_sets = [
              flag_set(
@@ -189,7 +201,7 @@ index 3ad569b..5e90d8f 100644
                      flag_group(
                          flags = sanitizer.cflags,
 diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
-index 00ef405..0a91af6 100644
+index 0e55fd7..7c8787f 100644
 --- a/toolchain/defs.bzl
 +++ b/toolchain/defs.bzl
 @@ -54,11 +54,11 @@ def _gcc_toolchain_impl(rctx):
@@ -266,7 +278,7 @@ index 00ef405..0a91af6 100644
      extra_ldflags = [
          lib.format(
              include_prefix = include_prefix,
-@@ -193,19 +163,20 @@ def _gcc_toolchain_impl(rctx):
+@@ -193,14 +163,14 @@ def _gcc_toolchain_impl(rctx):
              "-B%workspace%/{include_prefix}lib",
              "-B%workspace%/lib64",
              "-B%workspace%/{include_prefix}lib64",
@@ -285,18 +297,21 @@ index 00ef405..0a91af6 100644
          ]
      ]
      extra_ldflags.extend(rctx.attr.extra_ldflags)
+@@ -217,6 +187,7 @@ def _gcc_toolchain_impl(rctx):
+     extra_asmflags.extend(rctx.attr.extra_asmflags)
  
      rctx.file("BUILD.bazel", _TOOLCHAIN_BUILD_FILE_CONTENT.format(
 +        target_arch = rctx.attr.target_arch,
          gcc_toolchain_workspace_name = rctx.attr.gcc_toolchain_workspace_name,
          target_compatible_with = target_compatible_with,
          target_settings = target_settings,
-@@ -218,65 +189,20 @@ def _gcc_toolchain_impl(rctx):
+@@ -229,66 +200,21 @@ def _gcc_toolchain_impl(rctx):
          # Flags
          extra_cflags = _format_flags(extra_cflags),
          extra_cxxflags = _format_flags(extra_cxxflags),
 -        extra_fflags = _format_flags(extra_fflags),
          extra_ldflags = _format_flags(extra_ldflags),
+         extra_asmflags = _format_flags(extra_asmflags),
      ))
  
  AVAILABLE_GCC_VERSIONS = {
@@ -309,13 +324,17 @@ index 00ef405..0a91af6 100644
 -            "url": "https://github.com/f0rmiga/gcc-builds/releases/download/18082025/gcc-toolchain-12.5.0-armv7.tar.xz",
 -            "sha256": "a0ef76c8cc517b3d76dd2f09b1a371975b2ff1082e2f9372ed79af01b9292934",
 -        },
--        "x86_64": {
++    "11.4.0": {
+         "x86_64": {
 -            "url": "https://github.com/f0rmiga/gcc-builds/releases/download/18082025/gcc-toolchain-12.5.0-x86_64.tar.xz",
 -            "sha256": "51076e175839b434bb2dc0006c0096916df585e8c44666d35b0e3ce821d535db",
--        },
--    },
++            "url": "https://dd-agent-omnibus.s3.amazonaws.com/bazel/datadog_agent_cc_toolchain_x86_64.tar.gz",
++            "sha256": "5b85c1bcd1743c9f4bbc3c18c0af32f9164375bc8d7fa540a3cd2bbac72bca6b",
+         },
+     },
 -    "13.4.0": {
--        "aarch64": {
++    "12.3.0": {
+         "aarch64": {
 -            "url": "https://github.com/f0rmiga/gcc-builds/releases/download/18082025/gcc-toolchain-13.4.0-aarch64.tar.xz",
 -            "sha256": "770cf6bf62bdf78763de526d3a9f5cae4c19f1a3aca0ef8f18b05f1a46d1ffaf",
 -        },
@@ -323,17 +342,13 @@ index 00ef405..0a91af6 100644
 -            "url": "https://github.com/f0rmiga/gcc-builds/releases/download/18082025/gcc-toolchain-13.4.0-armv7.tar.xz",
 -            "sha256": "1b2739b5003c5a3f0ab7c4cc7fb95cc99c0e933982512de7255c2bd9ced757ad",
 -        },
-+    "11.4.0": {
-         "x86_64": {
+-        "x86_64": {
 -            "url": "https://github.com/f0rmiga/gcc-builds/releases/download/18082025/gcc-toolchain-13.4.0-x86_64.tar.xz",
 -            "sha256": "d96071c1b98499afd7b7b56ebd69ad414020edf66e982004acffe7df8aaf7e02",
-+            "url": "https://dd-agent-omnibus.s3.amazonaws.com/bazel/datadog_agent_cc_toolchain_x86_64.tar.gz",
-+            "sha256": "5b85c1bcd1743c9f4bbc3c18c0af32f9164375bc8d7fa540a3cd2bbac72bca6b",
-         },
-     },
+-        },
+-    },
 -    "14.3.0": {
-+    "12.3.0": {
-         "aarch64": {
+-        "aarch64": {
 -            "url": "https://github.com/f0rmiga/gcc-builds/releases/download/18082025/gcc-toolchain-14.3.0-aarch64.tar.xz",
 -            "sha256": "74b1f0072769f8865b62897ab962f6fce174115dab2e6596765bb4e700ffe0d1",
 -        },
@@ -363,7 +378,7 @@ index 00ef405..0a91af6 100644
          },
      },
  }
-@@ -296,10 +222,6 @@ _FEATURE_ATTRS = {
+@@ -308,10 +234,6 @@ _FEATURE_ATTRS = {
          doc = "Extra flags for compiling C++.",
          default = [],
      ),
@@ -374,16 +389,16 @@ index 00ef405..0a91af6 100644
      "extra_ldflags": attr.string_list(
          doc = "Extra flags for linking." +
                " %workspace% is rendered to the toolchain root path." +
-@@ -365,7 +287,7 @@ gcc_toolchain = repository_rule(
+@@ -381,7 +303,7 @@ gcc_toolchain = repository_rule(
  
  ATTRS_SHARED_WITH_MODULE_EXTENSION = {
      attr_name: _FEATURE_ATTRS[attr_name]
--    for attr_name in ["gcc_version", "gcc_versions", "extra_cflags", "extra_cxxflags", "extra_ldflags", "extra_fflags"]
-+    for attr_name in ["gcc_version", "gcc_versions", "extra_cflags", "extra_cxxflags", "extra_ldflags", "binary_prefix"]
+-    for attr_name in ["gcc_version", "gcc_versions", "extra_cflags", "extra_cxxflags", "extra_ldflags", "extra_fflags", "extra_asmflags"]
++    for attr_name in ["gcc_version", "gcc_versions", "extra_cflags", "extra_cxxflags", "extra_ldflags", "binary_prefix", "extra_asmflags"]
  }
  
  def _render_tool_paths(rctx, path_prefix, binary_prefix):
-@@ -394,10 +316,6 @@ def _render_tool_paths(rctx, path_prefix, binary_prefix):
+@@ -410,10 +332,6 @@ def _render_tool_paths(rctx, path_prefix, binary_prefix):
              path_prefix = path_prefix,
              binary_prefix = binary_prefix,
          ),
@@ -394,15 +409,15 @@ index 00ef405..0a91af6 100644
          "ld": "{path_prefix}/bin/{binary_prefix}ld".format(
              path_prefix = path_prefix,
              binary_prefix = binary_prefix,
-@@ -477,7 +395,6 @@ def gcc_declare_toolchain(
+@@ -493,7 +411,6 @@ def gcc_declare_toolchain(
          binary_prefix = binary_prefix,
          extra_cflags = kwargs.pop("extra_cflags", []),
          extra_cxxflags = kwargs.pop("extra_cxxflags", []),
 -        extra_fflags = kwargs.pop("extra_fflags", []),
          extra_ldflags = kwargs.pop("extra_ldflags", []),
+         extra_asmflags = kwargs.pop("extra_asmflags", []),
          includes = kwargs.pop("includes", []),
-         fincludes = kwargs.pop("fincludes", []),
-@@ -509,32 +426,15 @@ ARCHS = struct(
+@@ -526,32 +443,15 @@ ARCHS = struct(
  _TOOLCHAIN_BUILD_FILE_CONTENT = """\
  load("@rules_cc//cc:defs.bzl", "cc_toolchain")
  load("@{gcc_toolchain_workspace_name}//toolchain:cc_toolchain_config.bzl", "cc_toolchain_config")
@@ -436,15 +451,15 @@ index 00ef405..0a91af6 100644
      ],
      target_compatible_with = {target_compatible_with},
      target_settings = {target_settings},
-@@ -563,7 +463,6 @@ cc_toolchain_config(
+@@ -580,7 +480,6 @@ cc_toolchain_config(
      cxx_builtin_include_directories = {cxx_builtin_include_directories},
      extra_cflags = {extra_cflags},
      extra_cxxflags = {extra_cxxflags},
 -    extra_fflags = {extra_fflags},
      extra_ldflags = {extra_ldflags},
+     extra_asmflags = {extra_asmflags},
      tool_paths = tool_paths,
- )
-@@ -609,6 +508,7 @@ filegroup(
+@@ -627,6 +526,7 @@ filegroup(
          ":ld",
          ":ld.bfd",
          "xbin/ld",
@@ -452,7 +467,7 @@ index 00ef405..0a91af6 100644
      ],
      visibility = ["//visibility:public"],
  )
-@@ -620,16 +520,14 @@ filegroup(
+@@ -638,16 +538,14 @@ filegroup(
          "lib/gcc/{include_prefix}*/include/**",
          "lib/gcc/{include_prefix}*/include-fixed/**",
          "{include_prefix}include/**",
@@ -471,7 +486,7 @@ index 00ef405..0a91af6 100644
      ], allow_empty=True),
      visibility = ["//visibility:public"],
  )
-@@ -657,11 +555,9 @@ filegroup(
+@@ -675,11 +573,9 @@ filegroup(
          "bin/{binary_prefix}cpp",
          "bin/{binary_prefix}g++",
          "bin/{binary_prefix}gcc",
@@ -483,7 +498,7 @@ index 00ef405..0a91af6 100644
      ] + glob([
          "**/libexec/gcc/**/cc1plus",
          "**/libexec/gcc/**/cc1",
-@@ -670,9 +566,6 @@ filegroup(
+@@ -688,9 +584,6 @@ filegroup(
          "lib/libgmp.so*",
          "lib/libmpc.so*",
          "lib/libmpfr.so*",
@@ -493,7 +508,7 @@ index 00ef405..0a91af6 100644
      ], allow_empty=True),
      visibility = ["//visibility:public"],
  )
-@@ -684,6 +577,7 @@ filegroup(
+@@ -702,6 +595,7 @@ filegroup(
      srcs = [
          ":ar",
          "xbin/ar",
@@ -501,7 +516,7 @@ index 00ef405..0a91af6 100644
      ],
      visibility = ["//visibility:public"],
  )
-@@ -693,6 +587,7 @@ filegroup(
+@@ -711,6 +605,7 @@ filegroup(
      srcs = [
          ":as",
          "xbin/as",
@@ -509,7 +524,7 @@ index 00ef405..0a91af6 100644
      ],
      visibility = ["//visibility:public"],
  )
-@@ -708,6 +603,7 @@ filegroup(
+@@ -726,6 +621,7 @@ filegroup(
      srcs = [
          ":objcopy",
          "xbin/objcopy",
@@ -517,7 +532,7 @@ index 00ef405..0a91af6 100644
      ],
      visibility = ["//visibility:public"],
  )
-@@ -717,6 +613,7 @@ filegroup(
+@@ -735,6 +631,7 @@ filegroup(
      srcs = [
          ":strip",
          "xbin/strip",
@@ -525,7 +540,7 @@ index 00ef405..0a91af6 100644
      ],
      visibility = ["//visibility:public"],
  )
-@@ -726,6 +623,7 @@ filegroup(
+@@ -744,6 +641,7 @@ filegroup(
      srcs = [
          ":gcov",
          "xbin/gcov",
@@ -549,3 +564,6 @@ index 1eb37ab..b6b86d0 100644
              )
  
      # Since we know that for each gcc toolchain repository we'll generate the same files, we mark the rule as reproducible.
+-- 
+2.43.0
+

--- a/bazel/patches/gcc-toolchain/0002-fix-c-x86_64-header-locations-with-our-ctng-toolchai.patch
+++ b/bazel/patches/gcc-toolchain/0002-fix-c-x86_64-header-locations-with-our-ctng-toolchai.patch
@@ -1,7 +1,7 @@
 From efa6a5f60fdff0102a2f71993358efd1993a1e9b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Hugo=20Beauz=C3=A9e-Luyssen?= <hugo.beauzee@datadoghq.com>
 Date: Wed, 15 Oct 2025 09:57:35 +0200
-Subject: [PATCH] fix c++ x86_64 header locations with our ctng toolchain
+Subject: [PATCH 2/3] fix c++ x86_64 header locations with our ctng toolchain
 
 We always prefix the headers with the triplet, not only for arm
 ---

--- a/bazel/patches/gcc-toolchain/0003-add-nostdinc-to-asmflags.patch
+++ b/bazel/patches/gcc-toolchain/0003-add-nostdinc-to-asmflags.patch
@@ -1,0 +1,27 @@
+From 2bc6426c49bee2f6afd0af4bc5ab44779ed49f1e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hugo=20Beauz=C3=A9e-Luyssen?= <hugo.beauzee@datadoghq.com>
+Date: Mon, 27 Oct 2025 08:12:43 +0100
+Subject: [PATCH 3/3] add "-nostdinc" to asmflags
+
+---
+ toolchain/defs.bzl | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 2560783..84863bb 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -161,7 +161,9 @@ def _gcc_toolchain_impl(rctx):
+     ]
+     extra_ldflags.extend(rctx.attr.extra_ldflags)
+ 
+-    extra_asmflags = []
++    extra_asmflags = [
++        "-nostdinc",
++    ]
+     extra_asmflags.extend([
+         "-isystem{}".format(include)
+         for include in c_builtin_includes
+-- 
+2.43.0
+


### PR DESCRIPTION
### What does this PR do?

Add a new patch allowing to compile `.S` files

### Motivation

ASM with C preprocessor is used in our dependencies and we need to be able to build them.
Without this patch (which only adds `-nostdinc` to the compilation line) the build fails with this kind of error:
```
ERROR: /home/hugo.beauzee/.cache/bazel/_bazel_hugo.beauzee/95605d1a73395e0c041bb302da387b0e/external/+_repo_rules+python3/BUILD.bazel:323:10: Compiling Python/asm_trampoline.S failed: absolute path inclusion(s) found in rule '@@+_repo_rules+python3//:freeze_module':
the source file 'Python/asm_trampoline.S' includes the following non-builtin files with absolute paths (if these are builtin files, make sure these paths are in your toolchain):
  '/home/hugo.beauzee/.cache/bazel/_bazel_hugo.beauzee/95605d1a73395e0c041bb302da387b0e/external/gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64/x86_64-unknown-linux-gnu/sysroot/usr/include/stdc-predef.h'
```
bazel will take care of providing all required include flags, but using the built in ones will cause bazel to refuse to build as shown in the error above.

### Describe how you validated your changes

Local builds & CI for `gcrypt` & `zstd` which both include `.S` files

### Additional Notes
