### PR TITLE
Fix full-host-profiler binary path in README

### DIFF
--- a/cmd/host-profiler/README.md
+++ b/cmd/host-profiler/README.md
@@ -58,14 +58,14 @@ dda inv full-host-profiler.build
 
 ```bash
 # Standalone mode
-./bin/host-profiler/host-profiler run -c cmd/host-profiler/dist/host-profiler-config.yaml
+./bin/full-host-profiler/full-host-profiler run -c cmd/host-profiler/dist/host-profiler-config.yaml
 
 # Agent-integrated mode
 # First, start the Datadog Agent
 ./bin/agent/agent run -c ./dev/dist
 
 # Then, in another terminal, start the host-profiler with Agent integration
-./bin/host-profiler/host-profiler run \
+./bin/full-host-profiler/full-host-profiler run \
   -c cmd/host-profiler/dist/host-profiler-config.yaml \
   --core-config ./dev/dist/datadog.yaml
 ```


### PR DESCRIPTION
### What does this PR do?

Fixes the incorrect binary path in the host-profiler README. The binary is built as `full-host-profiler` but the documentation referenced `host-profiler`.

### Motivation

The run command in the README was using the wrong binary path (`./bin/host-profiler/host-profiler`), which would fail for users trying to run the full-host-profiler. The correct path is `./bin/full-host-profiler/full-host-profiler`.

### Describe how you validated your changes

Verified the correct binary path matches the build output directory structure.

### Additional Notes

This is a documentation-only change.