### PR TITLE
[OTAGENT-655] Remove unused sync timeout parameters from host profiler

### DIFF
--- a/cmd/host-profiler/subcommands/run/command.go
+++ b/cmd/host-profiler/subcommands/run/command.go
@@ -10,7 +10,6 @@ package run
 
 import (
 	"context"
-	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -19,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/host-profiler/globalparams"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
@@ -46,9 +44,7 @@ import (
 
 type cliParams struct {
 	*globalparams.GlobalParams
-	SyncTimeout       time.Duration
-	SyncOnInitTimeout time.Duration
-	GoRuntimeMetrics  bool
+	GoRuntimeMetrics bool
 }
 
 // MakeCommand creates the `run` command
@@ -64,8 +60,6 @@ func MakeCommand(globalConfGetter func() *globalparams.GlobalParams) []*cobra.Co
 			return runHostProfilerCommand(context.Background(), params)
 		},
 	}
-	cmd.Flags().DurationVar(&params.SyncTimeout, "sync-timeout", 3*time.Second, "Timeout for config sync requests.")
-	cmd.Flags().DurationVar(&params.SyncOnInitTimeout, "sync-on-init-timeout", 0, "How long should config sync retry at initialization before failing.")
 	cmd.Flags().BoolVar(&params.GoRuntimeMetrics, "go-runtime-metrics", false, "Enable Go runtime metrics collection.")
 	return []*cobra.Command{cmd}
 }
@@ -85,7 +79,7 @@ func runHostProfilerCommand(ctx context.Context, cliParams *cliParams) error {
 			}),
 			fx.Provide(collectorimpl.NewExtraFactoriesWithAgentCore),
 		)
-		opts = append(opts, getRemoteTaggerOptions(cliParams)...)
+		opts = append(opts, getRemoteTaggerOptions()...)
 		opts = append(opts, getTraceAgentOptions(ctx)...)
 
 	} else {
@@ -99,12 +93,11 @@ func run(collector collector.Component) error {
 	return collector.Run()
 }
 
-func getRemoteTaggerOptions(cliParams *cliParams) []fx.Option {
+func getRemoteTaggerOptions() []fx.Option {
 	return []fx.Option{
 		ipcfx.ModuleReadOnly(),
 		secretfx.Module(),
 		remoteTaggerFx.Module(tagger.NewRemoteParams()),
-		configsyncimpl.Module(configsyncimpl.NewParams(cliParams.SyncTimeout, true, cliParams.SyncOnInitTimeout)),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Removes the unused `--sync-timeout` and `--sync-on-init-timeout` CLI flags from the host profiler, along with their associated configuration sync module initialization.

### Motivation

These parameters were not being utilized and could be hardcoded internally if needed. Simplifying the CLI interface reduces configuration complexity.

### Describe how you validated your changes

- Existing unit tests pass
- Verified that the host profiler command builds successfully without these parameters

### Additional Notes

Closes OTAGENT-655