### PR TITLE
[OTAGENT-651] Uniformize logging in full host profiler

### DIFF
--- a/comp/host-profiler/collector/impl/receiver/executable_reporter.go
+++ b/comp/host-profiler/collector/impl/receiver/executable_reporter.go
@@ -10,6 +10,7 @@ package receiver
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"go.uber.org/zap"
@@ -27,12 +28,15 @@ type executableReporter struct {
 }
 
 func newExecutableReporter(config *reporter.SymbolUploaderConfig, logger *zap.Logger) (*executableReporter, error) {
+	// Wrap zap.Logger to implement the Logger interface expected by the reporter
+	wrappedLogger := newLogger(logger)
+
 	config.SymbolEndpoints = runner.GetValidSymbolEndpoints(
 		os.Getenv("DD_SITE"), os.Getenv("DD_API_KEY"), os.Getenv("DD_APP_KEY"),
 		config.SymbolEndpoints,
 		func(msg string) { logger.Info(msg) }, func(msg string) { logger.Warn(msg) })
 
-	symbolUploader, err := reporter.NewDatadogSymbolUploader(config)
+	symbolUploader, err := reporter.NewDatadogSymbolUploader(config, wrappedLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -50,4 +54,30 @@ func (m *executableReporter) Stop() error {
 
 func (m *executableReporter) ReportExecutable(args *ebpfreporter.ExecutableMetadata) {
 	m.symbolUploader.UploadSymbols(args)
+}
+
+// zapLoggerWrapper wraps a zap.Logger to implement the Logger interface
+type zapLoggerWrapper struct {
+	logger *zap.Logger
+}
+
+// newLogger creates a Logger from a zap.Logger
+func newLogger(zapLogger *zap.Logger) reporter.Logger {
+	return &zapLoggerWrapper{logger: zapLogger}
+}
+
+func (l *zapLoggerWrapper) Debugf(format string, args ...interface{}) {
+	l.logger.Debug(fmt.Sprintf(format, args...))
+}
+
+func (l *zapLoggerWrapper) Infof(format string, args ...interface{}) {
+	l.logger.Info(fmt.Sprintf(format, args...))
+}
+
+func (l *zapLoggerWrapper) Warnf(format string, args ...interface{}) {
+	l.logger.Warn(fmt.Sprintf(format, args...))
+}
+
+func (l *zapLoggerWrapper) Errorf(format string, args ...interface{}) {
+	l.logger.Error(fmt.Sprintf(format, args...))
 }

--- a/comp/host-profiler/collector/impl/receiver/executable_reporter.go
+++ b/comp/host-profiler/collector/impl/receiver/executable_reporter.go
@@ -67,17 +67,25 @@ func newLogger(zapLogger *zap.Logger) reporter.Logger {
 }
 
 func (l *zapLoggerWrapper) Debugf(format string, args ...interface{}) {
-	l.logger.Debug(fmt.Sprintf(format, args...))
+	if l.logger.Level() <= zap.DebugLevel {
+		l.logger.Debug(fmt.Sprintf(format, args...))
+	}
 }
 
 func (l *zapLoggerWrapper) Infof(format string, args ...interface{}) {
-	l.logger.Info(fmt.Sprintf(format, args...))
+	if l.logger.Level() <= zap.InfoLevel {
+		l.logger.Info(fmt.Sprintf(format, args...))
+	}
 }
 
 func (l *zapLoggerWrapper) Warnf(format string, args ...interface{}) {
-	l.logger.Warn(fmt.Sprintf(format, args...))
+	if l.logger.Level() <= zap.WarnLevel {
+		l.logger.Warn(fmt.Sprintf(format, args...))
+	}
 }
 
 func (l *zapLoggerWrapper) Errorf(format string, args ...interface{}) {
-	l.logger.Error(fmt.Sprintf(format, args...))
+	if l.logger.Level() <= zap.ErrorLevel {
+		l.logger.Error(fmt.Sprintf(format, args...))
+	}
 }

--- a/comp/host-profiler/collector/impl/receiver/factory.go
+++ b/comp/host-profiler/collector/impl/receiver/factory.go
@@ -41,7 +41,7 @@ func createProfilesReceiver(
 
 	var createProfiles xreceiver.CreateProfilesFunc
 	if config.SymbolUploader.Enabled {
-		executableReporter, err := newExecutableReporter(&config.SymbolUploader, logger)
+		executableReporter, err := newExecutableReporter(&config.SymbolUploader)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.8.1
 	github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f
 	github.com/DataDog/datadog-traceroute v0.1.30
-	github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0
+	github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251107101249-9a4abe96073a
 	github.com/DataDog/dd-trace-go/v2 v2.2.2 // indirect
 	github.com/DataDog/ebpf-manager v0.7.15
 	github.com/DataDog/go-libddwaf/v4 v4.3.2

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f h1:O+
 github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f/go.mod h1:E+dFku5SVIXDUj6apiBdDAzrUOR3xLz1bMgUOGjRAVQ=
 github.com/DataDog/datadog-traceroute v0.1.30 h1:ehk/21PbOIj6C+42BAQ9sfFEzeGyVwI4T4oEbJJItEA=
 github.com/DataDog/datadog-traceroute v0.1.30/go.mod h1:PU0w0AsVMEapWPgaqXEtBuDUlPQGlnHsaADsXVMKMts=
-github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0 h1:OEDWHLCabNtLF+OkbI1DlVLkxxK9QUVQUSIt8uZ3VY8=
-github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251013140043-83a1f38427f0/go.mod h1:KsvZuiis+8Ix3r+FEIew7LvryZeeIDrYyiTPMR14GOY=
+github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251107101249-9a4abe96073a h1:d/642y7XRLWw2js+cWSOadT8pwFPdkjupcnBB9vrmZA=
+github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251107101249-9a4abe96073a/go.mod h1:hacbqM+epZ00/dA2a9ahboed8h7HCZFhRdRPclgSoUU=
 github.com/DataDog/dd-trace-go/v2 v2.2.2 h1:t7RCS6et5z+xrvM9dqUPtCGoNOWTj0pcApzbktMZi2k=
 github.com/DataDog/dd-trace-go/v2 v2.2.2/go.mod h1:xvdSukALA8/NnVfTAnxqkZfLLO/6Vi4y5ooxfVy6dfk=
 github.com/DataDog/ebpf-manager v0.7.15 h1:14PbnvXFQccV3zexENfNuADAxCuwHNori7sK55CP0SU=


### PR DESCRIPTION
### What does this PR do?

Unifies logging format across the full host profiler by using a zap.Logger wrapper for OTel components, ensuring consistent log formatting with the Datadog Agent logs.

### Motivation

Previously, the full host profiler mixed two different log formats:
- Agent logs: `2025-11-04 14:49:15 UTC | CORE | INFO`
- OTel logs: `2025-11-04T14:49:16.388Z info`

This made logs harder to read and analyze.

### Describe how you validated your changes

Tested locally with the full host profiler running and verified all logs now use the consistent Agent format.

### Additional Notes

- Updated dd-otel-host-profiler dependency to support zap.Logger wrapper
- Enhanced executable reporter with proper logger integration