### PR TITLE
Use AL2023 for OTel EKS tests

### DIFF
--- a/test/new-e2e/tests/otel/otel-agent/infraattributes_eks_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/infraattributes_eks_test.go
@@ -40,7 +40,17 @@ agents:
           value: 'disable_operation_and_resource_name_logic_v2'
 `
 	t.Parallel()
-	e2e.Run(t, &iaEKSTestSuite{}, e2e.WithProvisioner(awskubernetes.EKSProvisioner(awskubernetes.WithEKSOptions(eks.WithLinuxNodeGroup()), awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(iaConfig)))))
+	e2e.Run(t, &iaEKSTestSuite{}, e2e.WithProvisioner(awskubernetes.EKSProvisioner(
+		awskubernetes.WithEKSOptions(
+			eks.WithLinuxNodeGroup(),
+			eks.WithUseAL2023Nodes(),
+		),
+		awskubernetes.WithAgentOptions(
+			kubernetesagentparams.WithHelmValues(values),
+			kubernetesagentparams.WithOTelAgent(),
+			kubernetesagentparams.WithOTelConfig(iaConfig),
+		),
+	)))
 }
 
 var eksParams = utils.IAParams{
@@ -97,7 +107,17 @@ agents:
           value: 'disable_operation_and_resource_name_logic_v2'
 `
 	t.Parallel()
-	e2e.Run(t, &iaUSTEKSTestSuite{}, e2e.WithProvisioner(awskubernetes.EKSProvisioner(awskubernetes.WithEKSOptions(eks.WithLinuxNodeGroup()), awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(iaConfig)))))
+	e2e.Run(t, &iaUSTEKSTestSuite{}, e2e.WithProvisioner(awskubernetes.EKSProvisioner(
+		awskubernetes.WithEKSOptions(
+			eks.WithLinuxNodeGroup(),
+			eks.WithUseAL2023Nodes(),
+		),
+		awskubernetes.WithAgentOptions(
+			kubernetesagentparams.WithHelmValues(values),
+			kubernetesagentparams.WithOTelAgent(),
+			kubernetesagentparams.WithOTelConfig(iaConfig),
+		),
+	)))
 }
 
 func (s *iaUSTEKSTestSuite) SetupSuite() {


### PR DESCRIPTION
### What does this PR do?
Updates otel-agent EKS tests to use AL2023 nodes

### Motivation

### Describe how you validated your changes

### Additional Notes
