### PR TITLE
[Backport 7.72.x] [ABLD-284] Fix filename on macOS: `libz.so`→`libz.dylib`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,13 @@ bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 
+# Temporary until a future rules_pkg release
+git_override(
+    module_name = "rules_pkg",
+    commit = "4eed5466fb7062e196c4fa01495e1dfe0cf5c850",
+    remote = "https://github.com/bazelbuild/rules_pkg",
+)
+
 #########################
 ## Prebuilt binaries   ##
 #########################

--- a/bazel/rules/so_symlink.bzl
+++ b/bazel/rules/so_symlink.bzl
@@ -1,0 +1,59 @@
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "pkg_mklink")
+
+_SPECS = [
+    struct(os = "linux", format = "{}.so{}"),
+    struct(os = "macos", format = "{}{}.dylib"),
+    struct(os = "windows", format = "{}.dll"),
+]
+
+def _gen_targets(base_name, src, libname, version, prefix, spec):
+    name = "{}_{}".format(base_name, spec.os)
+    platform = "@platforms//os:{}".format(spec.os)
+    target = spec.format.format(libname, ".{}".format(version))
+    targets = ["{}_real_name".format(name)]
+    pkg_files(
+        name = targets[-1],
+        srcs = [src],
+        prefix = prefix,
+        renames = {src: target},
+        target_compatible_with = [platform],
+    )
+
+    major = version.partition(".")[0]
+    for link_name, link_version in (("soname", ".{}".format(major)), ("linker_name", "")):
+        link = spec.format.format(libname, link_version)
+        if link == target:
+            continue
+        targets.append("{}_{}".format(name, link_name))
+        pkg_mklink(
+            name = targets[-1],
+            link_name = "{}{}".format(prefix, link),
+            target = target,
+            target_compatible_with = [platform],
+        )
+        target = link
+
+    pkg_filegroup(name = name, srcs = targets, target_compatible_with = [platform])
+    return platform, ":{}".format(name)
+
+def so_symlink(name, src, libname, version, prefix = "lib/"):
+    """Creates shared library symlink chain following Unix conventions.
+
+    Generates the common multilevel symlink hierarchy for shared libraries, for reference:
+    - `real name`: actual file with full version (e.g., libreadline.so.3.0 / libreadline.3.0.dylib)
+    - `soname`: major version symlink, for runtime ABI compatibility (e.g., libreadline.so.3 / libreadline.3.dylib)
+    - `linker name`: unversioned symlink, for development/linking (e.g., libreadline.so / libreadline.dylib)
+
+    See: `Program Library HOWTO` by David Wheeler, https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html
+
+    Args:
+        name: Name of the generated pkg_filegroup
+        src: Label of the cc_shared_library to package
+        libname: Library name without extension (e.g., "libreadline")
+        version: Full version string (e.g., "3.0")
+        prefix: Installation directory prefix (default: "lib/")
+    """
+    native.alias(
+        name = name,
+        actual = select(dict([_gen_targets(name, src, libname, version, prefix, spec) for spec in _SPECS])),
+    )

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -11,7 +11,7 @@ filegroup(
         "@sqlite3",
         "@xz",
         "@xz//:lzma",
-        "@zlib//:libz_so",
+        "@zlib//:z",
     ],
     visibility = ["//visibility:private"],
 )

--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -35,6 +35,7 @@
 
 """Agent specific BUILD file for zlib."""
 
+load("@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
@@ -140,17 +141,17 @@ cc_library(
 )
 
 cc_shared_library(
-    name = "libz_so",
-    shared_lib_name = "libz.so",
+    name = "z",
     win_def_file = "win32/zlib.def",
     deps = [":zlib"],
     visibility = ["//visibility:public"],
 )
 
-pkg_files(
+so_symlink(
     name = "lib_files",
-    srcs = [":libz_so"],
-    prefix = "lib",
+    src = ":z",
+    libname = "libz",
+    version = "1.3.1",
 )
 
 pkg_files(


### PR DESCRIPTION
Backport 0179ca317f5a438886a2c261ee1dac43f2d4939e from #42678.

___

### What does this PR do?
Correct the output filename used when installing `libz` on macOS.

### Motivation
#40965 led to an uncommon installation filename on macOS:
```
Only in 7.70.2/embedded/lib/: libz.1.3.1.dylib
Only in 7.70.2/embedded/lib/: libz.1.dylib
Only in 7.70.2/embedded/lib/: libz.dylib
Only in 7.74.0-devel/embedded/lib/: libz.so
```
... and `soname`:
```diff
--- 7.72.0	2025-11-04 14:08:21.023786737 +0100
+++ 7.74.0-devel	2025-11-04 14:08:22.854384653 +0100
@@ -1,4 +1,7 @@
-$ otool -L 7.70.2/embedded/lib/libz.1.3.1.dylib
-7.70.2/embedded/lib/libz.1.3.1.dylib:
-	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.3.1)
+$ otool -L 7.74.0-devel/embedded/lib/libz.so
+7.74.0-devel/embedded/lib/libz.so:
+	@rpath/libz.so (compatibility version 0.0.0, current version 0.0.0)
+	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
+	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1971.0.0)
+	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

### Describe how you validated your changes
`bazel run @zlib//:install -- --destdir=/tmp/embedded`
Verified for both:
- `arm64`: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1217705216
- `x86_64`: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1217705215

```
$ otool -L libz.1.3.1.dylib
libz.1.3.1.dylib:
	@rpath/libz.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

### Additional Notes
We must backport it to 7.73.x and maybe earlier branch(es).

We should probably review:
- libraries migrated to Bazel that don&#39;t leverage `so_symlink`,
- their `soname`s.