### PR TITLE
[Trace Agent] Add RWMutex to avoid concurrent read and write on span concentrator map

### DIFF
--- a/pkg/trace/stats/stats_test.go
+++ b/pkg/trace/stats/stats_test.go
@@ -1,0 +1,55 @@
+package stats
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrentNewStatSpanWithConfig tests the concurrent creation of StatSpan instances
+// using NewStatSpanWithConfig method of SpanConcentrator to ensure thread safety.
+func TestConcurrentNewStatSpanWithConfig(t *testing.T) {
+	// Initialize a SpanConcentrator
+	sc := NewSpanConcentrator(&SpanConcentratorConfig{
+		ComputeStatsBySpanKind: true,
+		BucketInterval:         int64((10 * time.Second).Nanoseconds()),
+	}, time.Now())
+
+	// Define a base StatSpanConfig to be used in span creation
+	baseCfg := StatSpanConfig{
+		Service:      "svc",
+		Resource:     "res",
+		Name:         "op",
+		Type:         "custom",
+		ParentID:     0,
+		Start:        time.Now().UnixNano(),
+		Duration:     int64(time.Millisecond * 100),
+		Error:        0,
+		Meta:         map[string]string{"span.kind": "client", "peer.service": "backend"},
+		Metrics:      map[string]float64{"_dd.measured": 1},
+		Mutex:        &sync.RWMutex{},
+		PeerTags:     []string{"peer.service", "aws.s3.bucket", "db.instance"},
+		HTTPMethod:   "GET",
+		HTTPEndpoint: "/v1/test",
+	}
+
+	// Launch concurrent span creation to test for race conditions
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 300; j++ {
+				cfg := baseCfg
+				cfg.Service = fmt.Sprintf("service-%d", i)
+				cfg.Resource = fmt.Sprintf("resource-%d", j%10)
+                cfg.Mutex.Lock()
+				cfg.Meta["peer.service"] = fmt.Sprintf("peer-%d", j%5)
+                cfg.Mutex.Unlock()
+				sc.NewStatSpanWithConfig(cfg)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -7,6 +7,7 @@ package stats
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -44,7 +45,22 @@ func TestGrainWithPeerTags(t *testing.T) {
 	sc := &SpanConcentrator{}
 	t.Run("none present", func(t *testing.T) {
 		assert := assert.New(t)
-		s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{"thing", "yo", "other", "", 0, 0, 0, 0, map[string]string{"span.kind": "client"}, map[string]float64{"_dd.measured": 1}, []string{"aws.s3.bucket", "db.instance", "db.system", "peer.service"}, "", ""})
+		s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{
+			Service:      "thing",
+			Resource:     "yo",
+			Name:         "other",
+			Type:         "",
+			ParentID:     0,
+			Start:        0,
+			Duration:     0,
+			Error:        0,
+			Meta:         map[string]string{"span.kind": "client"},
+			Metrics:      map[string]float64{"_dd.measured": 1},
+			Mutex:        &sync.RWMutex{},
+			PeerTags:     []string{"aws.s3.bucket", "db.instance", "db.system", "peer.service"},
+			HTTPMethod:   "",
+			HTTPEndpoint: "",
+		})
 		aggr := NewAggregationFromSpan(s, "", PayloadAggregationKey{
 			Env:         "default",
 			Hostname:    "default",
@@ -74,7 +90,22 @@ func TestGrainWithPeerTags(t *testing.T) {
 					ComputeStatsBySpanKind: spanKindEnabled,
 					BucketInterval:         (time.Duration(10) * time.Second).Nanoseconds(),
 				}, time.Now().Add(-time.Minute))
-				s, _ := sci.NewStatSpanWithConfig(StatSpanConfig{"thing", "yo", "other", "", 0, 0, 0, 0, map[string]string{"span.kind": "client", "server.address": "foo"}, nil, []string{"_dd.base_service", "server.address"}, "", ""})
+				s, _ := sci.NewStatSpanWithConfig(StatSpanConfig{
+					Service:      "thing",
+					Resource:     "yo",
+					Name:         "other",
+					Type:         "",
+					ParentID:     0,
+					Start:        0,
+					Duration:     0,
+					Error:        0,
+					Meta:         map[string]string{"span.kind": "client", "server.address": "foo"},
+					Metrics:      nil,
+					Mutex:        &sync.RWMutex{},
+					PeerTags:     []string{"_dd.base_service", "server.address"},
+					HTTPMethod:   "",
+					HTTPEndpoint: "",
+				})
 				if spanKindEnabled {
 					assert.Equal([]string{"server.address:foo"}, s.matchingPeerTags)
 				} else {
@@ -87,7 +118,22 @@ func TestGrainWithPeerTags(t *testing.T) {
 		for _, spanKind := range []string{"client", "internal"} {
 			t.Run(spanKind, func(t *testing.T) {
 				assert := assert.New(t)
-				s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{"thing", "yo", "other", "", 0, 0, 0, 0, map[string]string{"span.kind": spanKind, "_dd.base_service": "the-real-base", "server.address": "foo"}, map[string]float64{"_dd.measured": 1}, []string{"_dd.base_service", "server.address"}, "", ""})
+				s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{
+					Service:      "thing",
+					Resource:     "yo",
+					Name:         "other",
+					Type:         "",
+					ParentID:     0,
+					Start:        0,
+					Duration:     0,
+					Error:        0,
+					Meta:         map[string]string{"span.kind": spanKind, "_dd.base_service": "the-real-base", "server.address": "foo"},
+					Metrics:      map[string]float64{"_dd.measured": 1},
+					Mutex:        &sync.RWMutex{},
+					PeerTags:     []string{"_dd.base_service", "server.address"},
+					HTTPMethod:   "",
+					HTTPEndpoint: "",
+				})
 				if spanKind == "client" {
 					assert.Equal([]string{"_dd.base_service:the-real-base", "server.address:foo"}, s.matchingPeerTags)
 				} else {
@@ -99,7 +145,22 @@ func TestGrainWithPeerTags(t *testing.T) {
 	t.Run("partially present", func(t *testing.T) {
 		assert := assert.New(t)
 		meta := map[string]string{"span.kind": "client", "peer.service": "aws-s3", "aws.s3.bucket": "bucket-a"}
-		s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{"thing", "yo", "other", "", 0, 0, 0, 0, meta, map[string]float64{"_dd.measured": 1}, []string{"aws.s3.bucket", "db.instance", "db.system", "peer.service"}, "", ""})
+		s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{
+			Service:      "thing",
+			Resource:     "yo",
+			Name:         "other",
+			Type:         "",
+			ParentID:     0,
+			Start:        0,
+			Duration:     0,
+			Error:        0,
+			Meta:         meta,
+			Metrics:      map[string]float64{"_dd.measured": 1},
+			Mutex:        &sync.RWMutex{},
+			PeerTags:     []string{"aws.s3.bucket", "db.instance", "db.system", "peer.service"},
+			HTTPMethod:   "",
+			HTTPEndpoint: "",
+		})
 
 		aggr := NewAggregationFromSpan(s, "", PayloadAggregationKey{
 			Env:         "default",
@@ -126,7 +187,22 @@ func TestGrainWithPeerTags(t *testing.T) {
 	t.Run("peer ip quantization", func(t *testing.T) {
 		assert := assert.New(t)
 		meta := map[string]string{"span.kind": "client", "server.address": "129.49.218.65"}
-		s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{"thing", "yo", "other", "", 0, 0, 0, 0, meta, map[string]float64{"_dd.measured": 1}, []string{"server.address"}, "", ""})
+		s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{
+			Service:      "thing",
+			Resource:     "yo",
+			Name:         "other",
+			Type:         "",
+			ParentID:     0,
+			Start:        0,
+			Duration:     0,
+			Error:        0,
+			Meta:         meta,
+			Metrics:      map[string]float64{"_dd.measured": 1},
+			Mutex:        &sync.RWMutex{},
+			PeerTags:     []string{"server.address"},
+			HTTPMethod:   "",
+			HTTPEndpoint: "",
+		})
 
 		aggr := NewAggregationFromSpan(s, "", PayloadAggregationKey{
 			Env:         "default",
@@ -154,7 +230,22 @@ func TestGrainWithPeerTags(t *testing.T) {
 	t.Run("all present", func(t *testing.T) {
 		assert := assert.New(t)
 		meta := map[string]string{"span.kind": "client", "peer.service": "aws-dynamodb", "db.instance": "dynamo.test.us1", "db.system": "dynamodb"}
-		s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{"thing", "yo", "other", "", 0, 0, 0, 0, meta, map[string]float64{"_dd.measured": 1}, []string{"aws.s3.bucket", "db.instance", "db.system", "peer.service"}, "", ""})
+		s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{
+			Service:      "thing",
+			Resource:     "yo",
+			Name:         "other",
+			Type:         "",
+			ParentID:     0,
+			Start:        0,
+			Duration:     0,
+			Error:        0,
+			Meta:         meta,
+			Metrics:      map[string]float64{"_dd.measured": 1},
+			Mutex:        &sync.RWMutex{},
+			PeerTags:     []string{"aws.s3.bucket", "db.instance", "db.system", "peer.service"},
+			HTTPMethod:   "",
+			HTTPEndpoint: "",
+		})
 
 		aggr := NewAggregationFromSpan(s, "", PayloadAggregationKey{
 			Env:         "default",
@@ -185,7 +276,22 @@ func TestGrainWithSynthetics(t *testing.T) {
 	assert := assert.New(t)
 	sc := &SpanConcentrator{}
 	meta := map[string]string{traceutil.TagStatusCode: "418"}
-	s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{"thing", "yo", "other", "", 0, 0, 0, 0, meta, map[string]float64{"_dd.measured": 1}, nil, "", ""})
+	s, _ := sc.NewStatSpanWithConfig(StatSpanConfig{
+		Service:      "thing",
+		Resource:     "yo",
+		Name:         "other",
+		Type:         "",
+		ParentID:     0,
+		Start:        0,
+		Duration:     0,
+		Error:        0,
+		Meta:         meta,
+		Metrics:      map[string]float64{"_dd.measured": 1},
+		Mutex:        &sync.RWMutex{},
+		PeerTags:     nil,
+		HTTPMethod:   "",
+		HTTPEndpoint: "",
+	})
 
 	aggr := NewAggregationFromSpan(s, "synthetics-browser", PayloadAggregationKey{
 		Hostname:    "host-id",


### PR DESCRIPTION
### What does this PR do?

Add a RWMutex in the `StatSpanConfig` struct to protect the `Metric` and `Meta` map field in order to avoid concurrent read and write on it.

### Motivation

[Customer issue](https://github.com/DataDog/datadog-agent/issues/42628)

### Describe how you validated your changes

Added a test that was crashing because of concurrent read and write and repaired it with the RWMutex.