### PR TITLE
[CONTP-1080] Fix workloadmeta event pipeline blocking in stream-client in race condition

### DIFF
--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -916,7 +916,6 @@ func (w *workloadmeta) notifyChannel(name string, ch chan wmdef.EventBundle, eve
 		Events: events,
 	}
 	ch <- bundle
-
 	if wait {
 		select {
 		case <-bundle.Ch:

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -29,6 +29,7 @@ const (
 	pullCollectorInterval         = 5 * time.Second
 	maxCollectorPullTime          = 1 * time.Minute
 	eventBundleChTimeout          = 1 * time.Second
+	closeEventBundleChTimeout     = 10 * time.Second
 	eventChBufferSize             = 50
 )
 
@@ -917,12 +918,15 @@ func (w *workloadmeta) notifyChannel(name string, ch chan wmdef.EventBundle, eve
 	}
 
 	// Send with timeout to prevent indefinite blocking
+	// There are two timeouts here:
+	// 1. closeEventBundleChTimeout: time to wait to send the bundle to the subscriber channel.
+	// 2. eventBundleChTimeout: time to wait for the subscriber to acknowledge the bundle.
 	select {
 	case ch <- bundle:
 		// Successfully sent
-	case <-time.After(eventBundleChTimeout):
-		// Timeout sending to channel - subscriber not reading
-		log.Warnf("collector %q channel send timed out after %v, subscriber may be blocked. bundle size: %d", name, eventBundleChTimeout, len(bundle.Events))
+	case <-time.After(closeEventBundleChTimeout):
+		// Timeout sending to channel - subscriber not reading, events will be lost
+		log.Errorf("collector %q dropped %d event(s) after %v timeout, subscriber is not reading from channel. This may cause data inconsistency for this subscriber.", name, len(bundle.Events), closeEventBundleChTimeout)
 		telemetry.NotificationsSent.Inc(name, telemetry.StatusError)
 		// Close acknowledgment channel to prevent resource leak
 		close(bundle.Ch)

--- a/comp/core/workloadmeta/server/server.go
+++ b/comp/core/workloadmeta/server/server.go
@@ -43,33 +43,6 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 	}
 
 	workloadmetaEventsChannel := s.wmeta.Subscribe("stream-client", workloadmeta.NormalPriority, filter)
-
-	// Drain channel before unsubscribe to unblock any goroutines waiting to send
-	defer func() {
-		//  1. workloadmetaEventsChannel - The main event channel which is closed by Unsubscribe()
-		//  2. bundle.Ch - The acknowledgment channel inside each EventBundle which is closed here
-		drained := 0
-		timeout := time.After(100 * time.Millisecond)
-		for {
-			select {
-			case bundle, ok := <-workloadmetaEventsChannel:
-				if !ok {
-					return
-				}
-				drained++
-				// Close acknowledgment channel to prevent resource leak
-				if bundle.Ch != nil {
-					close(bundle.Ch)
-				}
-			case <-timeout:
-				if drained > 0 {
-					log.Infof("Drained %d unprocessed events from stream-client channel before unsubscribe", drained)
-				}
-				return
-			}
-		}
-	}()
-
 	defer s.wmeta.Unsubscribe(workloadmetaEventsChannel)
 
 	ticker := time.NewTicker(workloadmetaKeepAliveInterval)
@@ -99,11 +72,6 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 			}
 
 			if len(protobufEvents) > 0 {
-				// Check if client disconnected before attempting send
-				if out.Context().Err() != nil {
-					return out.Context().Err()
-				}
-
 				err := grpc.DoWithTimeout(func() error {
 					return out.Send(&pb.WorkloadmetaStreamResponse{
 						Events: protobufEvents,

--- a/releasenotes/notes/workloadmeta-stream-client-deadlock-fix-d90bb0c7215c6ed3.yaml
+++ b/releasenotes/notes/workloadmeta-stream-client-deadlock-fix-d90bb0c7215c6ed3.yaml
@@ -9,6 +9,5 @@
 fixes:
   - |
     Fixed a deadlock in the workloadmeta event pipeline where goroutines could block
-    indefinitely when sending events to subscribers. This occurred when a subscriber
-    (such as stream-client) was processing an event while new events arrived, causing
-    the channel buffer to fill and subsequent sends to block forever.
+    indefinitely when sending events to subscribers. Added a timeout to channel send
+    operations to prevent blocking when a subscriber's channel buffer is full.

--- a/releasenotes/notes/workloadmeta-stream-client-deadlock-fix-d90bb0c7215c6ed3.yaml
+++ b/releasenotes/notes/workloadmeta-stream-client-deadlock-fix-d90bb0c7215c6ed3.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a deadlock in the workloadmeta event pipeline where goroutines could block
+    indefinitely when sending events to subscribers. This occurred when a subscriber
+    (such as stream-client) was processing an event while new events arrived, causing
+    the channel buffer to fill and subsequent sends to block forever.


### PR DESCRIPTION
### What does this PR do?
 Added a timeout to the channel send operation in store.go:

```
  // Before
  ch <- bundle  // Blocks forever if channel full
```
```
  // After 
  select {
  case ch <- bundle:
      // Successfully sent
  case <-time.After(eventBundleChTimeout):
      // Timeout after 1 second - drop event for blocked subscriber
      log.Warnf("collector %q channel send timed out after %v, subscriber may be blocked. bundle size: %d", ...)
      telemetry.NotificationsSent.Inc(name, telemetry.StatusError)
      close(bundle.Ch)
      return
  }
```


### Motivation
 SMP tests showed 20-30% failure rate where replicas would freeze and stop tracking new containers. Memory metrics stayed constant while other replicas continued growing, indicating the workloadmeta event pipeline was deadlocked.

  The Bug:
  When a subscriber processes an event but blocks on downstream operations (e.g., gRPC send), subsequent events can cause a permanent deadlock:

  Timeline:
  1. Subscriber reads Event 1 from channel (buffer now empty)
  2. Subscriber blocks processing Event 1 (stuck in gRPC send for up to 1 minute)
  3. Event 2 arrives → goes into channel buffer (buffer now full)
  4. Event 3 arrives → blocks at `ch <- bundle` (line 918)
  5. Block has NO TIMEOUT → goroutine stuck forever
  6. Even after subscriber exits, blocked goroutines stay blocked (Go behavior)

  After fix the log is clearly showing how deadlock is generated and fixed:
```
2025-11-04 19:46:48 UTC | CORE | WARN | (comp/core/workloadmeta/impl/store.go:925 in notifyChannel) | collector "stream-client" channel send timed out after 1s, subscriber may be blocked. bundle size: 1
  |   | Nov 04 14:46:47.466 | i-0b9ffeebabfaf174a | 08450328-agent
2025-11-04 19:46:47 UTC | CORE | WARN | (comp/core/workloadmeta/impl/store.go:937 in notifyChannel) | collector "stream-client" did not close the event bundle channel in time, continuing with downstream collectors. bundle size: 1
  |   | Nov 04 14:46:45.104 | i-04f4ec16b8c34f569 | 08450328-agent
2025-11-04 19:46:45 UTC | CORE | WARN | (comp/core/workloadmeta/impl/store.go:925 in notifyChannel) | collector "stream-client" did not close the event bundle channel in time, continuing with downstream collectors. bundle size: 1
```
#### Explanation
```
  00s - Event 1 arrives:
  Send: ✓ Goes to buffer (slot filled)
        Subscriber reads it immediately
        Subscriber starts processing
        Subscriber BLOCKS on downstream send (outCh <- changes)

  01s - Event 1 ack timeout (line 937):
  After 1 second: Event 1 never acknowledged
  Warning: "did not close the event bundle channel in time"

 01s+ - Event 2 arrives:
  Send: ✓ Goes to buffer (now empty after subscriber read Event 1)
        Subscriber still BLOCKED, can't read Event 2
        Event 2 sits in buffer

  02s - Event 3 arrives :
  Send: ✗ BLOCKS - buffer full (Event 2 sitting there)
  After 1 second: Send timeout
  Warning: "channel send timed out after 1s" (line 925)
  Event 3 DROPPED  ==========> Deadlock is avoided in this fix
```


   #### Root Cause
Deadlock in store.go and [server.go](https://github.com/DataDog/datadog-agent/blob/main/comp/core/workloadmeta/server/server.go#L45-L89)
```
  Goroutine A (Event Handler):
  Line 724: w.subscribersMut.Lock()        // ✓ Lock acquired
  Line 854: for _, sub := range w.subscribers {
  Line 860:     w.notifyChannel(sub.name, sub.ch, evs, true)
  Line 918:         ch <- bundle             // ❌ BLOCKS FOREVER

  Goroutine B (StreamEntities trying to exit):
  defer s.wmeta.Unsubscribe(workloadmetaEventsChannel)
      ↓
  Line 178: w.subscribersMut.Lock()         // ❌ BLOCKS waiting for lock
                                                                   // Unsubscribe never completes
```

  The Deadlock Chain:
  Event handler holds lock → Blocks on channel send
                  ↓
  Unsubscribe can't get lock → Can't close channel
                  ↓
  Blocked sender never wakes up → Lock never released
                  ↓
  Deadlock happens  

####  When StreamEntities Exits:
 system-probe exits in agent
`system-probe exited with code 0, disabling
`
       ↓
`Client disconnects` → `out.Context().Done() fires` → `returns` → `defer Unsubscribe run`

### Describe how you validated your changes
 The fix should be validated in SMP test. 

### Additional Notes
