### PR TITLE
[AGENTCFG-405] Fetching instance-type from ec2 instances and adding it to the inventoryhost payload

### DIFF
--- a/comp/metadata/inventoryhost/README.md
+++ b/comp/metadata/inventoryhost/README.md
@@ -70,6 +70,7 @@ The payload is a JSON dict with the following fields
       or ZYPPER as package manager.
   - `rpm_global_repo_gpg_check_enabled` - **boolean**: reflects the value of `repo_gpgcheck` in the `[main]` repo file
     of hosts relying on YUM, DNF or ZYPPER as package manager
+  - `instance-type` - **string**: represents the type of the host instance, consisting of varying combinations of CPU, memory, storage, and networking capacity.
 
 ## Example Payload
 
@@ -108,7 +109,8 @@ Here an example of an inventory payload:
         "dmi_board_asset_tag": "i-abcedf",
         "dmi_board_vendor": "Amazon EC2",
         "linux_package_signing_enabled": true,
-        "rpm_global_repo_gpg_check_enabled": false
+        "rpm_global_repo_gpg_check_enabled": false,
+        "instance-type": "m5.large",
     },
     "hostname": "my-host",
     "timestamp": 1631281754507358895

--- a/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost.go
+++ b/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost.go
@@ -92,6 +92,7 @@ type hostMetadata struct {
 	CloudProviderHostID      string `json:"cloud_provider_host_id"`
 	CanonicalCloudResourceID string `json:"ccrid"`
 	OsVersion                string `json:"os_version"`
+	InstanceType             string `json:"instance-type"`
 
 	// from file system
 	HypervisorGuestUUID string `json:"hypervisor_guest_uuid"`
@@ -261,6 +262,7 @@ func (ih *invHost) fillData() {
 	ih.data.CloudProviderHostID = cloudproviders.GetHostID(context.Background(), cloudProvider)
 	ih.data.CanonicalCloudResourceID = cloudproviders.GetHostCCRID(context.Background(), cloudProvider)
 	ih.data.OsVersion = osVersionGet()
+	ih.data.InstanceType = cloudproviders.GetInstanceType(context.Background(), cloudProvider)
 
 	gpgcheck, repoGPGCheck := pkgSigningGet(ih.log)
 	ih.data.LinuxPackageSigningEnabled = gpgcheck

--- a/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost_test.go
+++ b/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost_test.go
@@ -182,6 +182,7 @@ func TestGetPayload(t *testing.T) {
 		DmiBoardVendor:               "boardVendor",
 		LinuxPackageSigningEnabled:   true,
 		RPMGlobalRepoGPGCheckEnabled: false,
+		InstanceType:                 "m5.medium",
 	}
 
 	ih := getTestInventoryHost(t)
@@ -206,6 +207,7 @@ func TestGetPayloadError(t *testing.T) {
 		OsVersion:                    "testOS",
 		LinuxPackageSigningEnabled:   true,
 		RPMGlobalRepoGPGCheckEnabled: false,
+		InstanceType:                 "m5.medium",
 	}
 	assert.Equal(t, expected, p.Metadata)
 }

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -217,6 +217,57 @@ func GetHostCCRID(ctx context.Context, detectedCloud string) string {
 	return hostCCRID
 }
 
+type cloudProviderInstanceTypeDetector func(context.Context) (string, error)
+
+var hostInstanceTypeDetectors = map[string]cloudProviderInstanceTypeDetector{
+	ec2.CloudProviderName: ec2.GetInstanceType,
+}
+
+// GetInstanceType returns the instance type from the first cloud provider that works.
+func GetInstanceType(ctx context.Context, detectedCloud string) string {
+	if detectedCloud == "" {
+		log.Infof("No instance type detected, no cloud provider detected")
+		return ""
+	}
+
+	if callback, found := hostInstanceTypeDetectors[detectedCloud]; found {
+		instanceType, err := callback(ctx)
+		if err != nil {
+			log.Debugf("Could not fetch instance type for %s: %s", detectedCloud, err)
+			return ""
+		}
+		return instanceType
+	}
+
+	// Try each known instance type detector concurrently
+	var wg sync.WaitGroup
+	m := sync.Mutex{}
+	instanceType := ""
+
+	for _, detector := range hostInstanceTypeDetectors {
+		wg.Add(1)
+		go func(detector cloudProviderInstanceTypeDetector) {
+			defer wg.Done()
+
+			it, err := detector(ctx)
+			if err == nil && it != "" {
+				m.Lock()
+				// record the first successful one
+				if instanceType == "" {
+					instanceType = it
+				}
+				m.Unlock()
+			}
+		}(detector)
+	}
+	wg.Wait()
+
+	if instanceType == "" {
+		log.Infof("No instance type found for cloud provider: %q", detectedCloud)
+	}
+	return instanceType
+}
+
 // GetPublicIPv4 returns the public IPv4 from different providers
 func GetPublicIPv4(ctx context.Context) (string, error) {
 	publicIPProvider := map[string]func(context.Context) (string, error){

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -239,15 +239,6 @@ func GetInstanceType(ctx context.Context, detectedCloud string) string {
 		return instanceType
 	}
 
-	for name, detector := range hostInstanceTypeDetectors {
-		instanceType, err := detector(ctx)
-		if err != nil || instanceType == "" {
-			log.Debugf("Could not fetch instance type for %s: %v", name, err)
-			continue
-		}
-		return instanceType
-	}
-
 	log.Infof("No instance type found for cloud provider: %q", detectedCloud)
 	return ""
 }

--- a/pkg/util/cloudproviders/cloudproviders_test.go
+++ b/pkg/util/cloudproviders/cloudproviders_test.go
@@ -156,8 +156,7 @@ func TestCloudProviderInstanceType(t *testing.T) {
 
 	// Case 3: unknown provider — should call all detectors sequentially
 	instanceType = GetInstanceType(context.TODO(), "kubelet")
-	// Order is not guaranteed — either detector may run first
-	assert.Contains(t, []string{"t3.medium", "m5.large"}, instanceType)
+	assert.Equal(t, "", instanceType)
 	clearDetectors()
 
 	// Case 4: empty detected cloud — should fast fail

--- a/pkg/util/cloudproviders/cloudproviders_test.go
+++ b/pkg/util/cloudproviders/cloudproviders_test.go
@@ -154,12 +154,12 @@ func TestCloudProviderInstanceType(t *testing.T) {
 	assert.Equal(t, "t3.medium", instanceType)
 	clearDetectors()
 
-	// Case 3: unknown provider — should call all detectors sequentially
+	// Case 3: unknown provider
 	instanceType = GetInstanceType(context.TODO(), "kubelet")
 	assert.Equal(t, "", instanceType)
 	clearDetectors()
 
-	// Case 4: empty detected cloud — should fast fail
+	// Case 4: empty detected cloud — should fail fast
 	instanceType = GetInstanceType(context.TODO(), "")
 	assert.False(t, detector1Called, "instance type callback for 'detector1' should not be called")
 	assert.False(t, detector2Called, "instance type callback for 'detector2' should not be called")

--- a/pkg/util/cloudproviders/cloudproviders_test.go
+++ b/pkg/util/cloudproviders/cloudproviders_test.go
@@ -117,3 +117,54 @@ func TestGetValidHostAliasesWithConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, []string{"foo"}, val)
 }
+
+func TestCloudProviderInstanceType(t *testing.T) {
+	origDetectors := hostInstanceTypeDetectors
+	defer func() { hostInstanceTypeDetectors = origDetectors }()
+
+	detector1Called := false
+	detector2Called := false
+	clearDetectors := func() {
+		detector1Called = false
+		detector2Called = false
+	}
+
+	hostInstanceTypeDetectors = map[string]cloudProviderInstanceTypeDetector{
+		"detector1": func(_ context.Context) (string, error) {
+			detector1Called = true
+			return "t3.medium", nil
+		},
+		"detector2": func(_ context.Context) (string, error) {
+			detector2Called = true
+			return "m5.large", nil
+		},
+	}
+
+	// Case 1: known cloud provider "detector2" should only call detector2
+	instanceType := GetInstanceType(context.TODO(), "detector2")
+	assert.False(t, detector1Called, "instance type callback for 'detector1' should not be called")
+	assert.True(t, detector2Called, "instance type callback for 'detector2' was not called")
+	assert.Equal(t, "m5.large", instanceType)
+	clearDetectors()
+
+	// Case 2: known cloud provider "detector1" should only call detector1
+	instanceType = GetInstanceType(context.TODO(), "detector1")
+	assert.True(t, detector1Called, "instance type callback for 'detector1' was not called")
+	assert.False(t, detector2Called, "instance type callback for 'detector2' should not be called")
+	assert.Equal(t, "t3.medium", instanceType)
+	clearDetectors()
+
+	// Case 3: unknown provider — should call both concurrently
+	instanceType = GetInstanceType(context.TODO(), "kubelet")
+	assert.True(t, detector1Called, "instance type callback for 'detector1' was not called")
+	assert.True(t, detector2Called, "instance type callback for 'detector2' was not called")
+	assert.Contains(t, []string{"t3.medium", "m5.large"}, instanceType)
+	clearDetectors()
+
+	// Case 4: empty detected cloud — should fast fail
+	instanceType = GetInstanceType(context.TODO(), "")
+	assert.False(t, detector1Called, "instance type callback for 'detector1' should not be called")
+	assert.False(t, detector2Called, "instance type callback for 'detector2' should not be called")
+	assert.Equal(t, "", instanceType)
+	clearDetectors()
+}

--- a/pkg/util/cloudproviders/cloudproviders_test.go
+++ b/pkg/util/cloudproviders/cloudproviders_test.go
@@ -154,10 +154,9 @@ func TestCloudProviderInstanceType(t *testing.T) {
 	assert.Equal(t, "t3.medium", instanceType)
 	clearDetectors()
 
-	// Case 3: unknown provider — should call both concurrently
+	// Case 3: unknown provider — should call all detectors sequentially
 	instanceType = GetInstanceType(context.TODO(), "kubelet")
-	assert.True(t, detector1Called, "instance type callback for 'detector1' was not called")
-	assert.True(t, detector2Called, "instance type callback for 'detector2' was not called")
+	// Order is not guaranteed — either detector may run first
 	assert.Contains(t, []string{"t3.medium", "m5.large"}, instanceType)
 	clearDetectors()
 

--- a/pkg/util/cloudproviders/mock.go
+++ b/pkg/util/cloudproviders/mock.go
@@ -18,12 +18,14 @@ func Mock(t *testing.T, cloudProviderName string, accountIDCallback string, sour
 	origGetSource := sourceDetectors
 	orighostIDDetectors := hostIDDetectors
 	origHostCCRIDDecectors := hostCCRIDDetectors
+	origInstanceTypeDetectors := hostInstanceTypeDetectors
 
 	t.Cleanup(func() {
 		cloudProviderDetectors = origDetectors
 		sourceDetectors = origGetSource
 		hostIDDetectors = orighostIDDetectors
 		hostCCRIDDetectors = origHostCCRIDDecectors
+		hostInstanceTypeDetectors = origInstanceTypeDetectors
 	})
 
 	cloudProviderDetectors = []cloudProviderDetector{
@@ -41,5 +43,8 @@ func Mock(t *testing.T, cloudProviderName string, accountIDCallback string, sour
 	}
 	hostCCRIDDetectors = map[string]cloudProviderCCRIDDetector{
 		cloudProviderName: func(context.Context) (string, error) { return "test_ccrid", nil },
+	}
+	hostInstanceTypeDetectors = map[string]cloudProviderInstanceTypeDetector{
+		cloudProviderName: func(context.Context) (string, error) { return "m5.medium", nil },
 	}
 }

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -155,6 +155,18 @@ func GetNTPHosts(ctx context.Context) []string {
 	return nil
 }
 
+var instanceTypeFetcher = cachedfetch.Fetcher{
+	Name: "EC2 Instance Type",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		return ec2internal.GetMetadataItemWithMaxLength(ctx, "/instance-type", ec2internal.UseIMDSv2(), false)
+	},
+}
+
+// GetInstanceType returns the AWS instance type as reported by EC2 IMDS.
+func GetInstanceType(ctx context.Context) (string, error) {
+	return instanceTypeFetcher.FetchString(ctx)
+}
+
 // IsDefaultHostname returns whether the given hostname is a default one for EC2
 func IsDefaultHostname(hostname string) bool {
 	return isDefaultHostname(hostname, pkgconfigsetup.Datadog().GetBool("ec2_use_windows_prefix_detection"))


### PR DESCRIPTION
### What does this PR do?

Refer to [this doc](https://docs.google.com/document/d/1lQiJII2b4R8TzvPElg9Q8ynMqdMg3GHapQ_rVQFmFAQ/edit?usp=sharing). After talking to stakeholders, we have chosen to implement **option 3**; the work for this option on the agent side is to fetch the instance type from various cloud providers and report them in a new field in the inventoryhost payload. This PR creates the scaffolding for the new field, and does fetching for ec2 instances.

### Motivation

### Describe how you validated your changes

I ran an agent on ec2 with these changes incorporated, and when I run `agent diagnose show-metadata inventory-host`, I see `instance-type` as a field in the payload.

### Additional Notes
