### PR TITLE
[Backport 7.73.x][ECS] Detect process hostname when deploying as a sidecar in ECS Mana…

### DIFF
--- a/comp/otelcol/collector-contrib/impl/go.mod
+++ b/comp/otelcol/collector-contrib/impl/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
 	github.com/Code-Hex/go-generics-cache v1.5.1 // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.73.0-rc.3 // indirect

--- a/comp/otelcol/collector-contrib/impl/go.sum
+++ b/comp/otelcol/collector-contrib/impl/go.sum
@@ -31,8 +31,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0 h1:bhPu0F6BGUGBaDw4h576asJcffFatYufy8w3/39prqA=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
 	github.com/Code-Hex/go-generics-cache v1.5.1 // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.73.0-rc.3 // indirect

--- a/comp/otelcol/ddflareextension/impl/go.sum
+++ b/comp/otelcol/ddflareextension/impl/go.sum
@@ -36,8 +36,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0 h1:bhPu0F6BGUGBaDw4h576asJcffFatYufy8w3/39prqA=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.73.0-rc.3
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.73.0-rc.3 // indirect

--- a/comp/otelcol/logsagentpipeline/go.sum
+++ b/comp/otelcol/logsagentpipeline/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9 h1:uX4ZqokylxBI67r+AN09CiFY+s8Frmf33YZlyqIMBc4=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9/go.mod h1:QGomve/3EbYfi58jADS97U2OKfsxqh2pWemuT0azbdk=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -30,7 +30,7 @@ require (
 )
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.73.0-rc.3 // indirect

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.sum
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9 h1:uX4ZqokylxBI67r+AN09CiFY+s8Frmf33YZlyqIMBc4=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9/go.mod h1:QGomve/3EbYfi58jADS97U2OKfsxqh2pWemuT0azbdk=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -51,7 +51,7 @@ require (
 )
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.73.0-rc.3 // indirect

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0 h1:bhPu0F6BGUGBaDw4h576asJcffFatYufy8w3/39prqA=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go/v5 v5.8.1 h1:+GOES5W9zpKlhwHptZVW2C0NLVf7ilr7pHkDcbNvpIc=

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -42,7 +42,7 @@ require (
 require go.yaml.in/yaml/v2 v2.4.3 // indirect
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.73.0-rc.3 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0 h1:bhPu0F6BGUGBaDw4h576asJcffFatYufy8w3/39prqA=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go/v5 v5.8.1 h1:+GOES5W9zpKlhwHptZVW2C0NLVf7ilr7pHkDcbNvpIc=

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -52,7 +52,7 @@ require (
 require go.yaml.in/yaml/v2 v2.4.3 // indirect
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.73.0-rc.3 // indirect

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.9.2
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/DataDog/agent-payload/v5 v5.0.172
+	github.com/DataDog/agent-payload/v5 v5.0.174
 	github.com/DataDog/appsec-internal-go v1.14.0
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def v0.73.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/CycloneDX/cyclonedx-go v0.9.2 h1:688QHn2X/5nRezKe2ueIVCt+NRqf7fl3AVQk
 github.com/CycloneDX/cyclonedx-go v0.9.2/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/appsec-internal-go v1.14.0 h1:MIEZ015kdpeSZSFYBQteSmg8f7zkQTWbMDHbSL9zBx8=
 github.com/DataDog/appsec-internal-go v1.14.0/go.mod h1:9YppRCpElfGX+emXOKruShFYsdPq7WEPq/Fen4tYYpk=
 github.com/DataDog/aptly v1.5.3 h1:oLsRvjuXSVM4ia0N83dU3KiQeiJ6BaszYbTZOkSfDlw=

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -24,7 +24,7 @@ require (
 )
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.73.0-rc.3 // indirect

--- a/pkg/logs/pipeline/go.sum
+++ b/pkg/logs/pipeline/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9 h1:uX4ZqokylxBI67r+AN09CiFY+s8Frmf33YZlyqIMBc4=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9/go.mod h1:QGomve/3EbYfi58jADS97U2OKfsxqh2pWemuT0azbdk=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=

--- a/pkg/logs/processor/go.mod
+++ b/pkg/logs/processor/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/logs/processor
 go 1.24.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172
+	github.com/DataDog/agent-payload/v5 v5.0.174
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/model v0.73.0-rc.3

--- a/pkg/logs/processor/go.sum
+++ b/pkg/logs/processor/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9 h1:uX4ZqokylxBI67r+AN09CiFY+s8Frmf33YZlyqIMBc4=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9/go.mod h1:QGomve/3EbYfi58jADS97U2OKfsxqh2pWemuT0azbdk=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/pkg/process/checks/host_info.go
+++ b/pkg/process/checks/host_info.go
@@ -175,6 +175,8 @@ func getContainerHostType() model.ContainerHostType {
 		return model.ContainerHostType_fargateECS
 	case fargate.EKS:
 		return model.ContainerHostType_fargateEKS
+	case fargate.ECSManagedInstances:
+		return model.ContainerHostType_sidecar
 	}
 	return model.ContainerHostType_notSpecified
 }

--- a/pkg/process/util/api/go.mod
+++ b/pkg/process/util/api/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/process/util/api
 go 1.24.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172
+	github.com/DataDog/agent-payload/v5 v5.0.174
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.73.0-rc.3
 	github.com/gogo/protobuf v1.3.2

--- a/pkg/process/util/api/go.sum
+++ b/pkg/process/util/api/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9 h1:uX4ZqokylxBI67r+AN09CiFY+s8Frmf33YZlyqIMBc4=

--- a/pkg/process/util/containers/containers.go
+++ b/pkg/process/util/containers/containers.go
@@ -343,7 +343,7 @@ func computeContainerAddrs(container *workloadmeta.Container) []*model.Container
 
 func convertContainerRuntime(runtime workloadmeta.ContainerRuntime) string {
 	// ECSFargate is special and used to be mapped to "ECS"
-	if runtime == workloadmeta.ContainerRuntimeECSFargate {
+	if runtime == workloadmeta.ContainerRuntimeECSFargate || runtime == workloadmeta.ContainerRuntimeECSManagedInstances {
 		return "ECS"
 	}
 

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/serializer
 go 1.24.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172
+	github.com/DataDog/agent-payload/v5 v5.0.174
 	github.com/DataDog/datadog-agent/comp/core/config v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.73.0-rc.3

--- a/pkg/serializer/go.sum
+++ b/pkg/serializer/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -124,9 +124,9 @@ func newSystemCollector(cache *provider.Cache, wlm option.Option[workloadmeta.Co
 	if env.IsContainerized() {
 		collectors = &provider.Collectors{}
 
-		// When the Agent runs as a sidecar (e.g. Fargate) with shared PID namespace, we can use the system collector in some cases.
+		// When the Agent runs as a sidecar (e.g. Fargate or Managed Instances) with shared PID namespace, we can use the system collector in some cases.
 		// TODO: Check how we could detect shared PID namespace instead of makeing assumption
-		isAgentSidecar := env.IsFeaturePresent(env.ECSFargate) || env.IsFeaturePresent(env.EKSFargate)
+		isAgentSidecar := env.IsFeaturePresent(env.ECSFargate) || env.IsFeaturePresent(env.EKSFargate) || env.IsECSSidecarMode(pkgconfigsetup.Datadog())
 
 		// With sysfs we can always get cgroup stats
 		if env.IsHostSysAvailable() {

--- a/pkg/util/ecs/metadata/clients_nodocker.go
+++ b/pkg/util/ecs/metadata/clients_nodocker.go
@@ -43,3 +43,10 @@ func V2() (*v2.Client, error) {
 func V3orV4FromCurrentTask() (*v3or4.Client, error) {
 	return nil, docker.ErrDockerNotCompiled
 }
+
+// V4FromCurrentTask returns a client for the ECS metadata API v4 by detecting
+// the endpoint address from the task the executable is running in. Returns an
+// error if it was not possible to detect the endpoint address.
+func V4FromCurrentTask() (*v3or4.Client, error) {
+	return nil, docker.ErrDockerNotCompiled
+}

--- a/pkg/util/ecs/metadata/v3or4/client_nodocker.go
+++ b/pkg/util/ecs/metadata/v3or4/client_nodocker.go
@@ -8,5 +8,22 @@
 //nolint:revive // TODO(CINT) Fix revive linter
 package v3or4
 
+import "context"
+
 // Client represents a client for a metadata v3 or v4 API endpoint.
 type Client struct{}
+
+// NewDefaultClient creates a new client for the default metadata v2 API endpoint.
+func NewDefaultClient() *Client {
+	return new(Client)
+}
+
+// GetTask returns the current task.
+func (c *Client) GetTask(context.Context) (*Task, error) {
+	return new(Task), nil
+}
+
+// GetTaskWithTags returns the current task, including propagated resource tags.
+func (c *Client) GetTaskWithTags(context.Context) (*Task, error) {
+	return new(Task), nil
+}

--- a/pkg/util/fargate/detection.go
+++ b/pkg/util/fargate/detection.go
@@ -36,6 +36,9 @@ func GetOrchestrator() OrchestratorName {
 	if env.IsFeaturePresent(env.ECSFargate) {
 		return ECS
 	}
+	if env.IsFeaturePresent(env.ECSManagedInstances) {
+		return ECSManagedInstances
+	}
 	return Unknown
 }
 

--- a/pkg/util/fargate/hostname_process.go
+++ b/pkg/util/fargate/hostname_process.go
@@ -21,11 +21,11 @@ import (
 // - ECS: fargate_task:<TaskARN>
 // - EKS: value of kubernetes_kubelet_nodename
 func GetFargateHost(ctx context.Context) (string, error) {
-	return getFargateHost(ctx, GetOrchestrator(), getECSHost, getEKSHost)
+	return getFargateHost(ctx, GetOrchestrator(), getECSHost, getEKSHost, getECSManagedInstancesHost)
 }
 
 // getFargateHost is separated from GetFargateHost for testing purpose
-func getFargateHost(ctx context.Context, orchestrator OrchestratorName, ecsFunc, eksFunc func(context.Context) (string, error)) (string, error) {
+func getFargateHost(ctx context.Context, orchestrator OrchestratorName, ecsFunc, eksFunc, ecsManagedInstancesFunc func(context.Context) (string, error)) (string, error) {
 	// Fargate should have no concept of host names
 	// we set the hostname depending on the orchestrator
 	switch orchestrator {
@@ -33,6 +33,8 @@ func getFargateHost(ctx context.Context, orchestrator OrchestratorName, ecsFunc,
 		return ecsFunc(ctx)
 	case EKS:
 		return eksFunc(ctx)
+	case ECSManagedInstances:
+		return ecsManagedInstancesFunc(ctx)
 	}
 	return "", errors.New("unknown Fargate orchestrator")
 }
@@ -55,4 +57,18 @@ func getECSHost(ctx context.Context) (string, error) {
 func getEKSHost(context.Context) (string, error) {
 	// Use the node name as hostname
 	return GetEKSFargateNodename()
+}
+
+func getECSManagedInstancesHost(ctx context.Context) (string, error) {
+	client, err := ecsmeta.V4FromCurrentTask()
+	if err != nil {
+		log.Debugf("error while initializing ECS metadata V4 client: %s", err)
+		return "", err
+	}
+
+	taskMeta, err := client.GetTask(ctx)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sidecar_host:%s", taskMeta.TaskARN), nil
 }

--- a/pkg/util/fargate/types.go
+++ b/pkg/util/fargate/types.go
@@ -14,6 +14,8 @@ const (
 	ECS OrchestratorName = "ECS"
 	// EKS represents AWS EKS
 	EKS OrchestratorName = "EKS"
+	// ECSManagedInstances represents AWS ECS Managed Instances
+	ECSManagedInstances OrchestratorName = "ECSManagedInstances"
 	// Unknown is used when we cannot retrieve the orchestrator
 	Unknown OrchestratorName = "Unknown"
 )

--- a/releasenotes/notes/managed-instances-process-host-3dcb30ad94b6efdb.yaml
+++ b/releasenotes/notes/managed-instances-process-host-3dcb30ad94b6efdb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes live process and containers for Agents running as a sidecar in Amazon ECS Managed Instances.

--- a/test/fakeintake/go.mod
+++ b/test/fakeintake/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 // every datadog-agent module replaced in the fakeintake go.mod needs to be copied in the Dockerfile
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172
+	github.com/DataDog/agent-payload/v5 v5.0.174
 	github.com/DataDog/datadog-agent/comp/netflow/payload v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/metrics v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/networkpath/payload v0.73.0-rc.3

--- a/test/fakeintake/go.sum
+++ b/test/fakeintake/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -7,7 +7,7 @@ go 1.24.9
 // TODO: Implement hard check in CI
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172
+	github.com/DataDog/agent-payload/v5 v5.0.174
 	github.com/DataDog/datadog-agent/pkg/util/option v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.73.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.73.0-rc.3

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -4,8 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/appsec-internal-go v1.14.0 h1:MIEZ015kdpeSZSFYBQteSmg8f7zkQTWbMDHbSL9zBx8=
 github.com/DataDog/appsec-internal-go v1.14.0/go.mod h1:9YppRCpElfGX+emXOKruShFYsdPq7WEPq/Fen4tYYpk=
 github.com/DataDog/datadog-api-client-go v1.16.0 h1:5jOZv1m98criCvYTa3qpW8Hzv301nbZX3K9yJtwGyWY=

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -71,7 +71,7 @@ require (
 )
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.172 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.174 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.73.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.73.0-rc.3 // indirect

--- a/test/otel/go.sum
+++ b/test/otel/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.172 h1:GeWUr6O6Ev0JhxiK53ktgK0oDaVpT4zMEJz7+KSjohc=
-github.com/DataDog/agent-payload/v5 v5.0.172/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
+github.com/DataDog/agent-payload/v5 v5.0.174 h1:QKqVOph6VM5jAXDgPeb/7QH3b4cZZNYOhFpDE5FgtEY=
+github.com/DataDog/agent-payload/v5 v5.0.174/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0 h1:bhPu0F6BGUGBaDw4h576asJcffFatYufy8w3/39prqA=
 github.com/DataDog/datadog-api-client-go/v2 v2.47.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go/v5 v5.8.1 h1:+GOES5W9zpKlhwHptZVW2C0NLVf7ilr7pHkDcbNvpIc=


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/commit/f196cbd322f2b6b62c10a44be7af31d86cf140f2 from https://github.com/DataDog/datadog-agent/pull/42461

### What does this PR do?
Fixes hostname detection for the process-component when running on ECS Managed Instances as a sidecar. The agent will set the host to sidecar_host:TASK_ARN and set the container host type to ContainerHostType_sidecar

### Motivation
When deploying as a sidecar in ECS, we don't want process/containers to report with the host tag. Instead, we want the host to be the task. This behavior is consistent with how we handle fargate hosts for process/containers.

### Describe how you validated your changes
- Deployed the datadog agent using image datadog/agent-dev:stzou-exp-74-full into ECS using Managed Instance as launch type with DD_ECS_DEPLOYMENT_MODE=sidecar.
- validated that live process/container data is reported with the proper tagging and hostname.
<img width="400" height="302" alt="image" src="https://github.com/user-attachments/assets/d97e00e5-5467-435f-a13a-416de2f720ea" />