### PR TITLE
chore(ssi): refactor webhook and tests

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -202,7 +202,7 @@ func generateAutoInstrumentationWebhook(wmeta workloadmeta.Component, datadogCon
 		configWebhook.NewMutator(configWebhook.NewMutatorConfig(datadogConfig), apm),
 		apm,
 	)
-	return autoinstrumentation.NewWebhook(config, wmeta, mutator)
+	return autoinstrumentation.NewWebhook(config.Webhook, wmeta, mutator)
 }
 
 // controllerBase acts as a base class for ControllerV1 and ControllerV1beta1.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -15,17 +15,10 @@ import (
 	"strconv"
 	"strings"
 
-	admiv1 "k8s.io/api/admission/v1"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
 
-	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
-	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -38,99 +31,6 @@ const (
 	// apmInjectionErrorAnnotationKey this annotation is added when the apm auto-instrumentation admission controller failed to mutate the Pod.
 	apmInjectionErrorAnnotationKey = "apm.datadoghq.com/injection-error"
 )
-
-// Webhook is the auto instrumentation webhook
-type Webhook struct {
-	name            string
-	resources       map[string][]string
-	operations      []admissionregistrationv1.OperationType
-	matchConditions []admissionregistrationv1.MatchCondition
-
-	wmeta   workloadmeta.Component
-	mutator mutatecommon.Mutator
-
-	// use to store all the config option from the config component to avoid costly lookups in the admission webhook hot path.
-	config *WebhookConfig
-}
-
-// NewWebhook returns a new Webhook dependent on the injection filter.
-func NewWebhook(config *Config, wmeta workloadmeta.Component, mutator mutatecommon.Mutator) (*Webhook, error) {
-	webhook := &Webhook{
-		name:            webhookName,
-		resources:       map[string][]string{"": {"pods"}},
-		operations:      []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
-		matchConditions: []admissionregistrationv1.MatchCondition{},
-		mutator:         mutator,
-		wmeta:           wmeta,
-		config:          config.Webhook,
-	}
-
-	log.Debug("Successfully created SSI webhook")
-	return webhook, nil
-}
-
-// Name returns the name of the webhook
-func (w *Webhook) Name() string {
-	return w.name
-}
-
-// WebhookType returns the type of the webhook
-func (w *Webhook) WebhookType() common.WebhookType {
-	return common.MutatingWebhook
-}
-
-// IsEnabled returns whether the webhook is enabled
-func (w *Webhook) IsEnabled() bool {
-	return w.config.IsEnabled
-}
-
-// Endpoint returns the endpoint of the webhook
-func (w *Webhook) Endpoint() string {
-	return w.config.Endpoint
-}
-
-// Resources returns the kubernetes resources for which the webhook should
-// be invoked
-func (w *Webhook) Resources() map[string][]string {
-	return w.resources
-}
-
-// Timeout returns the timeout for the webhook
-func (w *Webhook) Timeout() int32 {
-	return 0
-}
-
-// Operations returns the operations on the resources specified for which
-// the webhook should be invoked
-func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
-	return w.operations
-}
-
-// LabelSelectors returns the label selectors that specify when the webhook
-// should be invoked
-func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (*metav1.LabelSelector, *metav1.LabelSelector) {
-	return common.DefaultLabelSelectors(useNamespaceSelector, common.LabelSelectorsConfig{
-		ExcludeNamespaces: mutatecommon.DefaultDisabledNamespaces(),
-	})
-}
-
-// MatchConditions returns the Match Conditions used for fine-grained
-// request filtering
-func (w *Webhook) MatchConditions() []admissionregistrationv1.MatchCondition {
-	return w.matchConditions
-}
-
-// WebhookFunc returns the function that mutates the resources
-func (w *Webhook) WebhookFunc() admission.WebhookFunc {
-	return func(request *admission.Request) *admiv1.AdmissionResponse {
-		return common.MutationResponse(mutatecommon.Mutate(request.Object, request.Namespace, w.Name(), w.inject, request.DynamicClient))
-	}
-}
-
-func (w *Webhook) inject(pod *corev1.Pod, ns string, cl dynamic.Interface) (bool, error) {
-	log.Debugf("Mutating pod with SSI %q", mutatecommon.PodString(pod))
-	return w.mutator.MutatePod(pod, ns, cl)
-}
 
 func initContainerName(lang language) string {
 	return fmt.Sprintf("datadog-lib-%s-init", lang)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -26,8 +26,6 @@ const (
 	volumeName = "datadog-auto-instrumentation"
 	mountPath  = "/datadog-lib"
 
-	webhookName = "lib_injection"
-
 	// apmInjectionErrorAnnotationKey this annotation is added when the apm auto-instrumentation admission controller failed to mutate the Pod.
 	apmInjectionErrorAnnotationKey = "apm.datadoghq.com/injection-error"
 )

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -127,22 +127,6 @@ func NewConfig(datadogConfig config.Component) (*Config, error) {
 	}, nil
 }
 
