### PR TITLE
[backport 7.73.x][SBOM] bump trivy to include offlinejar fix (#42798)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -988,7 +988,7 @@ replace github.com/vishvananda/netlink => github.com/DataDog/netlink v1.0.1-0.20
 // Use custom Trivy fork to reduce binary size
 // Pull in replacements needed by upstream Trivy
 // Maps to Trivy fork https://github.com/DataDog/trivy/commits/djc/main-dd-060
-replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20251024065956-6fa645cdca17
+replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20251106154236-a76e7d352d21
 
 // Prevent dependencies to be bumped by Trivy
 // github.com/DataDog/aptly@v1.5.3 depends on gopenpgp/v2, so we use latest version of go-crypto before the move to gopenpgp/v3

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/DataDog/nikos v1.12.12 h1:72YrdzMeQT3wcXIDgiS1ClU53SzUdR7uAbp5FSSpo5k
 github.com/DataDog/nikos v1.12.12/go.mod h1:kZGOhfE76+nXS7V5PAlIw3MRxWKM70ynET4VeuZ4U4k=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=
 github.com/DataDog/sketches-go v1.4.7/go.mod h1:eAmQ/EBmtSO+nQp7IZMZVRPT4BQTmIc5RZQ+deGlTPM=
-github.com/DataDog/trivy v0.0.0-20251024065956-6fa645cdca17 h1:1fYy7TyoALua6eTlzbSDep4NzWI0d2RC0LoHqQ4zBos=
-github.com/DataDog/trivy v0.0.0-20251024065956-6fa645cdca17/go.mod h1:PTxRTPpO/cM2OqNLPPKVGtLhEBhORyrXT6mAjplzsRA=
+github.com/DataDog/trivy v0.0.0-20251106154236-a76e7d352d21 h1:o+LHuvopfxtZ/3qCskn1u/k+XxS+1V7DrmuwE0DtI6s=
+github.com/DataDog/trivy v0.0.0-20251106154236-a76e7d352d21/go.mod h1:PTxRTPpO/cM2OqNLPPKVGtLhEBhORyrXT6mAjplzsRA=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9 h1:uX4ZqokylxBI67r+AN09CiFY+s8Frmf33YZlyqIMBc4=
 github.com/DataDog/viper v1.14.1-0.20251008075154-b33ffa9792d9/go.mod h1:QGomve/3EbYfi58jADS97U2OKfsxqh2pWemuT0azbdk=
 github.com/DataDog/watermarkpodautoscaler/apis v0.0.0-20250108152814-82e58d0231d1 h1:9hiwoIk8FOsXDkdcdgNJ48iYaPfn+/7bXEwAnnfKjTc=


### PR DESCRIPTION
This PR bumps trivy to include https://github.com/DataDog/trivy/pull/29 fixing the propagation of jar related options to the image artifact scanners.


(cherry picked from commit 94b9f7f6ec8d28df7bae3cc21de5142581f14125)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
