### PR TITLE
[BACKPORT 7.72.X] fix(installer): Use getent to evaluate groups & users

### DIFF
--- a/cmd/installer/user/user_nix.go
+++ b/cmd/installer/user/user_nix.go
@@ -10,8 +10,7 @@ package user
 
 import (
 	"fmt"
-	"os/user"
-	"strconv"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
 	"syscall"
 )
 
@@ -27,25 +26,17 @@ func IsRoot() bool {
 // Note that we actually only set dd-agent as the effective user, not the real user, in oder to
 // escalate privileges back when needed.
 func RootToDatadogAgent() error {
-	datadogAgentGroup, err := user.LookupGroup("dd-agent")
+	gid, err := user.GetGroupID("dd-agent")
 	if err != nil {
 		return fmt.Errorf("failed to lookup dd-agent group: %s", err)
-	}
-	gid, err := strconv.Atoi(datadogAgentGroup.Gid)
-	if err != nil {
-		return fmt.Errorf("failed to convert dd-agent group ID to int: %s", err)
 	}
 	err = syscall.Setegid(gid)
 	if err != nil {
 		return fmt.Errorf("failed to setegid: %s", err)
 	}
-	datadogAgentUser, err := user.Lookup("dd-agent")
+	uid, err := user.GetUserID("dd-agent")
 	if err != nil {
 		return fmt.Errorf("failed to lookup dd-agent user: %s", err)
-	}
-	uid, err := strconv.Atoi(datadogAgentUser.Uid)
-	if err != nil {
-		return fmt.Errorf("failed to convert dd-agent user ID to int: %s", err)
 	}
 	err = syscall.Seteuid(uid)
 	if err != nil {

--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -15,10 +15,126 @@ import (
 	"os/exec"
 	"os/user"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// GetGroupID returns the ID of the given group.
+func GetGroupID(groupName string) (int, error) {
+	if _, err := exec.LookPath("getent"); err == nil {
+		cmd := exec.Command("getent", "group", groupName)
+		output, err := cmd.Output()
+		if err == nil {
+			// Expected output format is groupname:password:gid:users
+			parts := strings.Split(strings.TrimSpace(string(output)), ":")
+			if len(parts) >= 3 {
+				gid, err := strconv.Atoi(parts[2])
+				if err == nil {
+					return gid, nil
+				}
+			}
+		}
+	}
+
+	// Fallback to user package
+	group, err := user.LookupGroup(groupName)
+	if err != nil {
+		return 0, err
+	}
+	gid, err := strconv.Atoi(group.Gid)
+	if err != nil {
+		return 0, fmt.Errorf("error converting gid to int: %w", err)
+	}
+	return gid, nil
+}
+
+// GetUserID returns the ID of the given user.
+func GetUserID(userName string) (int, error) {
+	if _, err := exec.LookPath("getent"); err == nil {
+		cmd := exec.Command("getent", "passwd", userName)
+		output, err := cmd.Output()
+		if err == nil {
+			// Expected output format is username:password:uid:gid:gecos:homedir:shell
+			parts := strings.Split(strings.TrimSpace(string(output)), ":")
+			if len(parts) >= 3 {
+				uid, err := strconv.Atoi(parts[2])
+				if err == nil {
+					return uid, nil
+				}
+			}
+		}
+	}
+
+	// Fallback to user package
+	u, err := user.Lookup(userName)
+	if err != nil {
+		return 0, err
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, fmt.Errorf("error converting uid to int: %w", err)
+	}
+	return uid, nil
+}
+
+// IsUserInGroup checks if a user is a member of a group.
+func IsUserInGroup(userName, groupName string) (bool, error) {
+	if _, err := exec.LookPath("getent"); err == nil {
+		groupCmd := exec.Command("getent", "group", groupName)
+		groupOutput, err := groupCmd.Output()
+		if err == nil {
+			// Expected output format is groupname:password:gid:user1,user2,user3
+			groupParts := strings.Split(strings.TrimSpace(string(groupOutput)), ":")
+			if len(groupParts) >= 3 {
+				groupGid := groupParts[2]
+
+				// Get the user's primary GID
+				userCmd := exec.Command("getent", "passwd", userName)
+				userOutput, err := userCmd.Output()
+				if err == nil {
+					// Expected output format is username:password:uid:gid:gecos:homedir:shell
+					userParts := strings.Split(strings.TrimSpace(string(userOutput)), ":")
+					if len(userParts) >= 4 {
+						userPrimaryGid := userParts[3]
+						// Check if the group is the user's primary group
+						if userPrimaryGid == groupGid {
+							return true, nil
+						}
+					}
+				}
+
+				// Check if user is in the supplementary group members list
+				if len(groupParts) >= 4 && groupParts[3] != "" {
+					users := strings.Split(groupParts[3], ",")
+					for _, u := range users {
+						if strings.TrimSpace(u) == userName {
+							return true, nil
+						}
+					}
+				}
+				return false, nil
+			}
+		}
+	}
+
+	// Fallback to user package
+	group, err := user.LookupGroup(groupName)
+	if err != nil {
+		return false, err
+	}
+	u, err := user.Lookup(userName)
+	if err != nil {
+		return false, err
+	}
+	userGroups, err := u.GroupIds()
+	if err != nil {
+		return false, fmt.Errorf("error getting groups for user %s: %w", userName, err)
+	}
+	return slices.Contains(userGroups, group.Gid), nil
+}
 
 // EnsureAgentUserAndGroup ensures that the user and group required by the agent are present on the system.
 func EnsureAgentUserAndGroup(ctx context.Context, installPath string) error {
@@ -39,7 +155,7 @@ func ensureGroup(ctx context.Context, groupName string) (err error) {
 	defer func() {
 		span.Finish(err)
 	}()
-	_, err = user.LookupGroup(groupName)
+	_, err = GetGroupID(groupName)
 	if err == nil {
 		return nil
 	}
@@ -59,7 +175,7 @@ func ensureUser(ctx context.Context, userName string, installPath string) (err e
 	defer func() {
 		span.Finish(err)
 	}()
-	_, err = user.Lookup(userName)
+	_, err = GetUserID(userName)
 	if err == nil {
 		return nil
 	}
@@ -81,20 +197,11 @@ func ensureUserInGroup(ctx context.Context, userName string, groupName string) (
 	}()
 	// Check if user is already in group and abort if it is -- this allows us
 	// to skip where the user / group are set in LDAP / AD
-	group, err := user.LookupGroup(groupName)
+	userInGroup, err := IsUserInGroup(userName, groupName)
 	if err != nil {
-		return fmt.Errorf("error looking up %s group: %w", groupName, err)
+		return fmt.Errorf("error checking if user %s is in group %s: %w", userName, groupName, err)
 	}
-	user, err := user.Lookup(userName)
-	if err != nil {
-		return fmt.Errorf("error looking up %s user: %w", userName, err)
-	}
-	userGroups, err := user.GroupIds()
-	if err != nil {
-		return fmt.Errorf("error getting groups for user %s: %w", userName, err)
-	}
-	if slices.Contains(userGroups, group.Gid) {
-		// User is already in the group, nothing to do
+	if userInGroup {
 		return nil
 	}
 	err = exec.CommandContext(ctx, "usermod", "-g", groupName, userName).Run()

--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -24,6 +24,10 @@ import (
 
 // GetGroupID returns the ID of the given group.
 func GetGroupID(groupName string) (int, error) {
+	if groupName == "root" {
+		return 0, nil
+	}
+
 	if _, err := exec.LookPath("getent"); err == nil {
 		cmd := exec.Command("getent", "group", groupName)
 		output, err := cmd.Output()
@@ -53,6 +57,7 @@ func GetGroupID(groupName string) (int, error) {
 
 // GetUserID returns the ID of the given user.
 func GetUserID(userName string) (int, error) {
+
 	if _, err := exec.LookPath("getent"); err == nil {
 		cmd := exec.Command("getent", "passwd", userName)
 		output, err := cmd.Output()

--- a/pkg/fleet/installer/setup/common/setup_nix.go
+++ b/pkg/fleet/installer/setup/common/setup_nix.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -26,7 +26,7 @@ func (s *Setup) postInstallPackages() (err error) {
 func (s *Setup) addAgentToAdditionalGroups() {
 	for _, group := range s.DdAgentAdditionalGroups {
 		// Add dd-agent user to additional group for permission reason, in particular to enable reading log files not world readable
-		if _, err := user.LookupGroup(group); err != nil {
+		if _, err := user.GetGroupID(group); err != nil {
 			log.Infof("Skipping group %s as it does not exist", group)
 			continue
 		}

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -352,3 +352,141 @@ func (s *packageAgentSuite) TestNoWorldWritableFiles() {
 		}
 	}
 }
+
+func (s *packageAgentSuite) TestInstallWithNSSUser() {
+	// This test verifies that the agent installer works correctly when dd-agent
+	// user/group exist in NSS (Name Service Switch) but not in /etc/passwd or /etc/group.
+	// This simulates scenarios where users are managed via LDAP, Active Directory, or other
+	// NSS-compatible systems.
+
+	// Step 1: Clean up any existing dd-agent user/group
+	s.host.Run("sudo userdel dd-agent 2>/dev/null || true")
+	s.host.Run("sudo groupdel dd-agent 2>/dev/null || true")
+
+	// Capture initial state of /etc/passwd and /etc/group to verify no changes
+	initialPasswd := s.host.Run("cat /etc/passwd")
+	initialGroup := s.host.Run("cat /etc/group")
+
+	// Step 2: Set up NSS extrausers
+	// We use libnss-extrausers which reads from /var/lib/extrausers
+	// This works through nsswitch.conf without needing environment variables
+
+	// Install libnss-extrausers
+	if s.host.GetPkgManager() == "apt" {
+		s.host.Run("sudo apt-get update && sudo apt-get install -y libnss-extrausers")
+	} else if s.host.GetPkgManager() == "yum" {
+		_, err := s.Env().RemoteHost.Execute("sudo yum install -y libnss-extrausers")
+		if err != nil {
+			s.T().Skip("libnss-extrausers not available on this system")
+			return
+		}
+	} else if s.host.GetPkgManager() == "zypper" {
+		_, err := s.Env().RemoteHost.Execute("sudo zypper install -y libnss-extrausers")
+		if err != nil {
+			s.T().Skip("libnss-extrausers not available on this system")
+			return
+		}
+	}
+
+	// Create the extrausers directory structure
+	s.host.Run("sudo mkdir -p /var/lib/extrausers")
+	s.host.Run("sudo touch /var/lib/extrausers/passwd /var/lib/extrausers/group")
+	s.host.Run("sudo chmod 644 /var/lib/extrausers/passwd /var/lib/extrausers/group")
+
+	// Find an available UID/GID that doesn't conflict with existing users/groups
+	// Check UIDs/GIDs from 900-999 to find unused ones
+	var uid, gid int
+	for id := 900; id < 1000; id++ {
+		// Check if GID is available
+		_, err := s.Env().RemoteHost.Execute(fmt.Sprintf("getent group %d", id))
+		if err != nil {
+			// GID is available
+			gid = id
+			break
+		}
+	}
+	if gid == 0 {
+		s.T().Fatal("Could not find available GID in range 900-999")
+	}
+
+	for id := 900; id < 1000; id++ {
+		// Check if UID is available
+		_, err := s.Env().RemoteHost.Execute(fmt.Sprintf("getent passwd %d", id))
+		if err != nil {
+			// UID is available
+			uid = id
+			break
+		}
+	}
+	if uid == 0 {
+		s.T().Fatal("Could not find available UID in range 900-999")
+	}
+
+	s.T().Logf("Using UID=%d GID=%d for dd-agent user/group", uid, gid)
+
+	// Create dd-agent group in extrausers
+	s.host.Run(fmt.Sprintf("echo 'dd-agent:x:%d:' | sudo tee /var/lib/extrausers/group", gid))
+
+	// Create dd-agent user in extrausers (without home directory)
+	s.host.Run(fmt.Sprintf("echo 'dd-agent:x:%d:%d:Datadog Agent:/nonexistent:/usr/sbin/nologin' | sudo tee /var/lib/extrausers/passwd", uid, gid))
+
+	// Backup and update nsswitch.conf
+	s.host.Run("sudo cp /etc/nsswitch.conf /etc/nsswitch.conf.backup")
+	s.host.Run("sudo sed -i 's/^passwd:.*/passwd:         files extrausers/' /etc/nsswitch.conf")
+	s.host.Run("sudo sed -i 's/^group:.*/group:          files extrausers/' /etc/nsswitch.conf")
+
+	// Set up cleanup in defer to remove extrausers configuration
+	// This MUST run regardless of test outcome
+	defer func() {
+		s.T().Log("Cleaning up NSS extrausers configuration")
+		// Restore nsswitch.conf
+		s.host.Run("sudo mv /etc/nsswitch.conf.backup /etc/nsswitch.conf")
+		// Clean up the extrausers directory
+		s.host.Run("sudo rm -rf /var/lib/extrausers")
+		// Also clean up the dd-agent user/group if they were created
+		s.host.Run("sudo userdel dd-agent 2>/dev/null || true")
+		s.host.Run("sudo groupdel dd-agent 2>/dev/null || true")
+		// Restart nscd if it's running to clear NSS cache
+		s.host.Run("sudo systemctl restart nscd 2>/dev/null || true")
+	}()
+
+	// Step 3: Verify that getent can find the user/group (confirming NSS is working)
+	getentUser := s.host.Run("getent passwd dd-agent")
+	assert.Contains(s.T(), getentUser, "dd-agent", "dd-agent user should be visible via getent")
+
+	getentGroup := s.host.Run("getent group dd-agent")
+	assert.Contains(s.T(), getentGroup, "dd-agent", "dd-agent group should be visible via getent")
+
+	// Verify user is NOT in /etc/passwd
+	etcPasswd := s.host.Run("cat /etc/passwd")
+	assert.NotContains(s.T(), etcPasswd, "dd-agent", "dd-agent should NOT be in /etc/passwd before install")
+
+	// Verify group is NOT in /etc/group
+	etcGroup := s.host.Run("cat /etc/group")
+	assert.NotContains(s.T(), etcGroup, "dd-agent", "dd-agent should NOT be in /etc/group before install")
+
+	// Step 4: Install the agent
+	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	defer s.Purge()
+
+	// Step 5: Verify no new entries were added to /etc/passwd or /etc/group
+	finalPasswd := s.host.Run("cat /etc/passwd")
+	finalGroup := s.host.Run("cat /etc/group")
+
+	assert.Equal(s.T(), initialPasswd, finalPasswd, "/etc/passwd should not change during installation")
+	assert.Equal(s.T(), initialGroup, finalGroup, "/etc/group should not change during installation")
+
+	// Step 6: Verify the agent is installed and running
+	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit)
+
+	state := s.host.State()
+	state.AssertUserExists("dd-agent")
+	state.AssertGroupExists("dd-agent")
+
+	// Verify agent files have correct ownership
+	state.AssertDirExists("/opt/datadog-agent", 0755, "dd-agent", "dd-agent")
+	state.AssertFileExists("/etc/datadog-agent/datadog.yaml", 0640, "dd-agent", "dd-agent")
+
+	s.T().Log("Successfully installed agent with NSS-managed user/group")
+}


### PR DESCRIPTION
### What does this PR do?
Backports https://github.com/DataDog/datadog-agent/pull/42130; https://github.com/DataDog/datadog-agent/pull/42264; https://github.com/DataDog/datadog-agent/pull/42793 to 7.72.x

### Motivation
Fixes an issue where `dd-agent` not present in `/etc/passwd` but present elsewhere (e.g. eDir, Azure AD...) would result in either failure or creation of a duplicate user in `/etc/passwd`.

### Describe how you validated your changes
New E2E test in https://github.com/DataDog/datadog-agent/pull/42793

### Additional Notes
