### PR TITLE
fix: Remove legacy global container include interaction with metrics and logs collection

### DIFF
--- a/comp/core/workloadfilter/impl/filter_test.go
+++ b/comp/core/workloadfilter/impl/filter_test.go
@@ -253,6 +253,73 @@ func TestCombinedFilter(t *testing.T) {
 	assert.Equal(t, true, res)
 }
 
+func TestContainerAutodiscoveryFilterScopes(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    string
+		scope     workloadfilter.Scope
+		container *workloadfilter.Container
+		expected  bool
+	}{
+		{
+			name: "Global include interact with logs exclude",
+			config: `
+container_include: ["kube_namespace:default"]
+container_exclude_logs: ["name:nginx"]
+`,
+			scope: workloadfilter.LogsFilter,
+			container: workloadmetafilter.CreateContainer(
+				&workloadmeta.Container{
+					EntityMeta: workloadmeta.EntityMeta{
+						Name: "nginx",
+					},
+				},
+				workloadmetafilter.CreatePod(
+					&workloadmeta.KubernetesPod{
+						EntityMeta: workloadmeta.EntityMeta{
+							Namespace: "default",
+						},
+					},
+				),
+			),
+			expected: true,
+		},
+		{
+			name: "Global include interact with metrics exclude",
+			config: `
+container_include: ["image:agent"]
+container_exclude_metrics: ["kube_namespace:datadog-agent"]
+`,
+			scope: workloadfilter.MetricsFilter,
+			container: workloadmetafilter.CreateContainer(
+				&workloadmeta.Container{
+					Image: workloadmeta.ContainerImage{
+						RawName: "agent",
+					},
+				},
+				workloadmetafilter.CreatePod(
+					&workloadmeta.KubernetesPod{
+						EntityMeta: workloadmeta.EntityMeta{
+							Namespace: "datadog-agent",
+						},
+					},
+				),
+			),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.NewFromYAML(t, tt.config)
+			filterStore := newFilterStoreObject(t, mockConfig)
+			filterBundle := filterStore.GetContainerAutodiscoveryFilters(tt.scope)
+			res := filterBundle.IsExcluded(tt.container)
+			assert.Equal(t, tt.expected, res, "Container exclusion result mismatch")
+		})
+	}
+}
+
 func TestContainerSBOMFilter(t *testing.T) {
 
 	tests := []struct {

--- a/comp/core/workloadfilter/impl/filter_utils.go
+++ b/comp/core/workloadfilter/impl/filter_utils.go
@@ -149,10 +149,11 @@ func (pf *filterSelection) computeContainerAutodiscoveryFilters(cfg config.Compo
 	flist := make([][]workloadfilter.ContainerFilter, 2)
 
 	high := []workloadfilter.ContainerFilter{workloadfilter.ContainerADAnnotations}
-	low := []workloadfilter.ContainerFilter{workloadfilter.LegacyContainerGlobal}
+	low := []workloadfilter.ContainerFilter{}
 
 	switch filterScope {
 	case workloadfilter.GlobalFilter:
+		low = append(low, workloadfilter.LegacyContainerGlobal)
 		if len(cfg.GetStringSlice("container_include")) == 0 {
 			low = append(low, workloadfilter.LegacyContainerACInclude)
 		}

--- a/releasenotes/notes/fix-exclude-container-85b88eddaaeb57e5.yaml
+++ b/releasenotes/notes/fix-exclude-container-85b88eddaaeb57e5.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    In Agent v7.69.0, the Autodiscovery filtering mechanism began applying
+    filters defined in `container_include` to metrics and logs collection.
+    This reverts the behavior to respect only the product specific filters.


### PR DESCRIPTION
Backport 122b9f95ab607cd05ecb442e72e0a488ac8be256 from #42647.

___

### What does this PR do?

The `NewAutodiscoveryFilter` ([code](https://github.com/DataDog/datadog-agent/blob/7.69.0/pkg/util/containers/filter.go#L298-L322)) originally separated out the rules defined by `container_exclude` and `container_include` to not interact with product specific rules like `container_exclude_logs` or `container_exclude_metrics`.

This change restores the behavior of the `container_include` option to not interact with product specific rules. This allows users to still exclude the collection of one particular product while including the container collection for other products.

### Motivation

Restore behavior of `container_include`

### Describe how you validated your changes

Unit tests

### Additional Notes

This has no impact on `container_exclude` because if a hypothetical container was excluded by that config option then no code related to the subproducts would ever be reached in Autodiscovery.