### PR TITLE
[ABLD-284] Fix filename on macOS: `libz.so`→`libz.dylib`

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -14,7 +14,7 @@ filegroup(
         "@patchelf",
         "@sqlite3",
         "@xz//:lzma",
-        "@zlib//:libz_so",
+        "@zlib//:z",
     ] + select({
         "@platforms//os:linux": [
             "@attr",

--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -142,7 +142,6 @@ cc_library(
 
 cc_shared_library(
     name = "libz_so",
-    shared_lib_name = "libz.so",
     win_def_file = "win32/zlib.def",
     deps = [":zlib"],
     visibility = ["//visibility:public"],

--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -141,7 +141,7 @@ cc_library(
 )
 
 cc_shared_library(
-    name = "libz_so",
+    name = "z",
     win_def_file = "win32/zlib.def",
     deps = [":zlib"],
     visibility = ["//visibility:public"],
@@ -149,7 +149,7 @@ cc_shared_library(
 
 so_symlink(
     name = "lib_files",
-    src = ":libz_so",
+    src = ":z",
     libname = "libz",
     version = "1.3.1",
 )

--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -35,6 +35,7 @@
 
 """Agent specific BUILD file for zlib."""
 
+load("@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
@@ -147,10 +148,11 @@ cc_shared_library(
     visibility = ["//visibility:public"],
 )
 
-pkg_files(
+so_symlink(
     name = "lib_files",
-    srcs = [":libz_so"],
-    prefix = "lib",
+    src = ":libz_so",
+    libname = "libz",
+    version = "1.3.1",
 )
 
 pkg_files(


### PR DESCRIPTION
### What does this PR do?
Correct the output filename used when installing `libz` on macOS.

### Motivation
#40965 led to an uncommon installation filename on macOS:
```
Only in 7.70.2/embedded/lib/: libz.1.3.1.dylib
Only in 7.70.2/embedded/lib/: libz.1.dylib
Only in 7.70.2/embedded/lib/: libz.dylib
Only in 7.74.0-devel/embedded/lib/: libz.so
```
... and `soname`:
```diff
--- 7.72.0	2025-11-04 14:08:21.023786737 +0100
+++ 7.74.0-devel	2025-11-04 14:08:22.854384653 +0100
@@ -1,4 +1,7 @@
-$ otool -L 7.70.2/embedded/lib/libz.1.3.1.dylib
-7.70.2/embedded/lib/libz.1.3.1.dylib:
-	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.3.1)
+$ otool -L 7.74.0-devel/embedded/lib/libz.so
+7.74.0-devel/embedded/lib/libz.so:
+	@rpath/libz.so (compatibility version 0.0.0, current version 0.0.0)
+	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
+	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1971.0.0)
+	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

### Describe how you validated your changes
`bazel run @zlib//:install -- --destdir=/tmp/embedded`
Verified for both:
- `arm64`: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1217705216
- `x86_64`: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1217705215

```
$ otool -L libz.1.3.1.dylib
libz.1.3.1.dylib:
	@rpath/libz.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

### Additional Notes
We must backport it to 7.73.x and maybe earlier branch(es).

We should probably review:
- libraries migrated to Bazel that don't leverage `so_symlink`,
- their `soname`s.