### PR TITLE
[AGENTRUN-867] Move log types to separate package and simplify logger interface

### DIFF
--- a/pkg/util/log/levels.go
+++ b/pkg/util/log/levels.go
@@ -5,43 +5,38 @@
 
 package log
 
-import "github.com/cihub/seelog"
+import "github.com/DataDog/datadog-agent/pkg/util/log/types"
 
 // LogLevel is the type of log levels
 //
 //nolint:revive // keeping the original type name from seelog
-type LogLevel seelog.LogLevel
+type LogLevel = types.LogLevel
 
 // Log levels
 const (
-	TraceLvl    LogLevel = seelog.TraceLvl
-	DebugLvl    LogLevel = seelog.DebugLvl
-	InfoLvl     LogLevel = seelog.InfoLvl
-	WarnLvl     LogLevel = seelog.WarnLvl
-	ErrorLvl    LogLevel = seelog.ErrorLvl
-	CriticalLvl LogLevel = seelog.CriticalLvl
-	Off         LogLevel = seelog.Off
+	TraceLvl    LogLevel = types.TraceLvl
+	DebugLvl    LogLevel = types.DebugLvl
+	InfoLvl     LogLevel = types.InfoLvl
+	WarnLvl     LogLevel = types.WarnLvl
+	ErrorLvl    LogLevel = types.ErrorLvl
+	CriticalLvl LogLevel = types.CriticalLvl
+	Off         LogLevel = types.Off
 )
 
 // Log level string representations
 const (
-	TraceStr    = seelog.TraceStr
-	DebugStr    = seelog.DebugStr
-	InfoStr     = seelog.InfoStr
-	WarnStr     = seelog.WarnStr
-	ErrorStr    = seelog.ErrorStr
-	CriticalStr = seelog.CriticalStr
-	OffStr      = seelog.OffStr
+	TraceStr    = types.TraceStr
+	DebugStr    = types.DebugStr
+	InfoStr     = types.InfoStr
+	WarnStr     = types.WarnStr
+	ErrorStr    = types.ErrorStr
+	CriticalStr = types.CriticalStr
+	OffStr      = types.OffStr
 )
-
-func (level LogLevel) String() string {
-	return seelog.LogLevel(level).String()
-}
 
 // LogLevelFromString returns a LogLevel from a string
 //
 //nolint:revive // keeping the original function name from seelog
 func LogLevelFromString(levelStr string) (LogLevel, bool) {
-	level, ok := seelog.LogLevelFromString(levelStr)
-	return LogLevel(level), ok
+	return types.LogLevelFromString(levelStr)
 }

--- a/pkg/util/log/logger.go
+++ b/pkg/util/log/logger.go
@@ -7,70 +7,11 @@ package log
 
 import (
 	"github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/types"
 )
 
-// LoggerInterface provides basic logging methods.
-type LoggerInterface interface {
-	// Tracef formats message according to format specifier
-	// and writes to log with level = Trace.
-	Tracef(format string, params ...interface{})
-
-	// Debugf formats message according to format specifier
-	// and writes to log with level = Debug.
-	Debugf(format string, params ...interface{})
-
-	// Infof formats message according to format specifier
-	// and writes to log with level = Info.
-	Infof(format string, params ...interface{})
-
-	// Warnf formats message according to format specifier
-	// and writes to log with level = Warn.
-	Warnf(format string, params ...interface{}) error
-
-	// Errorf formats message according to format specifier
-	// and writes to log with level = Error.
-	Errorf(format string, params ...interface{}) error
-
-	// Criticalf formats message according to format specifier
-	// and writes to log with level = Critical.
-	Criticalf(format string, params ...interface{}) error
-
-	// Trace formats message using the default formats for its operands
-	// and writes to log with level = Trace
-	Trace(v ...interface{})
-
-	// Debug formats message using the default formats for its operands
-	// and writes to log with level = Debug
-	Debug(v ...interface{})
-
-	// Info formats message using the default formats for its operands
-	// and writes to log with level = Info
-	Info(v ...interface{})
-
-	// Warn formats message using the default formats for its operands
-	// and writes to log with level = Warn
-	Warn(v ...interface{}) error
-
-	// Error formats message using the default formats for its operands
-	// and writes to log with level = Error
-	Error(v ...interface{}) error
-
-	// Critical formats message using the default formats for its operands
-	// and writes to log with level = Critical
-	Critical(v ...interface{}) error
-
-	// Close flushes all the messages in the logger and closes it. It cannot be used after this operation.
-	Close()
-
-	// Flush flushes all the messages in the logger.
-	Flush()
-
-	// SetAdditionalStackDepth sets the additional number of frames to skip by runtime.Caller
-	SetAdditionalStackDepth(depth int) error
-
-	// Sets logger context that can be used in formatter funcs and custom receivers
-	SetContext(context interface{})
-}
+type LoggerInterface = types.LoggerInterface
 
 // Default returns a default logger
 func Default() LoggerInterface {

--- a/pkg/util/log/logger.go
+++ b/pkg/util/log/logger.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log/types"
 )
 
+// LoggerInterface provides basic logging methods that can be used from outside the log package.
 type LoggerInterface = types.LoggerInterface
 
 // Default returns a default logger

--- a/pkg/util/log/logger.go
+++ b/pkg/util/log/logger.go
@@ -10,7 +10,67 @@ import (
 )
 
 // LoggerInterface provides basic logging methods.
-type LoggerInterface seelog.LoggerInterface
+type LoggerInterface interface {
+	// Tracef formats message according to format specifier
+	// and writes to log with level = Trace.
+	Tracef(format string, params ...interface{})
+
+	// Debugf formats message according to format specifier
+	// and writes to log with level = Debug.
+	Debugf(format string, params ...interface{})
+
+	// Infof formats message according to format specifier
+	// and writes to log with level = Info.
+	Infof(format string, params ...interface{})
+
+	// Warnf formats message according to format specifier
+	// and writes to log with level = Warn.
+	Warnf(format string, params ...interface{}) error
+
+	// Errorf formats message according to format specifier
+	// and writes to log with level = Error.
+	Errorf(format string, params ...interface{}) error
+
+	// Criticalf formats message according to format specifier
+	// and writes to log with level = Critical.
+	Criticalf(format string, params ...interface{}) error
+
+	// Trace formats message using the default formats for its operands
+	// and writes to log with level = Trace
+	Trace(v ...interface{})
+
+	// Debug formats message using the default formats for its operands
+	// and writes to log with level = Debug
+	Debug(v ...interface{})
+
+	// Info formats message using the default formats for its operands
+	// and writes to log with level = Info
+	Info(v ...interface{})
+
+	// Warn formats message using the default formats for its operands
+	// and writes to log with level = Warn
+	Warn(v ...interface{}) error
+
+	// Error formats message using the default formats for its operands
+	// and writes to log with level = Error
+	Error(v ...interface{}) error
+
+	// Critical formats message using the default formats for its operands
+	// and writes to log with level = Critical
+	Critical(v ...interface{}) error
+
+	// Close flushes all the messages in the logger and closes it. It cannot be used after this operation.
+	Close()
+
+	// Flush flushes all the messages in the logger.
+	Flush()
+
+	// SetAdditionalStackDepth sets the additional number of frames to skip by runtime.Caller
+	SetAdditionalStackDepth(depth int) error
+
+	// Sets logger context that can be used in formatter funcs and custom receivers
+	SetContext(context interface{})
+}
 
 // Default returns a default logger
 func Default() LoggerInterface {

--- a/pkg/util/log/types/types.go
+++ b/pkg/util/log/types/types.go
@@ -8,6 +8,69 @@ package types
 
 import "github.com/cihub/seelog"
 
+// LoggerInterface provides basic logging methods that can be used from outside the log package.
+type LoggerInterface interface {
+	// Trace formats message using the default formats for its operands
+	// and writes to log with level = Trace
+	Trace(v ...interface{})
+
+	// Debug formats message using the default formats for its operands
+	// and writes to log with level = Debug
+	Debug(v ...interface{})
+
+	// Info formats message using the default formats for its operands
+	// and writes to log with level = Info
+	Info(v ...interface{})
+
+	// Warn formats message using the default formats for its operands
+	// and writes to log with level = Warn
+	Warn(v ...interface{}) error
+
+	// Error formats message using the default formats for its operands
+	// and writes to log with level = Error
+	Error(v ...interface{}) error
+
+	// Critical formats message using the default formats for its operands
+	// and writes to log with level = Critical
+	Critical(v ...interface{}) error
+
+	// Close flushes all the messages in the logger and closes it. It cannot be used after this operation.
+	Close()
+
+	// Flush flushes all the messages in the logger.
+	Flush()
+
+	// SetAdditionalStackDepth sets the additional number of frames to skip by runtime.Caller
+	SetAdditionalStackDepth(depth int) error
+
+	// Sets logger context that can be used in formatter funcs and custom receivers
+	SetContext(context interface{})
+
+	// Tracef formats message according to format specifier
+	// and writes to log with level = Trace.
+	Tracef(format string, params ...interface{})
+
+	// Debugf formats message according to format specifier
+	// and writes to log with level = Debug.
+	Debugf(format string, params ...interface{})
+
+	// Infof formats message according to format specifier
+	// and writes to log with level = Info.
+	Infof(format string, params ...interface{})
+
+	// Warnf formats message according to format specifier
+	// and writes to log with level = Warn.
+	Warnf(format string, params ...interface{}) error
+
+	// Errorf formats message according to format specifier
+	// and writes to log with level = Error.
+	Errorf(format string, params ...interface{}) error
+
+	// Criticalf formats message according to format specifier
+	// and writes to log with level = Critical.
+	Criticalf(format string, params ...interface{}) error
+}
+
 // LogLevel is the type of log levels
 //
 //nolint:revive // keeping the original type name from seelog

--- a/pkg/util/log/types/types.go
+++ b/pkg/util/log/types/types.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package types contains the types for the log package.
+package types
+
+import "github.com/cihub/seelog"
+
+// LogLevel is the type of log levels
+//
+//nolint:revive // keeping the original type name from seelog
+type LogLevel seelog.LogLevel
+
+// Log levels
+const (
+	TraceLvl    LogLevel = seelog.TraceLvl
+	DebugLvl    LogLevel = seelog.DebugLvl
+	InfoLvl     LogLevel = seelog.InfoLvl
+	WarnLvl     LogLevel = seelog.WarnLvl
+	ErrorLvl    LogLevel = seelog.ErrorLvl
+	CriticalLvl LogLevel = seelog.CriticalLvl
+	Off         LogLevel = seelog.Off
+)
+
+// Log level string representations
+const (
+	TraceStr    = seelog.TraceStr
+	DebugStr    = seelog.DebugStr
+	InfoStr     = seelog.InfoStr
+	WarnStr     = seelog.WarnStr
+	ErrorStr    = seelog.ErrorStr
+	CriticalStr = seelog.CriticalStr
+	OffStr      = seelog.OffStr
+)
+
+func (level LogLevel) String() string {
+	return seelog.LogLevel(level).String()
+}
+
+// LogLevelFromString returns a LogLevel from a string
+//
+//nolint:revive // keeping the original function name from seelog
+func LogLevelFromString(levelStr string) (LogLevel, bool) {
+	level, ok := seelog.LogLevelFromString(levelStr)
+	return LogLevel(level), ok
+}


### PR DESCRIPTION
### What does this PR do?
- move `pkg/util/log` types and constants to `pkg/util/log/types`
- remove unneeded functions from `LoggerInterface`

### Motivation
Allow using an implementation not based on `seelog`.
Moving the types to a different package makes avoiding import cycles easier.

### Describe how you validated your changes
No functional changes.

### Additional Notes
This is the last preparatory step to introduce an slog-based logger.