### PR TITLE
UnmarshalKey implicitly converts scalars to slices

### DIFF
--- a/pkg/config/structure/compatibility_test.go
+++ b/pkg/config/structure/compatibility_test.go
@@ -275,3 +275,78 @@ func TestUnmarshalKeyMapToBools(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, objBool2, testBool{A: false, B: true})
 }
+
+type TargetStruct struct {
+	BoolToString  string   `mapstructure:"bool_to_string"`
+	NumToString   string   `mapstructure:"num_to_string"`
+	BoolToInt     int      `mapstructure:"bool_to_int"`
+	StringToInt   int      `mapstructure:"string_to_int"`
+	StringToInt2  int      `mapstructure:"string_to_int2"`
+	IntToBool     bool     `mapstructure:"int_to_bool"`
+	IntToBool2    bool     `mapstructure:"int_to_bool2"`
+	StringToBool  bool     `mapstructure:"string_to_bool"`
+	StringToBool2 bool     `mapstructure:"string_to_bool2"`
+	StringToBool3 bool     `mapstructure:"string_to_bool3"`
+	StringToBool4 bool     `mapstructure:"string_to_bool4"`
+	StrSlice      []string `mapstructure:"str_slice"`
+	IntSlice      []int    `mapstructure:"int_slice"`
+}
+
+func TestUnmarshalWeaklyTyped(t *testing.T) {
+	// Validate that UnmarshalKey uses mapstructure's implicit conversion from
+	// mapstructure's WeaklyTypedInput setting.
+	// https://github.com/mitchellh/mapstructure/blob/8508981c8b6c964e6986dd8aa85490e70ce3c2e2/mapstructure.go#L229
+	dataYaml := `
+my_target:
+  bool_to_string:  true
+  num_to_string:   5
+  bool_to_int:     true
+  string_to_int:   "345"
+  string_to_int2:  "0x123"
+  int_to_bool:     3
+  int_to_bool2:    0
+  string_to_bool:  T
+  string_to_bool2: True
+  string_to_bool3: "1"
+  string_to_bool4: "FALSE"
+  str_slice:       abc
+  int_slice:       7
+`
+	viperConf, ntmConf := constructBothConfigs(dataYaml, false, func(cfg model.Setup) {
+		cfg.SetKnown("my_target") //nolint:forbidigo // legit usage, often used for UnmarshalKey settings
+	})
+
+	var target TargetStruct
+	err := viperConf.UnmarshalKey("my_target", &target)
+	assert.Equal(t, "1", target.BoolToString)
+	assert.Equal(t, "5", target.NumToString)
+	assert.Equal(t, 1, target.BoolToInt)
+	assert.Equal(t, 345, target.StringToInt)
+	assert.Equal(t, 291, target.StringToInt2)
+	assert.Equal(t, true, target.IntToBool)
+	assert.Equal(t, false, target.IntToBool2)
+	assert.Equal(t, true, target.StringToBool)
+	assert.Equal(t, true, target.StringToBool2)
+	assert.Equal(t, true, target.StringToBool3)
+	assert.Equal(t, false, target.StringToBool4)
+	assert.Equal(t, []string{"abc"}, target.StrSlice)
+	assert.Equal(t, []int{7}, target.IntSlice)
+	require.NoError(t, err)
+
+	target = TargetStruct{}
+	err = unmarshalKeyReflection(ntmConf, "my_target", &target)
+	assert.Equal(t, "true", target.BoolToString)
+	assert.Equal(t, "5", target.NumToString)
+	assert.Equal(t, 1, target.BoolToInt)
+	assert.Equal(t, 345, target.StringToInt)
+	assert.Equal(t, 291, target.StringToInt2)
+	assert.Equal(t, true, target.IntToBool)
+	assert.Equal(t, false, target.IntToBool2)
+	assert.Equal(t, true, target.StringToBool)
+	assert.Equal(t, true, target.StringToBool2)
+	assert.Equal(t, true, target.StringToBool3)
+	assert.Equal(t, false, target.StringToBool4)
+	assert.Equal(t, []string{"abc"}, target.StrSlice)
+	assert.Equal(t, []int{7}, target.IntSlice)
+	require.NoError(t, err)
+}

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -564,7 +564,10 @@ func copyAny(target reflect.Value, input nodetreemodel.Node, currPath []string, 
 func makeNodeArray(vals interface{}) ([]nodetreemodel.Node, error) {
 	s := reflect.ValueOf(vals)
 	if s.Kind() != reflect.Slice {
-		return nil, fmt.Errorf("value is not a slice")
+		// Work like mapstructure's WeaklyTypedInput setting, implicitly convert
+		// a scalar into a slice when necessary
+		node, _ := nodetreemodel.NewNodeTree(vals, model.SourceUnknown)
+		return []nodetreemodel.Node{node}, nil
 	}
 
 	res := make([]nodetreemodel.Node, 0, s.Len())

--- a/pkg/config/structure/unmarshal_test.go
+++ b/pkg/config/structure/unmarshal_test.go
@@ -104,14 +104,6 @@ user:
 
 	confYaml = `
 user:
-  jobs: 30
-`
-	mockConfig = newConfigFromYaml(t, confYaml)
-	err = unmarshalKeyReflection(mockConfig, "user", &person)
-	assert.ErrorContains(t, err, `at [jobs], []T required, but input is not an array: &{30`)
-
-	confYaml = `
-user:
   age:
   - plumber
   - teacher


### PR DESCRIPTION
### What does this PR do?

When UnmarshalKey is used to write to a struct, and a field of that struct has type `[]T`, a single `T` will be implicitly converted to `[]T`. This follows how `mapstructure`'s WeaklyTypedInput setting works.

### Motivation

Compatibility with Viper.

### Describe how you validated your changes

Unit tests cover this change.

### Additional Notes
