### PR TITLE
add direct marshal support to USM encoders

### DIFF
--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -49,7 +49,7 @@ func mergeDynamicTags(dynamicTags ...map[string]struct{}) (out map[string]struct
 }
 
 // FormatConnection converts a ConnectionStats into an model.Connection
-func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionStats, routes map[network.Via]RouteIdx, usmEncoders []usmEncoder, dnsFormatter *dnsFormatter, ipc ipCache, tagsSet *network.TagsSet, sysProbePid uint32) {
+func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionStats, routes map[network.Via]RouteIdx, usmEncoders []USMEncoder, dnsFormatter *dnsFormatter, ipc ipCache, tagsSet *network.TagsSet, sysProbePid uint32) {
 
 	builder.SetPid(int32(conn.Pid))
 

--- a/pkg/network/encoding/marshal/modeler.go
+++ b/pkg/network/encoding/marshal/modeler.go
@@ -23,7 +23,7 @@ var (
 
 // ConnectionsModeler contains all the necessary structs for modeling a connection.
 type ConnectionsModeler struct {
-	usmEncoders  []usmEncoder
+	usmEncoders  []USMEncoder
 	dnsFormatter *dnsFormatter
 	ipc          ipCache
 	routeIndex   map[network.Via]RouteIdx
@@ -43,7 +43,7 @@ func NewConnectionsModeler(conns *network.Connections) (*ConnectionsModeler, err
 		return nil, fmt.Errorf("failed to get root namespace PID: %w", err)
 	}
 	return &ConnectionsModeler{
-		usmEncoders:  initializeUSMEncoders(conns),
+		usmEncoders:  InitializeUSMEncoders(conns),
 		ipc:          ipc,
 		dnsFormatter: newDNSFormatter(conns, ipc),
 		routeIndex:   make(map[network.Via]RouteIdx),

--- a/pkg/network/encoding/marshal/usm.go
+++ b/pkg/network/encoding/marshal/usm.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
@@ -17,12 +18,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// usmEncoder represents the interface for a generic connections' encoder.
-type usmEncoder interface {
+// USMEncoder represents the interface for a generic connections' encoder.
+type USMEncoder interface {
 	// Close closes the encoder.
 	Close()
 	// EncodeConnection encodes USM data for a given connection into the given builder. Returns static tags and dynamic tags.
 	EncodeConnection(network.ConnectionStats, *model.ConnectionBuilder) (uint64, map[string]struct{})
+	// EncodeConnectionDirect encodes USM data for a given connection directly onto the model.Connection object. Returns static tags and dynamic tags.
+	EncodeConnectionDirect(network.ConnectionStats, *model.Connection) (uint64, map[string]struct{})
 }
 
 // USMConnectionIndex provides a generic container for USM data pre-aggregated by connection

--- a/pkg/network/encoding/marshal/usm_encoders_linux.go
+++ b/pkg/network/encoding/marshal/usm_encoders_linux.go
@@ -11,8 +11,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 )
 
-func initializeUSMEncoders(conns *network.Connections) []usmEncoder {
-	encoders := make([]usmEncoder, 0)
+// InitializeUSMEncoders creates a slice of encoders that apply to the data in conns
+func InitializeUSMEncoders(conns *network.Connections) []USMEncoder {
+	encoders := make([]USMEncoder, 0)
 
 	if encoder := newHTTPEncoder(conns.USMData.HTTP); encoder != nil {
 		encoders = append(encoders, encoder)

--- a/pkg/network/encoding/marshal/usm_encoders_unsupported.go
+++ b/pkg/network/encoding/marshal/usm_encoders_unsupported.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 )
 
-func initializeUSMEncoders(*network.Connections) []usmEncoder {
+// InitializeUSMEncoders creates a slice of encoders that apply to the data in conns
+func InitializeUSMEncoders(*network.Connections) []USMEncoder {
 	return nil
 }

--- a/pkg/network/encoding/marshal/usm_encoders_windows.go
+++ b/pkg/network/encoding/marshal/usm_encoders_windows.go
@@ -11,8 +11,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 )
 
-func initializeUSMEncoders(conns *network.Connections) []usmEncoder {
-	encoders := make([]usmEncoder, 0, 1)
+// InitializeUSMEncoders creates a slice of encoders that apply to the data in conns
+func InitializeUSMEncoders(conns *network.Connections) []USMEncoder {
+	encoders := make([]USMEncoder, 0, 1)
 
 	if encoder := newHTTPEncoder(conns.USMData.HTTP); encoder != nil {
 		encoders = append(encoders, encoder)

--- a/pkg/network/encoding/marshal/usm_http.go
+++ b/pkg/network/encoding/marshal/usm_http.go
@@ -12,6 +12,7 @@ import (
 	"io"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
@@ -35,7 +36,21 @@ func newHTTPEncoder(httpPayloads map[http.Key]*http.RequestStats) *httpEncoder {
 	}
 }
 
-func (e *httpEncoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (uint64, map[string]struct{}) {
+func (e *httpEncoder) EncodeConnectionDirect(c network.ConnectionStats, conn *model.Connection) (staticTags uint64, dynamicTags map[string]struct{}) {
+	var buf bytes.Buffer
+	staticTags, dynamicTags = e.encodeData(c, &buf)
+	conn.HttpAggregations = buf.Bytes()
+	return
+}
+
+func (e *httpEncoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (staticTags uint64, dynamicTags map[string]struct{}) {
+	builder.SetHttpAggregations(func(b *bytes.Buffer) {
+		staticTags, dynamicTags = e.encodeData(c, b)
+	})
+	return
+}
+
+func (e *httpEncoder) encodeData(c network.ConnectionStats, w io.Writer) (uint64, map[string]struct{}) {
 	if e == nil {
 		return 0, nil
 	}
@@ -45,18 +60,6 @@ func (e *httpEncoder) EncodeConnection(c network.ConnectionStats, builder *model
 		return 0, nil
 	}
 
-	var (
-		staticTags  uint64
-		dynamicTags map[string]struct{}
-	)
-
-	builder.SetHttpAggregations(func(b *bytes.Buffer) {
-		staticTags, dynamicTags = e.encodeData(connectionData, b)
-	})
-	return staticTags, dynamicTags
-}
-
-func (e *httpEncoder) encodeData(connectionData *USMConnectionData[http.Key, *http.RequestStats], w io.Writer) (uint64, map[string]struct{}) {
 	var staticTags uint64
 	dynamicTags := make(map[string]struct{})
 	e.httpAggregationsBuilder.Reset(w)

--- a/pkg/network/encoding/marshal/usm_http2.go
+++ b/pkg/network/encoding/marshal/usm_http2.go
@@ -12,6 +12,7 @@ import (
 	"io"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
@@ -35,7 +36,21 @@ func newHTTP2Encoder(http2Payloads map[http.Key]*http.RequestStats) *http2Encode
 	}
 }
 
-func (e *http2Encoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (uint64, map[string]struct{}) {
+func (e *http2Encoder) EncodeConnectionDirect(c network.ConnectionStats, conn *model.Connection) (staticTags uint64, dynamicTags map[string]struct{}) {
+	var buf bytes.Buffer
+	staticTags, dynamicTags = e.encodeData(c, &buf)
+	conn.Http2Aggregations = buf.Bytes()
+	return
+}
+
+func (e *http2Encoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (staticTags uint64, dynamicTags map[string]struct{}) {
+	builder.SetHttp2Aggregations(func(b *bytes.Buffer) {
+		staticTags, dynamicTags = e.encodeData(c, b)
+	})
+	return
+}
+
+func (e *http2Encoder) encodeData(c network.ConnectionStats, w io.Writer) (uint64, map[string]struct{}) {
 	if e == nil {
 		return 0, nil
 	}
@@ -45,18 +60,6 @@ func (e *http2Encoder) EncodeConnection(c network.ConnectionStats, builder *mode
 		return 0, nil
 	}
 
-	var (
-		staticTags  uint64
-		dynamicTags map[string]struct{}
-	)
-
-	builder.SetHttp2Aggregations(func(b *bytes.Buffer) {
-		staticTags, dynamicTags = e.encodeData(connectionData, b)
-	})
-	return staticTags, dynamicTags
-}
-
-func (e *http2Encoder) encodeData(connectionData *USMConnectionData[http.Key, *http.RequestStats], w io.Writer) (uint64, map[string]struct{}) {
 	var staticTags uint64
 	dynamicTags := make(map[string]struct{})
 	e.http2AggregationsBuilder.Reset(w)

--- a/pkg/network/encoding/marshal/usm_kafka.go
+++ b/pkg/network/encoding/marshal/usm_kafka.go
@@ -36,24 +36,30 @@ func newKafkaEncoder(kafkaPayloads map[kafka.Key]*kafka.RequestStats) *kafkaEnco
 	}
 }
 
-func (e *kafkaEncoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (uint64, map[string]struct{}) {
+func (e *kafkaEncoder) EncodeConnectionDirect(c network.ConnectionStats, conn *model.Connection) (staticTags uint64, dynamicTags map[string]struct{}) {
+	var buf bytes.Buffer
+	staticTags = e.encodeData(c, &buf)
+	conn.DataStreamsAggregations = buf.Bytes()
+	return
+}
+
+func (e *kafkaEncoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (staticTags uint64, dynamicTags map[string]struct{}) {
+	builder.SetDataStreamsAggregations(func(b *bytes.Buffer) {
+		staticTags = e.encodeData(c, b)
+	})
+	return
+}
+
+func (e *kafkaEncoder) encodeData(c network.ConnectionStats, w io.Writer) uint64 {
 	if e == nil {
-		return 0, nil
+		return 0
 	}
 
 	connectionData := e.byConnection.Find(c)
 	if connectionData == nil || len(connectionData.Data) == 0 || connectionData.IsPIDCollision(c) {
-		return 0, nil
+		return 0
 	}
 
-	staticTags := uint64(0)
-	builder.SetDataStreamsAggregations(func(b *bytes.Buffer) {
-		staticTags = e.encodeData(connectionData, b)
-	})
-	return staticTags, nil
-}
-
-func (e *kafkaEncoder) encodeData(connectionData *USMConnectionData[kafka.Key, *kafka.RequestStats], w io.Writer) uint64 {
 	var staticTags uint64
 	e.kafkaAggregationsBuilder.Reset(w)
 

--- a/pkg/network/encoding/marshal/usm_postgres.go
+++ b/pkg/network/encoding/marshal/usm_postgres.go
@@ -12,6 +12,7 @@ import (
 	"io"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/postgres"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
@@ -35,24 +36,30 @@ func newPostgresEncoder(postgresPayloads map[postgres.Key]*postgres.RequestStat)
 	}
 }
 
-func (e *postgresEncoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (uint64, map[string]struct{}) {
+func (e *postgresEncoder) EncodeConnectionDirect(c network.ConnectionStats, conn *model.Connection) (staticTags uint64, dynamicTags map[string]struct{}) {
+	var buf bytes.Buffer
+	staticTags = e.encodeData(c, &buf)
+	conn.DatabaseAggregations = buf.Bytes()
+	return
+}
+
+func (e *postgresEncoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (staticTags uint64, dynamicTags map[string]struct{}) {
+	builder.SetDatabaseAggregations(func(b *bytes.Buffer) {
+		staticTags = e.encodeData(c, b)
+	})
+	return
+}
+
+func (e *postgresEncoder) encodeData(c network.ConnectionStats, w io.Writer) uint64 {
 	if e == nil {
-		return 0, nil
+		return 0
 	}
 
 	connectionData := e.byConnection.Find(c)
 	if connectionData == nil || len(connectionData.Data) == 0 || connectionData.IsPIDCollision(c) {
-		return 0, nil
+		return 0
 	}
 
-	staticTags := uint64(0)
-	builder.SetDatabaseAggregations(func(b *bytes.Buffer) {
-		staticTags |= e.encodeData(connectionData, b)
-	})
-	return staticTags, nil
-}
-
-func (e *postgresEncoder) encodeData(connectionData *USMConnectionData[postgres.Key, *postgres.RequestStat], w io.Writer) uint64 {
 	var staticTags uint64
 	e.postgresAggregationsBuilder.Reset(w)
 

--- a/pkg/network/encoding/marshal/usm_redis.go
+++ b/pkg/network/encoding/marshal/usm_redis.go
@@ -36,24 +36,30 @@ func newRedisEncoder(redisPayloads map[redis.Key]*redis.RequestStats) *redisEnco
 	}
 }
 
-func (e *redisEncoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (uint64, map[string]struct{}) {
+func (e *redisEncoder) EncodeConnectionDirect(c network.ConnectionStats, conn *model.Connection) (staticTags uint64, dynamicTags map[string]struct{}) {
+	var buf bytes.Buffer
+	staticTags = e.encodeData(c, &buf)
+	conn.DatabaseAggregations = buf.Bytes()
+	return
+}
+
+func (e *redisEncoder) EncodeConnection(c network.ConnectionStats, builder *model.ConnectionBuilder) (staticTags uint64, dynamicTags map[string]struct{}) {
+	builder.SetDatabaseAggregations(func(b *bytes.Buffer) {
+		staticTags = e.encodeData(c, b)
+	})
+	return
+}
+
+func (e *redisEncoder) encodeData(c network.ConnectionStats, w io.Writer) uint64 {
 	if e == nil {
-		return 0, nil
+		return 0
 	}
 
 	connectionData := e.byConnection.Find(c)
 	if connectionData == nil || len(connectionData.Data) == 0 || connectionData.IsPIDCollision(c) {
-		return 0, nil
+		return 0
 	}
 
-	staticTags := uint64(0)
-	builder.SetDatabaseAggregations(func(b *bytes.Buffer) {
-		staticTags |= e.encodeData(connectionData, b)
-	})
-	return staticTags, nil
-}
-
-func (e *redisEncoder) encodeData(connectionData *USMConnectionData[redis.Key, *redis.RequestStats], w io.Writer) uint64 {
 	var staticTags uint64
 	e.redisAggregationsBuilder.Reset(w)
 


### PR DESCRIPTION
### What does this PR do?

- Adds support to USM marshal encoders to write directly to a `model.Connection`.
- Exports the `USMEncoder` interface and `InitializeUSMEncoders` function, to allow usage in other packages.

### Motivation

This is supporting work for system-probe sending directly to the backend. Since system-probe will not be serializing to the intermediate protobuf messages AND will have to queue messages with the forwarder, we cannot utilize the existing "builder" APIs.

### Describe how you validated your changes

### Additional Notes
