### PR TITLE
fix(assign_issue): Allow non write users

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -46,6 +46,7 @@ jobs:
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         github_token: ${{ steps.octo-sts.outputs.token }}
+        allowed_non_write_users: '*' # If not set the action will always use the event actor permissions.
         claude_args : --allowedTools "Read,Write,Bash(gh issue edit:*)"
         prompt: |
           # Datadog Agent - Intelligent Issue Triage System


### PR DESCRIPTION
### What does this PR do?
Allow non-write users to activate the action.

### Motivation
As stated [here](https://github.com/anthropics/claude-code-action/blob/main/action.yml#L30-L31), we need to activate the `non-write` users permissions for this workflow, as it's meant to be executed on external users issues. Otherwise it [fails](https://github.com/DataDog/datadog-agent/actions/runs/19113298888/job/54615741769) as the action relies on event actor permissions.
As this workflow is only labelling issues, this permission is ok

### Describe how you validated your changes
n/a

### Additional Notes
