### PR TITLE
force install agent package on windows

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -232,7 +232,9 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallFromOldInstaller$"
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallIgnoreMajorMinor$"
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallCurrentWithOldInstallerScript$"
-      - EXTRA_PARAMS: --run "TestInstallScriptWithAgentUser$"
+      - EXTRA_PARAMS: --run "TestInstallScript$/TestReinstallAfterMSIUninstall$"
+      - EXTRA_PARAMS: --run "TestInstallScriptWithAgentUser$/TestInstallScriptWithAgentUser"
+      - EXTRA_PARAMS: --run "TestInstallScriptWithAgentUser$/TestInstallScriptChangesAgentUser$"
       - EXTRA_PARAMS: --run "TestInstallScriptWithAgentUserOnDC$"
       # installer-package
       - EXTRA_PARAMS: --run "TestInstaller$"

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -166,7 +167,12 @@ func (s *Setup) installPackage(name string, url string) (err error) {
 	span.SetTopLevel()
 
 	s.Out.WriteString(fmt.Sprintf("Installing %s...\n", name))
-	err = s.installer.Install(ctx, url, nil)
+	if runtime.GOOS == "windows" && name == DatadogAgentPackage {
+		// TODO(WINA-2018): Add support for skipping the installation of the core Agent if it is already installed
+		err = s.installer.ForceInstall(ctx, url, nil)
+	} else {
+		err = s.installer.Install(ctx, url, nil)
+	}
 	if err != nil {
 		return err
 	}

--- a/releasenotes/notes/windows-setup-forceinstall-agent-278f2058908686db.yaml
+++ b/releasenotes/notes/windows-setup-forceinstall-agent-278f2058908686db.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix regression in 7.72.0 in the install script on Windows (``Install-Datadog.ps1`` and ``datadog-installer-x86_64.exe``) that would not reinstall the Agent if the same version was just uninstalled.
+    Fix regression in 7.72.0 where the install script on Windows (``Install-Datadog.ps1`` and ``datadog-installer-x86_64.exe``) does not reinstall the Agent if the same version was just uninstalled.

--- a/releasenotes/notes/windows-setup-forceinstall-agent-278f2058908686db.yaml
+++ b/releasenotes/notes/windows-setup-forceinstall-agent-278f2058908686db.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix regression in 7.72.0 in the install script on Windows (``Install-Datadog.ps1`` and ``datadog-installer-x86_64.exe``) that would not reinstall the Agent if the same version was just uninstalled.

--- a/test/new-e2e/tests/installer/windows/suites/install-script/agent-user_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/agent-user_test.go
@@ -61,3 +61,10 @@ func (s *testInstallScriptWithAgentUserSuite) TestInstallScriptWithAgentUser() {
 		HasAService("datadogagent").
 		WithIdentity(identity)
 }
+
+// TestInstallScriptChangesAgentUser tests that the install script changes the agent user when the Agent is already installed
+func (s *testInstallScriptWithAgentUserSuite) TestInstallScriptChangesAgentUser() {
+	s.TestInstallScriptWithAgentUser()
+	s.agentUser = s.agentUser + "2"
+	s.TestInstallScriptWithAgentUser()
+}

--- a/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
@@ -7,12 +7,14 @@ package agenttests
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
 type testInstallScriptSuite struct {
@@ -204,4 +206,14 @@ func (s *testInstallScriptSuite) TestInstallCurrentWithOldInstallerScript() {
 			s.Require().Contains(version, s.CurrentAgentVersion().Version())
 		})
 	s.AssertSuccessfulAgentPromoteExperiment(s.CurrentAgentVersion().PackageVersion())
+}
+
+// TestReinstallAfterMSIUninstall tests that the install script can reinstall the agent after MSI uninstallation.
+// This is a regression test for the 7.72.0 issue (WINA-2017) where reinstallation was skipped after uninstall.
+func (s *testInstallScriptSuite) TestReinstallAfterMSIUninstall() {
+	s.installCurrent()
+	s.Require().NoError(windowsAgent.UninstallAgent(s.Env().RemoteHost,
+		filepath.Join(s.SessionOutputDir(), "uninstall.log"),
+	))
+	s.installCurrent()
 }


### PR DESCRIPTION
### What does this PR do?
force run the Agent MSI on Windows in the install script when installing the Agent package

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2017
fix issue that prevented reinstalling the Agent with the install script after uninstalling the same version of the Agent. The installation is skipped because `packages.db` is stale.

### Additional Notes
regression of https://github.com/DataDog/datadog-agent/pull/33600 introduced by https://github.com/DataDog/datadog-agent/pull/40477. `bootstrap` and `setup` have different code paths for installing packages.

https://github.com/DataDog/datadog-agent/pull/42551 (in 7,73+) fixes the uninstall part of the problem because purge removes `packges.db`. But we need to backport to 7.72.x which doesn't have that patch. Plus, we also want to re-run the MSI if the MSI params change. A TODO comment references https://datadoghq.atlassian.net/browse/WINA-2018, to try to enable skipping reinstall if possible

Workaround(s) if needed (choose one):
- Run the Agent MSI instead of the install script
- Delete `C:\ProgramData\Datadog\Installer\packages\packages.db` then re-run the install script