### PR TITLE
feat(fleet): Add feature_remote_updates_enabled to inventoryagent payload

### DIFF
--- a/comp/metadata/inventoryagent/README.md
+++ b/comp/metadata/inventoryagent/README.md
@@ -81,6 +81,7 @@ The payload is a JSON dict with the following fields
   - `feature_networks_http_enabled` - **bool**: True if HTTP monitoring is enabled for Network Performance Monitoring (see: `service_monitoring_config.http.enabled` config option in `system-probe.yaml`).
   - `feature_networks_https_enabled` - **bool**: True if HTTPS monitoring is enabled for Universal Service Monitoring (see: `service_monitoring_config.tls.native.enabled` config option in `system-probe.yaml`).
   - `feature_remote_configuration_enabled` - **bool**: True if Remote Configuration is enabled (see: `remote_configuration.enabled` config option).
+  - `feature_remote_updates_enabled` - **bool**: True if Remote Updates is enabled (see: `remote_updates` config option).
   - `feature_usm_enabled` - **bool**: True if Universal Service Monitoring is enabled (see: `service_monitoring_config.enabled` config option in `system-probe.yaml`)
   - `feature_usm_http2_enabled` - **bool**: True if HTTP2 monitoring is enabled for Universal Service Monitoring (see: `service_monitoring_config.http2.enabled` config option in `system-probe.yaml`).
   - `feature_usm_kafka_enabled` - **bool**: True if Kafka monitoring is enabled for Universal Service Monitoring (see: `service_monitoring_config.enable_kafka_monitoring` config option in `system-probe.yaml`)

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -244,6 +244,7 @@ func (ia *inventoryagent) fetchCoreAgentMetadata() {
 	ia.data["feature_logs_enabled"] = ia.conf.GetBool("logs_enabled")
 	ia.data["feature_imdsv2_enabled"] = ia.conf.GetBool("ec2_prefer_imdsv2")
 	ia.data["feature_remote_configuration_enabled"] = ia.conf.GetBool("remote_configuration.enabled")
+	ia.data["feature_remote_updates_enabled"] = ia.conf.GetBool("remote_updates")
 	ia.data["feature_container_images_enabled"] = ia.conf.GetBool("container_image.enabled")
 
 	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("container_image.enabled") && ia.conf.GetBool("sbom.container_image.enabled")

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -173,6 +173,7 @@ func TestInitData(t *testing.T) {
 		"ec2_prefer_imdsv2":                           true,
 		"process_config.container_collection.enabled": true,
 		"remote_configuration.enabled":                true,
+		"remote_updates":                              true,
 		"process_config.process_collection.enabled":   true,
 		"container_image.enabled":                     true,
 		"sbom.enabled":                                true,
@@ -208,6 +209,7 @@ func TestInitData(t *testing.T) {
 		"feature_imdsv2_enabled":                     true,
 		"feature_processes_container_enabled":        true,
 		"feature_remote_configuration_enabled":       true,
+		"feature_remote_updates_enabled":             true,
 		"feature_process_enabled":                    true,
 		"feature_container_images_enabled":           true,
 


### PR DESCRIPTION
### What does this PR do?
Adds a `feature_remote_updates_enabled` field to the inventoryagent metadata payload

### Motivation
Improving the experience in Fleet Automation

### Describe how you validated your changes
Unit tests

### Additional Notes
