### PR TITLE
Update quality gate limits for idle and logs

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "214 MiB"
+      upper_bound: "179 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_pss_bytes
-      upper_bound: "250 MiB"
+      upper_bound: "205 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?

Decreases quality gate limits for:

- `quality_gate_idle`: 214 MiB -> 179 MiB
- `quality_gate_logs`: 250 MiB -> 205 MiB

### Motivation

Lock in memory usage decreases via decreasing limits.

### Describe how you validated your changes

Used last 3 days' worth of data, added ~10 MiB safety margin.

### Additional Notes

Recent `quality_gate_idle_all_features` results do not include a Python check. Adding one is expected to increase memory usage, and based on the results we saw in https://github.com/DataDog/datadog-agent/pull/42692 with a small replicate count, we feel we need a larger sample size before we drop the memory limit for that bounds check.

The other experiments might tolerate a larger decrease, but it seemed prudent to lock in a big drop first, then fine-tune the limits in subsequent pull requests.
