### PR TITLE
[AGENTRUN-881] Improving telemetry forwarding via remoteAgentRegistry

### DIFF
--- a/comp/core/telemetry/component.go
+++ b/comp/core/telemetry/component.go
@@ -54,4 +54,11 @@ type Component interface {
 
 	// Gather exposes metrics from the general or default telemetry registry (see options.DefaultMetric)
 	Gather(defaultGather bool) ([]*MetricFamily, error)
+
+	// GatherText exposes metrics from the general or default telemetry registry (see options.DefaultMetric) in text format
+	GatherText(defaultGather bool, filter MetricFilter) (string, error)
 }
+
+// MetricFilter is a function that filters metrics based on their name
+// It returns true if the metric should be included, false if it should be excluded
+type MetricFilter func(*MetricFamily) bool

--- a/comp/core/telemetry/component.go
+++ b/comp/core/telemetry/component.go
@@ -58,7 +58,3 @@ type Component interface {
 	// GatherText exposes metrics from the general or default telemetry registry (see options.DefaultMetric) in text format
 	GatherText(defaultGather bool, filter MetricFilter) (string, error)
 }
-
-// MetricFilter is a function that filters metrics based on their name
-// It returns true if the metric should be included, false if it should be excluded
-type MetricFilter func(*MetricFamily) bool

