### PR TITLE
bzip2: ensure the header can be accessed by the dependent libs

### DIFF
--- a/deps/bzip2.BUILD.bazel
+++ b/deps/bzip2.BUILD.bazel
@@ -104,6 +104,7 @@ cc_library(
         "@platforms//os:windows": ["_CRT_NONSTDC_NO_WARNINGS"],
         "//conditions:default": [],
     }),
+    includes = ['.'],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
### What does this PR do?

Fixup the definition of `@bzip2//:bz2`

### Motivation

Without the includes parameter, bazel only passes the path to bzip2 header location with `-iquote` but many depending libraries include the header with `<bzip2.h>` which requires `-isystem` instead

### Describe how you validated your changes

Local build with a python module depending on `bz2`:
```
  /home/hugo.beauzee/.cache/bazel/_bazel_hugo.beauzee/install/eb6bebcb4f9bcd23452d653bb61ca1b0/process-wrapper '--timeout=0' '--kill_delay=15' '--stats=/home/hugo.beauzee/.cache/bazel/_bazel_hugo.beauzee/95605d1a73395e0c041bb302da387b0e/sandbox/processwrapper-sandbox/4671/stats.out' external/gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64/xbin/gcc -MD -MF bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/_objs/module__bz2/_bz2module.pic.d '-frandom-seed=bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/_objs/module__bz2/_bz2module.pic.o' -fPIC -DNDEBUG -DPy_BUILD_CORE_BUILTIN -iquote external/+_repo_rules+python3 -iquote bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3 -iquote external/+_repo_rules+bzip2 -iquote bazel-out/k8-fastbuild/bin/external/+_repo_rules+bzip2 -isystem external/+_repo_rules+python3/Include/internal -isystem bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/Include/internal -isystem external/+_repo_rules+python3/Objects -isystem bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/Objects -isystem external/+_repo_rules+python3/Include -isystem bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/Include -isystem external/+_repo_rules+python3/Python -isystem bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/Python -isystem external/+_repo_rules+python3/Include/internal/mimalloc -isystem bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/Include/internal/mimalloc -isystem external/+_repo_rules+python3/Objects/mimalloc -isystem bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/Objects/mimalloc '-std=c11' -no-canonical-prefixes -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -nostdinc -Bexternal/gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64/bin -Bexternal/gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64/xbin -isystemexternal/gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64/lib/gcc/x86_64-unknown-linux-gnu/11.4.0/include -isystemexternal/gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64/lib/gcc/x86_64-unknown-linux-gnu/11.4.0/include-fixed -isystemexternal/gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64/x86_64-unknown-linux-gnu/sysroot/usr/include -c external/+_repo_rules+python3/Modules/_bz2module.c -o bazel-out/k8-fastbuild/bin/external/+_repo_rules+python3/_objs/module__bz2/_bz2module.pic.o)
external/+_repo_rules+python3/Modules/_bz2module.c:9:10: fatal error: bzlib.h: No such file or directory
    9 | #include <bzlib.h>
      |          ^~~~~~~~~
compilation terminated.
```
notice that the bzip2 include folder is only passed with `-iquote`: ` -iquote external/+_repo_rules+bzip2 -iquote bazel-out/k8-fastbuild/bin/external/+_repo_rules+bzip2`

### Additional Notes
