### PR TITLE
[AGENTRUN-882] Bootstrap systemProbe remoteAgent implementation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -394,6 +394,9 @@
 # trace-agent logging implementation should also notify agent-apm
 /comp/core/log/impl-trace @DataDog/agent-apm
 
+# remoteagent implementation should also notify their respective teams
+/comp/core/remoteagent/impl-systemprobe @DataDog/agent-runtimes @DataDog/ebpf-platform
+
 # pkg
 /pkg/                                   @DataDog/agent-runtimes
 /pkg/api/                               @DataDog/agent-runtimes

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -39,6 +39,7 @@ import (
 	systemprobeloggerfx "github.com/DataDog/datadog-agent/comp/core/log/fx-systemprobe"
 	"github.com/DataDog/datadog-agent/comp/core/pid"
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
+	remoteagentfx "github.com/DataDog/datadog-agent/comp/core/remoteagent/fx-systemprobe"
 	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
@@ -155,6 +156,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				remotehostnameimpl.Module(),
 				configsyncimpl.Module(configsyncimpl.NewParams(configSyncTimeout, true, configSyncTimeout)),
+				remoteagentfx.Module(),
 			)
 		},
 	}

--- a/comp/core/remoteagent/fx-systemprobe/fx.go
+++ b/comp/core/remoteagent/fx-systemprobe/fx.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the remoteagent component
+package fx
+
+import (
+	"go.uber.org/fx"
+
+	remoteagent "github.com/DataDog/datadog-agent/comp/core/remoteagent/def"
+	remoteagentimpl "github.com/DataDog/datadog-agent/comp/core/remoteagent/impl-systemprobe"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			remoteagentimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[remoteagent.Component](),
+
+		// Since no other component depends on remoteagent, we add this dummy invocation to ensure it gets instantiated when the module is used.
+		fx.Invoke(func(_ remoteagent.Component) {}),
+	)
+}

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package systemprobeimpl implements the remoteagent component interface
+package systemprobeimpl
+
+import (
+	"context"
+	"net"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	remoteagent "github.com/DataDog/datadog-agent/comp/core/remoteagent/def"
+	"github.com/DataDog/datadog-agent/comp/core/remoteagent/helper"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+)
+
+// Requires defines the dependencies for the remoteagent component
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+	Log       log.Component
+	IPC       ipc.Component
+	Config    config.Component
+	Telemetry telemetry.Component
+}
+
+// Provides defines the output of the remoteagent component
+type Provides struct {
+	Comp remoteagent.Component
+}
+
+// NewComponent creates a new remoteagent component
+func NewComponent(reqs Requires) (Provides, error) {
+	registryAddress := net.JoinHostPort(reqs.Config.GetString("cmd_host"), reqs.Config.GetString("cmd_port"))
+
+	remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(reqs.IPC, reqs.Log, reqs.Config, reqs.Lifecycle, registryAddress, flavor.GetFlavor(), flavor.GetHumanReadableFlavor())
+	if err != nil {
+		return Provides{}, err
+	}
+
+	remoteagentImpl := &remoteagentImpl{
+		log:               reqs.Log,
+		ipc:               reqs.IPC,
+		cfg:               reqs.Config,
+		telemetry:         reqs.Telemetry,
+		remoteAgentServer: remoteAgentServer,
+	}
+
+	// Add your gRPC services implementations here:
+	pbcore.RegisterTelemetryProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
+
+	provides := Provides{
+		Comp: remoteagentImpl,
+	}
+	return provides, nil
+}
+
+type remoteagentImpl struct {
+	log       log.Component
+	ipc       ipc.Component
+	cfg       config.Component
+	telemetry telemetry.Component
+
+	remoteAgentServer *helper.UnimplementedRemoteAgentServer
+	pbcore.UnimplementedTelemetryProviderServer
+}
+
+func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetryRequest) (*pbcore.GetTelemetryResponse, error) {
+	prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
+	// Add here the metric names that should be included in the telemetry response.
+	// This is useful to avoid sending too many metrics to the Core Agent.
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	return &pbcore.GetTelemetryResponse{
+		Payload: &pbcore.GetTelemetryResponse_PromText{
+			PromText: prometheusText,
+		},
+	}, nil
+}


### PR DESCRIPTION
### What does this PR do?

Bootstraps the system-probe agent with the remote agent component to enable telemetry forwarding to the core agent. This adds the necessary infrastructure for system-probe to register with the core agent and expose a gRPC TelemetryProvider service, initially with an empty metric filter.

### Motivation

This is part of the ongoing effort to standardize telemetry forwarding across all Datadog agent components using the remote agent architecture.

### Describe how you validated your changes
Confirmed metrics are forwarded properly through our internal experimental deployments.

### Additional Notes

- The metric filter in `GetTelemetry()` is currently empty - specific metrics will be added in follow-up PRs once we determine which system-probe metrics should be forwarded
- CODEOWNERS updated to ensure proper team oversight of the system-probe remote agent implementation