### PR TITLE
[ AGNTLOG-384 ] Shift the logs agent file tailer to a dependency-injected file opener

### DIFF
--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -22,7 +22,9 @@ import (
 	filelauncher "github.com/DataDog/datadog-agent/pkg/logs/launchers/file"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	"github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
 	"github.com/DataDog/datadog-agent/pkg/serverless/streamlogs"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
@@ -65,6 +67,8 @@ func (a *logAgent) SetupPipeline(
 	fileValidatePodContainer := a.config.GetBool("logs_config.validate_pod_container_id")
 	fileScanPeriod := time.Duration(a.config.GetFloat64("logs_config.file_scan_period") * float64(time.Second))
 	fileWildcardSelectionMode := a.config.GetString("logs_config.file_wildcard_selection_mode")
+	fileOpener := opener.NewFileOpener()
+	fingerprinter := file.NewFingerprinter(fingerprintConfig, fileOpener)
 	lnchrs.AddLauncher(filelauncher.NewLauncher(
 		fileLimits,
 		filelauncher.DefaultSleepDuration,
@@ -73,7 +77,9 @@ func (a *logAgent) SetupPipeline(
 		fileWildcardSelectionMode,
 		a.flarecontroller,
 		a.tagger,
-		fingerprintConfig))
+		fileOpener,
+		fingerprinter,
+	))
 	a.schedulers = schedulers.NewSchedulers(a.sources, a.services)
 	a.destinationsCtx = destinationsCtx
 	a.pipelineProvider = pipelineProvider

--- a/comp/logs/agent/agentimpl/analyze_logs_init.go
+++ b/comp/logs/agent/agentimpl/analyze_logs_init.go
@@ -22,6 +22,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
+	"github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
 )
 
 // SetUpLaunchers intializes the launcher. The launchers schedule the tailers to read the log files provided by the analyze-logs command
