### PR TITLE
[Network Path] upgrade datadog-traceroute to v0.1.30.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.72.0-rc.5
 	github.com/DataDog/datadog-go/v5 v5.8.1
 	github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f
-	github.com/DataDog/datadog-traceroute v0.1.29
+	github.com/DataDog/datadog-traceroute v0.1.30
 	github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0
 	github.com/DataDog/dd-trace-go/v2 v2.2.2 // indirect
 	github.com/DataDog/ebpf-manager v0.7.15

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/DataDog/datadog-go/v5 v5.8.1 h1:+GOES5W9zpKlhwHptZVW2C0NLVf7ilr7pHkDc
 github.com/DataDog/datadog-go/v5 v5.8.1/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f h1:O+Ls4K2v4lQpGum7yYWM3aRZ3vJ/Ibvk/Ma/NqXwtWI=
 github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f/go.mod h1:E+dFku5SVIXDUj6apiBdDAzrUOR3xLz1bMgUOGjRAVQ=
-github.com/DataDog/datadog-traceroute v0.1.29 h1:l6vQHYORtdoZn3xriLorsHe9QuNja6Sr4JyJ2WDwi3Q=
-github.com/DataDog/datadog-traceroute v0.1.29/go.mod h1:PU0w0AsVMEapWPgaqXEtBuDUlPQGlnHsaADsXVMKMts=
+github.com/DataDog/datadog-traceroute v0.1.30 h1:ehk/21PbOIj6C+42BAQ9sfFEzeGyVwI4T4oEbJJItEA=
+github.com/DataDog/datadog-traceroute v0.1.30/go.mod h1:PU0w0AsVMEapWPgaqXEtBuDUlPQGlnHsaADsXVMKMts=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0 h1:OEDWHLCabNtLF+OkbI1DlVLkxxK9QUVQUSIt8uZ3VY8=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0/go.mod h1:KsvZuiis+8Ix3r+FEIew7LvryZeeIDrYyiTPMR14GOY=
 github.com/DataDog/dd-trace-go/v2 v2.2.2 h1:t7RCS6et5z+xrvM9dqUPtCGoNOWTj0pcApzbktMZi2k=


### PR DESCRIPTION
### What does this PR do?
[Network Path] upgrade datadog-traceroute to v0.1.30.

### Motivation

https://github.com/DataDog/datadog-traceroute/releases/tag/v0.1.30

This fixed an important issue with traceroute TCP SACK:

> [CNM-4802] Improve handling of SACK method to avoid getting destination not reachable from traceroutes and e2e probes. by @jmw51798 in https://github.com/DataDog/datadog-traceroute/pull/61

### Describe how you validated your changes

### Additional Notes


[CNM-4802]: https://datadoghq.atlassian.net/browse/CNM-4802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