### PR TITLE
Improve skaffold config to deploy agent on local kind cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,9 @@ test/fakeintake/build/*
 # dev container
 .devcontainer/
 
+# skaffold
+.skaffold/values.yaml
+
 # Allow Single Machine Performance material to ignore excludes
 !test/regression/**
 !test/workload-checks/**

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -16,6 +16,8 @@ deploy:
     releases:
       - name: datadog-agent
         remoteChart: datadog/datadog
+        valuesFiles: [".skaffold/values.yaml"]
+        namespace: "datadog-agent-helm"
         setValueTemplates:
           datadog:
             apiKey: "{{cmd \"bash\" \"-c\" \"echo $DD_API_KEY\"}}"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -18,6 +18,7 @@ deploy:
         remoteChart: datadog/datadog
         valuesFiles: [".skaffold/values.yaml"]
         namespace: "datadog-agent-helm"
+        createNamespace: true
         setValueTemplates:
           datadog:
             apiKey: "{{cmd \"bash\" \"-c\" \"echo $DD_API_KEY\"}}"

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -132,6 +132,13 @@ def setup(
     configure_skaffold(devcontainer, SkaffoldProfile(skaffoldProfile))
     configure_claude_code(devcontainer, claude_code)
 
+    # Skaffold helm deployement will include '.skaffold/values.yaml'
+    # so it must at least exists, it can be empty or filled by the user
+    if skaffoldProfile is not None:
+        helm_values = Path(".skaffold/values.yaml")
+        if not helm_values.exists():
+            helm_values.touch()
+
     # Add per user configuration
     user_config_path = Path.home() / ".devcontainer" / "agent_overrides.json"
     if os.path.exists(user_config_path):


### PR DESCRIPTION
- Bumped the version of helm chart used to deploy datadog-agent
- Remove invalid options in `skaffold` call
- Add helper to dda command and options:
  - disabled log trailling, it shows logs for all containers from all pods mixed together, can't really read it.
  - allow users to change log level for skaffold
- Allow users to extend helm values with a `value.yaml` file. That file can't be commited, and an example is provided for convenience.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
