### PR TITLE
[ AGNTLOG-328 ] Fortify the windows fingerprint functionality to help prevent log duplication

### DIFF
--- a/pkg/logs/internal/decoder/decoder_mock.go
+++ b/pkg/logs/internal/decoder/decoder_mock.go
@@ -53,10 +53,27 @@ func (d *MockDecoder) GetLineCount() int64 {
 	return 0
 }
 
+// MockDecoderOptions are the options for creating a mock decoder
+type MockDecoderOptions struct {
+	InputChanSize  int
+	OutputChanSize int
+}
+
+// NewMockDecoderWithOptions creates a new mock decoder with the given options
+func NewMockDecoderWithOptions(options *MockDecoderOptions) *MockDecoder {
+	if options == nil {
+		return NewMockDecoder()
+	}
+	return &MockDecoder{
+		inputChan:  make(chan *message.Message, options.InputChanSize),
+		outputChan: make(chan *message.Message, options.OutputChanSize),
+	}
+}
+
 // NewMockDecoder creates a new mock decoder
 func NewMockDecoder() *MockDecoder {
 	return &MockDecoder{
-		inputChan:  make(chan *message.Message),
-		outputChan: make(chan *message.Message),
+		inputChan:  make(chan *message.Message, 10),
+		outputChan: make(chan *message.Message, 10),
 	}
 }

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -487,6 +487,7 @@ func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.Tail
 		CapacityMonitor: monitor,
 		Registry:        s.registry,
 		Fingerprint:     fingerprint,
+		Fingerprinter:   s.fingerprinter,
 		Rotated:         true,
 		FileOpener:      s.fileOpener,
 	}
@@ -614,6 +615,7 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 		CapacityMonitor: capacityMonitor,
 		Registry:        s.registry,
 		Fingerprint:     fingerprint,
+		Fingerprinter:   s.fingerprinter,
 		FileOpener:      s.fileOpener,
 	}
 
@@ -634,7 +636,7 @@ func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, patt
 	} else {
 		log.Debugf("Creating new tailer for %s with no fingerprint", file.Path)
 	}
-	return t.NewRotatedTailer(file, channel, monitor, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo, s.tagger, fingerprint, s.registry)
+	return t.NewRotatedTailer(file, channel, monitor, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo, s.tagger, fingerprint, s.fingerprinter, s.registry)
 }
 
 // CheckProcessTelemetry checks process file statistics and logs warnings about file handle usage

