### PR TITLE
[CNM-4676] Fix flaky test failures by fixing data races in TestGetPendingConns and TestPerfBatchStateCleanup.

### DIFF
--- a/pkg/network/tracer/connection/perf_batching_test.go
+++ b/pkg/network/tracer/connection/perf_batching_test.go
@@ -71,9 +71,9 @@ func TestGetPendingConns(t *testing.T) {
 	batch.Len++
 	updateBatch()
 
+	pendingConns = pendingConns[:0]
 	// We should now get only the connection that hasn't been processed before
 	go manager.Flush()
-	pendingConns = pendingConns[:0]
 	<-flushDone
 	assert.GreaterOrEqual(t, len(pendingConns), 1)
 	var found bool

--- a/pkg/network/tracer/connection/perf_batching_test.go
+++ b/pkg/network/tracer/connection/perf_batching_test.go
@@ -28,10 +28,8 @@ const (
 
 func TestGetPendingConns(t *testing.T) {
 	var pendingConns []*network.ConnectionStats
-	flushDone := make(chan struct{})
 	manager := newTestBatchManager(t, func(conn *network.ConnectionStats) {
 		if conn == nil {
-			flushDone <- struct{}{}
 			return
 		}
 		pendingConns = append(pendingConns, conn)
@@ -50,8 +48,7 @@ func TestGetPendingConns(t *testing.T) {
 	}
 	updateBatch()
 
-	go manager.Flush()
-	<-flushDone
+	manager.Flush()
 	assert.GreaterOrEqual(t, len(pendingConns), 2)
 	for _, pid := range []uint32{pidMax + 1, pidMax + 2} {
 		found := false
@@ -73,8 +70,7 @@ func TestGetPendingConns(t *testing.T) {
 
 	pendingConns = pendingConns[:0]
 	// We should now get only the connection that hasn't been processed before
-	go manager.Flush()
-	<-flushDone
+	manager.Flush()
 	assert.GreaterOrEqual(t, len(pendingConns), 1)
 	var found bool
 	for _, p := range pendingConns {


### PR DESCRIPTION
### What does this PR do?
[CNM-4676] Fix flaky test by fixing data races in TestGetPendingConns and TestPerfBatchStateCleanup.

### Motivation

### Describe how you validated your changes

### Additional Notes


[CNM-4676]: https://datadoghq.atlassian.net/browse/CNM-4676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