### PR TITLE
Enable nodetreemodel CI job

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -62,14 +62,12 @@ tests_linux-x64-py3:
     CONDA_ENV: ddpy3
 
 tests_nodetreemodel:
-  # Tests are currently not passing
-  # They are being fixed, and we want to track progress on this work
   extends:
     - .rtloader_tests
     - .linux_tests
     - .linux_x64
   after_script:
-    # Don't upload junit results, which prevents e2e tests from running (they will fail)
+    - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   rules:
@@ -80,7 +78,6 @@ tests_nodetreemodel:
     CONDA_ENV: ddpy3
     # This env var enables the NTM config implementation
     DD_CONF_NODETREEMODEL: enable
-  allow_failure: true
 
 tests_nodetreemodel_unmarshal:
   extends:


### PR DESCRIPTION
### What does this PR do?

Enable job `tests_nodetreemodel` in the CI now that all tests are passing.

### Motivation

Switch to NTM soon, to remove our dependency on viper.

### Describe how you validated your changes

### Additional Notes