--- a/comp/core/telemetry/gather_filters.go
+++ b/comp/core/telemetry/gather_filters.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"regexp"
+	"slices"
+)
+
+// NoFilter returns a MetricFilter that includes all metrics
+// This is not recommended since it will heavily impact costs
+func NoFilter(*MetricFamily) bool {
+	return true
+}
+
+// StaticMetricFilter filters metrics based on their name
+// It returns true if the metric name is in the list, false otherwise
+func StaticMetricFilter(metricNames ...string) MetricFilter {
+	return func(mf *MetricFamily) bool {
+		return slices.Contains(metricNames, *mf.Name)
+	}
+}
+
+// RegexMetricFilter filters metrics based on their name using regular expressions
+// It returns true if the metric name matches at least one of the regular expressions, false otherwise
+func RegexMetricFilter(regexes ...regexp.Regexp) MetricFilter {
+	return func(mf *MetricFamily) bool {
+		for _, regex := range regexes {
+			if regex.MatchString(*mf.Name) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// BatchMetricFilter combines multiple MetricFilters into a single MetricFilter
+// It returns true if at least one of the filters return true, false otherwise
+func BatchMetricFilter(filters ...MetricFilter) MetricFilter {
+	return func(mf *MetricFamily) bool {
+		for _, filter := range filters {
+			if filter(mf) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/comp/core/telemetry/gather_filters.go
+++ b/comp/core/telemetry/gather_filters.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+//go:build !serverless
+
 package telemetry
 
 import (
@@ -20,7 +22,7 @@ func NoFilter(*MetricFamily) bool {
 // It returns true if the metric name is in the list, false otherwise
 func StaticMetricFilter(metricNames ...string) MetricFilter {
 	return func(mf *MetricFamily) bool {
-		return slices.Contains(metricNames, *mf.Name)
+		return slices.Contains(metricNames, mf.GetName())
 	}
 }
 
@@ -29,7 +31,7 @@ func StaticMetricFilter(metricNames ...string) MetricFilter {
 func RegexMetricFilter(regexes ...regexp.Regexp) MetricFilter {
 	return func(mf *MetricFamily) bool {
 		for _, regex := range regexes {
-			if regex.MatchString(*mf.Name) {
+			if regex.MatchString(mf.GetName()) {
 				return true
 			}
 		}

--- a/comp/core/telemetry/gather_filters_test.go
+++ b/comp/core/telemetry/gather_filters_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+//go:build !serverless
+
 package telemetry
 
 import (

--- a/comp/core/telemetry/gather_filters_test.go
+++ b/comp/core/telemetry/gather_filters_test.go
@@ -1,0 +1,225 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoFilter(t *testing.T) {
+	tests := []struct {
+		name       string
+		metricName string
+		expected   bool
+	}{
+		{
+			name:       "accepts any metric",
+			metricName: "any_metric_name",
+			expected:   true,
+		},
+		{
+			name:       "accepts empty metric name",
+			metricName: "",
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mf := &MetricFamily{Name: &tt.metricName}
+			result := NoFilter(mf)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStaticMetricFilter(t *testing.T) {
+	tests := []struct {
+		name        string
+		filterNames []string
+		metricName  string
+		expectMatch bool
+	}{
+		{
+			name:        "matches single metric",
+			filterNames: []string{"test_metric"},
+			metricName:  "test_metric",
+			expectMatch: true,
+		},
+		{
+			name:        "does not match different metric",
+			filterNames: []string{"test_metric"},
+			metricName:  "other_metric",
+			expectMatch: false,
+		},
+		{
+			name:        "matches one of multiple metrics",
+			filterNames: []string{"metric_a", "metric_b", "metric_c"},
+			metricName:  "metric_b",
+			expectMatch: true,
+		},
+		{
+			name:        "does not match when not in list",
+			filterNames: []string{"metric_a", "metric_b"},
+			metricName:  "metric_c",
+			expectMatch: false,
+		},
+		{
+			name:        "empty filter list matches nothing",
+			filterNames: []string{},
+			metricName:  "any_metric",
+			expectMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := StaticMetricFilter(tt.filterNames...)
+			mf := &MetricFamily{Name: &tt.metricName}
+			result := filter(mf)
+			assert.Equal(t, tt.expectMatch, result)
+		})
+	}
+}
+
+func TestRegexMetricFilter(t *testing.T) {
+	tests := []struct {
+		name        string
+		regexes     []string
+		metricName  string
+		expectMatch bool
+	}{
+		{
+			name:        "matches simple pattern",
+			regexes:     []string{"^test_.*"},
+			metricName:  "test_metric",
+			expectMatch: true,
+		},
+		{
+			name:        "does not match when pattern differs",
+			regexes:     []string{"^test_.*"},
+			metricName:  "prod_metric",
+			expectMatch: false,
+		},
+		{
+			name:        "matches one of multiple patterns",
+			regexes:     []string{"^test_.*", "^prod_.*", ".*_gauge$"},
+			metricName:  "prod_counter",
+			expectMatch: true,
+		},
+		{
+			name:        "matches suffix pattern",
+			regexes:     []string{".*_counter$"},
+			metricName:  "requests_counter",
+			expectMatch: true,
+		},
+		{
+			name:        "matches middle pattern",
+			regexes:     []string{".*_http_.*"},
+			metricName:  "server_http_requests",
+			expectMatch: true,
+		},
+		{
+			name:        "does not match any pattern",
+			regexes:     []string{"^test_.*", ".*_counter$"},
+			metricName:  "prod_gauge",
+			expectMatch: false,
+		},
+		{
+			name:        "empty regex list matches nothing",
+			regexes:     []string{},
+			metricName:  "any_metric",
+			expectMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiledRegexes := make([]regexp.Regexp, len(tt.regexes))
+			for i, r := range tt.regexes {
+				compiledRegexes[i] = *regexp.MustCompile(r)
+			}
+			filter := RegexMetricFilter(compiledRegexes...)
+			mf := &MetricFamily{Name: &tt.metricName}
+			result := filter(mf)
+			assert.Equal(t, tt.expectMatch, result)
+		})
+	}
+}
+
+func TestBatchMetricFilter(t *testing.T) {
+	tests := []struct {
+		name        string
+		filters     []MetricFilter
+		metricName  string
+		expectMatch bool
+	}{
+		{
+			name: "matches when first filter matches",
+			filters: []MetricFilter{
+				StaticMetricFilter("test_metric"),
+				StaticMetricFilter("other_metric"),
+			},
+			metricName:  "test_metric",
+			expectMatch: true,
+		},
+		{
+			name: "matches when second filter matches",
+			filters: []MetricFilter{
+				StaticMetricFilter("other_metric"),
+				StaticMetricFilter("test_metric"),
+			},
+			metricName:  "test_metric",
+			expectMatch: true,
+		},
+		{
+			name: "matches when any filter matches",
+			filters: []MetricFilter{
+				StaticMetricFilter("metric_a"),
+				RegexMetricFilter(*regexp.MustCompile("^test_.*")),
+				StaticMetricFilter("metric_c"),
+			},
+			metricName:  "test_counter",
+			expectMatch: true,
+		},
+		{
+			name: "does not match when no filter matches",
+			filters: []MetricFilter{
+				StaticMetricFilter("metric_a"),
+				StaticMetricFilter("metric_b"),
+			},
+			metricName:  "metric_c",
+			expectMatch: false,
+		},
+		{
+			name: "combines static and regex filters",
+			filters: []MetricFilter{
+				StaticMetricFilter("exact_match"),
+				RegexMetricFilter(*regexp.MustCompile(".*_counter$")),
+			},
+			metricName:  "requests_counter",
+			expectMatch: true,
+		},
+		{
+			name:        "empty filter list matches nothing",
+			filters:     []MetricFilter{},
+			metricName:  "any_metric",
+			expectMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := BatchMetricFilter(tt.filters...)
+			mf := &MetricFamily{Name: &tt.metricName}
+			result := filter(mf)
+			assert.Equal(t, tt.expectMatch, result)
+		})
+	}
+}

--- a/comp/core/telemetry/go.mod
+++ b/comp/core/telemetry/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.61.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.67.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/fx v1.24.0
 )
@@ -19,7 +20,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/common v0.67.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/spf13/cobra v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/comp/core/telemetry/noopsimpl/telemetry.go
+++ b/comp/core/telemetry/noopsimpl/telemetry.go
@@ -99,6 +99,10 @@ func (t *noopImpl) Gather(bool) ([]*telemetry.MetricFamily, error) {
 	return nil, nil
 }
 
+func (t *noopImpl) GatherText(bool, telemetry.MetricFilter) (string, error) {
+	return "", nil
+}
+
 // GetCompatComponent returns a component wrapping telemetry global variables
 // TODO (components): Remove this when all telemetry is migrated to the component
 func GetCompatComponent() telemetry.Component {

--- a/comp/core/telemetry/options.go
+++ b/comp/core/telemetry/options.go
@@ -21,6 +21,10 @@ type Options struct {
 	DefaultMetric bool
 }
 
+// MetricFilter is a function that filters metrics based on their name
+// It returns true if the metric should be included, false if it should be excluded
+type MetricFilter func(*MetricFamily) bool
+
 // DefaultOptions for telemetry metrics which don't need to specify any option.
 var DefaultOptions = Options{
 	// By default, we want to separate the subsystem and the metric name with a

--- a/comp/core/telemetry/telemetryimpl/telemetry_test.go
+++ b/comp/core/telemetry/telemetryimpl/telemetry_test.go
@@ -132,3 +132,66 @@ func TestGoMetrics(t *testing.T) {
 	assert.Contains(t, metricNames, "go_threads")
 	assert.Contains(t, metricNames, "go_gc_duration_seconds")
 }
+
+func TestGatherText(t *testing.T) {
+	tel := fxutil.Test[telemetry.Mock](t, MockModule())
+
+	// Create test metrics
+	counter := tel.NewSimpleCounter("test_subsystem", "test_counter", "test counter help")
+	counter.Inc()
+
+	gauge := tel.NewSimpleGauge("test_subsystem", "test_gauge", "test gauge help")
+	gauge.Set(42.0)
+
+	tests := []struct {
+		name           string
+		filter         telemetry.MetricFilter
+		expectInOutput []string
+		expectNotIn    []string
+		expectEmpty    bool
+	}{
+		{
+			name:           "NoFilter includes all metrics",
+			filter:         telemetry.NoFilter,
+			expectInOutput: []string{"test_subsystem__test_counter", "test_subsystem__test_gauge"},
+		},
+		{
+			name:           "StaticMetricFilter includes only specified metrics",
+			filter:         telemetry.StaticMetricFilter("test_subsystem__test_counter"),
+			expectInOutput: []string{"test_subsystem__test_counter"},
+			expectNotIn:    []string{"test_subsystem__test_gauge"},
+		},
+		{
+			name:           "StaticMetricFilter with multiple metrics",
+			filter:         telemetry.StaticMetricFilter("test_subsystem__test_counter", "test_subsystem__test_gauge"),
+			expectInOutput: []string{"test_subsystem__test_counter", "test_subsystem__test_gauge"},
+		},
+		{
+			name:        "Filter returns empty when no metrics match",
+			filter:      telemetry.StaticMetricFilter("nonexistent_metric"),
+			expectEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := tel.GatherText(false, tt.filter)
+			require.NoError(t, err)
+
+			if tt.expectEmpty {
+				assert.Empty(t, output)
+				return
+			}
+
+			require.NotEmpty(t, output)
+
+			for _, expected := range tt.expectInOutput {
+				assert.Contains(t, output, expected)
+			}
+
+			for _, notExpected := range tt.expectNotIn {
+				assert.NotContains(t, output, notExpected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  ### What does this PR do?
  This PR hardens the telemetry forwarding mechanism for remote agents by:
  - Adding a `remote_agent` label to all metrics collected from remote agents for better observability
  - Implementing proper error handling with logging instead of panicking when metric collection fails
  - Adding support for metric filtering via new `MetricFilter` functionality to control which metrics are forwarded
  - Gracefully handling unsupported metric types (SUMMARY, HISTOGRAM) with warning logs instead of failing silently
  - Introducing a new `GatherText()` method that exports metrics in Prometheus text format with filtering support

  ### Motivation

  The previous implementation lacked robustness when collecting telemetry from remote agents:
  - Failures during metric collection could crash the system (using `MustNewConstMetric`)
  - No way to identify which remote agent a metric originated from
  - No mechanism to filter/control which metrics to forward, potentially increasing costs
  - Unsupported metric types were ignored silently without visibility
  - No flexible way to export filtered metrics in text format

  ### Describe how you validated your changes

  - Added comprehensive unit tests for the new metric filtering functionality (`gather_filters_test.go`)
  - Updated existing tests in `services_test.go` to verify the `remote_agent` label is properly added
  - Updated telemetry component tests to validate the new `GatherText()` method with various filters
  - Verified error handling paths with nil checks and proper logging

  ### Additional Notes

  The filtering system includes:
  - `NoFilter`: Includes all metrics (not recommended for production)
  - `StaticMetricFilter`: Allowlist specific metric names
  - `RegexMetricFilter`: Pattern-based filtering
  - `BatchMetricFilter`: Combine multiple filters