### PR TITLE
Allow only agent-delivery to merge to the release branches

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -12,7 +12,7 @@ skip_labels: true
 branches:
   ^7\.[0-9]+\.x$:
     github_teams_restrictions:
-      - agent-supply-chain
+      - agent-delivery
   ^6\.[0-9]+\.x$:
     github_teams_restrictions:
       - agent-supply-chain


### PR DESCRIPTION
### What does this PR do?

Allow only agent-delivery to merge to the release branches. We want only release coordinators to merge backport PRs to the release branches.

### Motivation

Stabilise release process.