--- a/pkg/logs/tailers/file/fingerprint_mock.go
+++ b/pkg/logs/tailers/file/fingerprint_mock.go
@@ -35,7 +35,6 @@ type fingerprintStore struct {
 }
 
 func (f *fingerprintStore) Next() *types.Fingerprint {
-	fmt.Println("Next", f.idx, len(f.fingerprints))
 	if len(f.fingerprints) == 0 {
 		return newInvalidFingerprint(nil)
 	}

--- a/pkg/logs/tailers/file/fingerprint_mock.go
+++ b/pkg/logs/tailers/file/fingerprint_mock.go
@@ -10,21 +10,41 @@ package file
 import (
 	"fmt"
 
+	"github.com/spf13/afero"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
 )
 
 // FingerprinterMock is a mock implementation of the Fingerprinter interface
 type FingerprinterMock struct {
 	shouldFileFingerprint map[string]bool
-	fingerprints          map[string]*types.Fingerprint
+	fingerprints          map[string]*fingerprintStore
 }
 
 // NewFingerprinterMock creates a new FingerprintMock
 func NewFingerprinterMock() *FingerprinterMock {
 	return &FingerprinterMock{
 		shouldFileFingerprint: make(map[string]bool),
-		fingerprints:          make(map[string]*types.Fingerprint),
+		fingerprints:          make(map[string]*fingerprintStore),
 	}
+}
+
+type fingerprintStore struct {
+	idx          int
+	fingerprints []*types.Fingerprint
+}
+
+func (f *fingerprintStore) Next() *types.Fingerprint {
+	fmt.Println("Next", f.idx, len(f.fingerprints))
+	if len(f.fingerprints) == 0 {
+		return newInvalidFingerprint(nil)
+	}
+	if f.idx >= len(f.fingerprints) {
+		return f.fingerprints[len(f.fingerprints)-1]
+	}
+	fingerprint := f.fingerprints[f.idx]
+	f.idx++
+	return fingerprint
 }
 
 // SetShouldFileFingerprint sets whether or not the given file should be fingerprinted
@@ -40,27 +60,47 @@ func (f *FingerprinterMock) ShouldFileFingerprint(file *File) bool {
 // SetFingerprint sets the fingerprint for the given file
 func (f *FingerprinterMock) SetFingerprint(filepath string, fingerprint *types.Fingerprint) {
 	f.shouldFileFingerprint[filepath] = true
-	f.fingerprints[filepath] = fingerprint
+	f.fingerprints[filepath] = &fingerprintStore{
+		fingerprints: []*types.Fingerprint{fingerprint},
+	}
 }
 
 // SetInvalidFingerprint sets an invalid fingerprint for the given file
 func (f *FingerprinterMock) SetInvalidFingerprint(filepath string) {
 	f.shouldFileFingerprint[filepath] = true
-	f.fingerprints[filepath] = &types.Fingerprint{Value: types.InvalidFingerprintValue, Config: nil}
+	f.fingerprints[filepath] = &fingerprintStore{
+		fingerprints: []*types.Fingerprint{newInvalidFingerprint(nil)},
+	}
+}
+
+// SetSequence sets a sequence of fingerprints for the given file
+func (f *FingerprinterMock) SetSequence(filepath string, fingerprints ...*types.Fingerprint) {
+	f.shouldFileFingerprint[filepath] = true
+	f.fingerprints[filepath] = &fingerprintStore{
+		fingerprints: fingerprints,
+	}
 }
 
 // ComputeFingerprint returns previously set fingerprint for the given file, or an error if no fingerprint was set
 func (f *FingerprinterMock) ComputeFingerprint(file *File) (*types.Fingerprint, error) {
-	if fingerprint, ok := f.fingerprints[file.Path]; ok {
-		return fingerprint, nil
+	if store, ok := f.fingerprints[file.Path]; ok {
+		return store.Next(), nil
 	}
 	return nil, fmt.Errorf("no fingerprint set for file %s", file.Path)
 }
 
 // ComputeFingerprintFromConfig returns previously set fingerprint for the given file path, or an error if no fingerprint was set
 func (f *FingerprinterMock) ComputeFingerprintFromConfig(filepath string, _ *types.FingerprintConfig) (*types.Fingerprint, error) {
-	if fingerprint, ok := f.fingerprints[filepath]; ok {
-		return fingerprint, nil
+	if store, ok := f.fingerprints[filepath]; ok {
+		return store.Next(), nil
 	}
 	return nil, fmt.Errorf("no fingerprint set for file %s", filepath)
+}
+
+// ComputeFingerprintFromHandle returns previously set fingerprint for the given File, or an error if no fingerprint was set
+func (f *FingerprinterMock) ComputeFingerprintFromHandle(osFile afero.File, _ *types.FingerprintConfig) (*types.Fingerprint, error) {
+	if store, ok := f.fingerprints[osFile.Name()]; ok {
+		return store.Next(), nil
+	}
+	return nil, fmt.Errorf("no fingerprint set for file %s", osFile.Name())
 }

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -129,6 +129,7 @@ type Tailer struct {
 	bytesRead       *status.CountInfo
 	movingSum       *util.MovingSum
 	fingerprint     *logstypes.Fingerprint
+	fingerprinter   Fingerprinter
 	registry        auditor.Registry
 	CapacityMonitor *metrics.CapacityMonitor
 	fileOpener      opener.FileOpener
@@ -143,8 +144,9 @@ type TailerOptions struct {
 	Info            *status.InfoRegistry     // Required
 	Rotated         bool                     // Optional
 	TagAdder        tag.EntityTagAdder       // Required
-	Fingerprint     *logstypes.Fingerprint   //Optional
-	Registry        auditor.Registry         //Required
+	Fingerprint     *logstypes.Fingerprint   // Optional
+	Fingerprinter   Fingerprinter            // Required
+	Registry        auditor.Registry         // Required
 	CapacityMonitor *metrics.CapacityMonitor // Required
 	FileOpener      opener.FileOpener        // Required
 }
@@ -203,6 +205,7 @@ func NewTailer(opts *TailerOptions) *Tailer {
 		bytesRead:                    bytesRead,
 		movingSum:                    movingSum,
 		fingerprint:                  opts.Fingerprint,
+		fingerprinter:                opts.Fingerprinter,
 		CapacityMonitor:              opts.CapacityMonitor,
 		registry:                     opts.Registry,
 		fileOpener:                   opts.FileOpener,
@@ -231,6 +234,7 @@ func (t *Tailer) NewRotatedTailer(
 	info *status.InfoRegistry,
 	tagAdder tag.EntityTagAdder,
 	fingerprint *logstypes.Fingerprint,
+	fingerprinter Fingerprinter,
 	registry auditor.Registry,
 ) *Tailer {
 	options := &TailerOptions{
@@ -243,6 +247,7 @@ func (t *Tailer) NewRotatedTailer(
 		TagAdder:        tagAdder,
 		CapacityMonitor: capacityMonitor,
 		Fingerprint:     fingerprint,
+		Fingerprinter:   fingerprinter,
 		Registry:        registry,
 		FileOpener:      t.fileOpener,
 	}

--- a/pkg/logs/tailers/file/tailer_windows.go
+++ b/pkg/logs/tailers/file/tailer_windows.go
@@ -10,7 +10,6 @@ package file
 import (
 	"io"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/spf13/afero"
@@ -21,7 +20,7 @@ import (
 
 // setup sets up the file tailer
 func (t *Tailer) setup(offset int64, whence int) error {
-	fullpath, err := filepath.Abs(t.file.Path)
+	fullpath, err := t.fileOpener.Abs(t.file.Path)
 	if err != nil {
 		return err
 	}
@@ -81,7 +80,20 @@ func (t *Tailer) readAvailable() (int, error) {
 			offset := t.lastReadOffset.Load()
 			if sz < offset {
 				log.Debugf("File size of %s is shorter than last read offset; returning EOF", t.fullpath)
+				t.didFileRotate.Store(true)
 				return bytes, io.EOF
+			}
+
+			if t.fingerprint != nil {
+				currentFingerprint, err := t.fingerprinter.ComputeFingerprintFromHandle(f, t.fingerprint.Config)
+				if err != nil {
+					return bytes, err
+				}
+				if !currentFingerprint.Equals(t.fingerprint) {
+					log.Infof("Fingerprint mismatch detected mid read, file %s has rotated", t.fullpath)
+					t.didFileRotate.Store(true)
+					return bytes, io.EOF
+				}
 			}
 
 			_, err = f.Seek(offset, io.SeekStart)

--- a/pkg/logs/tailers/file/tailer_windows_test.go
+++ b/pkg/logs/tailers/file/tailer_windows_test.go
@@ -102,7 +102,6 @@ func TestReadAvailableRotation(t *testing.T) {
 	tailer, _ := newTestTailer(t, mockFile.Name(), nil, nil, opener, mockDecoderOptions)
 	tailer.windowsOpenFileTimeout = 0
 	go func() {
-		time.Sleep(10 * time.Millisecond)
 		<-tailer.decoder.InputChan()
 		<-tailer.decoder.InputChan()
 		tailer.decoder.Start()
@@ -171,7 +170,6 @@ func TestReadAvailableFingerprintMismatchMidRead(t *testing.T) {
 	tailer.fingerprint = originalFingerprint
 	tailer.windowsOpenFileTimeout = 0
 	go func() {
-		time.Sleep(10 * time.Millisecond)
 		<-tailer.decoder.InputChan()
 		tailer.decoder.Start()
 	}()

--- a/pkg/logs/tailers/file/tailer_windows_test.go
+++ b/pkg/logs/tailers/file/tailer_windows_test.go
@@ -1,0 +1,182 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test && windows
+
+package file
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+	"github.com/DataDog/datadog-agent/pkg/logs/types"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
+)
+
+// newTestTailer creates a tailer configured similarly to suite setup in tailer_test.go
+// but without starting readForever; it allows direct calls to readAvailable.
+func newTestTailer(t *testing.T, testPath string, fingerprint *types.Fingerprint, fingerprinter Fingerprinter, opener opener.FileOpener, decoderOptions *decoder.MockDecoderOptions) (*Tailer, chan *message.Message) {
+	t.Helper()
+
+	outputChan := make(chan *message.Message, 20)
+	source := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type: config.FileType,
+		Path: testPath,
+	}))
+	sleepDuration := 1 * time.Millisecond
+	info := status.NewInfoRegistry()
+
+	decoder := decoder.NewMockDecoderWithOptions(decoderOptions)
+
+	tailerOptions := &TailerOptions{
+		OutputChan:      outputChan,
+		Decoder:         decoder,
+		File:            NewFile(testPath, source.UnderlyingSource(), false),
+		SleepDuration:   sleepDuration,
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditor.NewMockRegistry(),
+		Fingerprint:     fingerprint,
+		Fingerprinter:   fingerprinter,
+		FileOpener:      opener,
+	}
+
+	tailer := NewTailer(tailerOptions)
+	tailer.setup(0, io.SeekStart)
+
+	return tailer, outputChan
+}
+
+func TestReadAvailable(t *testing.T) {
+	mockFile := opener.NewMockFile("test.log", [][]byte{
+		[]byte("one\ntwo\n"),
+		[]byte("three\nfour\n"),
+	})
+
+	opener := opener.NewMockFileOpener()
+	opener.AddMockFile(mockFile)
+
+	fingerprinterMock := NewFingerprinterMock()
+	tailer, _ := newTestTailer(t, mockFile.Name(), nil, fingerprinterMock, opener, nil)
+	n, err := tailer.readAvailable()
+	assert.ErrorIs(t, err, io.EOF, "Expected EOF, got %v", err)
+	assert.Equal(t, mockFile.FileSize(), n, "Expected to have read the entire file of %d bytes, got %d", mockFile.FileSize(), n)
+
+	assert.Equal(t, 2, len(tailer.decoder.InputChan()), "Expected 2 messages to have been decoded")
+}
+
+func TestReadAvailableRotation(t *testing.T) {
+	mockFile := opener.NewMockFile(
+		"test.log",
+		[][]byte{
+			[]byte("one\ntwo\n"),
+			[]byte("three\nfour\n"),
+		},
+		[][]byte{
+			[]byte("five\nsix\n"),
+		},
+	)
+
+	firstFileSize := mockFile.FileSize()
+
+	opener := opener.NewMockFileOpener()
+	opener.AddMockFile(mockFile)
+
+	mockDecoderOptions := &decoder.MockDecoderOptions{
+		InputChanSize:  0,
+		OutputChanSize: 0,
+	}
+
+	tailer, _ := newTestTailer(t, mockFile.Name(), nil, nil, opener, mockDecoderOptions)
+	tailer.windowsOpenFileTimeout = 0
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		<-tailer.decoder.InputChan()
+		<-tailer.decoder.InputChan()
+		tailer.decoder.Start()
+	}()
+	n, err := tailer.readAvailable()
+	assert.ErrorIs(t, err, io.EOF, "Expected EOF, got %v", err)
+	assert.Equal(t, firstFileSize, n, "Expected to have read the first file of %d bytes, got %d", firstFileSize, n)
+	assert.Equal(t, true, tailer.didFileRotate.Load(), "Expected file to have rotated")
+}
+func TestReadAvailableFingerprintMismatch(t *testing.T) {
+	mockFile := opener.NewMockFile(
+		"test.log",
+		[][]byte{
+			[]byte("one\ntwo\n"),
+			[]byte("three\nfour\n"),
+		},
+	)
+	opener := opener.NewMockFileOpener()
+	opener.AddMockFile(mockFile)
+
+	originalFingerprint := &types.Fingerprint{Value: 1234567890, Config: nil}
+	fingerprinterMock := NewFingerprinterMock()
+	fingerprinterMock.SetSequence(
+		mockFile.Name(),
+		&types.Fingerprint{Value: 6789012345, Config: nil}, // Different fingerprint from original
+	)
+
+	tailer, _ := newTestTailer(t, mockFile.Name(), nil, fingerprinterMock, opener, nil)
+	tailer.fingerprint = originalFingerprint
+	n, err := tailer.readAvailable()
+
+	assert.ErrorIs(t, err, io.EOF, "Expected EOF, got %v", err)
+	assert.Equal(t, 0, n, "Expected 0 bytes read, got %d", n)
+	assert.Equal(t, true, tailer.didFileRotate.Load(), "Expected file to have rotated")
+}
+
+func TestReadAvailableFingerprintMismatchMidRead(t *testing.T) {
+	firstLine := []byte("one\ntwo\n")
+	mockFile := opener.NewMockFile(
+		"test.log",
+		[][]byte{
+			firstLine,
+			[]byte("three\nfour\n"),
+		},
+	)
+
+	firstLineSize := len(firstLine)
+
+	opener := opener.NewMockFileOpener()
+	opener.AddMockFile(mockFile)
+
+	originalFingerprint := &types.Fingerprint{Value: 1234567890, Config: nil}
+	fingerprinterMock := NewFingerprinterMock()
+	fingerprinterMock.SetSequence(
+		mockFile.Name(),
+		originalFingerprint,
+		&types.Fingerprint{Value: 6789012345, Config: nil},
+	)
+
+	mockDecoderOptions := &decoder.MockDecoderOptions{
+		InputChanSize:  0,
+		OutputChanSize: 0,
+	}
+
+	tailer, _ := newTestTailer(t, mockFile.Name(), nil, fingerprinterMock, opener, mockDecoderOptions)
+	tailer.fingerprint = originalFingerprint
+	tailer.windowsOpenFileTimeout = 0
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		<-tailer.decoder.InputChan()
+		tailer.decoder.Start()
+	}()
+	n, err := tailer.readAvailable()
+	assert.ErrorIs(t, err, io.EOF, "Expected EOF, got %v", err)
+	assert.Equal(t, firstLineSize, n, "Expected to have read the first line of %d bytes, got %d", firstLineSize, n)
+	assert.Equal(t, true, tailer.didFileRotate.Load(), "Expected file to have rotated")
+}

--- a/pkg/logs/util/opener/file_mock.go
+++ b/pkg/logs/util/opener/file_mock.go
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package opener
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/afero"
+)
+
+// MockFileInfo is a mock implementation of the os.FileInfo interface
+type MockFileInfo struct {
+	os.FileInfo
+	size int64
+}
+
+// Size returns the size of the file
+func (m *MockFileInfo) Size() int64 {
+	return m.size
+}
+
+// MockFile is a mock implementation of the afero.File interface
+type MockFile struct {
+	afero.File
+	readIdx      int
+	fileContents fileContents // Data to return for each read
+	currentPos   int64        // Track position for Seek
+	name         string       // Name of the file
+}
+
+type fileContents struct {
+	fileIdx   int
+	outputs   [][][]byte
+	fileSizes []int64
+}
+
+func newFileContents(outputs [][][]byte) fileContents {
+	fileSizes := make([]int64, len(outputs))
+	for fileIdx, output := range outputs {
+		for _, output := range output {
+			fileSizes[fileIdx] += int64(len(output))
+		}
+	}
+	return fileContents{
+		fileIdx:   0,
+		outputs:   outputs,
+		fileSizes: fileSizes,
+	}
+}
+
+func (f *fileContents) getBytesAt(readIdx int) *[]byte {
+	if f.fileIdx >= len(f.outputs) {
+		return nil
+	}
+	fileContents := f.outputs[f.fileIdx]
+	if readIdx >= len(fileContents) {
+		return nil
+	}
+	data := fileContents[readIdx]
+	return &data
+}
+
+func (f *fileContents) rotateIfDone(readIdx int) bool {
+	if readIdx >= len(f.outputs[f.fileIdx]) && f.fileIdx < len(f.outputs)-1 {
+		f.fileIdx++
+		return true
+	}
+	return false
+}
+
+func (f *fileContents) getFileSize() int64 {
+	return f.fileSizes[f.fileIdx]
+}
+
+// NewMockFile creates a new MockFile with the given expected outputs
+func NewMockFile(name string, expectedOutputs ...[][]byte) *MockFile {
+	fileSize := 0
+	for _, output := range expectedOutputs {
+		fileSize += len(output)
+	}
+	return &MockFile{
+		name:         name,
+		fileContents: newFileContents(expectedOutputs),
+	}
+}
+
+// Name returns the name of the file
+func (m *MockFile) Name() string {
+	return m.name
+}
+
+// Path returns the path of the file
+func (m *MockFile) Path() string {
+	return m.name
+}
+
+// FileSize returns the size of the file
+func (m *MockFile) FileSize() int {
+	return int(m.fileContents.getFileSize())
+}
+
+// CurrentPos returns the current position of the file
+func (m *MockFile) CurrentPos() int {
+	return int(m.currentPos)
+}
+
+// Read reads data from the file
+func (m *MockFile) Read(p []byte) (int, error) {
+	data := m.fileContents.getBytesAt(m.readIdx)
+	if data == nil {
+		return 0, io.EOF
+	}
+
+	m.readIdx++
+	n := copy(p, *data)
+	m.currentPos += int64(n)
+
+	didRotate := m.fileContents.rotateIfDone(m.readIdx)
+	if didRotate {
+		m.readIdx = 0
+		m.currentPos = 0
+	}
+
+	return n, nil
+}
+
+// Stat returns the file info
+func (m *MockFile) Stat() (os.FileInfo, error) {
+	return &MockFileInfo{size: m.fileContents.getFileSize()}, nil
+}
+
+// Seek sets the position for the next Read
+func (m *MockFile) Seek(offset int64, _ int) (int64, error) {
+	m.currentPos = offset
+	return offset, nil
+}
+
+// Close closes the file
+func (m *MockFile) Close() error {
+	return nil
+}

--- a/pkg/logs/util/opener/open.go
+++ b/pkg/logs/util/opener/open.go
@@ -7,6 +7,8 @@
 package opener
 
 import (
+	"path/filepath"
+
 	"github.com/spf13/afero"
 
 	internalOpener "github.com/DataDog/datadog-agent/pkg/logs/internal/util/opener"
@@ -17,6 +19,7 @@ import (
 type FileOpener interface {
 	OpenLogFile(path string) (afero.File, error)
 	OpenShared(path string) (afero.File, error)
+	Abs(path string) (string, error)
 }
 
 // NewFileOpener creates a new FileOpener
@@ -39,4 +42,9 @@ func (f *fileOpenerImpl) OpenLogFile(path string) (afero.File, error) {
 // OpenShared utilizes an os-specific implementation to open a generic file in a shared mode.
 func (f *fileOpenerImpl) OpenShared(path string) (afero.File, error) {
 	return filesystem.OpenShared(path)
+}
+
+// Abs returns the absolute path of the file (wrapper around filepath.Abs)
+func (f *fileOpenerImpl) Abs(path string) (string, error) {
+	return filepath.Abs(path)
 }

--- a/pkg/logs/util/opener/open_mock.go
+++ b/pkg/logs/util/opener/open_mock.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package opener
+
+import (
+	"fmt"
+
+	"github.com/spf13/afero"
+)
+
+// MockFileOpener is a mock implementation of the opener.Opener interface
+type MockFileOpener struct {
+	MockedFiles map[string]*MockFile
+}
+
+// NewMockFileOpener creates a new MockFileOpener
+func NewMockFileOpener() *MockFileOpener {
+	return &MockFileOpener{
+		MockedFiles: make(map[string]*MockFile),
+	}
+}
+
+// AddMockFile adds a mock file to the MockFileOpener
+func (m *MockFileOpener) AddMockFile(file *MockFile) {
+	m.MockedFiles[file.Name()] = file
+}
+
+// OpenShared returns the specified mock file or an error if the file was not added to the mock opener.
+func (m *MockFileOpener) OpenShared(path string) (afero.File, error) {
+	file, ok := m.MockedFiles[path]
+	if !ok {
+		return nil, fmt.Errorf("file not found: %s", path)
+	}
+	return file, nil
+}
+
+// OpenLogFile returns the specified mock file or an error if the file was not added to the mock opener.
+func (m *MockFileOpener) OpenLogFile(path string) (afero.File, error) {
+	file, ok := m.MockedFiles[path]
+	if !ok {
+		return nil, fmt.Errorf("file not found: [ %s ]", path)
+	}
+	return file, nil
+}
+
+// Abs returns a mock path consisting of just the filename
+func (m *MockFileOpener) Abs(path string) (string, error) {
+	return path, nil
+}


### PR DESCRIPTION
### What does this PR do?
Currently the fingerprinting feature on windows is an effective tool to protect against cases of log loss when attempting to write small log files in bursts. However, unlike linux the protections around log duplication in the same environment are much less robust. This MR works to close the gaps between these systems by (when fingerprinting is enabled) guaranteeing that the windows tailer has opened the file it expects to have opened during every read loop.
This comes at a tradeoff with respect to resource usage: fingerprinting in general requires more io/cpu resource and this change will incrementally increase this usage. 

### Motivation

### Describe how you validated your changes
Unit test capability has been expanded with an initial implementation of "file mocks" and associated concepts

### Additional Notes
