### PR TITLE
Upgrade skaffold configuration

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -16,7 +16,8 @@ deploy:
     releases:
       - name: datadog-agent
         remoteChart: datadog/datadog
-        version: 3.88.1
+        version: 3.141.0
+        # valuesFiles: ["your/custom/datadog-agent/values.yaml"]
         setValueTemplates:
           datadog:
             apiKey: "{{cmd \"bash\" \"-c\" \"echo $DD_API_KEY\"}}"
@@ -37,10 +38,32 @@ deploy:
             tag: "{{.IMAGE_TAG_agent}}"
             doNotCheckTag: true
 profiles:
+  - name: devcontainer
+    activation:
+      - kubeContext: kind
+        command: dev
+        env: "SKAFFOLD_KIND_BUILD_TYPE=devcontainer"
+    requiresAllActivations: true
+    build:
+      artifacts:
+        - image: agent
+          custom:
+            buildCommand: "docker exec -t $DEVENV_CONTAINER_NAME /bin/bash -c \"
+              export DOCKER_DEFAULT_PLATFORM=$DOCKER_DEFAULT_PLATFORM &&
+              cd go/src/github.com/DataDog/datadog-agent &&
+              dda inv agent.hacky-dev-image-build --target-image=$IMAGE_REPO:$IMAGE_TAG\""
+        - image: clusteragent
+          custom:
+            buildCommand: "docker exec -t $DEVENV_CONTAINER_NAME /bin/bash -c \"
+              export DOCKER_DEFAULT_PLATFORM=$DOCKER_DEFAULT_PLATFORM &&
+              cd go/src/github.com/DataDog/datadog-agent &&
+              dda inv cluster-agent.hacky-dev-image-build --target-image=$IMAGE_REPO:$IMAGE_TAG\""
   - name: kind
     activation:
     - kubeContext: kind
       command: dev
+      env: "SKAFFOLD_KIND_BUILD_TYPE=local"
+    requiresAllActivations: true
     build:
       artifacts:
       - image: agent

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -27,6 +27,7 @@ DEVCONTAINER_IMAGE = "registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64"
 
 
 class SkaffoldProfile(Enum):
+    DEVCONTAINER = "devcontainer"
     KIND = "kind"
     MINIKUBE = "minikube"
     NONE = None
@@ -152,7 +153,7 @@ def setup(
 
 def configure_skaffold(devcontainer: dict, profile: SkaffoldProfile):
     match profile:
-        case SkaffoldProfile.KIND:
+        case SkaffoldProfile.KIND | SkaffoldProfile.DEVCONTAINER:
             devcontainer["runArgs"].append("--network=host")  # to connect to the kind api-server
             # add requires extensions
             additional_extensions = ["GoogleCloudTools.cloudcode"]


### PR DESCRIPTION
### What does this PR do?

Skaffold configuration:
- bump helm chart version
- add a new profile to build the agent using the docker-compose based devcontainer
- skaffold has some autobuild system that triggers based on what it found on the running mahcine. This means if you have kind installed and you want 2 different types of build image, you must add some mechanism to differentiate both build systems. In our case we want to have: local (use current running machine), and docker-compose based devcontainer to build the agent.
- Force skaffold to use a profile only if it matches all selectors, using `requiresAllActivations` and an env variable to select which profile the user wants (`SKAFFOLD_KIND_BUILD_TYPE=local` for local builds and `SKAFFOLD_KIND_BUILD_TYPE=devcontainer` for using de docker-compose based builder).
- Upgrade the dda invoke command to use the given profile passed as argument.
- Fix the dda invoke command to use latest cli arguments for skaffold
- Add extra parameters to dda invoke command to pass the profile to be used and disable log tailing.
- Allow users to extend their helm deployement too with a static value file using `valuesFiles`

How to use it ?

run skaffold using docker-compose based agent builder and deploy it on the current local kind cluster
```
dda inv skaffold.dev --profile devcontainer
```

run skaffold using the the local python dda command to build the agent and deploy it on the current local kind cluster
```
dda inv skaffold.dev --profile kind
```

### Motivation

faster local deploy of the agent when developing on the agent.

### Describe how you validated your changes

run the command, and it works.

### Additional Notes

example when using the new devcontainer profile:

```
dda inv skaffold.dev --profile devcontainer
Starting the Skaffold cluster, profile: devcontainer
Generating tags...
 - agent -> agent:e5f195d1ad
 - clusteragent -> clusteragent:e5f195d1ad
Checking cache...
 - agent: Not found. Building
 - clusteragent: Not found. Building
Starting build...
Found [kind-kind-alexandre-lavigne] context, using local docker daemon.
Building 2 artifacts in parallel
Building [clusteragent]...
Target platforms: [linux/arm64]
....
 docker build the agent image
...
#37 exporting to image
#37 exporting layers
#37 exporting layers 0.4s done
#37 writing image sha256:2472f1fc8fde64fc58df07b1dfeefd9781e18c8ff6196e31f7f4073bafc7bebb done
#37 naming to docker.io/library/agent:e5f195d1ad done
#37 DONE 0.4s
Build [agent] succeeded
Tags used in deployment:
 - agent -> agent:2472f1fc8fde64fc58df07b1dfeefd9781e18c8ff6196e31f7f4073bafc7bebb
 - clusteragent -> clusteragent:b4a563b4afbe96bfc12f10057f87fe45679c58ebe2da062f840668902d0dd87c
Starting deploy...
Loading images into kind cluster nodes...
 - agent:2472f1fc8fde64fc58df07b1dfeefd9781e18c8ff6196e31f7f4073bafc7bebb -> Loaded
 - clusteragent:b4a563b4afbe96bfc12f10057f87fe45679c58ebe2da062f840668902d0dd87c -> Loaded
Images loaded in 39.431 seconds
Helm release datadog-agent not installed. Installing...
...
helm install the agent
....
Waiting for deployments to stabilize...
 - datadog-agent-helm:deployment/datadog-agent-cluster-agent: waiting for rollout to finish: 0 of 1 updated replicas are available...
 - datadog-agent-helm:deployment/datadog-agent-cluster-agent is ready.
Deployments stabilized in 31.065 seconds
Listing files to watch...
 - agent
 - clusteragent
Press Ctrl+C to exit
```
