### PR TITLE
feat(assign_issue): Enable manual trigger of the assign issue workflow

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -4,10 +4,16 @@ name: "Assign issue to a team"
 on:
   issues:
     types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to triage'
+        required: true
+        type: number
 
 jobs:
   set_pending_label:
-    if: github.event.issue.state == 'open'
+    if: github.event_name == 'issues' && github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -37,6 +43,36 @@ jobs:
         scope: DataDog/datadog-agent
         policy: self.assign-issue.label-issue
 
+    - name: Get issue details
+      id: get-issue
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      with:
+        github-token: ${{ steps.octo-sts.outputs.token }}
+        script: |
+          let issue;
+          if (context.eventName === 'workflow_dispatch') {
+            // Fetch issue details when manually triggered
+            const issueNumber = ${{ github.event.inputs.issue_number || 'null' }};
+            const response = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            issue = response.data;
+          } else {
+            // Use issue from event payload
+            issue = context.payload.issue;
+          }
+
+          // Set outputs for use in later steps
+          core.setOutput('title', issue.title);
+          core.setOutput('number', issue.number);
+          core.setOutput('author', issue.user.login);
+          core.setOutput('url', issue.html_url);
+          core.setOutput('body', issue.body || '');
+
+          return issue;
+
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -54,13 +90,13 @@ jobs:
           You are an expert triage system for the Datadog Agent repository. Your job is to analyze this GitHub issue and determine which team should handle it. You have full access to the Datadog Agent codebase and can use all available tools to analyze issues.
 
           ## Current Issue
-          **Title:** ${{ github.event.issue.title }}
-          **Number:** #${{ github.event.issue.number }}
-          **Author:** @${{ github.event.issue.user.login }}
-          **URL:** ${{ github.event.issue.url }}
+          **Title:** ${{ steps.get-issue.outputs.title }}
+          **Number:** #${{ steps.get-issue.outputs.number }}
+          **Author:** @${{ steps.get-issue.outputs.author }}
+          **URL:** ${{ steps.get-issue.outputs.url }}
           **Body:**
           ```
-          ${{ github.event.issue.body }}
+          ${{ steps.get-issue.outputs.body }}
           ```
 
           ## Analysis Protocol
@@ -141,12 +177,19 @@ jobs:
         SLACK: ${{ steps.extract-label.outputs.slack }}
         CONFIDENCE: ${{ steps.extract-label.outputs.confidence }}
         EXPLANATION: ${{ steps.extract-label.outputs.explanation }}
+        ISSUE_TITLE: "${{ steps.get-issue.outputs.title }}"
+        ISSUE_NUMBER: "${{ steps.get-issue.outputs.number }}"
+        ISSUE_URL: "${{ steps.get-issue.outputs.url }}"
       with:
         script: |
           const { WebClient } = require('@slack/web-api');
 
-          // Get issue details
-          const issue = context.payload.issue;
+          // Get issue details from environment (works for both event types)
+          const issue = {
+            title: process.env.ISSUE_TITLE,
+            number: process.env.ISSUE_NUMBER,
+            html_url: process.env.ISSUE_URL
+          };
           const teamName = process.env.TEAM;
           const channel = process.env.SLACK;
           const confidence = process.env.CONFIDENCE;


### PR DESCRIPTION
### What does this PR do?
- Enable possibility to trigger the workflow assignment on-demand

### Motivation
Assignation of "past" issues
https://datadoghq.atlassian.net/browse/ACIX-1160

### Describe how you validated your changes
Validated on a personal fork of the agent
- [update](https://github.com/chouetz/datadog-agent/commit/312aa05c38643c82d9f8f0bc5ca6ee0782142bf6)
- [trigger](https://github.com/chouetz/datadog-agent/actions/runs/19107936552)

### Additional Notes
