### PR TITLE
Add a new kubernetes informer for CRD objects

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -367,6 +367,7 @@ func start(log log.Component,
 
 	ctx := controllers.ControllerContext{
 		InformerFactory:        apiCl.InformerFactory,
+		CRDInformerFactory:     apiCl.CustomResourceDefinitionInformerFactory,
 		DynamicClient:          apiCl.DynamicInformerCl,
 		DynamicInformerFactory: apiCl.DynamicInformerFactory,
 		Client:                 apiCl.InformerCl,

--- a/pkg/util/kubernetes/apiserver/controllers/names.go
+++ b/pkg/util/kubernetes/apiserver/controllers/names.go
@@ -16,9 +16,11 @@ const (
 	autoscalersControllerName controllerName = "autoscalers"
 	servicesControllerName    controllerName = "services"
 	endpointsControllerName   controllerName = "endpoints"
+	crdControllerName         controllerName = "crd"
 )
 
 const (
 	endpointsInformer apiserver.InformerName = "v1/endpoints"
 	servicesInformer  apiserver.InformerName = "v1/services"
+	crdInformer       apiserver.InformerName = "v1/crd"
 )


### PR DESCRIPTION
### What does this PR do?

Add a new informer for all kubernetes objects of from the apiextensions. This object will later be used to be notified when some `CustomResourceDefinitions` are created/updated/deleted.

This will commonly used for 2 dev purposes, introducing it now.

### Motivation

For the coming OKRs we will required being notified on CRD creation/update/deletion.

In order for multiple people to work on their OKRs at the same time and benefit from the provided informer we would like to merge that first.

### Describe how you validated your changes

### Additional Notes

*this has no impact* it's pretty much dead code, until someone, calls the informer to setup dans handlers to be notified.
Otherwise that piece of code is doing nothing and completely harmless.

As well, naming can be discussed, I was not inspired at all.