### PR TITLE
Update CEL Workload Exclude to not Gracefully Crash During Runtime Errors

### DIFF
--- a/comp/core/workloadfilter/impl/filter_test.go
+++ b/comp/core/workloadfilter/impl/filter_test.go
@@ -991,6 +991,46 @@ cel_workload_exclude:
 	})
 }
 
+func TestCELWorkloadExcludeFilteringRuntimeErrors(t *testing.T) {
+
+	yamlConfig := `
+cel_workload_exclude:
+- products: ["global"]
+  rules:
+    pods:
+      - "100"
+- products:
+    - metrics
+  rules:
+    pods:
+      - "pod.annotations['non-existent-key'] != 'x'"
+`
+
+	mockConfig := configmock.NewFromYAML(t, yamlConfig)
+	filterStore := newFilterStoreObject(t, mockConfig)
+
+	pod := workloadmetafilter.CreatePod(
+		&workloadmeta.KubernetesPod{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "my-pod",
+				Namespace: "test",
+			},
+		},
+	)
+
+	t.Run("Nonexistent annotation on pod", func(t *testing.T) {
+		filterBundle := filterStore.GetPodFilters([][]workloadfilter.PodFilter{{workloadfilter.PodFilter(workloadfilter.PodCELMetrics)}})
+		assert.Nil(t, filterBundle.GetErrors())
+		assert.Equal(t, workloadfilter.Unknown, filterBundle.GetResult(pod))
+	})
+
+	t.Run("Non-boolean result on rule", func(t *testing.T) {
+		filterBundle := filterStore.GetPodFilters([][]workloadfilter.PodFilter{{workloadfilter.PodFilter(workloadfilter.PodCELGlobal)}})
+		assert.Nil(t, filterBundle.GetErrors())
+		assert.Equal(t, workloadfilter.Unknown, filterBundle.GetResult(pod))
+	})
+}
+
 func TestCELProcessLogsFiltering(t *testing.T) {
 	yamlConfig := `
 cel_workload_exclude:

--- a/comp/core/workloadfilter/program/cel_program.go
+++ b/comp/core/workloadfilter/program/cel_program.go
@@ -8,16 +8,13 @@
 package program
 
 import (
-	"os"
-
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/google/cel-go/cel"
 )
 
-// CELProgram is a structure that holds two CEL programs:
-// one for inclusion (higher priority) and one for exclusion (lower priority).
+// CELProgram is a structure that holds a CEL program for exclusion.
 type CELProgram struct {
 	Name                 string
 	Exclude              cel.Program
@@ -37,14 +34,10 @@ func (p CELProgram) Evaluate(entity workloadfilter.Filterable) workloadfilter.Re
 					return workloadfilter.Excluded
 				}
 			} else {
-				log.Criticalf(`filter '%s' from 'cel_workload_exclude' failed to convert value to bool: %v`, p.Name, out.Value())
-				log.Flush()
-				os.Exit(1)
+				log.Debugf(`filter '%s' from 'cel_workload_exclude' failed to convert value to bool: %v`, p.Name, out.Value())
 			}
 		} else {
-			log.Criticalf(`filter '%s' from 'cel_workload_exclude' failed to convert evaluate: %v`, p.Name, out.Value())
-			log.Flush()
-			os.Exit(1)
+			log.Debugf(`filter '%s' from 'cel_workload_exclude' failed to evaluate: %v`, p.Name, err)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

With the new `cel_workload_exclude` option for advanced container discovery management, we want to crash the Agent whenever users have any input misconfiguration issue. This is important because if filters are misconfigured then the Agent may collect telemetry which may impact customer billing. However, we only want to gracefully crash the Agent when there is a parsing or compile error of the user defined program. Is there is any sort of runtime error then we should keep the Agent running, log any issues, and allow the execution of any other relevant filters.

### Motivation

Avoid crashing from runtime errors from `cel_workload_exclude` to provide a better user experience. Instead just log the errors.

### Describe how you validated your changes

Unit tests.

Previously you see the following errors if you had a non-boolean rule or a non-existent annotation used in the rule:

```
2025-11-04 19:46:24 UTC | CRITICAL | (comp/core/workloadfilter/program/cel_program.go:39 in Evaluate) | filter 'PodCELGlobalProgram' from 'cel_workload_exclude' failed to convert value to bool: 100
```
OR
```
2025-11-04 19:47:43 UTC | CRITICAL | (comp/core/workloadfilter/program/cel_program.go:44 in Evaluate) | filter 'PodCELMetricsProgram' from 'cel_workload_exclude' failed to evaluate: no such key: non-existent-key
```

Now, we've reconfigured the Agent to no longer gracefully crash with the critical error message, but instead just return `workloadfilter.Unknown`
