### PR TITLE
Tighten Quality Gates bounds

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "179 MiB"
+      upper_bound: "175 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -56,7 +56,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "497 MiB"
+      upper_bound: "485 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_pss_bytes
-      upper_bound: "205 MiB"
+      upper_bound: "200 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -30,7 +30,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total collector memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: 530 MiB
+      upper_bound: 475 MiB
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."


### PR DESCRIPTION
### What does this PR do?

Follow-up to https://github.com/DataDog/datadog-agent/pull/42699. We now have tighter bounds for each Quality Gate experiment:

* `quality_gate_idle`: 179 MiB -> 175 MiB
* `quality_gate_idle_all_features`: 497 MiB -> 485 MiB
* `quality_gate_logs`: 205 MiB -> 200 MiB
* `quality_gate_metrics_logs`: 530 MiB -> 475 MiB

The last two are especially compelling as they represent improvements for real workloads.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>