-// WebhookConfig use to store options from the config.Component for the autoinstrumentation webhook
-type WebhookConfig struct {
-	// IsEnabled is the flag to enable the autoinstrumentation webhook.
-	IsEnabled bool
-	// Endpoint is the endpoint to use for the autoinstrumentation webhook.
-	Endpoint string
-}
-
-// NewWebhookConfig retrieves the configuration for the autoinstrumentation webhook from the datadog config
-func NewWebhookConfig(datadogConfig config.Component) *WebhookConfig {
-	return &WebhookConfig{
-		IsEnabled: datadogConfig.GetBool("admission_controller.auto_instrumentation.enabled"),
-		Endpoint:  datadogConfig.GetString("admission_controller.auto_instrumentation.endpoint"),
-	}
-}
-
 // LanguageDetectionConfig is a struct to store the configuration for the language detection. It can be populated using
 // the datadog config through NewLanguageDetectionConfig.
 type LanguageDetectionConfig struct {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook.go
@@ -1,0 +1,132 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	admiv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// WebhookConfig use to store options from the config.Component for the autoinstrumentation webhook
+type WebhookConfig struct {
+	// IsEnabled is the flag to enable the autoinstrumentation webhook.
+	IsEnabled bool
+	// Endpoint is the endpoint to use for the autoinstrumentation webhook.
+	Endpoint string
+}
+
+// NewWebhookConfig retrieves the configuration for the autoinstrumentation webhook from the datadog config
+func NewWebhookConfig(datadogConfig config.Component) *WebhookConfig {
+	return &WebhookConfig{
+		IsEnabled: datadogConfig.GetBool("admission_controller.auto_instrumentation.enabled"),
+		Endpoint:  datadogConfig.GetString("admission_controller.auto_instrumentation.endpoint"),
+	}
+}
+
+// Webhook is the auto instrumentation webhook
+type Webhook struct {
+	name            string
+	resources       map[string][]string
+	operations      []admissionregistrationv1.OperationType
+	matchConditions []admissionregistrationv1.MatchCondition
+
+	wmeta   workloadmeta.Component
+	mutator mutatecommon.Mutator
+
+	// use to store all the config option from the config component to avoid costly lookups in the admission webhook hot path.
+	config *WebhookConfig
+}
+
+// NewWebhook returns a new Webhook dependent on the injection filter.
+func NewWebhook(config *Config, wmeta workloadmeta.Component, mutator mutatecommon.Mutator) (*Webhook, error) {
+	webhook := &Webhook{
+		name:            webhookName,
+		resources:       map[string][]string{"": {"pods"}},
+		operations:      []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+		matchConditions: []admissionregistrationv1.MatchCondition{},
+		mutator:         mutator,
+		wmeta:           wmeta,
+		config:          config.Webhook,
+	}
+
+	log.Debug("Successfully created SSI webhook")
+	return webhook, nil
+}
+
+// Name returns the name of the webhook
+func (w *Webhook) Name() string {
+	return w.name
+}
+
+// WebhookType returns the type of the webhook
+func (w *Webhook) WebhookType() common.WebhookType {
+	return common.MutatingWebhook
+}
+
+// IsEnabled returns whether the webhook is enabled
+func (w *Webhook) IsEnabled() bool {
+	return w.config.IsEnabled
+}
+
+// Endpoint returns the endpoint of the webhook
+func (w *Webhook) Endpoint() string {
+	return w.config.Endpoint
+}
+
+// Resources returns the kubernetes resources for which the webhook should
+// be invoked
+func (w *Webhook) Resources() map[string][]string {
+	return w.resources
+}
+
+// Timeout returns the timeout for the webhook
+func (w *Webhook) Timeout() int32 {
+	return 0
+}
+
+// Operations returns the operations on the resources specified for which
+// the webhook should be invoked
+func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
+	return w.operations
+}
+
+// LabelSelectors returns the label selectors that specify when the webhook
+// should be invoked
+func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (*metav1.LabelSelector, *metav1.LabelSelector) {
+	return common.DefaultLabelSelectors(useNamespaceSelector, common.LabelSelectorsConfig{
+		ExcludeNamespaces: mutatecommon.DefaultDisabledNamespaces(),
+	})
+}
+
+// MatchConditions returns the Match Conditions used for fine-grained
+// request filtering
+func (w *Webhook) MatchConditions() []admissionregistrationv1.MatchCondition {
+	return w.matchConditions
+}
+
+// WebhookFunc returns the function that mutates the resources
+func (w *Webhook) WebhookFunc() admission.WebhookFunc {
+	return func(request *admission.Request) *admiv1.AdmissionResponse {
+		return common.MutationResponse(mutatecommon.Mutate(request.Object, request.Namespace, w.Name(), w.inject, request.DynamicClient))
+	}
+}
+
+func (w *Webhook) inject(pod *corev1.Pod, ns string, cl dynamic.Interface) (bool, error) {
+	log.Debugf("Mutating pod with SSI %q", mutatecommon.PodString(pod))
+	return w.mutator.MutatePod(pod, ns, cl)
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook.go
@@ -22,7 +22,23 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// WebhookConfig use to store options from the config.Component for the autoinstrumentation webhook
+const (
+	// WebhookName is the name of the auto instrumentation webhook used for SSI.
+	WebhookName = "lib_injection"
+)
+
+var (
+	// WebhookResources are the Kubernetes resources this webhook should be invoked for.
+	WebhookResources = map[string][]string{"": {"pods"}}
+
+	// WebhookOperations are the operations on the resources specified for which the webhook should be invoked.
+	WebhookOperations = []admissionregistrationv1.OperationType{admissionregistrationv1.Create}
+
+	// WebhookMatchConditions are the Match Conditions used for fine-grained request filtering.
+	WebhookMatchConditions = []admissionregistrationv1.MatchCondition{}
+)
+
+// WebhookConfig use to store options from the config.Component for the autoinstrumentation webhook.
 type WebhookConfig struct {
 	// IsEnabled is the flag to enable the autoinstrumentation webhook.
 	IsEnabled bool
@@ -30,7 +46,7 @@ type WebhookConfig struct {
 	Endpoint string
 }
 
-// NewWebhookConfig retrieves the configuration for the autoinstrumentation webhook from the datadog config
+// NewWebhookConfig retrieves the configuration for the autoinstrumentation webhook from the datadog config.
 func NewWebhookConfig(datadogConfig config.Component) *WebhookConfig {
 	return &WebhookConfig{
 		IsEnabled: datadogConfig.GetBool("admission_controller.auto_instrumentation.enabled"),
@@ -38,95 +54,90 @@ func NewWebhookConfig(datadogConfig config.Component) *WebhookConfig {
 	}
 }
 
-// Webhook is the auto instrumentation webhook
+// Webhook is the auto instrumentation webhook used for Single Step Instrumentation.
 type Webhook struct {
 	name            string
 	resources       map[string][]string
 	operations      []admissionregistrationv1.OperationType
 	matchConditions []admissionregistrationv1.MatchCondition
-
-	wmeta   workloadmeta.Component
-	mutator mutatecommon.Mutator
-
-	// use to store all the config option from the config component to avoid costly lookups in the admission webhook hot path.
-	config *WebhookConfig
+	wmeta           workloadmeta.Component
+	mutator         mutatecommon.Mutator
+	config          *WebhookConfig
 }
 
 // NewWebhook returns a new Webhook dependent on the injection filter.
-func NewWebhook(config *Config, wmeta workloadmeta.Component, mutator mutatecommon.Mutator) (*Webhook, error) {
+func NewWebhook(config *WebhookConfig, wmeta workloadmeta.Component, mutator mutatecommon.Mutator) (*Webhook, error) {
 	webhook := &Webhook{
-		name:            webhookName,
-		resources:       map[string][]string{"": {"pods"}},
-		operations:      []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
-		matchConditions: []admissionregistrationv1.MatchCondition{},
+		name:            WebhookName,
+		resources:       WebhookResources,
+		operations:      WebhookOperations,
+		matchConditions: WebhookMatchConditions,
 		mutator:         mutator,
 		wmeta:           wmeta,
-		config:          config.Webhook,
+		config:          config,
 	}
 
 	log.Debug("Successfully created SSI webhook")
 	return webhook, nil
 }
 
-// Name returns the name of the webhook
+// Name returns the name of the webhook.
 func (w *Webhook) Name() string {
 	return w.name
 }
 
-// WebhookType returns the type of the webhook
+// WebhookType returns the type of the webhook.
 func (w *Webhook) WebhookType() common.WebhookType {
 	return common.MutatingWebhook
 }
 
-// IsEnabled returns whether the webhook is enabled
+// IsEnabled returns whether the webhook is enabled.
 func (w *Webhook) IsEnabled() bool {
 	return w.config.IsEnabled
 }
 
-// Endpoint returns the endpoint of the webhook
+// Endpoint returns the endpoint of the webhook.
 func (w *Webhook) Endpoint() string {
 	return w.config.Endpoint
 }
 
-// Resources returns the kubernetes resources for which the webhook should
-// be invoked
+// Resources returns the kubernetes resources for which the webhook should be invoked.
 func (w *Webhook) Resources() map[string][]string {
 	return w.resources
 }
 
-// Timeout returns the timeout for the webhook
+// Timeout returns the timeout for the webhook.
 func (w *Webhook) Timeout() int32 {
 	return 0
 }
 
-// Operations returns the operations on the resources specified for which
-// the webhook should be invoked
+// Operations returns the operations on the resources specified for which the webhook should be invoked.
 func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 	return w.operations
 }
 
-// LabelSelectors returns the label selectors that specify when the webhook
-// should be invoked
+// LabelSelectors returns the label selectors that specify when the webhook should be invoked.
 func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (*metav1.LabelSelector, *metav1.LabelSelector) {
 	return common.DefaultLabelSelectors(useNamespaceSelector, common.LabelSelectorsConfig{
 		ExcludeNamespaces: mutatecommon.DefaultDisabledNamespaces(),
 	})
 }
 
-// MatchConditions returns the Match Conditions used for fine-grained
-// request filtering
+// MatchConditions returns the Match Conditions used for fine-grained request filtering.
 func (w *Webhook) MatchConditions() []admissionregistrationv1.MatchCondition {
 	return w.matchConditions
 }
 
-// WebhookFunc returns the function that mutates the resources
+// WebhookFunc returns the function that will optionally mutate a pod.
 func (w *Webhook) WebhookFunc() admission.WebhookFunc {
 	return func(request *admission.Request) *admiv1.AdmissionResponse {
-		return common.MutationResponse(mutatecommon.Mutate(request.Object, request.Namespace, w.Name(), w.inject, request.DynamicClient))
+		return common.MutationResponse(mutatecommon.Mutate(request.Object, request.Namespace, w.Name(), w.MutatePod, request.DynamicClient))
 	}
 }
 
-func (w *Webhook) inject(pod *corev1.Pod, ns string, cl dynamic.Interface) (bool, error) {
+// MutatePod will optionally mutate a pod, returning true if mutation occurs and an error if there is a problem. The
+// actual logic should be implemented in the mutator and this function is exposed only for testing.
+func (w *Webhook) MutatePod(pod *corev1.Pod, ns string, cl dynamic.Interface) (bool, error) {
 	log.Debugf("Mutating pod with SSI %q", mutatecommon.PodString(pod))
 	return w.mutator.MutatePod(pod, ns, cl)
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook_test.go
@@ -1,0 +1,272 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
+	admissioncommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+)
+
+func TestNewWebhookConfig(t *testing.T) {
+	tests := map[string]struct {
+		config   map[string]interface{}
+		expected *autoinstrumentation.WebhookConfig
+	}{
+		"defaults load as expected": {
+			expected: &autoinstrumentation.WebhookConfig{
+				IsEnabled: true,
+				Endpoint:  "/injectlib",
+			},
+		},
+		"disabled configuration is disabled": {
+			config: map[string]interface{}{
+				"admission_controller.auto_instrumentation.enabled": false,
+			},
+			expected: &autoinstrumentation.WebhookConfig{
+				IsEnabled: false,
+				Endpoint:  "/injectlib",
+			},
+		},
+		"updated endpoint is updated": {
+			config: map[string]interface{}{
+				"admission_controller.auto_instrumentation.endpoint": "/foo",
+			},
+			expected: &autoinstrumentation.WebhookConfig{
+				IsEnabled: true,
+				Endpoint:  "/foo",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockConfig := common.FakeConfigWithValues(t, test.config)
+			actual := autoinstrumentation.NewWebhookConfig(mockConfig)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestWebhookIsEnabled(t *testing.T) {
+	tests := map[string]struct {
+		config   *autoinstrumentation.WebhookConfig
+		expected bool
+	}{
+		"enabled configuration is enabled": {
+			config: &autoinstrumentation.WebhookConfig{
+				IsEnabled: true,
+			},
+			expected: true,
+		},
+		"disabled configuration is disabled": {
+			config: &autoinstrumentation.WebhookConfig{
+				IsEnabled: false,
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockMeta := common.FakeStore(t)
+			mockMutator := common.FakeMutator(t, false)
+
+			webhook, err := autoinstrumentation.NewWebhook(test.config, mockMeta, mockMutator)
+			require.NoError(t, err)
+
+			require.Equal(t, test.expected, webhook.IsEnabled())
+		})
+	}
+}
+
+func TestWebhookEndpoint(t *testing.T) {
+	tests := map[string]struct {
+		config   *autoinstrumentation.WebhookConfig
+		expected string
+	}{
+		"configuration sets endpoint": {
+			config: &autoinstrumentation.WebhookConfig{
+				Endpoint: "/foo",
+			},
+			expected: "/foo",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockMeta := common.FakeStore(t)
+			mockMutator := common.FakeMutator(t, false)
+
+			webhook, err := autoinstrumentation.NewWebhook(test.config, mockMeta, mockMutator)
+			require.NoError(t, err)
+
+			require.Equal(t, test.expected, webhook.Endpoint())
+		})
+	}
+}
+
+func TestWebhookLabelSelectors(t *testing.T) {
+	tests := map[string]struct {
+		config                    map[string]interface{}
+		useNamespaceSelector      bool
+		expectedSelector          *metav1.LabelSelector
+		expectedNamespaceSelector *metav1.LabelSelector
+	}{
+		"default config with namespace selector enabled only uses namespace selector": {
+			useNamespaceSelector: true,
+			expectedSelector:     nil,
+			expectedNamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					admissioncommon.EnabledLabelKey: "true",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      admissioncommon.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   common.DefaultDisabledNamespaces(),
+					},
+				},
+			},
+		},
+		"default config with namespace selector disabled uses both selectors": {
+			useNamespaceSelector: false,
+			expectedSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					admissioncommon.EnabledLabelKey: "true",
+				},
+			},
+			expectedNamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      admissioncommon.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   common.DefaultDisabledNamespaces(),
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockConfig := common.FakeConfigWithValues(t, test.config)
+			mockMeta := common.FakeStore(t)
+			mockMutator := common.FakeMutator(t, false)
+
+			config := autoinstrumentation.NewWebhookConfig(mockConfig)
+			webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator)
+			require.NoError(t, err)
+
+			namespaceSelector, selector := webhook.LabelSelectors(test.useNamespaceSelector)
+			require.Equal(t, test.expectedSelector, selector, "object selector does not match")
+			require.Equal(t, test.expectedNamespaceSelector, namespaceSelector, "namespace selector does not match")
+		})
+	}
+}
+
+func TestWebhookResources(t *testing.T) {
+	mockConfig := common.FakeConfig(t)
+	mockMeta := common.FakeStore(t)
+	mockMutator := common.FakeMutator(t, false)
+
+	config := autoinstrumentation.NewWebhookConfig(mockConfig)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator)
+	require.NoError(t, err)
+
+	require.Equal(t, autoinstrumentation.WebhookResources, webhook.Resources())
+}
+
+func TestWebhookTimeout(t *testing.T) {
+	mockConfig := common.FakeConfig(t)
+	mockMeta := common.FakeStore(t)
+	mockMutator := common.FakeMutator(t, false)
+
+	config := autoinstrumentation.NewWebhookConfig(mockConfig)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(0), webhook.Timeout())
+}
+
+func TestWebhookOperations(t *testing.T) {
+	mockConfig := common.FakeConfig(t)
+	mockMeta := common.FakeStore(t)
+	mockMutator := common.FakeMutator(t, false)
+
+	config := autoinstrumentation.NewWebhookConfig(mockConfig)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator)
+	require.NoError(t, err)
+
+	require.Equal(t, autoinstrumentation.WebhookOperations, webhook.Operations())
+}
+
+func TestWebhookMatchConditions(t *testing.T) {
+	mockConfig := common.FakeConfig(t)
+	mockMeta := common.FakeStore(t)
+	mockMutator := common.FakeMutator(t, false)
+
+	config := autoinstrumentation.NewWebhookConfig(mockConfig)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator)
+	require.NoError(t, err)
+
+	require.Equal(t, autoinstrumentation.WebhookMatchConditions, webhook.MatchConditions())
+}
+
+func TestWebhookName(t *testing.T) {
+	mockConfig := common.FakeConfig(t)
+	mockMeta := common.FakeStore(t)
+	mockMutator := common.FakeMutator(t, false)
+
+	config := autoinstrumentation.NewWebhookConfig(mockConfig)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator)
+	require.NoError(t, err)
+
+	require.Equal(t, autoinstrumentation.WebhookName, webhook.Name())
+}
+
+func TestWebhookType(t *testing.T) {
+	mockConfig := common.FakeConfig(t)
+	mockMeta := common.FakeStore(t)
+	mockMutator := common.FakeMutator(t, false)
+
+	config := autoinstrumentation.NewWebhookConfig(mockConfig)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator)
+	require.NoError(t, err)
+
+	require.Equal(t, admissioncommon.MutatingWebhook, webhook.WebhookType().String())
+}
+
+func TestWebhookFunc(t *testing.T) {
+	mockConfig := common.FakeConfig(t)
+	mockMeta := common.FakeStore(t)
+	mockMutator := common.FakeMutator(t, false)
+
+	config := autoinstrumentation.NewWebhookConfig(mockConfig)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator)
+	require.NoError(t, err)
+
+	pod := common.FakePod("foo")
+	b, err := json.Marshal(pod)
+	require.NoError(t, err)
+
+	resp := webhook.WebhookFunc()(&admission.Request{
+		Object:    b,
+		Namespace: "foo",
+	})
+	require.NotNil(t, resp)
+
+	require.Equal(t, true, mockMutator.Called)
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNewWebhookConfig(t *testing.T) {
 	tests := map[string]struct {
-		config   map[string]interface{}
+		config   map[string]any
 		expected *autoinstrumentation.WebhookConfig
 	}{
 		"defaults load as expected": {
@@ -32,7 +32,7 @@ func TestNewWebhookConfig(t *testing.T) {
 			},
 		},
 		"disabled configuration is disabled": {
-			config: map[string]interface{}{
+			config: map[string]any{
 				"admission_controller.auto_instrumentation.enabled": false,
 			},
 			expected: &autoinstrumentation.WebhookConfig{
@@ -41,7 +41,7 @@ func TestNewWebhookConfig(t *testing.T) {
 			},
 		},
 		"updated endpoint is updated": {
-			config: map[string]interface{}{
+			config: map[string]any{
 				"admission_controller.auto_instrumentation.endpoint": "/foo",
 			},
 			expected: &autoinstrumentation.WebhookConfig{
@@ -120,7 +120,7 @@ func TestWebhookEndpoint(t *testing.T) {
 
 func TestWebhookLabelSelectors(t *testing.T) {
 	tests := map[string]struct {
-		config                    map[string]interface{}
+		config                    map[string]any
 		useNamespaceSelector      bool
 		expectedSelector          *metav1.LabelSelector
 		expectedNamespaceSelector *metav1.LabelSelector

--- a/pkg/clusteragent/admission/mutate/common/mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/common/mutator_test.go
@@ -8,26 +8,10 @@
 package common
 
 import (
-	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/dynamic"
 )
-
-type MockMutator struct {
-	ShoudErr     bool
-	ShouldMutate bool
-	Called       bool
-}
-
-func (m *MockMutator) MutatePod(_ *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
-	m.Called = true
-	if m.ShoudErr {
-		return false, fmt.Errorf("error")
-	}
-	return m.ShouldMutate, nil
-}
 
 func TestMultiMutator(t *testing.T) {
 	tests := []struct {

--- a/pkg/clusteragent/admission/mutate/common/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/common/test_utils.go
@@ -330,8 +330,8 @@ type MockMutator struct {
 	Called bool
 }
 
-// MutatePod satifies the mutator interface.
-func (m *MockMutator) MutatePod(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
+// MutatePod satisfies the mutator interface.
+func (m *MockMutator) MutatePod(_ *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
 	m.Called = true
 	if m.ShoudErr {
 		return false, fmt.Errorf("error")
@@ -341,7 +341,7 @@ func (m *MockMutator) MutatePod(pod *corev1.Pod, _ string, _ dynamic.Interface) 
 }
 
 // FakeMutator provides a new mock of the mutator.
-func FakeMutator(t *testing.T, shouldErr bool) *MockMutator {
+func FakeMutator(_ *testing.T, shouldErr bool) *MockMutator {
 	return &MockMutator{
 		ShouldMutate: true,
 		ShoudErr:     shouldErr,

--- a/pkg/clusteragent/admission/mutate/common/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/common/test_utils.go
@@ -17,6 +17,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -24,6 +25,8 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -273,6 +276,16 @@ type MockDeployment struct {
 	Languages       languagemodels.LanguageSet
 }
 
+// FakeStore sets up an empty, fake workload metadata store.
+func FakeStore(t *testing.T) workloadmeta.Component {
+	return fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() coreconfig.Component { return coreconfig.NewMock(t) }),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+}
+
 // FakeStoreWithDeployment sets up a fake workloadmeta with the given
 // deployments
 func FakeStoreWithDeployment(t *testing.T, deployments []MockDeployment) workloadmeta.Component {
@@ -305,4 +318,46 @@ func FakeStoreWithDeployment(t *testing.T, deployments []MockDeployment) workloa
 	}
 
 	return mockStore
+}
+
+// MockMutator provides a mock that can be used in place of other mutators.
+type MockMutator struct {
+	// ShouldErr determines if the mutator should error when called.
+	ShoudErr bool
+	// ShouldMutate determines if the mutator should mutate when called.
+	ShouldMutate bool
+	// Called can be used to determine if the mutator was called after it was expected to be called.
+	Called bool
+}
+
+// MutatePod satifies the mutator interface.
+func (m *MockMutator) MutatePod(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
+	m.Called = true
+	if m.ShoudErr {
+		return false, fmt.Errorf("error")
+	}
+
+	return m.ShouldMutate, nil
+}
+
+// FakeMutator provides a new mock of the mutator.
+func FakeMutator(t *testing.T, shouldErr bool) *MockMutator {
+	return &MockMutator{
+		ShouldMutate: true,
+		ShoudErr:     shouldErr,
+	}
+}
+
+// FakeConfig provides a mock Datadog configuration. It's a helper so that all mocks can exist in test utils.
+func FakeConfig(t *testing.T) model.BuildableConfig {
+	return configmock.New(t)
+}
+
+// FakeConfigWithValues provides a moke Datadog config populated with a map of values.
+func FakeConfigWithValues(t *testing.T, values map[string]interface{}) model.BuildableConfig {
+	mockConfig := configmock.New(t)
+	for k, v := range values {
+		mockConfig.SetWithoutSource(k, v)
+	}
+	return mockConfig
 }


### PR DESCRIPTION
### What does this PR do?
This change cleans up the Auto Instrumentation webhook by isolating it into it's own file, documenting it, and adding tests for all public methods. 

### Motivation
As part of [SSI Kubernetes | Platform Stability](https://docs.google.com/document/d/1NqrPEUn3RfcdS_hQUQB-pJFJN9N-x5I202CB7s7CnwQ/edit?tab=t.0), we want to refactor the `autoinstrumentation` module to be able to support more rapid development while maintaining safety. This is one of many changes on the path to that.

### Describe how you validated your changes
There is no logic changes, and the additional unit tests validate/solidify all current behavior.

### Additional Notes
I will follow up with integration style tests in a separate PR. I originally thought they would be wrapped into this change, but honestly they make sense as a follow up. I have exposed `MutatePod` as public so that it can be tested in an integration style test without requiring the full webhook requests structure.
