### PR TITLE
Modifying tag of persistent runners

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -27,7 +27,7 @@
   cache: []
   variables:
     XDG_CACHE_HOME: /data/bzl
-  tags: [ "linux-persistent:amd64", "specific:true" ]
+  tags: [ "k8s-persistent:amd64", "specific:true" ]
 
 .bazel:runner:linux-arm64:
   extends: .linux_arm64


### PR DESCRIPTION
<details open><summary>

# Problem
</summary>

Unfortunately, when the persistent runners were provided to datadog-agent
an inconsistent tag with the rest of the repos was used.

</details>

<details open><summary>

# Solution
</summary>

Migrate to the correct tag.

</details>
