### PR TITLE
[Backport 7.72.x] [ABLD-284] Prevent `bazel` from linking Objective-C runtime at all

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,7 @@ build:windows --strategy=standalone # Valid values are: [dynamic_worker, standal
 # Disabling them for now.
 build:windows --noexperimental_convenience_symlinks
 
+common:macos --features=-macos_default_link_flags # https://github.com/bazelbuild/bazel/issues/23312
 # Make sure we support the minimum macos version we advertise
 # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 # https://bazel.build/reference/command-line-reference#flag--macos_minimum_os


### PR DESCRIPTION
Backport 0628a7202efa8591b11c754af8fc3a164c5e9daa from #42703.

___
### What does this PR do?
Removes references to the Objective-C runtime **for all macOS targets**:
```diff
--- 7.72.0	2025-11-04 14:08:21.023786737 +0100
+++ 7.74.0-devel	2025-11-04 14:08:22.854384653 +0100
@@ -1,4 +1,7 @@
-$ otool -L 7.70.2/embedded/lib/libz.1.3.1.dylib
-7.70.2/embedded/lib/libz.1.3.1.dylib:
-	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.3.1)
+$ otool -L 7.74.0-devel/embedded/lib/libz.so
+7.74.0-devel/embedded/lib/libz.so:
+	@rpath/libz.so (compatibility version 0.0.0, current version 0.0.0)
+	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
+	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1971.0.0)
+	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```
### Describe how you validated your changes
Verified for both:
- `arm64`: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1215277489
- `x86_64`: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1215277488

```
$ otool -L libz.so
libz.so:
	@rpath/libz.so (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```
### Motivation
We don't need nor plan to use them.

See:
- https://github.com/bazelbuild/bazel/issues/23312
- https://bazel.build/reference/command-line-reference#mod-flag--features
- https://bazel.googlesource.com/bazel/+/d56dc18e1978102e35fbcf92c5d63f9f9eef37cd%5E%21/