### PR TITLE
[ABLD-158] Build libcrypto on macos arm as part of all_deps test

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -26,6 +26,9 @@ filegroup(
             "@popt",
             "@zstd",
         ],
+        "//:macos_arm64": [
+            "@openssl3//:libcrypto",
+        ],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],


### PR DESCRIPTION
This is a temporary solution to get testing of it where we can, until all platforms are available.