### PR TITLE
Redo: create macOS `$TMPDIR` below `$RUNNER_TEMP_PROJECT_DIR`

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -25,19 +25,11 @@
   # Create custom temporary folder to isolate jobs from each other
   # We have to symlink it to /tmp/gitlabci to avoid some path length issues (sockets should be <= 104 characters on MacOS)
   - |
-    if [ -z "$TMPDIR" ]; then
-      echo "TMPDIR must be set" >& 2
-      exit 1
-    fi
-    # Remove the trailing slashes etc.
-    export OLDTMPDIR="$(realpath "$TMPDIR")"
-    sudo rm -rf "$OLDTMPDIR/gitlabci"
-    NEWTMPDIR="$OLDTMPDIR/gitlabci/$CI_JOB_ID"
-    mkdir -m 777 -p "$NEWTMPDIR"
-    sudo unlink /tmp/gitlabci 2> /dev/null || true
-    sudo ln -s "$NEWTMPDIR" /tmp/gitlabci
-    sudo chown "$USER":staff "$NEWTMPDIR" /tmp/gitlabci
-    export TMPDIR="/tmp/gitlabci"
+    export TMPDIR=/tmp/gitlabci
+    NEWTMPDIR="$RUNNER_TEMP_PROJECT_DIR/gitlabci"
+    rm -fr "$(realpath $TMPDIR)" "$NEWTMPDIR"
+    mkdir "$NEWTMPDIR"
+    sudo ln -fs "$NEWTMPDIR" $TMPDIR
     echo "Temporary folder created, TMPDIR=$TMPDIR -> $NEWTMPDIR"
 
 .install_python_dependencies:


### PR DESCRIPTION
Prior attempt: #42644 -> #42693.

### What does this PR do?
Create job-scoped `$TMPDIR` as a subfolder of `$RUNNER_TEMP_PROJECT_DIR` on macOS, **this time taking into account socket paths may be particularly long in tests**:
```
/Users/ec2-user/builds/UBPYdxHE3/0/DataDog/datadog-agent.tmp/gitlabci/TestGetCheckStartup2317052057/001/sysprobe.sock: bind: invalid argument
```

### Motivation
GitLab runners happen to expose a runner-specific environment [variable denoting a temporary directory](https://docs.gitlab.com/runner/configuration/advanced-configuration/#modify-git-lfs-endpoints) created alongside `$CI_PROJECT_DIR`. As we've already been using it when running [Bazel jobs in CI](https://github.com/DataDog/datadog-agent/blob/61c41ce625010b1e3e5e1a33cb8f6a5c93aae41a/tools/bazel#L23), the present change aims at leveraging the feature for other use cases, which allows to noticeably simplify the `$TMPDIR` creation sequence.

Although runner-specific directories don’t offer real sandboxing, they provide a practical boundary that minimizes cross-job interference - effectively the closest directory isolation we can get without a container or paravirtualized environment.

### Describe how you validated your changes
Run all macOS jobs.

### Additional Notes
`$RUNNER_TEMP_PROJECT_DIR` typically resolves to `$CI_PROJECT_DIR.tmp`, which and can be overridden if need be.