### PR TITLE
fix(test-infra): Align go.mod and image

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -21,7 +21,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.6-0.20251030085244-f068acd734c6
+	github.com/DataDog/test-infra-definitions v0.0.6-0.20251027095737-d6e5c4066496
 	github.com/aws/aws-sdk-go-v2 v1.39.2
 	github.com/aws/aws-sdk-go-v2/config v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.256.0

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -32,8 +32,8 @@ github.com/DataDog/orchestrion v1.4.0 h1:A1qePK5sZAo1d3VbgPy5vXhlftCMsPbzyxImOuM
 github.com/DataDog/orchestrion v1.4.0/go.mod h1:0xkQCBMS/9mLCExmGlmN0aEwEdStZ8RttapVRQHt518=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=
 github.com/DataDog/sketches-go v1.4.7/go.mod h1:eAmQ/EBmtSO+nQp7IZMZVRPT4BQTmIc5RZQ+deGlTPM=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251030085244-f068acd734c6 h1:w0d0rMnFkSJteUl4retIB0YR9H+uFtJBH+Y3diCnekg=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251030085244-f068acd734c6/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251027095737-d6e5c4066496 h1:ENBSsXDIPnsucsjq9jeaeImxlOxdgygG2N1xktRnBdY=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251027095737-d6e5c4066496/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=


### PR DESCRIPTION
### What does this PR do?
- Update the version of `test-infra-definitions` used in the `go.mod` file of the `test/new-e2e` folder of the repository. The version was currently not aligned with the one of the image defined [here](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/common/test_infra_version.yml#L8)

### Motivation
Tech debt

### Describe how you validated your changes

### Additional Notes
