### PR TITLE
[Backport 7.73.x] When detecting CCRID, log only once, and don't worry about k8s

### DIFF
--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -143,7 +143,7 @@ func GetHostAliases(ctx context.Context) ([]string, string) {
 
 	for _, hostAliasesDetector := range hostAliasesDetectors {
 		wg.Add(1)
-		go func(cloudAliasesDetector cloudProviderAliasesDetector) {
+		go func(hostAliasesDetector cloudProviderAliasesDetector) {
 			defer wg.Done()
 
 			cloudAliases, err := hostAliasesDetector.callback(ctx)

--- a/pkg/util/cloudproviders/cloudproviders_test.go
+++ b/pkg/util/cloudproviders/cloudproviders_test.go
@@ -27,21 +27,24 @@ func TestCloudProviderAliases(t *testing.T) {
 
 	hostAliasesDetectors = []cloudProviderAliasesDetector{
 		{
-			name: "detector1",
+			name:       "detector1",
+			isCloudEnv: true,
 			callback: func(_ context.Context) ([]string, error) {
 				detector1Called = true
 				return []string{"alias2"}, nil
 			},
 		},
 		{
-			name: "detector2",
+			name:       "detector2",
+			isCloudEnv: true,
 			callback: func(_ context.Context) ([]string, error) {
 				detector2Called = true
 				return nil, fmt.Errorf("error from detector2")
 			},
 		},
 		{
-			name: "detector3",
+			name:       "detector3",
+			isCloudEnv: true,
 			callback: func(_ context.Context) ([]string, error) {
 				detector3Called = true
 				return []string{"alias1", "alias2"}, nil


### PR DESCRIPTION
### What does this PR do?

Change cloudprovider detection so that it only logs about an ambiguous cloud detector if multiple actual cloud environments are detected.

### Motivation

1. When a cloud env is detected, and so is kubernetes, no need to log about it. Only log if 2 different cloud environments are detected.
2. Only need to log about this once, not every time the host payload is sent.

### Describe how you validated your changes

Manually ran.

### Additional Notes
(cherry picked from commit bb4d3a2)