@@ -45,6 +47,10 @@ func SetUpLaunchers(conf configComponent.Component, sourceProvider *sources.Conf
 	fileValidatePodContainer := pkgconfigsetup.Datadog().GetBool("logs_config.validate_pod_container_id")
 	fileScanPeriod := time.Duration(pkgconfigsetup.Datadog().GetFloat64("logs_config.file_scan_period") * float64(time.Second))
 	fileWildcardSelectionMode := pkgconfigsetup.Datadog().GetString("logs_config.file_wildcard_selection_mode")
+
+	fileOpener := opener.NewFileOpener()
+	fingerprinter := file.NewFingerprinter(*fingerprintConfig, fileOpener)
+
 	fileLauncher := filelauncher.NewLauncher(
 		fileLimits,
 		filelauncher.DefaultSleepDuration,
@@ -53,7 +59,8 @@ func SetUpLaunchers(conf configComponent.Component, sourceProvider *sources.Conf
 		fileWildcardSelectionMode,
 		flare.NewFlareController(),
 		nil,
-		*fingerprintConfig,
+		fileOpener,
+		fingerprinter,
 	)
 	tracker := tailers.NewTailerTracker()
 

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/procfilestats"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -61,8 +62,16 @@ type Launcher struct {
 	filesTailedBetweenScans []*tailer.File
 	// Stores pertinent information about old tailer when rotation occurs and fingerprinting isn't possible
 	oldInfoMap    map[string]*oldTailerInfo
+	fileOpener    opener.FileOpener
 	fingerprinter tailer.Fingerprinter
 }
+
+const (
+	// WildcardModeByName is the default mode and prioritizes files by name in reverse order
+	WildcardModeByName string = "by_name"
+	// WildcardModeByModificationTime prioritizes files by modification time
+	WildcardModeByModificationTime string = "by_modification_time"
+)
 
 type oldTailerInfo struct {
 	Pattern      *regexp.Regexp
@@ -70,13 +79,23 @@ type oldTailerInfo struct {
 }
 
 // NewLauncher returns a new launcher.
-func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePodContainerID bool, scanPeriod time.Duration, wildcardMode string, flarecontroller *flareController.FlareController, tagger tagger.Component, fingerprintConfig types.FingerprintConfig) *Launcher {
+func NewLauncher(
+	tailingLimit int,
+	tailerSleepDuration time.Duration,
+	validatePodContainerID bool,
+	scanPeriod time.Duration,
+	wildcardMode string,
+	flarecontroller *flareController.FlareController,
+	tagger tagger.Component,
+	fileOpener opener.FileOpener,
+	fingerprinter tailer.Fingerprinter,
+) *Launcher {
 
 	var wildcardStrategy fileprovider.WildcardSelectionStrategy
 	switch wildcardMode {
-	case "by_modification_time":
+	case WildcardModeByModificationTime:
 		wildcardStrategy = fileprovider.WildcardUseFileModTime
-	case "by_name":
+	case WildcardModeByName:
 		wildcardStrategy = fileprovider.WildcardUseFileName
 	default:
 		log.Warnf("Unknown wildcard mode specified: %q, defaulting to 'by_name' strategy.", wildcardMode)
@@ -97,7 +116,8 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 		tagger:                 tagger,
 		filesChan:              make(chan []*tailer.File, 1),
 		oldInfoMap:             make(map[string]*oldTailerInfo),
-		fingerprinter:          tailer.NewFingerprinter(fingerprintConfig),
+		fileOpener:             fileOpener,
+		fingerprinter:          fingerprinter,
 	}
 }
 
@@ -468,6 +488,7 @@ func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.Tail
 		Registry:        s.registry,
 		Fingerprint:     fingerprint,
 		Rotated:         true,
+		FileOpener:      s.fileOpener,
 	}
 
 	if fingerprint != nil {
@@ -593,6 +614,7 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 		CapacityMonitor: capacityMonitor,
 		Registry:        s.registry,
 		Fingerprint:     fingerprint,
+		FileOpener:      s.fileOpener,
 	}
 
 	if fingerprint != nil {

--- a/pkg/logs/tailers/file/fingerprint.go
+++ b/pkg/logs/tailers/file/fingerprint.go
@@ -9,10 +9,11 @@ import (
 	"bufio"
 	"hash/crc64"
 	"io"
-	"os"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/opener"
+	"github.com/spf13/afero"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -45,12 +46,14 @@ type Fingerprinter interface {
 // fingerprinterImpl is a struct that contains the fingerprinting configuration
 type fingerprinterImpl struct {
 	globalConfig types.FingerprintConfig
+	fileOpener   opener.FileOpener
 }
 
 // NewFingerprinter creates a new Fingerprinter with the given configuration
-func NewFingerprinter(fingerprintConfig types.FingerprintConfig) Fingerprinter {
+func NewFingerprinter(fingerprintConfig types.FingerprintConfig, opener opener.FileOpener) Fingerprinter {
 	return &fingerprinterImpl{
 		globalConfig: fingerprintConfig,
+		fileOpener:   opener,
 	}
 }
 
@@ -86,7 +89,7 @@ func (f *fingerprinterImpl) ComputeFingerprintFromConfig(filepath string, finger
 	if fingerprintConfig != nil && fingerprintConfig.FingerprintStrategy == types.FingerprintStrategyDisabled {
 		return newInvalidFingerprint(nil), nil
 	}
-	return computeFingerprint(filepath, fingerprintConfig)
+	return f.computeFingerprint(filepath, fingerprintConfig)
 }
 
 // ComputeFingerprint computes the fingerprint for the given file path
@@ -112,21 +115,21 @@ func (f *fingerprinterImpl) ComputeFingerprint(file *File) (*types.Fingerprint, 
 			MaxBytes:            fileFingerprintConfig.MaxBytes,
 		}
 
-		return computeFingerprint(file.Path, fingerprintConfig)
+		return f.computeFingerprint(file.Path, fingerprintConfig)
 	}
 
 	// If per-source config exists but no strategy is set, or no per-source config exists,
 	// fall back to global config
-	return computeFingerprint(file.Path, &f.globalConfig)
+	return f.computeFingerprint(file.Path, &f.globalConfig)
 }
 
 // computeFingerprint computes the fingerprint for the given file path
-func computeFingerprint(filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
+func (f *fingerprinterImpl) computeFingerprint(filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
 	if fingerprintConfig == nil {
 		return newInvalidFingerprint(nil), nil
 	}
 
-	fpFile, err := opener.OpenLogFile(filePath)
+	fpFile, err := f.fileOpener.OpenLogFile(filePath)
 	if err != nil {
 		log.Warnf("could not open file for fingerprinting %s: %v", filePath, err)
 		return newInvalidFingerprint(nil), err
@@ -148,7 +151,7 @@ func computeFingerprint(filePath string, fingerprintConfig *types.FingerprintCon
 }
 
 // computeFingerPrintByBytes computes fingerprint using byte-based approach for a given file path
-func computeFingerPrintByBytes(fpFile *os.File, filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
+func computeFingerPrintByBytes(fpFile afero.File, filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
 	bytesToSkip := fingerprintConfig.CountToSkip
 	maxBytes := fingerprintConfig.Count
 	// Skip the configured number of bytes
@@ -181,7 +184,7 @@ func computeFingerPrintByBytes(fpFile *os.File, filePath string, fingerprintConf
 }
 
 // computeFingerPrintByLines computes fingerprint using line-based approach for a given file path
-func computeFingerPrintByLines(fpFile *os.File, filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
+func computeFingerPrintByLines(fpFile afero.File, filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
 	linesToSkip := fingerprintConfig.CountToSkip
 	maxLines := fingerprintConfig.Count
 	maxBytes := fingerprintConfig.MaxBytes

--- a/pkg/logs/tailers/file/rotate_nix.go
+++ b/pkg/logs/tailers/file/rotate_nix.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/opener"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -23,7 +22,7 @@ import (
 // - removed and recreated
 // - truncated
 func (t *Tailer) DidRotate() (bool, error) {
-	f, err := opener.OpenLogFile(t.fullpath)
+	f, err := t.fileOpener.OpenLogFile(t.fullpath)
 	if err != nil {
 		return false, fmt.Errorf("open %q: %w", t.fullpath, err)
 	}

--- a/pkg/logs/tailers/file/rotate_windows.go
+++ b/pkg/logs/tailers/file/rotate_windows.go
@@ -10,7 +10,6 @@ package file
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -19,7 +18,7 @@ import (
 // On Windows, log rotation is identified by the file size being smaller
 // than the last offset read.
 func (t *Tailer) DidRotate() (bool, error) {
-	f, err := filesystem.OpenShared(t.fullpath)
+	f, err := t.fileOpener.OpenLogFile(t.fullpath)
 	if err != nil {
 		return false, fmt.Errorf("open %q: %w", t.fullpath, err)
 	}

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -18,6 +17,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/benbjohnson/clock"
+	"github.com/spf13/afero"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 	logstypes "github.com/DataDog/datadog-agent/pkg/logs/types"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -59,9 +60,9 @@ type Tailer struct {
 	// fullpath is the absolute path to file.Path.
 	fullpath string
 
-	// osFile is the os.File object from which log data is read.  The read implementation
+	// osFile is the afero.File object from which log data is read.  The read implementation
 	// is platform-specific, and not every platform will have a non-nil value here.
-	osFile *os.File
+	osFile afero.File
 
 	// tags are the tags to be attached to each log message, excluding tags provided
 	// by the tag provider.
@@ -130,6 +131,7 @@ type Tailer struct {
 	fingerprint     *logstypes.Fingerprint
 	registry        auditor.Registry
 	CapacityMonitor *metrics.CapacityMonitor
+	fileOpener      opener.FileOpener
 }
 
 // TailerOptions holds all possible parameters that NewTailer requires in addition to optional parameters that can be optionally passed into. This can be used for more optional parameters if required in future
@@ -144,6 +146,7 @@ type TailerOptions struct {
 	Fingerprint     *logstypes.Fingerprint   //Optional
 	Registry        auditor.Registry         //Required
 	CapacityMonitor *metrics.CapacityMonitor // Required
+	FileOpener      opener.FileOpener        // Required
 }
 
 // NewTailer returns an initialized Tailer, read to be started.
@@ -202,6 +205,7 @@ func NewTailer(opts *TailerOptions) *Tailer {
 		fingerprint:                  opts.Fingerprint,
 		CapacityMonitor:              opts.CapacityMonitor,
 		registry:                     opts.Registry,
+		fileOpener:                   opts.FileOpener,
 	}
 
 	if fileRotated {
@@ -240,6 +244,7 @@ func (t *Tailer) NewRotatedTailer(
 		CapacityMonitor: capacityMonitor,
 		Fingerprint:     fingerprint,
 		Registry:        registry,
+		FileOpener:      t.fileOpener,
 	}
 
 	return NewTailer(options)

--- a/pkg/logs/tailers/file/tailer_nix.go
+++ b/pkg/logs/tailers/file/tailer_nix.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
-	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/opener"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -29,7 +28,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 
 	log.Info("Opening", t.file.Path, "for tailer key", t.file.GetScanKey())
 
-	f, err := opener.OpenLogFile(fullpath)
+	f, err := t.fileOpener.OpenLogFile(fullpath)
 	if err != nil {
 		return err
 	}

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
 )
 
 var chanSize = 10
@@ -43,6 +44,43 @@ type TailerTestSuite struct {
 	source     *sources.ReplaceableSource
 }
 
+// createTailerOptions creates TailerOptions with common defaults.
+// Parameters that vary between tests can be customized via the opts parameter.
+type tailerTestOptions struct {
+	source     *sources.LogSource
+	isWildcard bool
+}
+
+func (suite *TailerTestSuite) createTailerOptions(opts *tailerTestOptions) *TailerOptions {
+	if opts == nil {
+		opts = &tailerTestOptions{}
+	}
+
+	// Default to suite.source if no source provided
+	source := opts.source
+	if source == nil {
+		source = suite.source.UnderlyingSource()
+	}
+
+	sleepDuration := 10 * time.Millisecond
+	info := status.NewInfoRegistry()
+
+	return &TailerOptions{
+		OutputChan:      suite.outputChan,
+		File:            NewFile(suite.testPath, source, opts.isWildcard),
+		SleepDuration:   sleepDuration,
+		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditor.NewMockRegistry(),
+		FileOpener:      opener.NewFileOpener(),
+	}
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(TailerTestSuite))
+}
+
 func (suite *TailerTestSuite) SetupTest() {
 	var err error
 	suite.testDir = suite.T().TempDir()
@@ -57,30 +95,14 @@ func (suite *TailerTestSuite) SetupTest() {
 		Type: config.FileType,
 		Path: suite.testPath,
 	}))
-	sleepDuration := 10 * time.Millisecond
-	info := status.NewInfoRegistry()
 
-	tailerOptions := &TailerOptions{
-		OutputChan:      suite.outputChan,
-		File:            NewFile(suite.testPath, suite.source.UnderlyingSource(), false),
-		SleepDuration:   sleepDuration,
-		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
-		Info:            info,
-		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
-		Registry:        auditor.NewMockRegistry(),
-	}
-
-	suite.tailer = NewTailer(tailerOptions)
+	suite.tailer = NewTailer(suite.createTailerOptions(nil))
 	suite.tailer.closeTimeout = closeTimeout
 }
 
 func (suite *TailerTestSuite) TearDownTest() {
 	suite.tailer.Stop()
 	suite.testFile.Close()
-}
-
-func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m, goleak.IgnoreCurrent())
 }
 
 func (suite *TailerTestSuite) TestStopAfterFileRotationWhenStuck() {
@@ -114,20 +136,8 @@ func (suite *TailerTestSuite) TestTailerTimeDurationConfig() {
 	suite.tailer.StartFromBeginning()
 
 	mockConfig.SetWithoutSource("logs_config.close_timeout", 42)
-	sleepDuration := 10 * time.Millisecond
-	info := status.NewInfoRegistry()
 
-	tailerOptions := &TailerOptions{
-		OutputChan:      suite.outputChan,
-		File:            NewFile(suite.testPath, suite.source.UnderlyingSource(), false),
-		SleepDuration:   sleepDuration,
-		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
-		Info:            info,
-		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
-		Registry:        auditor.NewMockRegistry(),
-	}
-
-	tailer := NewTailer(tailerOptions)
+	tailer := NewTailer(suite.createTailerOptions(nil))
 	tailer.StartFromBeginning()
 
 	suite.Equal(tailer.closeTimeout, time.Duration(42)*time.Second)
@@ -283,20 +293,11 @@ func (suite *TailerTestSuite) TestDirTagWhenTailingFiles() {
 		Type: config.FileType,
 		Path: suite.testPath,
 	})
-	sleepDuration := 10 * time.Millisecond
-	info := status.NewInfoRegistry()
 
-	tailerOptions := &TailerOptions{
-		OutputChan:      suite.outputChan,
-		File:            NewFile(suite.testPath, dirTaggedSource, true),
-		SleepDuration:   sleepDuration,
-		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
-		Info:            info,
-		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
-		Registry:        auditor.NewMockRegistry(),
-	}
-
-	suite.tailer = NewTailer(tailerOptions)
+	suite.tailer = NewTailer(suite.createTailerOptions(&tailerTestOptions{
+		source:     dirTaggedSource,
+		isWildcard: true,
+	}))
 	suite.tailer.StartFromBeginning()
 
 	_, err := suite.testFile.WriteString("foo\n")
@@ -315,20 +316,11 @@ func (suite *TailerTestSuite) TestBuildTagsFileOnly() {
 		Type: config.FileType,
 		Path: suite.testPath,
 	})
-	sleepDuration := 10 * time.Millisecond
-	info := status.NewInfoRegistry()
 
-	tailerOptions := &TailerOptions{
-		OutputChan:      suite.outputChan,
-		File:            NewFile(suite.testPath, dirTaggedSource, false),
-		SleepDuration:   sleepDuration,
-		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
-		Info:            info,
-		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
-		Registry:        auditor.NewMockRegistry(),
-	}
-
-	suite.tailer = NewTailer(tailerOptions)
+	suite.tailer = NewTailer(suite.createTailerOptions(&tailerTestOptions{
+		source:     dirTaggedSource,
+		isWildcard: false,
+	}))
 
 	suite.tailer.StartFromBeginning()
 
@@ -344,20 +336,11 @@ func (suite *TailerTestSuite) TestBuildTagsFileDir() {
 		Type: config.FileType,
 		Path: suite.testPath,
 	})
-	sleepDuration := 10 * time.Millisecond
-	info := status.NewInfoRegistry()
 
-	tailerOptions := &TailerOptions{
-		OutputChan:      suite.outputChan,
-		File:            NewFile(suite.testPath, dirTaggedSource, true),
-		SleepDuration:   sleepDuration,
-		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
-		Info:            info,
-		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
-		Registry:        auditor.NewMockRegistry(),
-	}
-
-	suite.tailer = NewTailer(tailerOptions)
+	suite.tailer = NewTailer(suite.createTailerOptions(&tailerTestOptions{
+		source:     dirTaggedSource,
+		isWildcard: true,
+	}))
 	suite.tailer.StartFromBeginning()
 
 	tags := suite.tailer.buildTailerTags()
@@ -378,20 +361,11 @@ func (suite *TailerTestSuite) TestTruncatedTag() {
 		Type: config.FileType,
 		Path: suite.testPath,
 	})
-	sleepDuration := 10 * time.Millisecond
-	info := status.NewInfoRegistry()
 
-	tailerOptions := &TailerOptions{
-		OutputChan:      suite.outputChan,
-		File:            NewFile(suite.testPath, source, true),
-		SleepDuration:   sleepDuration,
-		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
-		Info:            info,
-		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
-		Registry:        auditor.NewMockRegistry(),
-	}
-
-	suite.tailer = NewTailer(tailerOptions)
+	suite.tailer = NewTailer(suite.createTailerOptions(&tailerTestOptions{
+		source:     source,
+		isWildcard: true,
+	}))
 	suite.tailer.StartFromBeginning()
 
 	_, err := suite.testFile.WriteString("1234\n")
@@ -412,20 +386,9 @@ func (suite *TailerTestSuite) TestMutliLineAutoDetect() {
 	suite.source.Config().AutoMultiLine = &aml
 	suite.source.Config().AutoMultiLineSampleSize = 3
 
-	sleepDuration := 10 * time.Millisecond
-	info := status.NewInfoRegistry()
-
-	tailerOptions := &TailerOptions{
-		OutputChan:      suite.outputChan,
-		File:            NewFile(suite.testPath, suite.source.UnderlyingSource(), true),
-		SleepDuration:   sleepDuration,
-		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
-		Info:            info,
-		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
-		Registry:        auditor.NewMockRegistry(),
-	}
-
-	suite.tailer = NewTailer(tailerOptions)
+	suite.tailer = NewTailer(suite.createTailerOptions(&tailerTestOptions{
+		isWildcard: true,
+	}))
 
 	_, err = suite.testFile.WriteString(lines)
 	suite.Nil(err)
@@ -449,20 +412,7 @@ func (suite *TailerTestSuite) TestMutliLineAutoDetect() {
 func (suite *TailerTestSuite) TestDidRotateNilFullpath() {
 	suite.tailer.StartFromBeginning()
 
-	sleepDuration := 10 * time.Millisecond
-	info := status.NewInfoRegistry()
-
-	tailerOptions := &TailerOptions{
-		OutputChan:      suite.outputChan,
-		File:            NewFile(suite.testPath, suite.source.UnderlyingSource(), false),
-		SleepDuration:   sleepDuration,
-		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
-		Info:            info,
-		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
-		Registry:        auditor.NewMockRegistry(),
-	}
-
-	tailer := NewTailer(tailerOptions)
+	tailer := NewTailer(suite.createTailerOptions(nil))
 	tailer.fullpath = ""
 	tailer.StartFromBeginning()
 
@@ -513,6 +463,7 @@ func TestNoGoLeakWithNonBlockingStop(t *testing.T) {
 		Info:            info,
 		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
+		FileOpener:      opener.NewFileOpener(),
 	}
 
 	tailer := NewTailer(tailerOptions)

--- a/pkg/logs/tailers/file/tailer_windows.go
+++ b/pkg/logs/tailers/file/tailer_windows.go
@@ -13,8 +13,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
-	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -30,7 +31,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 	t.tags = t.buildTailerTags()
 
 	log.Info("Opening ", t.fullpath)
-	f, err := filesystem.OpenShared(t.fullpath)
+	f, err := t.fileOpener.OpenLogFile(t.fullpath)
 	if err != nil {
 		return err
 	}
@@ -55,7 +56,7 @@ func (t *Tailer) readAvailable() (int, error) {
 		return 0, io.EOF
 	}
 
-	var f *os.File
+	var f afero.File
 	defer func() {
 		if f != nil {
 			f.Close()
@@ -66,7 +67,7 @@ func (t *Tailer) readAvailable() (int, error) {
 	for {
 		if f == nil {
 			var err error
-			f, err = filesystem.OpenShared(t.fullpath)
+			f, err = t.fileOpener.OpenLogFile(t.fullpath)
 			if err != nil {
 				return bytes, err
 			}

--- a/pkg/logs/util/opener/open.go
+++ b/pkg/logs/util/opener/open.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package opener provides utilities to open log files with appropriate permissions.
+package opener
+
+import (
+	"github.com/spf13/afero"
+
+	internalOpener "github.com/DataDog/datadog-agent/pkg/logs/internal/util/opener"
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
+)
+
+// FileOpener is an interface that defines the method to open a log file.
+type FileOpener interface {
+	OpenLogFile(path string) (afero.File, error)
+	OpenShared(path string) (afero.File, error)
+}
+
+// NewFileOpener creates a new FileOpener
+func NewFileOpener() FileOpener {
+	return &fileOpenerImpl{}
+}
+
+// fileOpenerImpl is a struct that contains the default file opener implementation
+type fileOpenerImpl struct {
+}
+
+// OpenShared utilizes an os-specific implementation to open a file in a shared mode.
+// On some operating systems, this will involve making an attempt to open the file via a privileged logs client.
+// If the file is not intended to attempt privilege escalation for access (e.g. it is not a log file), then the OpenShared
+// function should be used instead. This will minimize avoidable error logs for failed privilege escalation attempts.
+func (f *fileOpenerImpl) OpenLogFile(path string) (afero.File, error) {
+	return internalOpener.OpenLogFile(path)
+}
+
+// OpenShared utilizes an os-specific implementation to open a file in a shared mode.
+func (f *fileOpenerImpl) OpenShared(path string) (afero.File, error) {
+	return filesystem.OpenShared(path)
+}

--- a/pkg/logs/util/opener/open.go
+++ b/pkg/logs/util/opener/open.go
@@ -28,7 +28,7 @@ func NewFileOpener() FileOpener {
 type fileOpenerImpl struct {
 }
 
-// OpenShared utilizes an os-specific implementation to open a file in a shared mode.
+// OpenLogFile utilizes an os-specific implementation to open a log file in a shared mode.
 // On some operating systems, this will involve making an attempt to open the file via a privileged logs client.
 // If the file is not intended to attempt privilege escalation for access (e.g. it is not a log file), then the OpenShared
 // function should be used instead. This will minimize avoidable error logs for failed privilege escalation attempts.
@@ -36,7 +36,7 @@ func (f *fileOpenerImpl) OpenLogFile(path string) (afero.File, error) {
 	return internalOpener.OpenLogFile(path)
 }
 
-// OpenShared utilizes an os-specific implementation to open a file in a shared mode.
+// OpenShared utilizes an os-specific implementation to open a generic file in a shared mode.
 func (f *fileOpenerImpl) OpenShared(path string) (afero.File, error) {
 	return filesystem.OpenShared(path)
 }


### PR DESCRIPTION
### What does this PR do?
This PR focuses on shifting the file tailer (and by extension the file fingerprinter) over to a mockable file opener entity.
Additional code tweaks include: 
- The two WildcardModes in the file tailer have been added as constants
- Several test suites have modified test component constructors to better facilitate the new dependency injection

There is only one expected change in actual execution logic, which is the move from the fingerprinter to call OpenLogFile instead of OpenShared. This would qualify as a bug fix were the fingerprinting feature released. 

### Motivation
The primary purpose for this change is to better support modularity/mockability in the logs agent

### Describe how you validated your changes

### Additional Notes
