### PR TITLE
[FA] Fix config v3 migration (#42454)

### DIFF
--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -29,6 +29,8 @@ const (
 	FileOperationMergePatch FileOperationType = "merge-patch"
 	// FileOperationDelete deletes the config at the given path.
 	FileOperationDelete FileOperationType = "delete"
+	// FileOperationDeleteAll deletes the config at the given path and all its subdirectories.
+	FileOperationDeleteAll FileOperationType = "delete-all"
 	// FileOperationCopy copies the config at the given path to the given path.
 	FileOperationCopy FileOperationType = "copy"
 	// FileOperationMove moves the config at the given path to the given path.
@@ -59,8 +61,10 @@ func (o *Operations) Apply(rootPath string) error {
 	if err != nil {
 		return err
 	}
+	defer root.Close()
 	for _, operation := range o.FileOperations {
-		err := operation.apply(root)
+		// TODO (go.1.25): we won't need rootPath in 1.25
+		err := operation.apply(root, rootPath)
 		if err != nil {
 			return err
 		}
@@ -76,7 +80,7 @@ type FileOperation struct {
 	Patch             json.RawMessage   `json:"patch,omitempty"`
 }
 
-func (a *FileOperation) apply(root *os.Root) error {
+func (a *FileOperation) apply(root *os.Root, rootPath string) error {
 	if !configNameAllowed(a.FilePath) {
 		return fmt.Errorf("modifying config file %s is not allowed", a.FilePath)
 	}
@@ -217,6 +221,14 @@ func (a *FileOperation) apply(root *os.Root) error {
 			return err
 		}
 		return nil
+	case FileOperationDeleteAll:
+		// TODO(go.1.25): os.Root.RemoveAll is only available starting go 1.25 so we'll use it instead
+		// We can't get the path from os.Root, so we have to use the rootPath.
+		err := os.RemoveAll(filepath.Join(rootPath, path))
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
 	default:
 		return fmt.Errorf("unknown operation type: %s", a.FileOperationType)
 	}
@@ -244,10 +256,21 @@ func ensureDir(root *os.Root, filePath string) error {
 		}
 
 		// Open the directory for the next iteration
-		currentRoot, err = currentRoot.OpenRoot(part)
+		nextRoot, err := currentRoot.OpenRoot(part)
 		if err != nil {
 			return err
 		}
+
+		// Close the previous root if it's not the original root
+		if currentRoot != root {
+			currentRoot.Close()
+		}
+		currentRoot = nextRoot
+	}
+
+	// Close the final root if it's not the original root
+	if currentRoot != root {
+		currentRoot.Close()
 	}
 	return nil
 }
@@ -267,13 +290,16 @@ var (
 )
 
 func configNameAllowed(file string) bool {
+	// Normalize path to use forward slashes for consistent matching on all platforms
+	normalizedFile := filepath.ToSlash(file)
+
 	// Matching everything under the legacy /managed directory
-	if strings.HasPrefix(file, "/managed") {
+	if strings.HasPrefix(normalizedFile, "/managed") {
 		return true
 	}
 
 	for _, allowedFile := range allowedConfigFiles {
-		match, err := filepath.Match(allowedFile, file)
+		match, err := filepath.Match(allowedFile, normalizedFile)
 		if err != nil {
 			return false
 		}
@@ -293,6 +319,21 @@ func buildOperationsFromLegacyInstaller(rootPath string) []FileOperation {
 		return allOps
 	}
 
+	// Check if stable is a symlink or not. If it's not we can return early
+	// because the migration is already done
+	existingStablePath := filepath.Join(rootPath, legacyPathPrefix)
+	info, err := os.Lstat(existingStablePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return allOps
+		}
+		return allOps
+	}
+	// If it's not a symlink, we can return early
+	if info.Mode()&os.ModeSymlink == 0 {
+		return allOps
+	}
+
 	// Eval legacyPathPrefix symlink from rootPath
 	// /etc/datadog-agent/managed/datadog-agent/aaaa-bbbb-cccc
 	stableDirPath, err := filepath.EvalSymlinks(filepath.Join(realRootPath, legacyPathPrefix))
@@ -306,6 +347,13 @@ func buildOperationsFromLegacyInstaller(rootPath string) []FileOperation {
 		return allOps
 	}
 
+	// Recursively delete targetPath/
+	// RemoveAll removes symlinks but not the content they point to as it uses os.Remove first
+	allOps = append(allOps, FileOperation{
+		FileOperationType: FileOperationDeleteAll,
+		FilePath:          "/managed",
+	})
+
 	err = filepath.Walk(stableDirPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -314,17 +362,12 @@ func buildOperationsFromLegacyInstaller(rootPath string) []FileOperation {
 			return nil
 		}
 
-		// Ignore application_monitoring.yaml as we need to keep it in the managed directory
-		if strings.HasSuffix(path, "application_monitoring.yaml") {
-			return nil
-		}
-
-		ops, err := buildOperationsFromLegacyConfigFile(path, realRootPath, managedDirSubPath)
+		op, err := buildOperationsFromLegacyConfigFile(path, realRootPath, managedDirSubPath)
 		if err != nil {
 			return err
 		}
 
-		allOps = append(allOps, ops...)
+		allOps = append(allOps, op)
 		return nil
 	})
 	if err != nil {
@@ -334,16 +377,14 @@ func buildOperationsFromLegacyInstaller(rootPath string) []FileOperation {
 	return allOps
 }
 
-func buildOperationsFromLegacyConfigFile(fullFilePath, fullRootPath, managedDirSubPath string) ([]FileOperation, error) {
-	var ops []FileOperation
-
+func buildOperationsFromLegacyConfigFile(fullFilePath, fullRootPath, managedDirSubPath string) (FileOperation, error) {
 	// Read the stable config file
 	stableDatadogYAML, err := os.ReadFile(fullFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return ops, nil
+			return FileOperation{}, nil
 		}
-		return ops, err
+		return FileOperation{}, err
 	}
 
 	// Since the config is YAML, we need to convert it to JSON
@@ -352,34 +393,35 @@ func buildOperationsFromLegacyConfigFile(fullFilePath, fullRootPath, managedDirS
 	var stableDatadogJSON interface{}
 	err = yaml.Unmarshal(stableDatadogYAML, &stableDatadogJSON)
 	if err != nil {
-		return ops, err
+		return FileOperation{}, err
 	}
 	stableDatadogJSONBytes, err := json.Marshal(stableDatadogJSON)
 	if err != nil {
-		return ops, err
+		return FileOperation{}, err
 	}
 
 	managedFilePath, err := filepath.Rel(fullRootPath, fullFilePath)
 	if err != nil {
-		return ops, err
+		return FileOperation{}, err
 	}
 	fPath, err := filepath.Rel(managedDirSubPath, managedFilePath)
 	if err != nil {
-		return ops, err
+		return FileOperation{}, err
 	}
 
-	// Add the merge patch operation
-	ops = append(ops, FileOperation{
+	op := FileOperation{
 		FileOperationType: FileOperationType(FileOperationMergePatch),
 		FilePath:          "/" + strings.TrimPrefix(fPath, "/"),
 		Patch:             stableDatadogJSONBytes,
-	})
+	}
+	if fPath == "application_monitoring.yaml" {
+		// Copy in managed directory
+		op = FileOperation{
+			FileOperationType: FileOperationMergePatch,
+			FilePath:          "/" + filepath.Join("managed", "datadog-agent", "stable", fPath),
+			Patch:             stableDatadogJSONBytes,
+		}
+	}
 
-	// Add the delete operation for the old file
-	ops = append(ops, FileOperation{
-		FileOperationType: FileOperationType(FileOperationDelete),
-		FilePath:          "/" + strings.TrimPrefix(managedFilePath, "/"),
-	})
-
-	return ops, nil
+	return op, nil
 }

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -6,8 +6,10 @@
 package config
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -36,7 +38,7 @@ func TestOperationApply_Patch(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check file content
@@ -69,7 +71,7 @@ func TestOperationApply_MergePatch(t *testing.T) {
 		Patch:             []byte(mergePatch),
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	updated, err := os.ReadFile(filePath)
@@ -97,7 +99,7 @@ func TestOperationApply_Delete(t *testing.T) {
 		FilePath:          "/datadog.yaml",
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 	_, err = os.Stat(filePath)
 	assert.Error(t, err)
@@ -121,7 +123,7 @@ func TestOperationApply_EmptyYAMLFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that the file now contains the patched value
@@ -148,7 +150,7 @@ func TestOperationApply_NoFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	filePath := filepath.Join(tmpDir, "datadog.yaml")
@@ -177,7 +179,7 @@ func TestOperationApply_DisallowedFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not allowed")
 }
@@ -205,7 +207,7 @@ func TestOperationApply_NestedConfigFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	updated, err := os.ReadFile(filePath)
@@ -315,24 +317,21 @@ func TestBuildOperationsFromLegacyConfigFile(t *testing.T) {
 	err = os.WriteFile(filepath.Join(managedDir, "datadog.yaml"), legacyConfig, 0644)
 	assert.NoError(t, err)
 
-	ops, err := buildOperationsFromLegacyConfigFile(filepath.Join(managedDir, "datadog.yaml"), tmpDir, legacyPathPrefix)
+	op, err := buildOperationsFromLegacyConfigFile(filepath.Join(managedDir, "datadog.yaml"), tmpDir, legacyPathPrefix)
 	assert.NoError(t, err)
-	assert.Len(t, ops, 2)
 
 	// Check merge patch operation
-	assert.Equal(t, FileOperationMergePatch, ops[0].FileOperationType)
-	assert.Equal(t, "/datadog.yaml", ops[0].FilePath)
-	assert.Equal(t, string(legacyConfig), string(ops[0].Patch))
-
-	// Check delete operation
-	assert.Equal(t, FileOperationDelete, ops[1].FileOperationType)
-	assert.Equal(t, filepath.Join(legacyPathPrefix, "datadog.yaml"), strings.TrimPrefix(strings.TrimPrefix(ops[1].FilePath, "/"), "\\"))
+	assert.Equal(t, FileOperationMergePatch, op.FileOperationType)
+	assert.Equal(t, "/datadog.yaml", op.FilePath)
+	assert.Equal(t, string(legacyConfig), string(op.Patch))
 }
 
 func TestBuildOperationsFromLegacyInstaller(t *testing.T) {
 	tmpDir := t.TempDir()
-	managedDir := filepath.Join(tmpDir, legacyPathPrefix)
+	managedDir := filepath.Join(tmpDir, filepath.Join("managed", "datadog-agent", "aaa-bbb-ccc"))
 	err := os.MkdirAll(managedDir, 0755)
+	assert.NoError(t, err)
+	err = os.Symlink(managedDir, filepath.Join(tmpDir, legacyPathPrefix))
 	assert.NoError(t, err)
 
 	// Create legacy config files
@@ -343,8 +342,8 @@ func TestBuildOperationsFromLegacyInstaller(t *testing.T) {
 
 	ops := buildOperationsFromLegacyInstaller(tmpDir)
 
-	// Should have 4 operations: 2 merge patches + 2 deletes
-	assert.Len(t, ops, 4)
+	// Should have 3 operations: 2 merge patches + 1 delete all
+	assert.Len(t, ops, 3)
 
 	// Check that we have operations for both files
 	filePaths := make(map[string]bool)
@@ -353,23 +352,30 @@ func TestBuildOperationsFromLegacyInstaller(t *testing.T) {
 	}
 	assert.True(t, filePaths["datadog.yaml"])
 	assert.True(t, filePaths["security-agent.yaml"])
-	assert.True(t, filePaths[filepath.Join("managed", "datadog-agent", "stable", "datadog.yaml")])
-	assert.True(t, filePaths[filepath.Join("managed", "datadog-agent", "stable", "security-agent.yaml")])
+	assert.Equal(t, FileOperationDeleteAll, ops[0].FileOperationType)
+	assert.Equal(t, "/managed", ops[0].FilePath)
 }
 
 func TestBuildOperationsFromLegacyConfigFileKeepApplicationMonitoring(t *testing.T) {
 	tmpDir := t.TempDir()
-	managedDir := filepath.Join(tmpDir, legacyPathPrefix)
+	managedDir := filepath.Join(tmpDir, filepath.Join("managed", "datadog-agent", "aaa-bbb-ccc"))
 	err := os.MkdirAll(managedDir, 0755)
 	assert.NoError(t, err)
+	err = os.Symlink(managedDir, filepath.Join(tmpDir, legacyPathPrefix))
+	assert.NoError(t, err)
 
-	// Create a legacy config file
 	legacyConfig := []byte("{\"bar\":123,\"foo\":\"legacy_value\"}")
 	err = os.WriteFile(filepath.Join(managedDir, "application_monitoring.yaml"), legacyConfig, 0644)
 	assert.NoError(t, err)
 
 	ops := buildOperationsFromLegacyInstaller(tmpDir)
-	assert.Len(t, ops, 0)
+	assert.Len(t, ops, 2)
+
+	assert.Equal(t, FileOperationDeleteAll, ops[0].FileOperationType)
+	assert.Equal(t, "/managed", ops[0].FilePath)
+	assert.Equal(t, FileOperationMergePatch, ops[1].FileOperationType)
+	assert.Equal(t, "/"+filepath.Join("managed", "datadog-agent", "stable", "application_monitoring.yaml"), ops[1].FilePath)
+	assert.Equal(t, string(legacyConfig), string(ops[1].Patch))
 }
 
 func TestOperationApply_Copy(t *testing.T) {
@@ -392,7 +398,7 @@ func TestOperationApply_Copy(t *testing.T) {
 		DestinationPath:   "/security-agent.yaml",
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that source file still exists
@@ -425,7 +431,7 @@ func TestOperationApply_Move(t *testing.T) {
 		DestinationPath:   "/otel-config.yaml",
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that source file no longer exists
@@ -460,7 +466,7 @@ func TestOperationApply_CopyWithNestedDestination(t *testing.T) {
 		DestinationPath:   "/conf.d/mycheck.d/config.yaml",
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that nested directories were created
@@ -494,7 +500,7 @@ func TestOperationApply_MoveWithNestedDestination(t *testing.T) {
 		DestinationPath:   "/conf.d/mycheck.d/config.yaml",
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that nested directories were created
@@ -525,7 +531,7 @@ func TestOperationApply_CopyMissingSource(t *testing.T) {
 		DestinationPath:   "/security-agent.yaml",
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.Error(t, err)
 }
 
@@ -542,6 +548,220 @@ func TestOperationApply_MoveMissingSource(t *testing.T) {
 		DestinationPath:   "/otel-config.yaml",
 	}
 
-	err = op.apply(root)
+	err = op.apply(root, tmpDir)
 	assert.Error(t, err)
+}
+
+func writeConfigV2(t *testing.T, v2Dir string) {
+	managedDir := filepath.Join(v2Dir, "managed", "datadog-agent")
+	err := os.MkdirAll(managedDir, 0755)
+	assert.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(managedDir, "v2"), 0755)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(filepath.Join(managedDir, "v2", "datadog.yaml"), []byte("log_level: debug\n"), 0644))
+	assert.NoError(t, os.WriteFile(filepath.Join(managedDir, "v2", "application_monitoring.yaml"), []byte("enabled: true\n"), 0644))
+	assert.NoError(t, os.MkdirAll(filepath.Join(managedDir, "v2", "conf.d", "mycheck.d"), 0755))
+	assert.NoError(t, os.WriteFile(filepath.Join(managedDir, "v2", "conf.d", "mycheck.d", "config.yaml"), []byte("foo: bar\n"), 0644))
+
+	// Create the stable and experiment symlinks
+	err = os.Symlink(filepath.Join(managedDir, "v2"), filepath.Join(managedDir, "stable"))
+	assert.NoError(t, err)
+	err = os.Symlink(filepath.Join(managedDir, "v2"), filepath.Join(managedDir, "experiment"))
+	assert.NoError(t, err)
+}
+
+func assertConfigV2(t *testing.T, v2Dir *string) {
+	if v2Dir == nil {
+		// On windows, experiments are not supported yet for configuration.
+		assert.Equal(t, "windows", runtime.GOOS)
+		return
+	}
+
+	// /managed/datadog-agent/stable -> /etc/datadog-agent/managed/datadog-agent/v2
+	// /managed/datadog-agent/experiment -> /etc/datadog-agent/managed/datadog-agent/v2
+	// /managed/datadog-agent/v2/
+	//     datadog.yaml
+	//     application_monitoring.yaml
+	//     conf.d/mycheck.d/config.yaml
+	managedDir := filepath.Join(*v2Dir, "managed", "datadog-agent")
+	info, err := os.Lstat(filepath.Join(managedDir, "v2"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeDir != 0)
+	info, err = os.Stat(filepath.Join(managedDir, "v2", "datadog.yaml"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink == 0)
+	info, err = os.Lstat(filepath.Join(managedDir, "v2", "application_monitoring.yaml"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink == 0)
+	info, err = os.Lstat(filepath.Join(managedDir, "v2", "conf.d", "mycheck.d", "config.yaml"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink == 0)
+
+	info, err = os.Lstat(filepath.Join(managedDir, "stable"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink != 0)
+	info, err = os.Lstat(filepath.Join(managedDir, "experiment"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink != 0)
+
+	// v2Dir/conf.d/mychecks.d/config.yaml does not exists
+	_, err = os.Lstat(filepath.Join(*v2Dir, "conf.d", "mycheck.d", "config.yaml"))
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func assertConfigV3(t *testing.T, v3Dir *string) {
+	if v3Dir == nil {
+		// On windows, experiments are not supported yet for configuration.
+		assert.Equal(t, "windows", runtime.GOOS)
+		return
+	}
+
+	// Check the content of the v3 directory
+	// /managed/datadog-agent/stable
+	//     application_monitoring.yaml
+	// No more symlinks
+	managedDir := filepath.Join(*v3Dir, "managed", "datadog-agent")
+	_, err := os.Stat(filepath.Join(managedDir, "experiment"))
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+
+	_, err = os.Stat(filepath.Join(managedDir, "v2"))
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+
+	stableInfo, err := os.Lstat(filepath.Join(managedDir, "stable"))
+	assert.NoError(t, err)
+	assert.True(t, stableInfo.Mode()&os.ModeSymlink == 0)
+
+	// Check the files are not here anymore, except application_monitoring.yaml
+	_, err = os.Lstat(filepath.Join(managedDir, "stable", "datadog.yaml"))
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+	info, err := os.Lstat(filepath.Join(managedDir, "stable", "application_monitoring.yaml"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink == 0)
+	_, err = os.Lstat(filepath.Join(managedDir, "stable", "conf.d", "mycheck.d", "config.yaml"))
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+
+	// v3Dir/conf.d/mychecks.d/config.yaml exists
+	_, err = os.Lstat(filepath.Join(*v3Dir, "conf.d", "mycheck.d", "config.yaml"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink == 0)
+}
+
+func assertDeploymentID(t *testing.T, dirs *Directories, stableDeploymentID string, experimentDeploymentID string) {
+	state, err := dirs.GetState()
+	assert.NoError(t, err)
+	assert.Equal(t, stableDeploymentID, state.StableDeploymentID)
+	assert.Equal(t, experimentDeploymentID, state.ExperimentDeploymentID)
+}
+
+func TestConfigV2ToV3(t *testing.T) {
+	stableTmpDir := t.TempDir()
+	managedDir := filepath.Join(stableTmpDir, "managed", "datadog-agent")
+	err := os.MkdirAll(managedDir, 0755)
+	assert.NoError(t, err)
+
+	// Create a v2 tree
+	writeConfigV2(t, stableTmpDir)
+	assertConfigV2(t, &stableTmpDir) // Make sure it's correct
+
+	// Convert v2 to v3
+	newDir := t.TempDir()
+	dirs := &Directories{
+		StablePath:     stableTmpDir,
+		ExperimentPath: newDir,
+	}
+
+	assertDeploymentID(t, dirs, "", "")
+
+	err = dirs.WriteExperiment(context.Background(), Operations{
+		DeploymentID: "experiment-456",
+		FileOperations: []FileOperation{
+			{FileOperationType: FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "info"}`)},
+		},
+	})
+	assert.NoError(t, err)
+
+	experimentDir := &newDir
+	stableDir := &stableTmpDir
+	if runtime.GOOS == "windows" {
+		experimentDir = &stableTmpDir
+		stableDir = nil
+	}
+
+	assertDeploymentID(t, dirs, "", "experiment-456")
+
+	assertConfigV2(t, stableDir) // Make sure nothing changed
+	assertConfigV3(t, experimentDir)
+
+	// Promote
+	err = dirs.PromoteExperiment(context.Background())
+	assert.NoError(t, err)
+	assertConfigV3(t, stableDir) // Make sure it changed
+
+	assertDeploymentID(t, dirs, "experiment-456", "")
+}
+
+func TestConfigV2Rollback(t *testing.T) {
+	stableTmpDir := t.TempDir()
+	managedDir := filepath.Join(stableTmpDir, "managed", "datadog-agent")
+	err := os.MkdirAll(managedDir, 0755)
+	assert.NoError(t, err)
+
+	// Create a v2 tree
+	writeConfigV2(t, stableTmpDir)
+	assertConfigV2(t, &stableTmpDir) // Make sure it's correct
+
+	// Convert v2 to v3
+	newDir := t.TempDir()
+	dirs := &Directories{
+		StablePath:     stableTmpDir,
+		ExperimentPath: newDir,
+	}
+
+	err = dirs.WriteExperiment(context.Background(), Operations{
+		DeploymentID: "experiment-456",
+		FileOperations: []FileOperation{
+			{FileOperationType: FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "info"}`)},
+		},
+	})
+	assert.NoError(t, err)
+
+	experimentDir := &newDir
+	stableDir := &stableTmpDir
+	if runtime.GOOS == "windows" {
+		experimentDir = &stableTmpDir
+		stableDir = nil
+	}
+
+	assertConfigV2(t, stableDir) // Make sure nothing changed
+	assertConfigV3(t, experimentDir)
+
+	assertDeploymentID(t, dirs, "", "experiment-456")
+
+	// Rollback
+	err = dirs.RemoveExperiment(context.Background())
+	assert.NoError(t, err)
+	assertConfigV2(t, stableDir) // Make sure it's still v2
+
+	// Write again
+	err = dirs.WriteExperiment(context.Background(), Operations{
+		DeploymentID: "experiment-789",
+		FileOperations: []FileOperation{
+			{FileOperationType: FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "info"}`)},
+		},
+	})
+	assert.NoError(t, err)
+	assertConfigV2(t, stableDir) // Make sure it's still v2
+	assertConfigV3(t, experimentDir)
+
+	// Promote
+	err = dirs.PromoteExperiment(context.Background())
+	assert.NoError(t, err)
+	assertConfigV3(t, stableDir) // Make sure it changed
+
+	assertDeploymentID(t, dirs, "experiment-789", "")
 }

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -121,6 +121,11 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 	if os.IsNotExist(err) {
 		return nil
 	}
+	// Ensure target directory exists before trying to write to it
+	err = os.MkdirAll(targetPath, 0755)
+	if err != nil {
+		return fmt.Errorf("error creating target directory: %w", err)
+	}
 	deploymentID, err := os.ReadFile(filepath.Join(sourcePath, deploymentIDFile))
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("error reading deployment ID file: %w", err)

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot-exp.service
@@ -11,7 +11,7 @@ PIDFile=/opt/datadog-agent/run/otel-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/otel-agent run --config /etc/datadog-agent-exp/otel-config.yaml --core-config /etc/datadog-agent-exp/datadog.yaml --pidfile /opt/datadog-agent/run/otel-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-exp.service
@@ -11,7 +11,7 @@ Type=simple
 PIDFile=/opt/datadog-agent/run/agent.pid
 User=dd-agent
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
 RuntimeDirectory=datadog

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-installer-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-installer-exp.service
@@ -11,7 +11,7 @@ Type=simple
 PIDFile=/opt/datadog-agent/run/installer.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/installer run -c /etc/datadog-agent-exp -p /opt/datadog-agent/run/installer.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-process-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-process-exp.service
@@ -10,7 +10,7 @@ PIDFile=/opt/datadog-agent/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/process-agent --cfgpath=/etc/datadog-agent-exp/datadog.yaml --sysprobe-config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-agent/run/process-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-security-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-security-exp.service
@@ -4,14 +4,14 @@ After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent-security.service
 ConditionPathExists=|/etc/datadog-agent-exp/security-agent.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/security-agent.yaml
+ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/security-agent.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-agent/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/security-agent start -c /etc/datadog-agent-exp/datadog.yaml -c /etc/datadog-agent-exp/security-agent.yaml --sysprobe-config /etc/datadog-agent-exp/system-probe.yaml --pidfile /opt/datadog-agent/run/security-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe-exp.service
@@ -6,14 +6,14 @@ After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
 ConditionPathExists=|/etc/datadog-agent-exp/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/system-probe.yaml
+ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-agent/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-trace-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-trace-exp.service
@@ -10,7 +10,7 @@ PIDFile=/opt/datadog-agent/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/trace-loader /etc/datadog-agent-exp/datadog.yaml /opt/datadog-agent/embedded/bin/trace-agent --config /etc/datadog-agent-exp/datadog.yaml --pidfile /opt/datadog-agent/run/trace-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot-exp.service
@@ -11,7 +11,7 @@ PIDFile=/opt/datadog-agent/run/otel-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/otel-agent run --config /etc/datadog-agent-exp/otel-config.yaml --core-config /etc/datadog-agent-exp/datadog.yaml --pidfile /opt/datadog-agent/run/otel-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-exp.service
@@ -11,7 +11,7 @@ Type=simple
 PIDFile=/opt/datadog-agent/run/agent.pid
 User=dd-agent
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
 RuntimeDirectory=datadog

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-installer-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-installer-exp.service
@@ -11,7 +11,7 @@ Type=simple
 PIDFile=/opt/datadog-agent/run/installer.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/installer run -c /etc/datadog-agent-exp -p /opt/datadog-agent/run/installer.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-process-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-process-exp.service
@@ -10,7 +10,7 @@ PIDFile=/opt/datadog-agent/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/process-agent --cfgpath=/etc/datadog-agent-exp/datadog.yaml --sysprobe-config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-agent/run/process-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-security-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-security-exp.service
@@ -4,14 +4,14 @@ After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent-security.service
 ConditionPathExists=|/etc/datadog-agent-exp/security-agent.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/security-agent.yaml
+ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/security-agent.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-agent/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/security-agent start -c /etc/datadog-agent-exp/datadog.yaml -c /etc/datadog-agent-exp/security-agent.yaml --sysprobe-config /etc/datadog-agent-exp/system-probe.yaml --pidfile /opt/datadog-agent/run/security-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe-exp.service
@@ -6,14 +6,14 @@ After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
 ConditionPathExists=|/etc/datadog-agent-exp/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/system-probe.yaml
+ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-agent/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-trace-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-trace-exp.service
@@ -10,7 +10,7 @@ PIDFile=/opt/datadog-agent/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-agent/embedded/bin/trace-loader /etc/datadog-agent-exp/datadog.yaml /opt/datadog-agent/embedded/bin/trace-agent --config /etc/datadog-agent-exp/datadog.yaml --pidfile /opt/datadog-agent/run/trace-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot-exp.service
@@ -11,7 +11,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/otel-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent-ddot/experiment/embedded/bin/otel-agent run --config /etc/datadog-agent-exp/otel-config.yaml --core-config /etc/datadog-agent-exp/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/otel-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-exp.service
@@ -11,7 +11,7 @@ Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 User=dd-agent
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
 RuntimeDirectory=datadog

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-installer-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-installer-exp.service
@@ -11,7 +11,7 @@ Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/installer.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/installer run -c /etc/datadog-agent-exp -p /opt/datadog-packages/datadog-agent/experiment/run/installer.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-process-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-process-exp.service
@@ -10,7 +10,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/process-agent --cfgpath=/etc/datadog-agent-exp/datadog.yaml --sysprobe-config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/process-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-security-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-security-exp.service
@@ -4,14 +4,14 @@ After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent-security.service
 ConditionPathExists=|/etc/datadog-agent-exp/security-agent.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/security-agent.yaml
+ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/security-agent.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/security-agent start -c /etc/datadog-agent-exp/datadog.yaml -c /etc/datadog-agent-exp/security-agent.yaml --sysprobe-config /etc/datadog-agent-exp/system-probe.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/security-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe-exp.service
@@ -6,14 +6,14 @@ After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
 ConditionPathExists=|/etc/datadog-agent-exp/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/system-probe.yaml
+ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-trace-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-trace-exp.service
@@ -10,7 +10,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/trace-loader /etc/datadog-agent-exp/datadog.yaml /opt/datadog-packages/datadog-agent/experiment/embedded/bin/trace-agent --config /etc/datadog-agent-exp/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/trace-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot-exp.service
@@ -11,7 +11,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/otel-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent-ddot/experiment/embedded/bin/otel-agent run --config /etc/datadog-agent-exp/otel-config.yaml --core-config /etc/datadog-agent-exp/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/otel-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-exp.service
@@ -11,7 +11,7 @@ Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 User=dd-agent
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
 RuntimeDirectory=datadog

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-installer-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-installer-exp.service
@@ -11,7 +11,7 @@ Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/installer.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/installer run -c /etc/datadog-agent-exp -p /opt/datadog-packages/datadog-agent/experiment/run/installer.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-process-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-process-exp.service
@@ -10,7 +10,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/process-agent --cfgpath=/etc/datadog-agent-exp/datadog.yaml --sysprobe-config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/process-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-security-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-security-exp.service
@@ -4,14 +4,14 @@ After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent-security.service
 ConditionPathExists=|/etc/datadog-agent-exp/security-agent.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/security-agent.yaml
+ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/security-agent.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/security-agent start -c /etc/datadog-agent-exp/datadog.yaml -c /etc/datadog-agent-exp/security-agent.yaml --sysprobe-config /etc/datadog-agent-exp/system-probe.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/security-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe-exp.service
@@ -6,14 +6,14 @@ After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
 ConditionPathExists=|/etc/datadog-agent-exp/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/system-probe.yaml
+ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-trace-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-trace-exp.service
@@ -10,7 +10,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
+Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/trace-loader /etc/datadog-agent-exp/datadog.yaml /opt/datadog-packages/datadog-agent/experiment/embedded/bin/trace-agent --config /etc/datadog-agent-exp/datadog.yaml --pidfile /opt/datadog-packages/datadog-agent/experiment/run/trace-agent.pid
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/main.go
+++ b/pkg/fleet/installer/packages/embedded/tmpl/main.go
@@ -144,7 +144,7 @@ var (
 	expDataOCI = systemdTemplateData{
 		InstallDir:       "/opt/datadog-packages/datadog-agent/experiment",
 		EtcDir:           "/etc/datadog-agent-exp",
-		FleetPoliciesDir: "/etc/datadog-agent/managed/datadog-agent/experiment",
+		FleetPoliciesDir: "/etc/datadog-agent-exp/managed/datadog-agent/stable",
 		PIDDir:           "/opt/datadog-packages/datadog-agent/experiment",
 		Stable:           false,
 	}
@@ -159,7 +159,7 @@ var (
 	expDataDebRpm = systemdTemplateData{
 		InstallDir:       "/opt/datadog-agent",
 		EtcDir:           "/etc/datadog-agent-exp",
-		FleetPoliciesDir: "/etc/datadog-agent/managed/datadog-agent/experiment",
+		FleetPoliciesDir: "/etc/datadog-agent-exp/managed/datadog-agent/stable",
 		PIDDir:           "/opt/datadog-agent",
 		Stable:           false,
 	}
@@ -174,7 +174,7 @@ var (
 	ddotExpDataOCI = systemdTemplateData{
 		InstallDir:       "/opt/datadog-packages/datadog-agent-ddot/experiment",
 		EtcDir:           "/etc/datadog-agent-exp",
-		FleetPoliciesDir: "/etc/datadog-agent/managed/datadog-agent/experiment",
+		FleetPoliciesDir: "/etc/datadog-agent-exp/managed/datadog-agent/stable",
 		PIDDir:           "/opt/datadog-packages/datadog-agent/experiment",
 		Stable:           false,
 	}

--- a/test/new-e2e/tests/installer/unix/config_test.go
+++ b/test/new-e2e/tests/installer/unix/config_test.go
@@ -49,11 +49,11 @@ func (s *configSuite) TestConfig() {
 }
 
 func (s *configSuite) TestMultipleConfigs() {
-	s.Agent.MustInstall(agent.WithRemoteUpdates())
-	defer s.Agent.MustUninstall()
+	s.agent.MustInstall(agent.WithRemoteUpdates())
+	defer s.agent.MustUninstall()
 
 	for i := 0; i < 3; i++ {
-		err := s.Backend.StartConfigExperiment(fleetbackend.ConfigOperations{
+		err := s.backend.StartConfigExperiment(fleetbackend.ConfigOperations{
 			DeploymentID: fmt.Sprintf("123-%d", i),
 			FileOperations: []fleetbackend.FileOperation{
 				{
@@ -64,7 +64,7 @@ func (s *configSuite) TestMultipleConfigs() {
 			},
 		})
 		require.NoError(s.T(), err)
-		config, err := s.Agent.Configuration()
+		config, err := s.agent.Configuration()
 		require.NoError(s.T(), err)
 		// Convert extra_tags to a slice of strings
 		extraTags := config["extra_tags"].([]interface{})
@@ -75,10 +75,10 @@ func (s *configSuite) TestMultipleConfigs() {
 			require.True(s.T(), ok, "tag %d is not a string", i)
 		}
 		require.Equal(s.T(), []string{fmt.Sprintf("debug:step-%d", i)}, extraTagsStrings)
-		err = s.Backend.PromoteConfigExperiment()
+		err = s.backend.PromoteConfigExperiment()
 		require.NoError(s.T(), err)
 
-		config, err = s.Agent.Configuration()
+		config, err = s.agent.Configuration()
 		require.NoError(s.T(), err)
 		// Convert extra_tags to a slice of strings
 		extraTags = config["extra_tags"].([]interface{})


### PR DESCRIPTION
Fix the symlinks for the new config experiments.

Start with a new `DeleteAll` instruction, doing a `os.RemoveAll` (to be replaced by root.RemoveAll when available).

Before this change, after a `install-config-experiment`
```
/etc/datadog-agent/managed/datadog-agent/stable -> /etc/datadog-agent/managed/datadog-agent/<version>
/etc/datadog-agent/managed/datadog-agent/experiment -> /etc/datadog-agent/managed/datadog-agent/<version>
/etc/datadog-agent/managed/datadog-agent/<version>/
    datadog.yaml
    application_monitoring.yaml

/etc/datadog-agent-exp/managed/datadog-agent/stable -> /etc/datadog-agent/managed/datadog-agent/<version>
/etc/datadog-agent-exp/managed/datadog-agent/experiment -> /etc/datadog-agent/managed/datadog-agent/<version>
/etc/datadog-agent-exp/managed/datadog-agent/<version>/
    application_monitoring.yaml
```

After this change, after a `install-config-experiment`
```
/etc/datadog-agent/managed/datadog-agent/stable -> /etc/datadog-agent/managed/datadog-agent/<version>
/etc/datadog-agent/managed/datadog-agent/experiment -> /etc/datadog-agent/managed/datadog-agent/<version>
/etc/datadog-agent/managed/datadog-agent/<version>/
    datadog.yaml
    application_monitoring.yaml

/etc/datadog-agent-exp/managed/datadog-agent/stable
    application_monitoring.yaml
```

This change also prevents the experiment units from loading the wrong `FleetPoliciesDir`


(cherry picked from commit 8b63a8db90df343d062cbc9368bea75bbf98c99b)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
