### PR TITLE
[AGENTRUN-548] Add slog based implementation replacing seelog

### DIFF
--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 replace github.com/cihub/seelog => github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf // v2.6
 
 require (
+	github.com/DataDog/datadog-agent/pkg/template v0.65.1
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.62.3
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/stretchr/testify v1.11.1

--- a/pkg/util/log/slog/filewriter/file_writer.go
+++ b/pkg/util/log/slog/filewriter/file_writer.go
@@ -1,0 +1,467 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Copyright (c) 2013 - Cloud Instruments Co., Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Package filewriter provides a rolling file writer.
+package filewriter
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// File and directory permitions.
+const (
+	defaultFilePermissions      = 0666
+	defaultDirectoryPermissions = 0767
+)
+
+// Common constants
+const (
+	rollingLogHistoryDelimiter = "."
+)
+
+// RollingNameMode is the type of the rolled file naming mode: prefix, postfix, etc.
+type RollingNameMode uint8
+
+// RollingNameMode values
+const (
+	RollingNameModePostfix = iota
+	RollingNameModePrefix
+)
+
+// rollerVirtual is an interface that represents all virtual funcs that are
+// called in different rolling writer subtypes.
+type rollerVirtual interface {
+	needsToRoll() bool                                  // Returns true if needs to switch to another file.
+	isFileRollNameValid(rname string) bool              // Returns true if logger roll file name (postfix/prefix/etc.) is ok.
+	sortFileRollNamesAsc(fs []string) ([]string, error) // Sorts logger roll file names in ascending order of their creation by logger.
+
+	// getNewHistoryRollFileName is called whenever we are about to roll the
+	// current log file. It returns the name the current log file should be
+	// rolled to.
+	getNewHistoryRollFileName(otherHistoryFiles []string) string
+
+	getCurrentFileName() string
+}
+
+// rollingFileWriter writes received messages to a file, until time interval passes
+// or file exceeds a specified limit. After that the current log file is renamed
+// and writer starts to log into a new file. You can set a limit for such renamed
+// files count, if you want, and then the rolling writer would delete older ones when
+// the files count exceed the specified limit.
+type rollingFileWriter struct {
+	fileName        string // log file name
+	currentDirPath  string
+	currentFile     *os.File
+	currentName     string
+	currentFileSize int64
+	fullName        bool
+	maxRolls        int
+	nameMode        RollingNameMode
+	self            rollerVirtual // Used for virtual calls
+	rollLock        sync.Mutex
+}
+
+func newRollingFileWriter(fpath string, maxr int, namemode RollingNameMode,
+	fullName bool) (*rollingFileWriter, error) {
+	rw := new(rollingFileWriter)
+	rw.currentDirPath, rw.fileName = filepath.Split(fpath)
+	if len(rw.currentDirPath) == 0 {
+		rw.currentDirPath = "."
+	}
+
+	rw.nameMode = namemode
+	rw.maxRolls = maxr
+	rw.fullName = fullName
+	return rw, nil
+}
+
+func (rw *rollingFileWriter) hasRollName(file string) bool {
+	switch rw.nameMode {
+	case RollingNameModePostfix:
+		rname := rw.fileName + rollingLogHistoryDelimiter
+		return strings.HasPrefix(file, rname)
+	case RollingNameModePrefix:
+		rname := rollingLogHistoryDelimiter + rw.fileName
+		return strings.HasSuffix(file, rname)
+	}
+	return false
+}
+
+func (rw *rollingFileWriter) createFullFileName(originalName, rollname string) string {
+	switch rw.nameMode {
+	case RollingNameModePostfix:
+		return originalName + rollingLogHistoryDelimiter + rollname
+	case RollingNameModePrefix:
+		return rollname + rollingLogHistoryDelimiter + originalName
+	}
+	return ""
+}
+
+func (rw *rollingFileWriter) getSortedLogHistory() ([]string, error) {
+	files, err := getDirFilePaths(rw.currentDirPath, nil, true)
+	if err != nil {
+		return nil, err
+	}
+	var validRollNames []string
+	for _, file := range files {
+		if rw.hasRollName(file) {
+			rname := rw.getFileRollName(file)
+			if rw.self.isFileRollNameValid(rname) {
+				validRollNames = append(validRollNames, rname)
+			}
+		}
+	}
+	sortedTails, err := rw.self.sortFileRollNamesAsc(validRollNames)
+	if err != nil {
+		return nil, err
+	}
+	validSortedFiles := make([]string, len(sortedTails))
+	for i, v := range sortedTails {
+		validSortedFiles[i] = rw.createFullFileName(rw.fileName, v)
+	}
+	return validSortedFiles, nil
+}
+
+func (rw *rollingFileWriter) createFileAndFolderIfNeeded() error {
+	var err error
+
+	if len(rw.currentDirPath) != 0 {
+		err = os.MkdirAll(rw.currentDirPath, defaultDirectoryPermissions)
+
+		if err != nil {
+			return err
+		}
+	}
+	rw.currentName = rw.self.getCurrentFileName()
+	filePath := filepath.Join(rw.currentDirPath, rw.currentName)
+
+	// This will either open the existing file (without truncating it) or
+	// create if necessary. Append mode avoids any race conditions.
+	rw.currentFile, err = os.OpenFile(filePath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, defaultFilePermissions)
+	if err != nil {
+		return err
+	}
+
+	stat, err := rw.currentFile.Stat()
+	if err != nil {
+		rw.currentFile.Close()
+		rw.currentFile = nil
+		return err
+	}
+
+	rw.currentFileSize = stat.Size()
+	return nil
+}
+
+func (rw *rollingFileWriter) deleteOldRolls(history []string) error {
+	if rw.maxRolls <= 0 {
+		return nil
+	}
+
+	rollsToDelete := len(history) - rw.maxRolls
+	if rollsToDelete <= 0 {
+		return nil
+	}
+
+	var err error
+	// In all cases (archive files or not) the files should be deleted.
+	for i := 0; i < rollsToDelete; i++ {
+		// Try best to delete files without breaking the loop.
+		if err = tryRemoveFile(filepath.Join(rw.currentDirPath, history[i])); err != nil {
+			reportInternalError(err)
+		}
+	}
+
+	return nil
+}
+
+func (rw *rollingFileWriter) getFileRollName(fileName string) string {
+	switch rw.nameMode {
+	case RollingNameModePostfix:
+		return fileName[len(rw.fileName+rollingLogHistoryDelimiter):]
+	case RollingNameModePrefix:
+		return fileName[:len(fileName)-len(rw.fileName+rollingLogHistoryDelimiter)]
+	}
+	return ""
+}
+
+func (rw *rollingFileWriter) roll() error {
+	// First, close current file.
+	err := rw.currentFile.Close()
+	if err != nil {
+		return err
+	}
+	rw.currentFile = nil
+
+	// Current history of all previous log files.
+	// For file roller it may be like this:
+	//     * ...
+	//     * file.log.4
+	//     * file.log.5
+	//     * file.log.6
+	//
+	// For date roller it may look like this:
+	//     * ...
+	//     * file.log.11.Aug.13
+	//     * file.log.15.Aug.13
+	//     * file.log.16.Aug.13
+	// Sorted log history does NOT include current file.
+	history, err := rw.getSortedLogHistory()
+	if err != nil {
+		return err
+	}
+	// Renames current file to create a new roll history entry
+	// For file roller it may be like this:
+	//     * ...
+	//     * file.log.4
+	//     * file.log.5
+	//     * file.log.6
+	//     n file.log.7  <---- RENAMED (from file.log)
+	newHistoryName := rw.createFullFileName(rw.fileName,
+		rw.self.getNewHistoryRollFileName(history))
+
+	err = os.Rename(filepath.Join(rw.currentDirPath, rw.currentName), filepath.Join(rw.currentDirPath, newHistoryName))
+	if err != nil {
+		return err
+	}
+
+	// Finally, add the newly added history file to the history archive
+	// and, if after that the archive exceeds the allowed max limit, older rolls
+	// must the removed/archived.
+	history = append(history, newHistoryName)
+	if len(history) > rw.maxRolls {
+		err = rw.deleteOldRolls(history)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (rw *rollingFileWriter) Write(bytes []byte) (n int, err error) {
+	rw.rollLock.Lock()
+	defer rw.rollLock.Unlock()
+
+	if rw.self.needsToRoll() {
+		if err := rw.roll(); err != nil {
+			return 0, err
+		}
+	}
+
+	if rw.currentFile == nil {
+		err := rw.createFileAndFolderIfNeeded()
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	n, err = rw.currentFile.Write(bytes)
+	rw.currentFileSize += int64(n)
+	return n, err
+}
+
+func (rw *rollingFileWriter) Close() error {
+	if rw.currentFile != nil {
+		e := rw.currentFile.Close()
+		if e != nil {
+			return e
+		}
+		rw.currentFile = nil
+	}
+	return nil
+}
+
+// --------------------------------------------------
+//      Rolling writer by SIZE
+// --------------------------------------------------
+
+// RollingFileWriterSize performs roll when file exceeds a specified limit.
+type RollingFileWriterSize struct {
+	*rollingFileWriter
+	maxFileSize int64
+}
+
+// NewRollingFileWriterSize creates a new RollingFileWriterSize.
+func NewRollingFileWriterSize(fpath string, maxSize int64, maxRolls int, namemode RollingNameMode) (*RollingFileWriterSize, error) {
+	rw, err := newRollingFileWriter(fpath, maxRolls, namemode, false)
+	if err != nil {
+		return nil, err
+	}
+	rws := &RollingFileWriterSize{rw, maxSize}
+	rws.self = rws
+	return rws, nil
+}
+
+func (rws *RollingFileWriterSize) needsToRoll() bool {
+	return rws.currentFileSize >= rws.maxFileSize
+}
+
+func (rws *RollingFileWriterSize) isFileRollNameValid(rname string) bool {
+	if len(rname) == 0 {
+		return false
+	}
+	_, err := strconv.Atoi(rname)
+	return err == nil
+}
+
+type rollSizeFileTailsSlice []string
+
+func (p rollSizeFileTailsSlice) Len() int {
+	return len(p)
+}
+func (p rollSizeFileTailsSlice) Less(i, j int) bool {
+	v1, _ := strconv.Atoi(p[i])
+	v2, _ := strconv.Atoi(p[j])
+	return v1 < v2
+}
+func (p rollSizeFileTailsSlice) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+func (rws *RollingFileWriterSize) sortFileRollNamesAsc(fs []string) ([]string, error) {
+	ss := rollSizeFileTailsSlice(fs)
+	sort.Sort(ss)
+	return ss, nil
+}
+
+func (rws *RollingFileWriterSize) getNewHistoryRollFileName(otherLogFiles []string) string {
+	v := 0
+	if len(otherLogFiles) != 0 {
+		latest := otherLogFiles[len(otherLogFiles)-1]
+		v, _ = strconv.Atoi(rws.getFileRollName(latest))
+	}
+	return fmt.Sprintf("%d", v+1)
+}
+
+func (rws *RollingFileWriterSize) getCurrentFileName() string {
+	return rws.fileName
+}
+
+func (rws *RollingFileWriterSize) String() string {
+	return fmt.Sprintf("Rolling file writer (By SIZE): filename: %s, maxFileSize: %v, maxRolls: %v",
+		rws.fileName,
+		rws.maxFileSize,
+		rws.maxRolls)
+}
+
+// --------------------------------------------------
+//      Helpers
+// --------------------------------------------------
+
+// filePathFilter is a filtering creteria function for file path.
+// Must return 'false' to set aside the given file.
+type filePathFilter func(filePath string) bool
+
+// getDirFilePaths return full paths of the files located in the directory.
+// Remark: Ignores files for which fileFilter returns false.
+func getDirFilePaths(dirPath string, fpFilter filePathFilter, pathIsName bool) ([]string, error) {
+	dfi, err := os.Open(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open directory %s: %w", dirPath, err)
+	}
+	defer dfi.Close()
+
+	var absDirPath string
+	if !filepath.IsAbs(dirPath) {
+		absDirPath, err = filepath.Abs(dirPath)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get absolute path of directory: %s", err.Error())
+		}
+	} else {
+		absDirPath = dirPath
+	}
+
+	// TODO: check if dirPath is really directory.
+	// Size of read buffer (i.e. chunk of items read at a time).
+	rbs := 2 << 5
+	filePaths := []string{}
+
+	var fp string
+L:
+	for {
+		// Read directory entities by reasonable chuncks
+		// to prevent overflows on big number of files.
+		fis, e := dfi.Readdir(rbs)
+		switch e {
+		// It's OK.
+		case nil:
+		// Do nothing, just continue cycle.
+		case io.EOF:
+			break L
+		// Indicate that something went wrong.
+		default:
+			return nil, e
+		}
+		// THINK: Maybe, use async running.
+		for _, fi := range fis {
+			// NB: Should work on every Windows and non-Windows OS.
+			if isRegular(fi.Mode()) {
+				if pathIsName {
+					fp = fi.Name()
+				} else {
+					// Build full path of a file.
+					fp = filepath.Join(absDirPath, fi.Name())
+				}
+				// Check filter condition.
+				if fpFilter != nil && !fpFilter(fp) {
+					continue
+				}
+				filePaths = append(filePaths, fp)
+			}
+		}
+	}
+	return filePaths, nil
+}
+
+func isRegular(m os.FileMode) bool {
+	return m&os.ModeType == 0
+}
+
+// tryRemoveFile gives a try removing the file
+// only ignoring an error when the file does not exist.
+func tryRemoveFile(filePath string) (err error) {
+	err = os.Remove(filePath)
+	if os.IsNotExist(err) {
+		err = nil
+		return
+	}
+	return
+}
+
+func reportInternalError(err error) {
+	fmt.Fprintf(os.Stderr, "log internal error: %s\n", err)
+}

--- a/pkg/util/log/slog/filewriter/file_writer_test.go
+++ b/pkg/util/log/slog/filewriter/file_writer_test.go
@@ -1,0 +1,407 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package filewriter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRollingFileWriterSize(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	require.NotNil(t, writer)
+
+	defer writer.Close()
+
+	assert.Equal(t, "test.log", writer.fileName)
+	assert.Equal(t, int64(1024), writer.maxFileSize)
+	assert.Equal(t, 5, writer.maxRolls)
+}
+
+func TestRollingFileWriterWrite(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	data := []byte("test log message\n")
+	n, err := writer.Write(data)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(data), n)
+
+	// Verify file was created
+	_, err = os.Stat(logPath)
+	assert.NoError(t, err)
+}
+
+func TestRollingFileWriterMultipleWrites(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	// Write multiple messages
+	for i := 0; i < 10; i++ {
+		_, err := writer.Write([]byte("test message\n"))
+		assert.NoError(t, err)
+	}
+
+	// Verify file exists and has content
+	stat, err := os.Stat(logPath)
+	assert.NoError(t, err)
+	assert.Greater(t, stat.Size(), int64(0))
+}
+
+func TestRollingFileWriterRollBySize(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	// Small max size to trigger rolling
+	maxSize := int64(100)
+	writer, err := NewRollingFileWriterSize(logPath, maxSize, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	// Write enough data to exceed max size
+	data := make([]byte, maxSize+10)
+	for i := range data {
+		data[i] = 'A'
+	}
+
+	_, err = writer.Write(data)
+	require.NoError(t, err)
+
+	// Write more to trigger roll
+	_, err = writer.Write([]byte("trigger roll\n"))
+	require.NoError(t, err)
+
+	// Check that rolled file exists
+	rolledPath := filepath.Join(tempDir, "test.log.1")
+	_, err = os.Stat(rolledPath)
+	require.NoError(t, err)
+}
+
+func TestRollingFileWriterClose(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+
+	_, err = writer.Write([]byte("test\n"))
+	require.NoError(t, err)
+
+	err = writer.Close()
+	require.NoError(t, err)
+
+	// Close should be idempotent
+	err = writer.Close()
+	require.NoError(t, err)
+}
+
+func TestRollingFileWriterPostfixNaming(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	assert.Equal(t, RollingNameMode(RollingNameModePostfix), writer.nameMode)
+
+	// Test roll name format
+	assert.True(t, writer.hasRollName("test.log.1"))
+	assert.True(t, writer.hasRollName("test.log.2"))
+	assert.False(t, writer.hasRollName("test.log"))
+	assert.False(t, writer.hasRollName("other.log.1"))
+}
+
+func TestRollingFileWriterPrefixNaming(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePrefix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	assert.Equal(t, RollingNameMode(RollingNameModePrefix), writer.nameMode)
+
+	// Test roll name format
+	assert.True(t, writer.hasRollName("1.test.log"))
+	assert.True(t, writer.hasRollName("2.test.log"))
+	assert.False(t, writer.hasRollName("test.log"))
+}
+
+func TestRollingFileWriterIsFileRollNameValid(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	assert.True(t, writer.isFileRollNameValid("1"))
+	assert.True(t, writer.isFileRollNameValid("123"))
+	assert.False(t, writer.isFileRollNameValid(""))
+	assert.False(t, writer.isFileRollNameValid("abc"))
+	assert.False(t, writer.isFileRollNameValid("1.2"))
+}
+
+func TestRollingFileWriterGetCurrentFileName(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	assert.Equal(t, "test.log", writer.getCurrentFileName())
+}
+
+func TestRollingFileWriterString(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	str := writer.String()
+	assert.Contains(t, str, "test.log")
+	assert.Contains(t, str, "1024")
+	assert.Contains(t, str, "5")
+}
+
+func TestRollingFileWriterDirectoryCreation(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "subdir", "nested", "test.log")
+
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	// Write to trigger directory creation
+	_, err = writer.Write([]byte("test\n"))
+	assert.NoError(t, err)
+
+	// Verify directory was created
+	_, err = os.Stat(filepath.Dir(logPath))
+	assert.NoError(t, err)
+}
+
+func TestRollingFileWriterMaxRollsZero(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	// maxRolls = 0 means unlimited rolls
+	writer, err := NewRollingFileWriterSize(logPath, 1024, 0, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	assert.Equal(t, 0, writer.maxRolls)
+}
+
+func TestRollingFileWriterRelativePath(t *testing.T) {
+	tempDir := t.TempDir()
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+
+	err := os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	writer, err := NewRollingFileWriterSize("test.log", 1024, 5, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	_, err = writer.Write([]byte("test\n"))
+	assert.NoError(t, err)
+
+	// Verify file was created in current directory
+	_, err = os.Stat("test.log")
+	assert.NoError(t, err)
+}
+
+func TestGetDirFilePaths(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create some test files
+	testFiles := []string{"file1.txt", "file2.log", "file3.txt"}
+	for _, f := range testFiles {
+		err := os.WriteFile(filepath.Join(tempDir, f), []byte("test"), 0644)
+		require.NoError(t, err)
+	}
+
+	// Get all files
+	files, err := getDirFilePaths(tempDir, nil, true)
+	assert.NoError(t, err)
+	assert.Len(t, files, 3)
+}
+
+func TestGetDirFilePathsWithFilter(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create some test files
+	testFiles := []string{"file1.txt", "file2.log", "file3.txt"}
+	for _, f := range testFiles {
+		err := os.WriteFile(filepath.Join(tempDir, f), []byte("test"), 0644)
+		require.NoError(t, err)
+	}
+
+	// Filter for .txt files only
+	filter := func(path string) bool {
+		return filepath.Ext(path) == ".txt"
+	}
+
+	files, err := getDirFilePaths(tempDir, filter, true)
+	assert.NoError(t, err)
+	assert.Len(t, files, 2)
+}
+
+func TestTryRemoveFile(t *testing.T) {
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "test.txt")
+
+	// Create a test file
+	err := os.WriteFile(testFile, []byte("test"), 0644)
+	require.NoError(t, err)
+
+	// Remove it
+	err = tryRemoveFile(testFile)
+	assert.NoError(t, err)
+
+	// Verify it's gone
+	_, err = os.Stat(testFile)
+	assert.True(t, os.IsNotExist(err))
+
+	// Removing non-existent file should not error
+	err = tryRemoveFile(testFile)
+	assert.NoError(t, err)
+}
+
+func TestIsRegular(t *testing.T) {
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "test.txt")
+
+	err := os.WriteFile(testFile, []byte("test"), 0644)
+	require.NoError(t, err)
+
+	info, err := os.Stat(testFile)
+	require.NoError(t, err)
+
+	assert.True(t, isRegular(info.Mode()))
+
+	// Directory should not be regular
+	dirInfo, err := os.Stat(tempDir)
+	require.NoError(t, err)
+	assert.False(t, isRegular(dirInfo.Mode()))
+}
+
+func TestRollingFileWriterExceedMaxRolls(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	// Set a very small max size to trigger rolling easily
+	maxSize := int64(50)
+	maxRolls := 3
+	writer, err := NewRollingFileWriterSize(logPath, maxSize, maxRolls, RollingNameModePostfix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	// Write enough data to trigger multiple rolls
+	// Each write is 60 bytes, exceeding maxSize, so each write should trigger a roll
+	data := make([]byte, 60)
+	for i := range data {
+		data[i] = 'A'
+	}
+
+	// Write 6 times to create more rolls than maxRolls allows
+	// This should create: test.log.1, test.log.2, test.log.3, test.log.4, test.log.5, test.log.6
+	// But with maxRolls=3, only the 3 most recent should be kept
+	for i := 0; i < 6; i++ {
+		_, err = writer.Write(data)
+		assert.NoError(t, err)
+	}
+
+	// Get all files in directory
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+
+	// Count log files (excluding the current test.log)
+	logFiles := make([]string, 0)
+	for _, f := range files {
+		name := f.Name()
+		if name != "test.log" && strings.HasPrefix(name, "test.log.") {
+			logFiles = append(logFiles, name)
+		}
+	}
+
+	// Should have at most maxRolls rolled files (plus the current file)
+	assert.LessOrEqual(t, len(logFiles), maxRolls,
+		"Expected at most %d rolled files, got %d: %v", maxRolls, len(logFiles), logFiles)
+
+	// Verify the current file exists
+	_, err = os.Stat(logPath)
+	assert.NoError(t, err)
+}
+
+func TestRollingFileWriterExceedMaxRollsPrefix(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	// Test with prefix mode
+	maxSize := int64(50)
+	maxRolls := 2
+	writer, err := NewRollingFileWriterSize(logPath, maxSize, maxRolls, RollingNameModePrefix)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	// Write enough data to trigger multiple rolls
+	data := make([]byte, 60)
+	for i := range data {
+		data[i] = 'B'
+	}
+
+	// Write 5 times to exceed maxRolls
+	for i := 0; i < 5; i++ {
+		_, err = writer.Write(data)
+		assert.NoError(t, err)
+	}
+
+	// Get all files in directory
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+
+	// Count log files (excluding the current test.log)
+	logFiles := make([]string, 0)
+	for _, f := range files {
+		name := f.Name()
+		if name != "test.log" && strings.HasSuffix(name, ".test.log") {
+			logFiles = append(logFiles, name)
+		}
+	}
+
+	// Should have at most maxRolls rolled files
+	assert.LessOrEqual(t, len(logFiles), maxRolls,
+		"Expected at most %d rolled files, got %d: %v", maxRolls, len(logFiles), logFiles)
+
+	// Verify the current file exists
+	_, err = os.Stat(logPath)
+	assert.NoError(t, err)
+}

--- a/pkg/util/log/slog/format/docs.go
+++ b/pkg/util/log/slog/format/docs.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package format provides functions to format log messages
+package format

--- a/pkg/util/log/slog/format/json.go
+++ b/pkg/util/log/slog/format/json.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+
+package format
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/formatters"
+)
+
+// JSON returns a function that formats a slog.Record as a JSON string.
+func JSON(loggerName string, logFormatRFC3339 bool) func(context.Context, slog.Record) string {
+	if loggerName == "JMXFETCH" {
+		return func(_ context.Context, record slog.Record) string {
+			return fmt.Sprintf(`{"msg":%s}\n`, formatters.Quote(record.Message))
+
+		}
+	}
+
+	dateFmt := formatters.Date(logFormatRFC3339)
+	return func(_ context.Context, record slog.Record) string {
+		frames := runtime.CallersFrames([]uintptr{record.PC})
+		frame, _ := frames.Next()
+
+		levelStr := formatters.LevelToString(record.Level)
+		shortFilePath := formatters.ShortFilePath(frame)
+		shortFunction := formatters.ShortFunction(frame)
+		extraJSONContext := formatters.ExtraJSONContext(record)
+
+		return fmt.Sprintf(`{"agent":"%s","time":"%s","level":"%s","file":"%s","line":"%d","func":"%s","msg":%s%s}\n`, strings.ToLower(loggerName), dateFmt(record.Time), levelStr, shortFilePath, frame.Line, shortFunction, formatters.Quote(record.Message), extraJSONContext)
+	}
+}

--- a/pkg/util/log/slog/format/json_serverless.go
+++ b/pkg/util/log/slog/format/json_serverless.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+
+package format
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/formatters"
+)
+
+// JSON returns a function that formats a slog.Record as a JSON string.
+func JSON(loggerName string, logFormatRFC3339 bool) func(context.Context, slog.Record) string {
+	dateFmt := formatters.Date(logFormatRFC3339)
+	return func(_ context.Context, record slog.Record) string {
+		frames := runtime.CallersFrames([]uintptr{record.PC})
+		frame, _ := frames.Next()
+
+		levelStr := formatters.LevelToString(record.Level)
+		shortFunction := formatters.ShortFunction(frame)
+
+		return fmt.Sprintf(`{"agent":"%s","time":"%s","level":"%s","file":"","line":"","func":"%s","msg":%s}\n`, strings.ToLower(loggerName), dateFmt(record.Time), levelStr, shortFunction, formatters.Quote(record.Message))
+	}
+}

--- a/pkg/util/log/slog/format/json_test.go
+++ b/pkg/util/log/slog/format/json_test.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+
+package format
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSON(t *testing.T) {
+	formatter := JSON("CORE", false)
+	require.NotNil(t, formatter)
+
+	record := slog.NewRecord(
+		time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC),
+		slog.LevelInfo,
+		"test message",
+		getCurrentPC(),
+	)
+
+	result := formatter(context.Background(), record)
+
+	// Result should end with newline and contain expected fields
+	assert.NotEmpty(t, result)
+
+	// Should contain expected components (not parsing JSON due to multiple lines)
+	assert.Contains(t, result, `"agent":"core"`)
+	assert.Contains(t, result, `"msg":"test message"`)
+	assert.Contains(t, result, `"level"`)
+	assert.Contains(t, result, `"file"`)
+	assert.Contains(t, result, `"line"`)
+	assert.Contains(t, result, `"func"`)
+	assert.Contains(t, result, `"time"`)
+}
+
+func TestJSONRFC3339(t *testing.T) {
+	formatter := JSON("CORE", true)
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+	record := slog.NewRecord(testTime, slog.LevelInfo, "test", getCurrentPC())
+
+	result := formatter(context.Background(), record)
+
+	// Check that time is in RFC3339 format (2023-11-04T15:30:45Z)
+	assert.Contains(t, result, "2023-11-04T15:30:45Z")
+}
+
+func TestJSONJMXFETCH(t *testing.T) {
+	formatter := JSON("JMXFETCH", false)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+	result := formatter(context.Background(), record)
+
+	// JMXFETCH should have simplified format with only msg field
+	assert.Contains(t, result, `"msg":"test message"`)
+	assert.NotContains(t, result, `"agent"`)
+	assert.NotContains(t, result, `"time"`)
+}
+
+func TestJSONWithAttributes(t *testing.T) {
+	formatter := JSON("CORE", false)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", getCurrentPC())
+	record.AddAttrs(
+		slog.String("key1", "value1"),
+		slog.Int("key2", 42),
+	)
+
+	result := formatter(context.Background(), record)
+
+	// Check that attributes are included in JSON output
+	assert.Contains(t, result, `"key1":"value1"`)
+	// key2 might be quoted as "42" in the output
+	assert.Contains(t, result, `"key2":`)
+}
+
+func TestJSONSpecialCharacters(t *testing.T) {
+	formatter := JSON("CORE", false)
+
+	// Test message with special characters that need escaping
+	message := `test "quoted"`
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, message, getCurrentPC())
+	result := formatter(context.Background(), record)
+
+	// Should contain escaped quotes in JSON
+	assert.Contains(t, result, `\"`)
+}
+
+func TestJSONEmptyMessage(t *testing.T) {
+	formatter := JSON("CORE", false)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "", getCurrentPC())
+	result := formatter(context.Background(), record)
+
+	// Should have empty msg field
+	assert.Contains(t, result, `"msg":""`)
+}
+
+func TestJSONLoggerNameCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"CORE", "core"},
+		{"JMX", "jmx"},
+		{"core", "core"},
+		{"Agent", "agent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			formatter := JSON(tt.input, false)
+
+			record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", getCurrentPC())
+			result := formatter(context.Background(), record)
+
+			if tt.input == "JMXFETCH" {
+				// Skip for JMXFETCH as it has different format
+				return
+			}
+
+			// Check agent name in JSON
+			assert.Contains(t, result, fmt.Sprintf(`"agent":"%s"`, tt.expected))
+		})
+	}
+}
+
+func TestJSONDifferentLevels(t *testing.T) {
+	formatter := JSON("CORE", false)
+
+	levels := []slog.Level{
+		slog.LevelDebug,
+		slog.LevelInfo,
+		slog.LevelWarn,
+		slog.LevelError,
+	}
+
+	for _, l := range levels {
+		t.Run(l.String(), func(t *testing.T) {
+			record := slog.NewRecord(time.Now(), l, "test", getCurrentPC())
+			result := formatter(context.Background(), record)
+
+			// Just check that level is present in output
+			assert.Contains(t, result, `"level"`)
+		})
+	}
+}

--- a/pkg/util/log/slog/format/test_utils.go
+++ b/pkg/util/log/slog/format/test_utils.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package format
+
+import "runtime"
+
+func getCurrentPC() uintptr {
+	var pc [1]uintptr
+	runtime.Callers(1, pc[:])
+	return pc[0]
+}

--- a/pkg/util/log/slog/format/text.go
+++ b/pkg/util/log/slog/format/text.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+
+package format
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/formatters"
+)
+
+// Text returns a function that formats a slog.Record as a string.
+func Text(loggerName string, logFormatRFC3339 bool) func(context.Context, slog.Record) string {
+	if loggerName == "JMXFETCH" {
+		return func(_ context.Context, record slog.Record) string {
+			return record.Message + "\n"
+		}
+	}
+
+	dateFmt := formatters.Date(logFormatRFC3339)
+	return func(_ context.Context, record slog.Record) string {
+		frames := runtime.CallersFrames([]uintptr{record.PC})
+		frame, _ := frames.Next()
+
+		levelStr := formatters.LevelToString(record.Level)
+		shortFilePath := formatters.ShortFilePath(frame)
+		shortFunction := formatters.ShortFunction(frame)
+		extraTextContext := formatters.ExtraTextContext(record)
+
+		return fmt.Sprintf("%s | %s | %s | (%s:%d in %s) | %s%s\n", dateFmt(record.Time), loggerName, levelStr, shortFilePath, frame.Line, shortFunction, extraTextContext, record.Message)
+	}
+}

--- a/pkg/util/log/slog/format/text_serverless.go
+++ b/pkg/util/log/slog/format/text_serverless.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+
+package format
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/formatters"
+)
+
+// Text returns a function that formats a slog.Record as a string.
+func Text(loggerName string, logFormatRFC3339 bool) func(context.Context, slog.Record) string {
+	dateFmt := formatters.Date(logFormatRFC3339)
+	return func(_ context.Context, record slog.Record) string {
+		levelStr := formatters.LevelToString(record.Level)
+
+		return fmt.Sprintf("%s | %s | %s | %s\n", dateFmt(record.Time), loggerName, levelStr, record.Message)
+	}
+}

--- a/pkg/util/log/slog/format/text_test.go
+++ b/pkg/util/log/slog/format/text_test.go
@@ -1,0 +1,179 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+
+package format
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestText(t *testing.T) {
+	formatter := Text("CORE", false)
+	require.NotNil(t, formatter)
+
+	record := slog.NewRecord(
+		time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC),
+		slog.LevelInfo,
+		"test message",
+		getCurrentPC(),
+	)
+
+	result := formatter(context.Background(), record)
+
+	// Should end with newline
+	assert.True(t, strings.HasSuffix(result, "\n"))
+
+	// Should contain expected components
+	assert.Contains(t, result, "CORE")
+	assert.Contains(t, result, "test message")
+	assert.Contains(t, result, "|")
+}
+
+func TestTextRFC3339(t *testing.T) {
+	formatter := Text("CORE", true)
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+	record := slog.NewRecord(testTime, slog.LevelInfo, "test", getCurrentPC())
+
+	result := formatter(context.Background(), record)
+
+	// Should contain RFC3339 formatted time
+	assert.Contains(t, result, "2023-11-04T15:30:45Z")
+}
+
+func TestTextJMXFETCH(t *testing.T) {
+	formatter := Text("JMXFETCH", false)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+	result := formatter(context.Background(), record)
+
+	// JMXFETCH should have simplified format
+	assert.Equal(t, "test message\n", result)
+}
+
+func TestTextWithAttributes(t *testing.T) {
+	formatter := Text("CORE", false)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", getCurrentPC())
+	record.AddAttrs(
+		slog.String("key1", "value1"),
+		slog.Int("key2", 42),
+	)
+
+	result := formatter(context.Background(), record)
+
+	// Should contain attributes
+	assert.Contains(t, result, "key1:value1")
+	assert.Contains(t, result, "key2:42")
+}
+
+func TestTextEmptyMessage(t *testing.T) {
+	formatter := Text("CORE", false)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "", getCurrentPC())
+	result := formatter(context.Background(), record)
+
+	// Should still have structure even with empty message
+	assert.Contains(t, result, "CORE")
+	assert.True(t, strings.HasSuffix(result, "\n"))
+}
+
+func TestTextDifferentLevels(t *testing.T) {
+	formatter := Text("CORE", false)
+
+	levels := []slog.Level{
+		slog.LevelDebug,
+		slog.LevelInfo,
+		slog.LevelWarn,
+		slog.LevelError,
+	}
+
+	for _, l := range levels {
+		t.Run(l.String(), func(t *testing.T) {
+			record := slog.NewRecord(time.Now(), l, "test", getCurrentPC())
+			result := formatter(context.Background(), record)
+
+			// Should contain the logger name and message
+			assert.Contains(t, result, "CORE")
+			assert.Contains(t, result, "test")
+		})
+	}
+}
+
+func TestTextLoggerName(t *testing.T) {
+	tests := []string{"CORE", "JMX", "AGENT", "PROCESS"}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			if name == "JMXFETCH" {
+				// Skip JMXFETCH as it has different format
+				return
+			}
+
+			formatter := Text(name, false)
+
+			record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", getCurrentPC())
+			result := formatter(context.Background(), record)
+
+			assert.Contains(t, result, name)
+		})
+	}
+}
+
+func TestTextFormat(t *testing.T) {
+	formatter := Text("CORE", false)
+
+	record := slog.NewRecord(
+		time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC),
+		slog.LevelInfo,
+		"test message",
+		getCurrentPC(),
+	)
+
+	result := formatter(context.Background(), record)
+
+	// Verify format structure: date | name | level | (file:line in func) | message
+	parts := strings.Split(strings.TrimSpace(result), "|")
+	assert.GreaterOrEqual(t, len(parts), 4)
+
+	// Check that parts contain expected content
+	assert.Contains(t, parts[0], "2023-11-04") // date
+	assert.Contains(t, parts[1], "CORE")       // name
+	// parts[2] is level - don't check exact value
+}
+
+func TestTextSpecialCharactersInMessage(t *testing.T) {
+	formatter := Text("CORE", false)
+
+	// Test message with special characters
+	message := "test | message | with | pipes"
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, message, getCurrentPC())
+
+	result := formatter(context.Background(), record)
+
+	// Message should be preserved
+	assert.Contains(t, result, message)
+}
+
+func TestTextMultilineMessage(t *testing.T) {
+	formatter := Text("CORE", false)
+
+	message := "line1\nline2\nline3"
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, message, getCurrentPC())
+
+	result := formatter(context.Background(), record)
+
+	// Multiline message should be preserved
+	assert.Contains(t, result, message)
+}

--- a/pkg/util/log/slog/formatters/context.go
+++ b/pkg/util/log/slog/formatters/context.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"log/slog"
+	"strconv"
+	"strings"
+)
+
+type contextFormat uint8
+
+const (
+	jsonFormat = contextFormat(iota)
+	textFormat
+)
+
+// ExtraJSONContext creates a JSON string of the record's attributes.
+func ExtraJSONContext(record slog.Record) string {
+	return extractContextString(jsonFormat, record)
+}
+
+// ExtraTextContext creates a text string of the record's attributes.
+func ExtraTextContext(record slog.Record) string {
+	return extractContextString(textFormat, record)
+}
+
+func extractContextString(format contextFormat, record slog.Record) string {
+	if record.NumAttrs() == 0 {
+		return ""
+	}
+
+	builder := strings.Builder{}
+	if format == jsonFormat {
+		builder.WriteString(",")
+	}
+
+	idx := 0
+	record.Attrs(func(a slog.Attr) bool {
+		idx++
+		addToBuilder(&builder, a.Key, a.Value, format, idx == record.NumAttrs())
+		return true
+	})
+
+	if format != jsonFormat {
+		builder.WriteString(" | ")
+	}
+
+	return builder.String()
+}
+
+func addToBuilder(builder *strings.Builder, key string, value slog.Value, format contextFormat, isLast bool) {
+	var buf []byte
+	appendFmt(builder, format, key, buf)
+	builder.WriteString(":")
+	appendFmt(builder, format, value.String(), buf)
+	if !isLast {
+		builder.WriteString(",")
+	}
+}
+
+func appendFmt(builder *strings.Builder, format contextFormat, s string, buf []byte) {
+	if format == jsonFormat {
+		buf = buf[:0]
+		buf = strconv.AppendQuote(buf, s)
+		builder.Write(buf)
+	} else {
+		builder.WriteString(s)
+	}
+}

--- a/pkg/util/log/slog/formatters/context_test.go
+++ b/pkg/util/log/slog/formatters/context_test.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractContextString(t *testing.T) {
+	assert.Equal(t, `,"foo":"bar"`, ExtraJSONContext(makeRecord("foo", "bar")))
+	assert.Equal(t, `foo:bar | `, ExtraTextContext(makeRecord("foo", "bar")))
+	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, ExtraJSONContext(makeRecord("foo", "bar", "bar", "buzz")))
+	assert.Equal(t, `foo:bar,bar:buzz | `, ExtraTextContext(makeRecord("foo", "bar", "bar", "buzz")))
+	assert.Equal(t, `,"foo":"b\"a\"r"`, ExtraJSONContext(makeRecord("foo", "b\"a\"r")))
+	assert.Equal(t, `,"foo":"3"`, ExtraJSONContext(makeRecord("foo", 3)))
+	assert.Equal(t, `,"foo":"4.131313131"`, ExtraJSONContext(makeRecord("foo", float64(4.131313131))))
+	assert.Equal(t, "", ExtraJSONContext(makeRecord()))
+	assert.Equal(t, ",\"!BADKEY\":\"2\",\"!BADKEY\":\"3\"", ExtraJSONContext(makeRecord(2, 3)))
+}
+
+func makeRecord(attrs ...interface{}) slog.Record {
+	record := slog.Record{}
+	record.Add(attrs...)
+	return record
+}

--- a/pkg/util/log/slog/formatters/date.go
+++ b/pkg/util/log/slog/formatters/date.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import "time"
+
+const logDateFormat = "2006-01-02 15:04:05 MST" // see time.Format for format syntax
+
+// Date returns a function that formats a time.Time to a string.
+func Date(logFormatRFC3339 bool) func(time.Time) string {
+	format := getLogDateFormat(logFormatRFC3339)
+	return func(t time.Time) string {
+		return t.Format(format)
+	}
+}
+
+func getLogDateFormat(logFormatRFC3339 bool) string {
+	if logFormatRFC3339 {
+		return time.RFC3339
+	}
+	return logDateFormat
+}

--- a/pkg/util/log/slog/formatters/date_test.go
+++ b/pkg/util/log/slog/formatters/date_test.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDate(t *testing.T) {
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+
+	formatter := Date(false)
+	result := formatter(testTime)
+
+	assert.Equal(t, "2023-11-04 15:30:45 UTC", result)
+}
+
+func TestDateRFC3339(t *testing.T) {
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+
+	formatter := Date(true)
+	result := formatter(testTime)
+
+	assert.Equal(t, "2023-11-04T15:30:45Z", result)
+}
+
+func TestDateWithTimezone(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("Timezone not available")
+	}
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, loc)
+
+	formatter := Date(false)
+	result := formatter(testTime)
+
+	assert.Equal(t, result, "2023-11-04 15:30:45 EDT")
+}
+
+func TestDateRFC3339WithTimezone(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("Timezone not available")
+	}
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, loc)
+
+	formatter := Date(true)
+	result := formatter(testTime)
+
+	assert.Equal(t, result, "2023-11-04T15:30:45-04:00")
+}
+
+func TestDateConsistency(t *testing.T) {
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+
+	formatter := Date(false)
+
+	// Multiple calls should return the same result
+	result1 := formatter(testTime)
+	result2 := formatter(testTime)
+
+	assert.Equal(t, result1, result2)
+}
+
+func TestDateZeroTime(t *testing.T) {
+	testTime := time.Time{}
+
+	formatter := Date(false)
+	result := formatter(testTime)
+
+	// Should not panic with zero time
+	assert.NotEmpty(t, result)
+}
+
+func TestGetLogDateFormat(t *testing.T) {
+	// Test default format
+	format := getLogDateFormat(false)
+	assert.Equal(t, logDateFormat, format)
+
+	// Test RFC3339 format
+	format = getLogDateFormat(true)
+	assert.Equal(t, time.RFC3339, format)
+}
+
+func TestDateWithNanoseconds(t *testing.T) {
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 123456789, time.UTC)
+
+	formatter := Date(false)
+	result := formatter(testTime)
+
+	// Default format doesn't include nanoseconds
+	assert.Equal(t, "2023-11-04 15:30:45 UTC", result)
+}
+
+func TestDateRFC3339WithNanoseconds(t *testing.T) {
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 123456789, time.UTC)
+
+	formatter := Date(true)
+	result := formatter(testTime)
+
+	assert.Equal(t, result, "2023-11-04T15:30:45Z")
+}

--- a/pkg/util/log/slog/formatters/docs.go
+++ b/pkg/util/log/slog/formatters/docs.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package formatters provides functions to format log messages.
+package formatters

--- a/pkg/util/log/slog/formatters/file.go
+++ b/pkg/util/log/slog/formatters/file.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"runtime"
+	"strings"
+)
+
+// ShortFilePath returns the short path of the file that the log message was emitted from.
+func ShortFilePath(frame runtime.Frame) string {
+	return extractShortPathFromFullPath(frame.File)
+}
+
+func extractShortPathFromFullPath(fullPath string) string {
+	shortPath := ""
+	if strings.Contains(fullPath, "-agent/") {
+		// We want to trim the part containing the path of the project
+		// ie DataDog/datadog-agent/ or DataDog/datadog-process-agent/
+		slices := strings.Split(fullPath, "-agent/")
+		shortPath = slices[len(slices)-1]
+	} else {
+		// For logging from dependencies, we want to log e.g.
+		// "collector@v0.35.0/service/collector.go"
+		slices := strings.Split(fullPath, "/")
+		atSignIndex := len(slices) - 1
+		for ; atSignIndex > 0; atSignIndex-- {
+			if strings.Contains(slices[atSignIndex], "@") {
+				break
+			}
+		}
+		shortPath = strings.Join(slices[atSignIndex:], "/")
+	}
+	return shortPath
+}

--- a/pkg/util/log/slog/formatters/file_test.go
+++ b/pkg/util/log/slog/formatters/file_test.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractShortPathFromFullPath(t *testing.T) {
+	// omnibus path
+	assert.Equal(t, "pkg/collector/scheduler.go", extractShortPathFromFullPath("/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/scheduler.go"))
+	// dev env path
+	assert.Equal(t, "cmd/agent/app/start.go", extractShortPathFromFullPath("/home/vagrant/go/src/github.com/DataDog/datadog-agent/cmd/agent/app/start.go"))
+	// relative path
+	assert.Equal(t, "pkg/collector/scheduler.go", extractShortPathFromFullPath("pkg/collector/scheduler.go"))
+	// no path
+	assert.Equal(t, "main.go", extractShortPathFromFullPath("main.go"))
+	// process agent
+	assert.Equal(t, "cmd/agent/collector.go", extractShortPathFromFullPath("/home/jenkins/workspace/process-agent-build-ddagent/go/src/github.com/DataDog/datadog-process-agent/cmd/agent/collector.go"))
+	// various possible dependency paths
+	assert.Equal(t, "collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/Users/runner/programming/go/pkg/mod/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
+	assert.Equal(t, "collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/modcache/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
+}

--- a/pkg/util/log/slog/formatters/level.go
+++ b/pkg/util/log/slog/formatters/level.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"log/slog"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/types"
+)
+
+// LevelToString converts a slog.Level to a string
+func LevelToString(level slog.Level) string {
+	return types.LogLevel(level).String()
+}

--- a/pkg/util/log/slog/formatters/level_test.go
+++ b/pkg/util/log/slog/formatters/level_test.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/types"
+)
+
+func TestLevelToString(t *testing.T) {
+	tests := []struct {
+		level    slog.Level
+		expected string
+	}{
+		{slog.Level(types.TraceLvl), "trace"},
+		{slog.Level(types.DebugLvl), "debug"},
+		{slog.Level(types.InfoLvl), "info"},
+		{slog.Level(types.WarnLvl), "warn"},
+		{slog.Level(types.ErrorLvl), "error"},
+		{slog.Level(types.CriticalLvl), "critical"},
+		{slog.Level(types.Off), "off"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := LevelToString(tt.level)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/util/log/slog/formatters/quote.go
+++ b/pkg/util/log/slog/formatters/quote.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import "strconv"
+
+// Quote quotes a message.
+func Quote(message string) string {
+	return strconv.Quote(message)
+}

--- a/pkg/util/log/slog/formatters/quote_test.go
+++ b/pkg/util/log/slog/formatters/quote_test.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuote(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello", `"hello"`},
+		{"hello world", `"hello world"`},
+		{"", `""`},
+		{"hello\nworld", `"hello\nworld"`},
+		{"hello\tworld", `"hello\tworld"`},
+		{`hello"world`, `"hello\"world"`},
+		{`hello\world`, `"hello\\world"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := Quote(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestQuoteSpecialCharacters(t *testing.T) {
+	// Test various special characters
+	result := Quote("line1\nline2\ttab\rcarriage")
+	assert.Contains(t, result, `\n`)
+	assert.Contains(t, result, `\t`)
+	assert.Contains(t, result, `\r`)
+}
+
+func TestQuoteUnicode(t *testing.T) {
+	result := Quote("hello 世界")
+	assert.Contains(t, result, "hello")
+	// Unicode characters should be preserved or escaped
+	assert.NotEmpty(t, result)
+}
+
+func TestQuoteEmptyString(t *testing.T) {
+	result := Quote("")
+	assert.Equal(t, `""`, result)
+}

--- a/pkg/util/log/slog/formatters/short_function.go
+++ b/pkg/util/log/slog/formatters/short_function.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"runtime"
+	"strings"
+)
+
+// ShortFunction returns the short function name of the function that the log message was emitted from.
+func ShortFunction(frame runtime.Frame) string {
+	return frame.Function[strings.LastIndexByte(frame.Function, '.')+1:]
+}

--- a/pkg/util/log/slog/formatters/short_function_test.go
+++ b/pkg/util/log/slog/formatters/short_function_test.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package formatters
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShortFunction(t *testing.T) {
+	tests := []struct {
+		name     string
+		function string
+		expected string
+	}{
+		{
+			name:     "simple function",
+			function: "main.main",
+			expected: "main",
+		},
+		{
+			name:     "package function",
+			function: "github.com/DataDog/datadog-agent/pkg/util/log.Info",
+			expected: "Info",
+		},
+		{
+			name:     "nested package",
+			function: "github.com/DataDog/datadog-agent/pkg/util/log/slog.TestShortFunction",
+			expected: "TestShortFunction",
+		},
+		{
+			name:     "method on struct",
+			function: "github.com/DataDog/datadog-agent/pkg/util/log.(*Logger).Info",
+			expected: "Info",
+		},
+		{
+			name:     "closure",
+			function: "github.com/DataDog/datadog-agent/pkg/util/log.TestFunc.func1",
+			expected: "func1",
+		},
+		{
+			name:     "no dot",
+			function: "main",
+			expected: "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame := runtime.Frame{
+				Function: tt.function,
+			}
+			result := ShortFunction(frame)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestShortFunctionEmptyFrame(t *testing.T) {
+	frame := runtime.Frame{
+		Function: "",
+	}
+	result := ShortFunction(frame)
+	// Should handle empty function name without panicking
+	assert.Equal(t, "", result)
+}
+
+func TestShortFunctionRealFrame(t *testing.T) {
+	// Get a real frame from the current call
+	var pc [1]uintptr
+	runtime.Callers(1, pc[:])
+	frames := runtime.CallersFrames(pc[:])
+	frame, _ := frames.Next()
+
+	result := ShortFunction(frame)
+
+	// Should extract the function name
+	assert.NotEmpty(t, result)
+	assert.NotContains(t, result, "/")
+	assert.Equal(t, "TestShortFunctionRealFrame", result)
+}
+
+func helperFunction() runtime.Frame {
+	var pc [1]uintptr
+	runtime.Callers(1, pc[:])
+	frames := runtime.CallersFrames(pc[:])
+	frame, _ := frames.Next()
+	return frame
+}
+
+func TestShortFunctionFromHelper(t *testing.T) {
+	frame := helperFunction()
+	result := ShortFunction(frame)
+
+	assert.Equal(t, "helperFunction", result)
+}

--- a/pkg/util/log/slog/handlers/async_handler.go
+++ b/pkg/util/log/slog/handlers/async_handler.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"container/list"
+	"context"
+	"log/slog"
+	"sync"
+)
+
+var _ slog.Handler = (*Async)(nil)
+
+// Async is a slog handler that asynchronously writes logs to another slog handler.
+type Async struct {
+	wg sync.WaitGroup
+
+	// the condition is that either:
+	// - there is something to flush
+	// - there is something to write
+	// - the handler is closed
+	cond     *sync.Cond
+	closed   bool
+	msgQueue list.List
+	flush    *flushMsg
+
+	innerHandler slog.Handler
+}
+
+type flushMsg struct {
+	queue list.List
+	done  chan struct{}
+}
+
+type msg struct {
+	ctx    context.Context
+	record slog.Record
+}
+
+// NewAsyncHandler creates a new Async handler.
+//
+// The Async must be closed to avoid leaks.
+func NewAsyncHandler(innerHandler slog.Handler) *Async {
+	handler := &Async{
+		innerHandler: innerHandler,
+		cond:         sync.NewCond(&sync.Mutex{}),
+	}
+
+	handler.start()
+
+	return handler
+}
+
+func (h *Async) writeList(queue list.List) {
+	for e := queue.Front(); e != nil; e = e.Next() {
+		msg := e.Value.(msg)
+		//TODO: should we print an error which happens when failing to log ?
+		_ = h.innerHandler.Handle(msg.ctx, msg.record)
+	}
+}
+
+func (h *Async) start() {
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+
+		h.cond.L.Lock()
+		for {
+			// if there is something to flush, do it
+			if h.flush != nil {
+				flush := h.flush
+				h.flush = nil
+				h.cond.L.Unlock()
+
+				h.writeList(flush.queue)
+				close(flush.done)
+
+				h.cond.L.Lock()
+				continue
+			}
+
+			// if there is something to write, do it
+			if h.msgQueue.Len() > 0 {
+				queue := h.msgQueue
+				h.msgQueue = list.List{}
+				h.cond.L.Unlock()
+
+				h.writeList(queue)
+
+				h.cond.L.Lock()
+				continue
+			}
+
+			// if the handler is closed, exit
+			if h.closed {
+				h.cond.L.Unlock()
+				break
+			}
+
+			h.cond.Wait()
+		}
+	}()
+}
+
+// Flush writes all messages in the queue to the inner handler.
+func (h *Async) Flush() {
+	h.cond.L.Lock()
+
+	// if the handler is already closed, just wait for the goroutine to finish
+	if h.closed {
+		h.cond.L.Unlock()
+		h.wg.Wait()
+		return
+	}
+
+	// wait for the current flushes to finish
+	for h.flush != nil {
+		flushDone := h.flush.done
+		h.cond.L.Unlock()
+		<-flushDone
+		h.cond.L.Lock()
+	}
+
+	// if there is nothing to write, do nothing
+	if h.msgQueue.Len() == 0 {
+		h.cond.L.Unlock()
+		return
+	}
+
+	queue := h.msgQueue
+	h.msgQueue = list.List{}
+
+	// set the new flush message
+	done := make(chan struct{})
+	h.flush = &flushMsg{queue, done}
+	h.cond.L.Unlock()
+
+	// wait for the flush to finish
+	<-done
+}
+
+// Handle writes a record to the handler.
+func (h *Async) Handle(ctx context.Context, r slog.Record) error {
+	h.cond.L.Lock()
+	if h.closed {
+		h.cond.L.Unlock()
+		return nil
+	}
+
+	h.msgQueue.PushBack(msg{ctx, r})
+	h.cond.L.Unlock()
+
+	h.cond.Broadcast()
+
+	return nil
+}
+
+// Enabled returns true if the handler is enabled for the given level.
+func (h *Async) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.innerHandler.Enabled(ctx, level)
+}
+
+// Close closes the handler.
+func (h *Async) Close() error {
+	h.cond.L.Lock()
+	h.closed = true
+	h.cond.Broadcast()
+	h.cond.L.Unlock()
+
+	h.wg.Wait() // wait for the goroutine to finish
+	return nil
+}
+
+// WithAttrs returns a new handler with the given attributes.
+func (h *Async) WithAttrs(_attrs []slog.Attr) slog.Handler {
+	panic("not implemented")
+}
+
+// WithGroup returns a new handler with the given group name.
+func (h *Async) WithGroup(_name string) slog.Handler {
+	panic("not implemented")
+}

--- a/pkg/util/log/slog/handlers/async_handler_test.go
+++ b/pkg/util/log/slog/handlers/async_handler_test.go
@@ -1,0 +1,266 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAsyncHandler(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	require.NotNil(t, handler)
+	assert.NotNil(t, handler.innerHandler)
+
+	err := handler.Close()
+	assert.NoError(t, err)
+}
+
+func TestAsyncHandlerHandle(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	defer func() {
+		err := handler.Close()
+		assert.NoError(t, err)
+	}()
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+	err := handler.Handle(context.Background(), record)
+	assert.NoError(t, err)
+
+	// Wait for async processing
+	handler.Flush()
+
+	assert.Equal(t, 1, inner.recordCount())
+	assert.Equal(t, "test message", inner.lastMessage())
+}
+
+func TestAsyncHandlerMultipleMessages(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	defer func() {
+		err := handler.Close()
+		assert.NoError(t, err)
+	}()
+
+	// Send multiple messages
+	for range 10 {
+		record := slog.NewRecord(time.Now(), slog.LevelInfo, "message", 0)
+		err := handler.Handle(context.Background(), record)
+		assert.NoError(t, err)
+	}
+
+	// Wait for all messages to be processed
+	handler.Flush()
+
+	assert.Equal(t, 10, inner.recordCount())
+}
+
+func TestAsyncHandlerFlush(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	defer func() {
+		err := handler.Close()
+		assert.NoError(t, err)
+	}()
+
+	// Send messages
+	for range 5 {
+		record := slog.NewRecord(time.Now(), slog.LevelInfo, "message", 0)
+		handler.Handle(context.Background(), record)
+	}
+
+	// Flush should wait for all messages to be written
+	handler.Flush()
+
+	assert.Equal(t, 5, inner.recordCount())
+
+	// Multiple flushes should be safe
+	handler.Flush()
+	handler.Flush()
+
+	assert.Equal(t, 5, inner.recordCount())
+}
+
+func TestAsyncHandlerClose(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	handler.Handle(context.Background(), record)
+
+	// Close should wait for pending messages
+	err := handler.Close()
+	assert.NoError(t, err)
+
+	// Messages sent before close should be processed
+	assert.Equal(t, 1, inner.recordCount())
+
+	// Messages sent after close should be ignored
+	handler.Handle(context.Background(), record)
+
+	// Give a small amount of time to ensure no processing happens
+	time.Sleep(10 * time.Millisecond)
+
+	assert.Equal(t, 1, inner.recordCount())
+}
+
+func TestAsyncHandlerEnabled(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	defer func() {
+		err := handler.Close()
+		assert.NoError(t, err)
+	}()
+
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+
+	inner.enabled = false
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+}
+
+func TestAsyncHandlerFlushAfterClose(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	handler.Handle(context.Background(), record)
+
+	// Close the handler first
+	err := handler.Close()
+	assert.NoError(t, err)
+
+	// All messages should have been processed during close
+	assert.Equal(t, 1, inner.recordCount())
+
+	// Flush after close should be safe and should not panic
+	handler.Flush()
+
+	// Message count should remain the same
+	assert.Equal(t, 1, inner.recordCount())
+
+	// Multiple flushes after close should also be safe
+	handler.Flush()
+	handler.Flush()
+
+	assert.Equal(t, 1, inner.recordCount())
+}
+
+func TestAsyncHandlerConcurrentWrites(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	defer func() {
+		err := handler.Close()
+		assert.NoError(t, err)
+	}()
+
+	var wg sync.WaitGroup
+	messageCount := 100
+	goroutines := 10
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range messageCount {
+				record := slog.NewRecord(time.Now(), slog.LevelInfo, "concurrent message", 0)
+				handler.Handle(context.Background(), record)
+			}
+		}()
+	}
+
+	wg.Wait()
+	handler.Flush()
+
+	assert.Equal(t, messageCount*goroutines, inner.recordCount())
+}
+
+func TestAsyncHandlerConcurrentFlushes(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	defer func() {
+		err := handler.Close()
+		assert.NoError(t, err)
+	}()
+
+	// block all the routines
+	handler.cond.L.Lock()
+
+	var wg sync.WaitGroup
+
+	// Add some messages
+	wg.Add(1)
+	messageCount := 100
+	go func() {
+		defer wg.Done()
+		for range messageCount {
+			record := slog.NewRecord(time.Now(), slog.LevelInfo, "message", 0)
+			handler.Handle(context.Background(), record)
+		}
+	}()
+
+	flushCount := 20
+	wg.Add(flushCount)
+	for range flushCount {
+		go func() {
+			defer wg.Done()
+			handler.Flush()
+		}()
+	}
+
+	handler.cond.L.Unlock()
+
+	wg.Wait()
+	handler.Flush()
+	assert.Equal(t, messageCount, inner.recordCount())
+}
+
+// Test that empty queue flush is handled correctly
+func TestAsyncHandlerFlushEmptyQueue(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	defer func() {
+		err := handler.Close()
+		assert.NoError(t, err)
+	}()
+
+	// Flush with no messages should be safe
+	handler.Flush()
+	assert.Equal(t, 0, inner.recordCount())
+}
+
+// Test that messages are processed in order
+func TestAsyncHandlerMessageOrder(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewAsyncHandler(inner)
+	defer func() {
+		err := handler.Close()
+		assert.NoError(t, err)
+	}()
+
+	// Send messages with different content
+	for i := range 10 {
+		record := slog.NewRecord(time.Now(), slog.LevelInfo, string(rune('A'+i)), 0)
+		handler.Handle(context.Background(), record)
+	}
+
+	handler.Flush()
+
+	inner.mu.Lock()
+	defer inner.mu.Unlock()
+
+	// Verify messages are in order
+	for i := range 10 {
+		assert.Equal(t, string(rune('A'+i)), inner.records[i].Message)
+	}
+}

--- a/pkg/util/log/slog/handlers/disabled_handler.go
+++ b/pkg/util/log/slog/handlers/disabled_handler.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+)
+
+var _ slog.Handler = disabled{}
+
+// disabled is a slog handler which never writes anything.
+//
+// This can be replaced by slog.Disabled once we update to Go 1.25
+type disabled struct{}
+
+// NewDisabledHandler returns a handler which never writes anything.
+func NewDisabledHandler() slog.Handler {
+	return disabled{}
+}
+
+// Enabled returns false
+func (disabled) Enabled(context.Context, slog.Level) bool {
+	return false
+}
+
+// Handle does nothing
+func (disabled) Handle(context.Context, slog.Record) error {
+	return nil
+}
+
+// WithAttrs does nothing
+func (d disabled) WithAttrs([]slog.Attr) slog.Handler {
+	return d
+}
+
+// WithGroup does nothing
+func (d disabled) WithGroup(string) slog.Handler {
+	return d
+}

--- a/pkg/util/log/slog/handlers/disabled_handler_test.go
+++ b/pkg/util/log/slog/handlers/disabled_handler_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisabledHandlerEnabled(t *testing.T) {
+	handler := NewDisabledHandler()
+
+	// Should always return false for any level
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestDisabledHandlerHandle(t *testing.T) {
+	handler := NewDisabledHandler()
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+	err := handler.Handle(context.Background(), record)
+
+	// Should not return an error
+	assert.NoError(t, err)
+}
+
+func TestDisabledHandlerWithAttrs(t *testing.T) {
+	handler := NewDisabledHandler()
+
+	attrs := []slog.Attr{
+		{Key: "key1", Value: slog.StringValue("value1")},
+		{Key: "key2", Value: slog.IntValue(42)},
+	}
+
+	newHandler := handler.WithAttrs(attrs)
+
+	// Should return a disabled handler (itself)
+	assert.NotNil(t, newHandler)
+	assert.False(t, newHandler.Enabled(context.Background(), slog.LevelInfo))
+}
+
+func TestDisabledHandlerWithGroup(t *testing.T) {
+	handler := NewDisabledHandler()
+
+	newHandler := handler.WithGroup("testgroup")
+
+	// Should return a disabled handler (itself)
+	assert.NotNil(t, newHandler)
+	assert.False(t, newHandler.Enabled(context.Background(), slog.LevelInfo))
+}

--- a/pkg/util/log/slog/handlers/docs.go
+++ b/pkg/util/log/slog/handlers/docs.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package handlers provides simple slog handlers
+package handlers

--- a/pkg/util/log/slog/handlers/format_handler.go
+++ b/pkg/util/log/slog/handlers/format_handler.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"io"
+	"log/slog"
+)
+
+var _ slog.Handler = (*format)(nil)
+
+// format is a slog handler that formats records and writes them to an io.Writer.
+type format struct {
+	formatter func(ctx context.Context, r slog.Record) string
+	writer    io.Writer
+}
+
+// NewFormatHandler returns a handler that formats records and writes them to an io.Writer.
+func NewFormatHandler(formatter func(ctx context.Context, r slog.Record) string, writer io.Writer) slog.Handler {
+	return &format{formatter: formatter, writer: writer}
+}
+
+// Handle writes a record to the writer.
+func (h *format) Handle(ctx context.Context, r slog.Record) error {
+	msg := h.formatter(ctx, r)
+	_, err := h.writer.Write([]byte(msg))
+	return err
+}
+
+// Enabled returns true if the handler is enabled for the given level.
+func (h *format) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+// WithAttrs returns a new handler with the given attributes.
+func (h *format) WithAttrs(_attrs []slog.Attr) slog.Handler {
+	panic("not implemented")
+}
+
+// WithGroup returns a new handler with the given group name.
+func (h *format) WithGroup(_name string) slog.Handler {
+	panic("not implemented")
+}

--- a/pkg/util/log/slog/handlers/format_handler_test.go
+++ b/pkg/util/log/slog/handlers/format_handler_test.go
@@ -1,0 +1,173 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFormatHandler(t *testing.T) {
+	var buf bytes.Buffer
+	formatter := func(_ context.Context, r slog.Record) string {
+		return r.Message + "\n"
+	}
+
+	handler := NewFormatHandler(formatter, &buf)
+	require.NotNil(t, handler)
+}
+
+func TestFormatHandlerHandle(t *testing.T) {
+	var buf bytes.Buffer
+	formatter := func(_ context.Context, r slog.Record) string {
+		return r.Message + "\n"
+	}
+
+	handler := NewFormatHandler(formatter, &buf)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+	err := handler.Handle(context.Background(), record)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test message\n", buf.String())
+}
+
+func TestFormatHandlerEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	formatter := func(_ context.Context, r slog.Record) string {
+		return r.Message
+	}
+
+	handler := NewFormatHandler(formatter, &buf)
+
+	// Should always return true
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelDebug))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestFormatHandlerMultipleMessages(t *testing.T) {
+	var buf bytes.Buffer
+	formatter := func(_ context.Context, r slog.Record) string {
+		return fmt.Sprintf("[%s] %s\n", r.Level, r.Message)
+	}
+
+	handler := NewFormatHandler(formatter, &buf)
+
+	messages := []struct {
+		level slog.Level
+		msg   string
+	}{
+		{slog.LevelInfo, "info message"},
+		{slog.LevelWarn, "warn message"},
+		{slog.LevelError, "error message"},
+	}
+
+	for _, m := range messages {
+		record := slog.NewRecord(time.Now(), m.level, m.msg, 0)
+		err := handler.Handle(context.Background(), record)
+		assert.NoError(t, err)
+	}
+
+	expected := "[INFO] info message\n[WARN] warn message\n[ERROR] error message\n"
+	assert.Equal(t, expected, buf.String())
+}
+
+func TestFormatHandlerCustomFormatter(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Custom formatter that includes timestamp and level
+	formatter := func(_ context.Context, r slog.Record) string {
+		return fmt.Sprintf("%s [%s] %s\n",
+			r.Time.Format("15:04:05"),
+			r.Level,
+			r.Message)
+	}
+
+	handler := NewFormatHandler(formatter, &buf)
+
+	now := time.Now()
+	record := slog.NewRecord(now, slog.LevelWarn, "warning message", 0)
+	err := handler.Handle(context.Background(), record)
+
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "[WARN] warning message")
+	assert.Contains(t, buf.String(), now.Format("15:04:05"))
+}
+
+func TestFormatHandlerEmptyMessage(t *testing.T) {
+	var buf bytes.Buffer
+	formatter := func(_ context.Context, r slog.Record) string {
+		return r.Message + "\n"
+	}
+
+	handler := NewFormatHandler(formatter, &buf)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "", 0)
+	err := handler.Handle(context.Background(), record)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "\n", buf.String())
+}
+
+func TestFormatHandlerWithRecordAttributes(t *testing.T) {
+	var buf bytes.Buffer
+	formatter := func(_ context.Context, r slog.Record) string {
+		var attrs []string
+		r.Attrs(func(a slog.Attr) bool {
+			attrs = append(attrs, fmt.Sprintf("%s=%v", a.Key, a.Value))
+			return true
+		})
+
+		if len(attrs) > 0 {
+			return fmt.Sprintf("%s [%s]\n", r.Message, attrs[0])
+		}
+		return r.Message + "\n"
+	}
+
+	handler := NewFormatHandler(formatter, &buf)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	record.AddAttrs(slog.String("key", "value"))
+
+	err := handler.Handle(context.Background(), record)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "key=")
+}
+
+func TestFormatHandlerFormatterUsesContext(t *testing.T) {
+	var buf bytes.Buffer
+
+	type contextKey string // to please the linter
+	var requestIDKey contextKey = "request_id"
+
+	// Formatter that uses context
+	formatter := func(ctx context.Context, r slog.Record) string {
+		if ctx != nil {
+			if value := ctx.Value(requestIDKey); value != nil {
+				return fmt.Sprintf("[%v] %s\n", value, r.Message)
+			}
+		}
+		return r.Message + "\n"
+	}
+
+	handler := NewFormatHandler(formatter, &buf)
+
+	ctx := context.WithValue(context.Background(), requestIDKey, "12345")
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+
+	err := handler.Handle(ctx, record)
+	assert.NoError(t, err)
+	assert.Equal(t, "[12345] test\n", buf.String())
+}

--- a/pkg/util/log/slog/handlers/level_handler.go
+++ b/pkg/util/log/slog/handlers/level_handler.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+)
+
+var _ slog.Handler = (*level)(nil)
+
+// level is a slog handler that filters logs based on a level.
+type level struct {
+	level        slog.Leveler
+	innerHandler slog.Handler
+}
+
+// NewLevelHandler returns a handler that filters logs based on a level.
+func NewLevelHandler(lvl slog.Leveler, innerHandler slog.Handler) slog.Handler {
+	return &level{level: lvl, innerHandler: innerHandler}
+}
+
+// Enabled returns true if the handler is enabled for the given level.
+func (h *level) Enabled(_ context.Context, level slog.Level) bool {
+	return h.level.Level() <= level
+}
+
+// Handle writes a record to the innerHandler.
+func (h *level) Handle(ctx context.Context, r slog.Record) error {
+	if !h.Enabled(ctx, r.Level) {
+		return nil
+	}
+
+	return h.innerHandler.Handle(ctx, r)
+}
+
+// WithAttrs returns a new handler with the given attributes.
+func (h *level) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &level{
+		level:        h.level,
+		innerHandler: h.innerHandler.WithAttrs(attrs),
+	}
+}
+
+// WithGroup returns a new handler with the given group name.
+func (h *level) WithGroup(name string) slog.Handler {
+	return &level{
+		level:        h.level,
+		innerHandler: h.innerHandler.WithGroup(name),
+	}
+}

--- a/pkg/util/log/slog/handlers/level_handler_test.go
+++ b/pkg/util/log/slog/handlers/level_handler_test.go
@@ -1,0 +1,194 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLevelHandler(t *testing.T) {
+	inner := newMockInnerHandler()
+	level := slog.LevelInfo
+
+	handler := NewLevelHandler(level, inner)
+	require.NotNil(t, handler)
+}
+
+func TestLevelHandlerEnabled(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelInfo, inner)
+
+	// Messages at or above the level should be enabled
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestLevelHandlerHandle(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelInfo, inner)
+
+	// Message at the level should be handled
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "info message", 0)
+	err := handler.Handle(context.Background(), record)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, inner.recordCount())
+	assert.Equal(t, "info message", inner.lastMessage())
+}
+
+func TestLevelHandlerHandleBelowLevel(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelInfo, inner)
+
+	// Message below the level should be filtered
+	record := slog.NewRecord(time.Now(), slog.LevelDebug, "debug message", 0)
+	err := handler.Handle(context.Background(), record)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, inner.recordCount())
+}
+
+func TestLevelHandlerHandleAboveLevel(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelInfo, inner)
+
+	// Message above the level should be handled
+	record := slog.NewRecord(time.Now(), slog.LevelError, "error message", 0)
+	err := handler.Handle(context.Background(), record)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, inner.recordCount())
+	assert.Equal(t, "error message", inner.lastMessage())
+}
+
+func TestLevelHandlerMultipleMessages(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelWarn, inner)
+
+	messages := []struct {
+		level    slog.Level
+		msg      string
+		expected bool
+	}{
+		{slog.LevelDebug, "debug", false},
+		{slog.LevelInfo, "info", false},
+		{slog.LevelWarn, "warn", true},
+		{slog.LevelError, "error", true},
+	}
+
+	for _, m := range messages {
+		record := slog.NewRecord(time.Now(), m.level, m.msg, 0)
+		handler.Handle(context.Background(), record)
+	}
+
+	// Only warn and error should be logged
+	assert.Equal(t, 2, inner.recordCount())
+}
+
+func TestLevelHandlerWithAttrs(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelInfo, inner)
+
+	attrs := []slog.Attr{
+		{Key: "key1", Value: slog.StringValue("value1")},
+	}
+
+	newHandler := handler.WithAttrs(attrs)
+	require.NotNil(t, newHandler)
+
+	// Should still be a level handler
+	assert.True(t, newHandler.Enabled(context.Background(), slog.LevelInfo))
+	assert.False(t, newHandler.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestLevelHandlerWithGroup(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelInfo, inner)
+
+	newHandler := handler.WithGroup("testgroup")
+	require.NotNil(t, newHandler)
+
+	// Should still be a level handler
+	assert.True(t, newHandler.Enabled(context.Background(), slog.LevelInfo))
+	assert.False(t, newHandler.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestLevelHandlerDebugLevel(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelDebug, inner)
+
+	// All standard levels should be enabled when debug level is set
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelDebug))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestLevelHandlerErrorLevel(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelError, inner)
+
+	// Only error should be enabled
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestLevelHandlerCustomLevel(t *testing.T) {
+	inner := newMockInnerHandler()
+	customLevel := slog.Level(5) // Custom level between info and warn
+	handler := NewLevelHandler(customLevel, inner)
+
+	// Test custom level filtering
+	assert.False(t, handler.Enabled(context.Background(), slog.Level(4)))
+	assert.True(t, handler.Enabled(context.Background(), slog.Level(5)))
+	assert.True(t, handler.Enabled(context.Background(), slog.Level(6)))
+}
+
+type customLeveler struct {
+	level slog.Level
+}
+
+func (c customLeveler) Level() slog.Level {
+	return c.level
+}
+
+func TestLevelHandlerWithCustomLeveler(t *testing.T) {
+	inner := newMockInnerHandler()
+	leveler := customLeveler{level: slog.LevelWarn}
+	handler := NewLevelHandler(leveler, inner)
+
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestLevelHandlerChaining(t *testing.T) {
+	inner := newMockInnerHandler()
+	handler := NewLevelHandler(slog.LevelInfo, inner)
+
+	// Chain multiple operations
+	handler = handler.WithAttrs([]slog.Attr{{Key: "attr1", Value: slog.StringValue("value1")}})
+	handler = handler.WithGroup("group1")
+
+	// Should still filter by level
+	record := slog.NewRecord(time.Now(), slog.LevelDebug, "debug", 0)
+	handler.Handle(context.Background(), record)
+	assert.Equal(t, 0, inner.recordCount())
+
+	record = slog.NewRecord(time.Now(), slog.LevelInfo, "info", 0)
+	handler.Handle(context.Background(), record)
+	assert.Equal(t, 1, inner.recordCount())
+}

--- a/pkg/util/log/slog/handlers/multi_handler.go
+++ b/pkg/util/log/slog/handlers/multi_handler.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+var _ slog.Handler = (*multi)(nil)
+
+// multi is a handler that writes to multiple handlers.
+//
+// TODO: replace with built-in multi-handler in Go 1.26
+type multi struct {
+	handlers []slog.Handler
+}
+
+// NewMultiHandler creates a new Handler that writes to multiple handlers.
+func NewMultiHandler(handlers ...slog.Handler) slog.Handler {
+	if len(handlers) == 1 {
+		return handlers[0]
+	}
+	return &multi{handlers: handlers}
+}
+
+// Handle writes a record to the handlers.
+func (h *multi) Handle(ctx context.Context, r slog.Record) error {
+	var errs []error
+	for _, handler := range h.handlers {
+		if err := handler.Handle(ctx, r); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Enabled returns true if the handler is enabled for the given level.
+func (h *multi) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range h.handlers {
+		if handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+// WithAttrs returns a new handler with the given attributes.
+func (h *multi) WithAttrs(attrs []slog.Attr) slog.Handler {
+	handlers := make([]slog.Handler, len(h.handlers))
+	for i, handler := range h.handlers {
+		handlers[i] = handler.WithAttrs(attrs)
+	}
+	return NewMultiHandler(handlers...)
+}
+
+// WithGroup returns a new handler with the given group name.
+func (h *multi) WithGroup(name string) slog.Handler {
+	handlers := make([]slog.Handler, len(h.handlers))
+	for i, handler := range h.handlers {
+		handlers[i] = handler.WithGroup(name)
+	}
+	return NewMultiHandler(handlers...)
+}

--- a/pkg/util/log/slog/handlers/multi_handler_test.go
+++ b/pkg/util/log/slog/handlers/multi_handler_test.go
@@ -1,0 +1,225 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMultiHandler(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+
+	handler := NewMultiHandler(inner1, inner2)
+	require.NotNil(t, handler)
+}
+
+func TestNewMultiHandlerSingleHandler(t *testing.T) {
+	inner := newMockInnerHandler()
+
+	// With a single handler, should return that handler directly
+	handler := NewMultiHandler(inner)
+	require.NotNil(t, handler)
+
+	// Should be the same handler
+	assert.Equal(t, inner, handler)
+}
+
+func TestMultiHandlerHandle(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+	handler := NewMultiHandler(inner1, inner2)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+	err := handler.Handle(context.Background(), record)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, inner1.recordCount())
+	assert.Equal(t, 1, inner2.recordCount())
+	assert.Equal(t, "test message", inner1.lastMessage())
+	assert.Equal(t, "test message", inner2.lastMessage())
+}
+
+func TestMultiHandlerHandleMultipleMessages(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+	handler := NewMultiHandler(inner1, inner2)
+
+	for i := 0; i < 5; i++ {
+		record := slog.NewRecord(time.Now(), slog.LevelInfo, "message", 0)
+		handler.Handle(context.Background(), record)
+	}
+
+	assert.Equal(t, 5, inner1.recordCount())
+	assert.Equal(t, 5, inner2.recordCount())
+}
+
+func TestMultiHandlerEnabled(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+
+	inner1.enabled = true
+	inner2.enabled = false
+
+	handler := NewMultiHandler(inner1, inner2)
+
+	// Should be enabled if at least one handler is enabled
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+}
+
+func TestMultiHandlerEnabledAllDisabled(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+
+	inner1.enabled = false
+	inner2.enabled = false
+
+	handler := NewMultiHandler(inner1, inner2)
+
+	// Should be disabled if all handlers are disabled
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+}
+
+func TestMultiHandlerEnabledAllEnabled(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+
+	inner1.enabled = true
+	inner2.enabled = true
+
+	handler := NewMultiHandler(inner1, inner2)
+
+	// Should be enabled if all handlers are enabled
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+}
+
+func TestMultiHandlerWithAttrs(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+	handler := NewMultiHandler(inner1, inner2)
+
+	attrs := []slog.Attr{
+		{Key: "key1", Value: slog.StringValue("value1")},
+	}
+
+	newHandler := handler.WithAttrs(attrs)
+	require.NotNil(t, newHandler)
+
+	// Should still work as a multi handler
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	newHandler.Handle(context.Background(), record)
+}
+
+func TestMultiHandlerWithGroup(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+	handler := NewMultiHandler(inner1, inner2)
+
+	newHandler := handler.WithGroup("testgroup")
+	require.NotNil(t, newHandler)
+
+	// Should still work as a multi handler
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	newHandler.Handle(context.Background(), record)
+}
+
+func TestMultiHandlerErrorHandling(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner1.err = errors.New("error1")
+	inner2 := newMockInnerHandler()
+	inner2.err = errors.New("error2")
+	handler := NewMultiHandler(inner1, inner2)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	err := handler.Handle(context.Background(), record)
+
+	// Should return combined errors
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error1")
+	assert.Contains(t, err.Error(), "error2")
+}
+
+func TestMultiHandlerPartialError(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+	inner2.err = errors.New("error2")
+	handler := NewMultiHandler(inner1, inner2)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	err := handler.Handle(context.Background(), record)
+
+	// Should return error from failing handler
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error2")
+
+	// But first handler should still have recorded the message
+	assert.Equal(t, 1, inner1.recordCount())
+}
+
+func TestMultiHandlerNoErrors(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+	handler := NewMultiHandler(inner1, inner2)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	err := handler.Handle(context.Background(), record)
+
+	// Should not return error when all handlers succeed
+	assert.NoError(t, err)
+}
+
+func TestMultiHandlerThreeHandlers(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+	inner3 := newMockInnerHandler()
+	handler := NewMultiHandler(inner1, inner2, inner3)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	err := handler.Handle(context.Background(), record)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, inner1.recordCount())
+	assert.Equal(t, 1, inner2.recordCount())
+	assert.Equal(t, 1, inner3.recordCount())
+}
+
+func TestMultiHandlerMixedLevels(t *testing.T) {
+	inner1 := NewLevelHandler(slog.LevelInfo, newMockInnerHandler())
+	inner2 := NewLevelHandler(slog.LevelError, newMockInnerHandler())
+
+	handler := NewMultiHandler(inner1, inner2)
+
+	// Info level should be enabled (first handler accepts it)
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelInfo))
+
+	// Error level should be enabled (both handlers accept it)
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+
+	// Debug level should be disabled (no handler accepts it)
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestMultiHandlerChaining(t *testing.T) {
+	inner1 := newMockInnerHandler()
+	inner2 := newMockInnerHandler()
+	handler := NewMultiHandler(inner1, inner2)
+
+	// Chain operations
+	handler = handler.WithAttrs([]slog.Attr{{Key: "attr1", Value: slog.StringValue("value1")}})
+	handler = handler.WithGroup("group1")
+
+	// Should still work
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
+	err := handler.Handle(context.Background(), record)
+	assert.NoError(t, err)
+}

--- a/pkg/util/log/slog/handlers/test_utils.go
+++ b/pkg/util/log/slog/handlers/test_utils.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+type mockInnerHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+	enabled bool
+	err     error
+}
+
+func newMockInnerHandler() *mockInnerHandler {
+	return &mockInnerHandler{
+		records: make([]slog.Record, 0),
+		enabled: true,
+	}
+}
+
+func (m *mockInnerHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return m.enabled
+}
+
+func (m *mockInnerHandler) Handle(_ context.Context, record slog.Record) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.records = append(m.records, record)
+	return m.err
+}
+
+func (m *mockInnerHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return m
+}
+
+func (m *mockInnerHandler) WithGroup(_ string) slog.Handler {
+	return m
+}
+
+func (m *mockInnerHandler) recordCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.records)
+}
+
+func (m *mockInnerHandler) lastMessage() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.records) == 0 {
+		return ""
+	}
+	return m.records[len(m.records)-1].Message
+}

--- a/pkg/util/log/slog/slog.go
+++ b/pkg/util/log/slog/slog.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package slog provides a slog-based implementation of the log package.
+package slog
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/handlers"
+)
+
+// Default returns a default logger
+func Default() *Wrapper {
+	// the default seelog logger is an asynchronous loop logger, prints to stdout,
+	// with format "%Ns [%Level] %Msg%n"
+	return nil //TODO: implement
+}
+
+// Disabled returns a disabled logger
+func Disabled() *Wrapper {
+	disabledHandler := handlers.NewDisabledHandler()
+	return newWrapper(disabledHandler)
+}

--- a/pkg/util/log/slog/slog_test.go
+++ b/pkg/util/log/slog/slog_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package slog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisabled(t *testing.T) {
+	logger := Disabled()
+	require.NotNil(t, logger)
+
+	// These should all be no-ops and not panic
+	logger.Trace("trace")
+	logger.Tracef("tracef %s", "test")
+	logger.Debug("debug")
+	logger.Debugf("debugf %s", "test")
+	logger.Info("info")
+	logger.Infof("infof %s", "test")
+
+	err := logger.Warn("warn")
+	assert.Equal(t, "warn", err.Error())
+
+	err = logger.Warnf("warnf %s", "test")
+	assert.Equal(t, "warnf test", err.Error())
+
+	err = logger.Error("error")
+	assert.Equal(t, "error", err.Error())
+
+	err = logger.Errorf("errorf %s", "test")
+	assert.Equal(t, "errorf test", err.Error())
+
+	err = logger.Critical("critical")
+	assert.Equal(t, "critical", err.Error())
+
+	err = logger.Criticalf("criticalf %s", "test")
+	assert.Equal(t, "criticalf test", err.Error())
+
+	logger.Flush()
+	logger.Close()
+}

--- a/pkg/util/log/slog/syslog/syslog.go
+++ b/pkg/util/log/slog/syslog/syslog.go
@@ -1,0 +1,216 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package syslog implements a syslog handler for the datadog agent.
+package syslog
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/formatters"
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/handlers"
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/types"
+)
+
+// Receiver implements seelog.CustomReceiver
+type Receiver struct {
+	uri  *url.URL
+	conn net.Conn
+
+	loggerName    string
+	writeHeader   func(*bytes.Buffer, slog.Level)
+	formatMessage func(*bytes.Buffer, slog.Record)
+}
+
+// NewReceiver creates a new syslog receiver
+func NewReceiver(loggerName string, jsonFormat bool, syslogURI string, syslogRFC bool) (*Receiver, error) {
+	s := &Receiver{
+		loggerName: loggerName,
+	}
+
+	if jsonFormat {
+		s.formatMessage = s.formatJSONMessage
+	} else {
+		s.formatMessage = s.formatTextMessage
+	}
+
+	if syslogURI != "" {
+		url, err := url.ParseRequestURI(syslogURI)
+		if err != nil {
+			return nil, errors.New("bad syslog receiver configuration - disabling")
+		}
+
+		s.uri = url
+	}
+
+	conn, err := getSyslogConnection(s.uri)
+	if err != nil {
+		fmt.Printf("%v\n", err)
+		return s, nil
+	}
+	s.conn = conn
+
+	s.writeHeader = getHeaderFormatter(20, syslogRFC)
+
+	return s, nil
+}
+
+// Handler returns a slog.Handler that writes to the syslog connection
+func (s *Receiver) Handler() slog.Handler {
+	return handlers.NewFormatHandler(s.format, s)
+}
+
+// format formats the log record into a string
+func (s *Receiver) format(_ context.Context, record slog.Record) string {
+	var buff bytes.Buffer
+
+	s.writeHeader(&buff, record.Level)
+	_ = buff.WriteByte(' ')
+	s.formatMessage(&buff, record)
+
+	return buff.String()
+}
+
+func (s *Receiver) formatTextMessage(buff *bytes.Buffer, record slog.Record) {
+	frames := runtime.CallersFrames([]uintptr{record.PC})
+	frame, _ := frames.Next()
+
+	level := formatters.LevelToString(record.Level)
+	shortFilePath := formatters.ShortFilePath(frame)
+	extraTextContext := formatters.ExtraTextContext(record)
+
+	funcShort := frame.Function[strings.LastIndexByte(frame.Function, '.')+1:]
+
+	fmt.Fprintf(buff, `%s | %s | (%s:%d in %s) | %s%s
+`, s.loggerName, level, shortFilePath, frame.Line, funcShort, extraTextContext, record.Message)
+}
+
+func (s *Receiver) formatJSONMessage(buff *bytes.Buffer, record slog.Record) {
+	frames := runtime.CallersFrames([]uintptr{record.PC})
+	frame, _ := frames.Next()
+
+	level := formatters.LevelToString(record.Level)
+	shortFilePath := formatters.ShortFilePath(frame)
+	extraJSONContext := formatters.ExtraJSONContext(record)
+
+	fmt.Fprintf(buff, `{"agent":"%s","level":"%s","relfile":"%s","line":"%d","msg":"%s"%s}
+`, strings.ToLower(s.loggerName), level, shortFilePath, frame.Line, record.Message, extraJSONContext)
+}
+
+// Write writes the message to the syslog connection
+func (s *Receiver) Write(message []byte) (int, error) {
+	if s.conn != nil {
+		n, err := s.conn.Write([]byte(message))
+		if err == nil {
+			return n, nil
+		}
+	}
+
+	// try to reconnect - close the connection first just in case
+	//                    we don't want fd leaks here.
+	if s.conn != nil {
+		s.conn.Close()
+	}
+	conn, err := getSyslogConnection(s.uri)
+	if err != nil {
+		return 0, err
+	}
+
+	s.conn = conn
+	n, err := s.conn.Write([]byte(message))
+	fmt.Printf("Retried: %v\n", message)
+	return n, err
+}
+
+// Close closes the syslog connection
+func (s *Receiver) Close() error {
+	if s.conn != nil {
+		return s.conn.Close()
+	}
+	return nil
+}
+
+var levelToSyslogSeverity = map[types.LogLevel]int{
+	// Mapping to RFC 5424 where possible
+	types.TraceLvl:    7,
+	types.DebugLvl:    7,
+	types.InfoLvl:     6,
+	types.WarnLvl:     4,
+	types.ErrorLvl:    3,
+	types.CriticalLvl: 2,
+	types.Off:         7,
+}
+
+var syslogAddrs = []string{"/dev/log", "/var/run/syslog", "/var/run/log"}
+
+func getHeaderFormatter(facility int, syslogRFC bool) func(*bytes.Buffer, slog.Level) {
+	defaultFacility := 20
+
+	if facility < 0 || facility > 23 {
+		facility = defaultFacility
+	}
+
+	pid := os.Getpid()
+	appName := filepath.Base(os.Args[0])
+
+	if syslogRFC { // RFC 5424
+		return func(buff *bytes.Buffer, level slog.Level) {
+			fmt.Fprintf(buff, "<%d>1 %s %d - -", facility*8+levelToSyslogSeverity[types.LogLevel(level)], appName, pid)
+		}
+	}
+
+	// otherwise old-school logging
+	return func(buff *bytes.Buffer, level slog.Level) {
+		fmt.Fprintf(buff, "<%d>%s[%d]:", facility*8+levelToSyslogSeverity[types.LogLevel(level)], appName, pid)
+	}
+}
+
+func getSyslogConnection(uri *url.URL) (net.Conn, error) {
+	var conn net.Conn
+	var err error
+
+	// local
+	localNetNames := []string{"unixgram", "unix"}
+	if uri == nil {
+		for _, netName := range localNetNames {
+			for _, addr := range syslogAddrs {
+				conn, err = net.Dial(netName, addr)
+				if err == nil { // on success
+					return conn, nil
+				}
+			}
+		}
+	} else {
+		switch uri.Scheme {
+		case "unix", "unixgram":
+			fmt.Printf("Trying to connect to: %s\n", uri.Path)
+			for _, netName := range localNetNames {
+				conn, err = net.Dial(netName, uri.Path)
+				if err == nil {
+					break
+				}
+			}
+		case "udp":
+			conn, err = net.Dial(uri.Scheme, uri.Host)
+		case "tcp":
+			conn, err = net.Dial("tcp", uri.Host)
+		}
+		if err == nil {
+			return conn, nil
+		}
+	}
+
+	return nil, errors.New("Unable to connect to syslog")
+}

--- a/pkg/util/log/slog/syslog/syslog_test.go
+++ b/pkg/util/log/slog/syslog/syslog_test.go
@@ -1,0 +1,602 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/types"
+)
+
+// setSyslogAddrs is a helper function that sets syslogAddrs for testing
+// and registers a cleanup function to restore the original value
+func setSyslogAddrs(t *testing.T, addrs []string) {
+	t.Helper()
+	originalAddrs := syslogAddrs
+	syslogAddrs = addrs
+	t.Cleanup(func() {
+		syslogAddrs = originalAddrs
+	})
+}
+
+// getTestPC returns a program counter for testing purposes
+// This captures the caller's PC for use in slog.Record
+func getTestPC() uintptr {
+	var pcs [1]uintptr
+	// Skip 2 frames: runtime.Callers itself and getTestPC
+	runtime.Callers(2, pcs[:])
+	return pcs[0]
+}
+
+// mockConn is a mock implementation of net.Conn for testing
+type mockConn struct {
+	buf       *bytes.Buffer
+	closed    bool
+	failWrite bool
+}
+
+func newMockConn() *mockConn {
+	return &mockConn{
+		buf: &bytes.Buffer{},
+	}
+}
+
+func (m *mockConn) Read(b []byte) (n int, err error) {
+	return m.buf.Read(b)
+}
+
+func (m *mockConn) Write(b []byte) (n int, err error) {
+	if m.failWrite {
+		return 0, io.ErrClosedPipe
+	}
+	return m.buf.Write(b)
+}
+
+func (m *mockConn) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockConn) LocalAddr() net.Addr {
+	return &net.UnixAddr{Name: "local", Net: "unix"}
+}
+
+func (m *mockConn) RemoteAddr() net.Addr {
+	return &net.UnixAddr{Name: "remote", Net: "unix"}
+}
+
+func (m *mockConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (m *mockConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (m *mockConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func TestNewReceiver(t *testing.T) {
+	// Use empty list to prevent actual syslog connections in tests
+	setSyslogAddrs(t, []string{})
+
+	tests := []struct {
+		name       string
+		loggerName string
+		jsonFormat bool
+		syslogURI  string
+		syslogRFC  bool
+		wantErr    bool
+	}{
+		{
+			name:       "text format without URI",
+			loggerName: "test-agent",
+			jsonFormat: false,
+			syslogURI:  "",
+			syslogRFC:  false,
+			wantErr:    false,
+		},
+		{
+			name:       "json format without URI",
+			loggerName: "test-agent",
+			jsonFormat: true,
+			syslogURI:  "",
+			syslogRFC:  false,
+			wantErr:    false,
+		},
+		{
+			name:       "with RFC 5424 format",
+			loggerName: "test-agent",
+			jsonFormat: false,
+			syslogURI:  "",
+			syslogRFC:  true,
+			wantErr:    false,
+		},
+		{
+			name:       "invalid URI",
+			loggerName: "test-agent",
+			jsonFormat: false,
+			syslogURI:  "://invalid",
+			syslogRFC:  false,
+			wantErr:    true,
+		},
+		{
+			name:       "valid unix URI format",
+			loggerName: "test-agent",
+			jsonFormat: false,
+			syslogURI:  "unix:///this/does/not/exist",
+			syslogRFC:  false,
+			wantErr:    false,
+		},
+		{
+			name:       "valid udp URI format",
+			loggerName: "test-agent",
+			jsonFormat: false,
+			syslogURI:  "udp://localhost:514",
+			syslogRFC:  false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receiver, err := NewReceiver(tt.loggerName, tt.jsonFormat, tt.syslogURI, tt.syslogRFC)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, receiver)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, receiver)
+				assert.Equal(t, tt.loggerName, receiver.loggerName)
+				assert.NotNil(t, receiver.formatMessage)
+				// Note: writeHeader may be nil if connection failed but that's ok
+				// since NewReceiver returns (receiver, nil) even on connection failure
+			}
+		})
+	}
+}
+
+func TestReceiver_formatTextMessage(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", false, "", false)
+	require.NoError(t, err)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", getTestPC())
+
+	var buff bytes.Buffer
+	receiver.formatTextMessage(&buff, record)
+
+	output := buff.String()
+	// Format: loggerName | level | (file:line in function) | message
+	pattern := `^test-agent \| \w+ \| \(.+syslog_test\.go:\d+ in TestReceiver_formatTextMessage\) \| test message\n$`
+	assert.Regexp(t, regexp.MustCompile(pattern), output)
+}
+
+func TestReceiver_formatTextMessageWithAttributes(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", false, "", false)
+	require.NoError(t, err)
+
+	record := slog.NewRecord(time.Now(), slog.LevelWarn, "warning message", getTestPC())
+	record.AddAttrs(slog.String("key", "value"))
+	record.AddAttrs(slog.Int("count", 42))
+
+	var buff bytes.Buffer
+	receiver.formatTextMessage(&buff, record)
+
+	output := buff.String()
+	// Format: loggerName | level | (file:line in function) | key:value,count:42 | message
+	pattern := `^test-agent \| warn \| \(.+\) \| key:value,count:42 \| warning message\n$`
+	assert.Regexp(t, regexp.MustCompile(pattern), output)
+}
+
+func TestReceiver_formatJSONMessage(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", true, "", false)
+	require.NoError(t, err)
+
+	record := slog.NewRecord(time.Now(), slog.LevelError, "error message", getTestPC())
+
+	var buff bytes.Buffer
+	receiver.formatJSONMessage(&buff, record)
+
+	jsonStr := buff.String()
+	var jsonOutput map[string]interface{}
+	err = json.Unmarshal([]byte(jsonStr), &jsonOutput)
+	require.NoError(t, err, "Output should be valid JSON: %s", jsonStr)
+
+	// Assert on individual fields
+	assert.Equal(t, "test-agent", jsonOutput["agent"])
+	assert.Equal(t, "error", jsonOutput["level"])
+	assert.Equal(t, "error message", jsonOutput["msg"])
+	assert.Contains(t, jsonOutput["relfile"], "syslog_test.go")
+	assert.NotEmpty(t, jsonOutput["line"])
+}
+
+func TestReceiver_formatJSONMessageWithAttributes(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", true, "", false)
+	require.NoError(t, err)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "info message", getTestPC())
+	record.AddAttrs(slog.String("key", "value"))
+	record.AddAttrs(slog.Int("count", 42))
+
+	var buff bytes.Buffer
+	receiver.formatJSONMessage(&buff, record)
+
+	jsonStr := buff.String()
+	var jsonOutput map[string]interface{}
+	err = json.Unmarshal([]byte(jsonStr), &jsonOutput)
+	require.NoError(t, err, "Output should be valid JSON: %s", jsonStr)
+
+	// Assert on individual fields
+	assert.Equal(t, "test-agent", jsonOutput["agent"])
+	assert.Equal(t, "info message", jsonOutput["msg"])
+	assert.Equal(t, "value", jsonOutput["key"])
+	assert.Equal(t, "42", jsonOutput["count"])
+}
+
+func TestReceiver_format(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", false, "", false)
+	require.NoError(t, err)
+
+	// Set up writeHeader since connection failed
+	receiver.writeHeader = getHeaderFormatter(20, false)
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", getTestPC())
+
+	output := receiver.format(context.Background(), record)
+
+	// Should contain syslog header and formatted message
+	// Format: <priority>appname[pid]: loggerName | level | (file:line in function) | message
+	// Note: format() adds newline internally from formatTextMessage
+	pattern := `^<\d+>\S+\[\d+\]: test-agent \| \w+ \| \(.+syslog_test\.go:\d+ in \w+\) \| test message\n$`
+	assert.Regexp(t, regexp.MustCompile(pattern), output)
+}
+
+func TestReceiver_Write(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", false, "", false)
+	require.NoError(t, err)
+
+	// Replace connection with mock
+	mockConn := newMockConn()
+	receiver.conn = mockConn
+
+	message := []byte("test log message\n")
+	n, err := receiver.Write(message)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(message), n)
+	assert.Equal(t, string(message), mockConn.buf.String())
+}
+
+func TestReceiver_WriteWithReconnect(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", false, "", false)
+	require.NoError(t, err)
+
+	// Set up a mock connection that fails on write
+	failingConn := newMockConn()
+	failingConn.failWrite = true
+	receiver.conn = failingConn
+
+	message := []byte("test log message\n")
+
+	// This will fail and trigger reconnection attempt
+	// Since we can't mock the reconnection, we expect an error
+	_, err = receiver.Write(message)
+	assert.Error(t, err)
+
+	// Should have attempted to close the old connection
+	assert.True(t, failingConn.closed)
+}
+
+func TestReceiver_Close(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", false, "", false)
+	require.NoError(t, err)
+
+	mockConn := newMockConn()
+	receiver.conn = mockConn
+
+	err = receiver.Close()
+	assert.NoError(t, err)
+	assert.True(t, mockConn.closed)
+}
+
+func TestGetHeaderFormatter(t *testing.T) {
+	// Get actual values that will be used in the formatter
+	pid := os.Getpid()
+	appName := filepath.Base(os.Args[0])
+
+	tests := []struct {
+		name         string
+		facility     int
+		syslogRFC    bool
+		level        slog.Level
+		wantPriority int
+		wantPattern  string
+	}{
+		{
+			name:         "RFC 5424 format info level",
+			facility:     20,
+			syslogRFC:    true,
+			level:        slog.LevelInfo,
+			wantPriority: 166, // 20*8 + 6 (info severity)
+			wantPattern:  `^<166>1 %s %d - -$`,
+		},
+		{
+			name:         "RFC 5424 format error level",
+			facility:     20,
+			syslogRFC:    true,
+			level:        slog.LevelError,
+			wantPriority: 163, // 20*8 + 3 (error severity)
+			wantPattern:  `^<163>1 %s %d - -$`,
+		},
+		{
+			name:         "old format info level",
+			facility:     20,
+			syslogRFC:    false,
+			level:        slog.LevelInfo,
+			wantPriority: 166,
+			wantPattern:  `^<166>%s\[%d\]:$`,
+		},
+		{
+			name:         "old format error level",
+			facility:     20,
+			syslogRFC:    false,
+			level:        slog.LevelError,
+			wantPriority: 163,
+			wantPattern:  `^<163>%s\[%d\]:$`,
+		},
+		{
+			name:         "invalid facility defaults to 20",
+			facility:     -1,
+			syslogRFC:    false,
+			level:        slog.LevelInfo,
+			wantPriority: 166,
+			wantPattern:  `^<166>%s\[%d\]:$`,
+		},
+		{
+			name:         "facility out of range defaults to 20",
+			facility:     25,
+			syslogRFC:    false,
+			level:        slog.LevelInfo,
+			wantPriority: 166,
+			wantPattern:  `^<166>%s\[%d\]:$`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := getHeaderFormatter(tt.facility, tt.syslogRFC)
+			require.NotNil(t, formatter)
+
+			var buff bytes.Buffer
+			formatter(&buff, tt.level)
+
+			output := buff.String()
+
+			// Build expected pattern with actual appName and PID
+			expectedPattern := fmt.Sprintf(tt.wantPattern, regexp.QuoteMeta(appName), pid)
+			assert.Regexp(t, regexp.MustCompile(expectedPattern), output,
+				"Output should match expected format with app name %q and PID %d", appName, pid)
+		})
+	}
+}
+
+func TestGetHeaderFormatterOldFormat(t *testing.T) {
+	formatter := getHeaderFormatter(20, false)
+
+	var buff bytes.Buffer
+	formatter(&buff, slog.LevelWarn)
+
+	output := buff.String()
+
+	// Old format: <priority>appname[pid]:
+	pattern := `^<\d+>\S+\[\d+\]:$`
+	assert.Regexp(t, regexp.MustCompile(pattern), output)
+}
+
+func TestGetSyslogConnection(t *testing.T) {
+	t.Run("nil URI attempts local connection", func(t *testing.T) {
+		// Set empty list to ensure connection fails in tests
+		setSyslogAddrs(t, []string{})
+
+		// This will fail in test environments since we have no valid addresses
+		conn, err := getSyslogConnection(nil)
+		if conn != nil {
+			defer conn.Close()
+		}
+		// Should fail since we have no valid syslog addresses
+		assert.Error(t, err)
+	})
+
+	t.Run("unix scheme with invalid path", func(t *testing.T) {
+		uri, _ := url.Parse("unix:///invalid/path/that/does/not/exist")
+		conn, err := getSyslogConnection(uri)
+		assert.Error(t, err)
+		assert.Nil(t, conn)
+	})
+
+	t.Run("unixgram scheme with invalid path", func(t *testing.T) {
+		uri, _ := url.Parse("unixgram:///invalid/path/that/does/not/exist")
+		conn, err := getSyslogConnection(uri)
+		assert.Error(t, err)
+		assert.Nil(t, conn)
+	})
+}
+
+func TestReceiver_IntegrationWithHandler(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", false, "", false)
+	require.NoError(t, err)
+
+	// Replace connection with mock and set up writeHeader
+	mockConn := newMockConn()
+	receiver.conn = mockConn
+	receiver.writeHeader = getHeaderFormatter(20, false)
+
+	// Get handler and log a message
+	handler := receiver.Handler()
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "integration test message", getTestPC())
+
+	err = handler.Handle(context.Background(), record)
+	assert.NoError(t, err)
+
+	// Check that message was written to mock connection
+	output := mockConn.buf.String()
+	// Format: <priority>appname[pid]: loggerName | level | (file:line in function) | message
+	pattern := `^<\d+>.+\[\d+\]: test-agent \| \w+ \| \(.+syslog_test\.go:\d+ in \w+\) \| integration test message\n$`
+	assert.Regexp(t, regexp.MustCompile(pattern), output)
+}
+
+func TestReceiver_IntegrationJSONFormat(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	receiver, err := NewReceiver("test-agent", true, "", true)
+	require.NoError(t, err)
+
+	// Replace connection with mock and set up writeHeader
+	mockConn := newMockConn()
+	receiver.conn = mockConn
+	receiver.writeHeader = getHeaderFormatter(20, true)
+
+	// Get handler and log a message
+	handler := receiver.Handler()
+	record := slog.NewRecord(time.Now(), slog.LevelWarn, "json test message", getTestPC())
+	record.AddAttrs(slog.String("user", "john"))
+
+	err = handler.Handle(context.Background(), record)
+	assert.NoError(t, err)
+
+	// Check that JSON message was written
+	output := mockConn.buf.String()
+
+	// Extract JSON part (after syslog header)
+	jsonStart := strings.Index(output, "{")
+	require.Greater(t, jsonStart, -1, "Output should contain JSON")
+
+	jsonPart := output[jsonStart:]
+	var jsonOutput map[string]interface{}
+	err = json.Unmarshal([]byte(jsonPart), &jsonOutput)
+	require.NoError(t, err, "Output should contain valid JSON: %s", jsonPart)
+
+	assert.Equal(t, "test-agent", jsonOutput["agent"])
+	assert.Equal(t, "json test message", jsonOutput["msg"])
+	assert.Equal(t, "john", jsonOutput["user"])
+}
+
+func TestReceiver_DifferentLogLevels(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	tests := []types.LogLevel{
+		types.DebugLvl,
+		types.InfoLvl,
+		types.WarnLvl,
+		types.ErrorLvl,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.String(), func(t *testing.T) {
+			receiver, err := NewReceiver("test-agent", false, "", false)
+			require.NoError(t, err)
+
+			mockConn := newMockConn()
+			receiver.conn = mockConn
+
+			record := slog.NewRecord(time.Now(), slog.Level(tt), "test message", getTestPC())
+
+			var buff bytes.Buffer
+			receiver.formatTextMessage(&buff, record)
+
+			output := buff.String()
+			// Format: loggerName | level | (file:line in function) | message
+			pattern := regexp.MustCompile(`^test-agent \| ` + regexp.QuoteMeta(tt.String()) + ` \| \(.+syslog_test\.go:\d+ in \w+\) \| test message\n$`)
+			assert.Regexp(t, pattern, output)
+		})
+	}
+}
+
+func TestReceiver_LoggerNameCasing(t *testing.T) {
+	setSyslogAddrs(t, []string{})
+
+	tests := []struct {
+		name       string
+		loggerName string
+		jsonFormat bool
+		expected   string
+	}{
+		{
+			name:       "uppercase logger name in JSON",
+			loggerName: "CORE",
+			jsonFormat: true,
+			expected:   `"agent":"core"`,
+		},
+		{
+			name:       "mixed case logger name in JSON",
+			loggerName: "DataDog-Agent",
+			jsonFormat: true,
+			expected:   `"agent":"datadog-agent"`,
+		},
+		{
+			name:       "logger name preserved in text",
+			loggerName: "CORE",
+			jsonFormat: false,
+			expected:   "CORE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receiver, err := NewReceiver(tt.loggerName, tt.jsonFormat, "", false)
+			require.NoError(t, err)
+
+			record := slog.NewRecord(time.Now(), slog.LevelInfo, "test", getTestPC())
+			var buff bytes.Buffer
+
+			if tt.jsonFormat {
+				receiver.formatJSONMessage(&buff, record)
+			} else {
+				receiver.formatTextMessage(&buff, record)
+			}
+
+			output := buff.String()
+			assert.Contains(t, output, tt.expected)
+		})
+	}
+}

--- a/pkg/util/log/slog/template.go
+++ b/pkg/util/log/slog/template.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package slog
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/formatters"
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/types"
+)
+
+// TemplateFormatter returns a function that formats a slog.Record as a string using a template.
+func TemplateFormatter(t *testing.T, tmpl string) func(context.Context, slog.Record) string {
+	return func(_ context.Context, r slog.Record) string {
+		frames := runtime.CallersFrames([]uintptr{r.PC})
+		frame, _ := frames.Next()
+		context := map[string]interface{}{
+			"record": r,
+			"time":   r.Time,
+			"level":  types.LogLevel(r.Level),
+			"l":      types.LogLevel(r.Level).String()[0],
+			"msg":    r.Message,
+			"frame":  frame,
+			"line":   frame.Line,
+			"func":   frame.Function,
+			"file":   frame.File,
+		}
+		funcs := template.FuncMap{
+			"Date":     func(format string) string { return r.Time.Format(format) },
+			"DateTime": func() string { return r.Time.Format("2006-01-02 15:04:05.000 MST") },
+			"Ns":       func() int64 { return r.Time.UnixNano() },
+			"Level":    func() string { return types.LogLevel(r.Level).Capitalized() },
+			"LEVEL":    func() string { return types.LogLevel(r.Level).Uppercase() },
+
+			"ToUpper": strings.ToUpper,
+			"Quote":   formatters.Quote,
+
+			"FuncShort":        func() string { return formatters.ShortFunction(frame) },
+			"ShortFile":        func() string { return formatters.ShortFilePath(frame) },
+			"RelFile":          func() string { return formatters.ShortFilePath(frame) },
+			"ExtraTextContext": func() string { return formatters.ExtraTextContext(r) },
+			"ExtraJSONContext": func() string { return formatters.ExtraJSONContext(r) },
+		}
+
+		// Create template with functions registered before parsing
+		tmplObj, err := template.New("").Funcs(funcs).Parse(tmpl)
+		require.NoError(t, err)
+
+		var buff bytes.Buffer
+		err = tmplObj.Execute(&buff, context)
+		require.NoError(t, err)
+
+		return buff.String()
+	}
+}

--- a/pkg/util/log/slog/template_test.go
+++ b/pkg/util/log/slog/template_test.go
@@ -1,0 +1,404 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/types"
+)
+
+func TestTemplateFormatterBasic(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.msg}}")
+	require.NotNil(t, formatter)
+
+	record := slog.NewRecord(
+		time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC),
+		slog.Level(types.InfoLvl),
+		"test message",
+		0,
+	)
+
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "test message", result)
+}
+
+func TestTemplateFormatterWithLevel(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{Level}} - {{.msg}}")
+
+	levels := []struct {
+		level    slog.Level
+		expected string
+	}{
+		{slog.Level(types.TraceLvl), "Trace - test"},
+		{slog.Level(types.DebugLvl), "Debug - test"},
+		{slog.Level(types.InfoLvl), "Info - test"},
+		{slog.Level(types.WarnLvl), "Warn - test"},
+		{slog.Level(types.ErrorLvl), "Error - test"},
+		{slog.Level(types.CriticalLvl), "Critical - test"},
+	}
+
+	for _, tc := range levels {
+		t.Run(tc.expected, func(t *testing.T) {
+			record := slog.NewRecord(time.Now(), tc.level, "test", 0)
+			result := formatter(context.Background(), record)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestTemplateFormatterWithLEVEL(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{LEVEL}} - {{.msg}}")
+
+	levels := []struct {
+		level    slog.Level
+		expected string
+	}{
+		{slog.Level(types.TraceLvl), "TRACE - test"},
+		{slog.Level(types.DebugLvl), "DEBUG - test"},
+		{slog.Level(types.InfoLvl), "INFO - test"},
+		{slog.Level(types.WarnLvl), "WARN - test"},
+		{slog.Level(types.ErrorLvl), "ERROR - test"},
+		{slog.Level(types.CriticalLvl), "CRITICAL - test"},
+	}
+
+	for _, tc := range levels {
+		t.Run(tc.expected, func(t *testing.T) {
+			record := slog.NewRecord(time.Now(), tc.level, "test", 0)
+			result := formatter(context.Background(), record)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestTemplateFormatterWithLevelChar(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.l}} - {{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+	assert.Contains(t, result, " - test")
+	// The .l field is a single byte representing the first character of the level
+	parts := strings.Split(result, " - ")
+	require.Len(t, parts, 2)
+	levelChar := strings.TrimSpace(parts[0])
+	assert.NotEmpty(t, levelChar)
+}
+
+func TestTemplateFormatterWithDateTime(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{DateTime}} | {{.msg}}")
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+	record := slog.NewRecord(testTime, slog.Level(types.InfoLvl), "test", 0)
+
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "2023-11-04 15:30:45.000 UTC | test", result)
+}
+
+func TestTemplateFormatterWithDate(t *testing.T) {
+	formatter := TemplateFormatter(t, `{{Date "2006-01-02"}} | {{.msg}}`)
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+	record := slog.NewRecord(testTime, slog.Level(types.InfoLvl), "test", 0)
+
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "2023-11-04 | test", result)
+}
+
+func TestTemplateFormatterWithCustomDateFormat(t *testing.T) {
+	formatter := TemplateFormatter(t, `{{Date "15:04:05"}} - {{.msg}}`)
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+	record := slog.NewRecord(testTime, slog.Level(types.InfoLvl), "test", 0)
+
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "15:30:45 - test", result)
+}
+
+func TestTemplateFormatterWithNs(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{Ns}} | {{.msg}}")
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 123456789, time.UTC)
+	record := slog.NewRecord(testTime, slog.Level(types.InfoLvl), "test", 0)
+
+	result := formatter(context.Background(), record)
+	assert.Contains(t, result, " | test")
+	nsPart := strings.Split(result, " | ")[0]
+	assert.Regexp(t, `^\d+$`, nsPart)
+}
+
+func TestTemplateFormatterWithToUpper(t *testing.T) {
+	formatter := TemplateFormatter(t, `{{ToUpper .msg}}`)
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test message", 0)
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "TEST MESSAGE", result)
+}
+
+func TestTemplateFormatterWithQuote(t *testing.T) {
+	formatter := TemplateFormatter(t, `{{Quote .msg}}`)
+
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name:     "no special chars",
+			message:  "simple message",
+			expected: "simple message",
+		},
+		{
+			name:     "with spaces",
+			message:  "message with spaces",
+			expected: "message with spaces",
+		},
+		{
+			name:     "with quotes",
+			message:  `message with "quotes"`,
+			expected: `message with "quotes"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), tc.message, 0)
+			result := formatter(context.Background(), record)
+			// Quote function behavior depends on formatters.Quote implementation
+			assert.NotEmpty(t, result)
+		})
+	}
+}
+
+func TestTemplateFormatterWithFuncShort(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{FuncShort}} | {{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+	assert.Contains(t, result, " | test")
+}
+
+func TestTemplateFormatterWithShortFile(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{ShortFile}} | {{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+	assert.Contains(t, result, " | test")
+}
+
+func TestTemplateFormatterWithRelFile(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{RelFile}} | {{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+	assert.Contains(t, result, " | test")
+}
+
+func TestTemplateFormatterWithLine(t *testing.T) {
+	formatter := TemplateFormatter(t, "line:{{.line}} | {{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+	assert.Contains(t, result, "line:")
+	assert.Contains(t, result, " | test")
+}
+
+func TestTemplateFormatterWithFile(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.file}} | {{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+	assert.Contains(t, result, " | test")
+}
+
+func TestTemplateFormatterWithFunc(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.func}} | {{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+	assert.Contains(t, result, " | test")
+}
+
+func TestTemplateFormatterWithExtraTextContext(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.msg}}{{ExtraTextContext}}")
+
+	t.Run("no attributes", func(t *testing.T) {
+		record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+		result := formatter(context.Background(), record)
+		assert.Equal(t, "test", result)
+	})
+
+	t.Run("with attributes", func(t *testing.T) {
+		record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+		record.AddAttrs(
+			slog.String("key1", "value1"),
+			slog.Int("key2", 42),
+		)
+		result := formatter(context.Background(), record)
+		assert.Contains(t, result, "test")
+		// ExtraTextContext should add attributes
+		assert.Contains(t, result, "key1")
+		assert.Contains(t, result, "value1")
+		assert.Contains(t, result, "key2")
+		assert.Contains(t, result, "42")
+	})
+}
+
+func TestTemplateFormatterWithExtraJSONContext(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.msg}}{{ExtraJSONContext}}")
+
+	t.Run("no attributes", func(t *testing.T) {
+		record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+		result := formatter(context.Background(), record)
+		assert.Equal(t, "test", result)
+	})
+
+	t.Run("with attributes", func(t *testing.T) {
+		record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+		record.AddAttrs(
+			slog.String("key1", "value1"),
+			slog.Int("key2", 42),
+		)
+		result := formatter(context.Background(), record)
+		assert.Contains(t, result, "test")
+		// ExtraJSONContext should add attributes in JSON format
+		assert.Contains(t, result, "key1")
+		assert.Contains(t, result, "value1")
+		assert.Contains(t, result, "key2")
+		assert.Contains(t, result, "42")
+	})
+}
+
+func TestTemplateFormatterComplexTemplate(t *testing.T) {
+	formatter := TemplateFormatter(t, `{{DateTime}} | {{LEVEL}} | {{ShortFile}}:{{.line}} in {{FuncShort}} | {{.msg}}{{ExtraTextContext}}`)
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+	record := slog.NewRecord(testTime, slog.Level(types.InfoLvl), "test message", 0)
+	record.AddAttrs(slog.String("user", "admin"))
+
+	result := formatter(context.Background(), record)
+
+	// Check all components are present
+	assert.Contains(t, result, "2023-11-04")
+	assert.Contains(t, result, "INFO")
+	assert.Contains(t, result, "test message")
+	assert.Contains(t, result, "user")
+	assert.Contains(t, result, "admin")
+	assert.Contains(t, result, "|")
+}
+
+func TestTemplateFormatterEmptyMessage(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "", 0)
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "", result)
+}
+
+func TestTemplateFormatterMultilineMessage(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.msg}}")
+
+	message := "line1\nline2\nline3"
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), message, 0)
+	result := formatter(context.Background(), record)
+	assert.Equal(t, message, result)
+}
+
+func TestTemplateFormatterSpecialCharacters(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.msg}}")
+
+	specialMessages := []string{
+		"message | with | pipes",
+		"message with \"quotes\"",
+		"message with 'apostrophes'",
+		"message with \ttabs",
+		"message with \\backslashes",
+	}
+
+	for _, msg := range specialMessages {
+		t.Run(msg, func(t *testing.T) {
+			record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), msg, 0)
+			result := formatter(context.Background(), record)
+			assert.Equal(t, msg, result)
+		})
+	}
+}
+
+func TestTemplateFormatterInvalidTemplate(t *testing.T) {
+	// Invalid template syntax - will fail when executed
+	// We can't test this directly since TemplateFormatter uses require.NoError
+	// which will fail the test. Instead, we test that a valid template doesn't fail.
+	formatter := TemplateFormatter(t, "{{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "test", result)
+}
+
+func TestTemplateFormatterAccessingRecordFields(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.record.Message}}")
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+	record := slog.NewRecord(testTime, slog.Level(types.InfoLvl), "test", 0)
+
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "test", result)
+}
+
+func TestTemplateFormatterContextFields(t *testing.T) {
+	formatter := TemplateFormatter(t, "level={{.level}} msg={{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+
+	assert.Contains(t, result, "level=")
+	assert.Contains(t, result, "msg=test")
+}
+
+func TestTemplateFormatterNilContext(t *testing.T) {
+	formatter := TemplateFormatter(t, "{{.msg}}")
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	// Pass nil context - should be handled gracefully
+	result := formatter(nil, record)
+	assert.Equal(t, "test", result)
+}
+
+func TestTemplateFormatterTimeFields(t *testing.T) {
+	formatter := TemplateFormatter(t, `{{Date "2006"}}-{{Date "01"}}-{{Date "02"}}`)
+
+	testTime := time.Date(2023, 11, 4, 15, 30, 45, 0, time.UTC)
+	record := slog.NewRecord(testTime, slog.Level(types.InfoLvl), "test", 0)
+
+	result := formatter(context.Background(), record)
+	assert.Equal(t, "2023-11-04", result)
+}
+
+func TestTemplateFormatterFrameFields(t *testing.T) {
+	formatter := TemplateFormatter(t, `{{.frame.Function}} {{.frame.Line}}`)
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+
+	// Frame fields should be present even if empty
+	assert.NotEmpty(t, result)
+}
+
+func TestTemplateFormatterCombinedFunctions(t *testing.T) {
+	formatter := TemplateFormatter(t, `{{ToUpper (Level)}} - {{Quote .msg}}`)
+
+	record := slog.NewRecord(time.Now(), slog.Level(types.InfoLvl), "test", 0)
+	result := formatter(context.Background(), record)
+
+	assert.Contains(t, result, "INFO")
+	assert.Contains(t, result, " - ")
+}

--- a/pkg/util/log/slog/types/types.go
+++ b/pkg/util/log/slog/types/types.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package types contains the types for the slog based implementation of the log package.
+package types
+
+import (
+	"log/slog"
+)
+
+// LogLevel is the type of log levels
+type LogLevel slog.Level
+
+// Log levels
+const (
+	TraceLvl    LogLevel = LogLevel(slog.LevelDebug - 4)
+	DebugLvl    LogLevel = LogLevel(slog.LevelDebug)
+	InfoLvl     LogLevel = LogLevel(slog.LevelInfo)
+	WarnLvl     LogLevel = LogLevel(slog.LevelWarn)
+	ErrorLvl    LogLevel = LogLevel(slog.LevelError)
+	CriticalLvl LogLevel = LogLevel(slog.LevelError + 4)
+	Off         LogLevel = LogLevel(slog.LevelError + 8)
+)
+
+// String returns the string representation of the log level
+func (l LogLevel) String() string {
+	switch l {
+	case TraceLvl:
+		return "trace"
+	case DebugLvl:
+		return "debug"
+	case InfoLvl:
+		return "info"
+	case WarnLvl:
+		return "warn"
+	case ErrorLvl:
+		return "error"
+	case CriticalLvl:
+		return "critical"
+	case Off:
+		return "off"
+	default:
+		return "unknown"
+	}
+}
+
+// Capitalized returns the capitalized string representation of the log level
+func (l LogLevel) Capitalized() string {
+	switch l {
+	case TraceLvl:
+		return "Trace"
+	case DebugLvl:
+		return "Debug"
+	case InfoLvl:
+		return "Info"
+	case WarnLvl:
+		return "Warn"
+	case ErrorLvl:
+		return "Error"
+	case CriticalLvl:
+		return "Critical"
+	case Off:
+		return "Off"
+	default:
+		return "Unknown"
+	}
+}
+
+// Uppercase returns the uppercase string representation of the log level
+func (l LogLevel) Uppercase() string {
+	switch l {
+	case TraceLvl:
+		return "TRACE"
+	case DebugLvl:
+		return "DEBUG"
+	case InfoLvl:
+		return "INFO"
+	case WarnLvl:
+		return "WARN"
+	case ErrorLvl:
+		return "ERROR"
+	case CriticalLvl:
+		return "CRITICAL"
+	case Off:
+		return "OFF"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/pkg/util/log/slog/wrapper.go
+++ b/pkg/util/log/slog/wrapper.go
@@ -1,0 +1,224 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package slog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/types"
+)
+
+const baseStackDepth = 4
+
+// Wrapper is a wrapper around the slog.Handler interface.
+// It implements the LoggerInterface interface.
+type Wrapper struct {
+	handler slog.Handler
+	flush   func()
+	close   func()
+
+	attrs           []slog.Attr
+	extraStackDepth int
+}
+
+func newWrapper(handler slog.Handler) *Wrapper {
+	return newWrapperWithCloseAndFlush(handler, func() {}, func() {})
+}
+
+func newWrapperWithCloseAndFlush(handler slog.Handler, flush func(), close func()) *Wrapper {
+	return &Wrapper{
+		handler: handler,
+		flush:   flush,
+		close:   close,
+	}
+}
+
+func (w *Wrapper) handleLazy(level types.LogLevel, message fmt.Stringer) {
+	if w.handler.Enabled(context.Background(), slog.Level(level)) {
+		w.handle(level, message.String())
+	}
+}
+
+func (w *Wrapper) handleError(level types.LogLevel, message string) error {
+	if w.handler.Enabled(context.Background(), slog.Level(level)) {
+		w.handle(level, message)
+	}
+	return errors.New(message)
+}
+
+func (w *Wrapper) handle(level types.LogLevel, message string) {
+	var pc [1]uintptr
+	runtime.Callers(baseStackDepth+w.extraStackDepth, pc[:])
+	r := slog.NewRecord(
+		time.Now().UTC(),
+		slog.Level(level),
+		message,
+		pc[0],
+	)
+
+	// we only set a context to perform a single log, so adding them directly on the record is fine
+	// this can be optimized once we stop using seelog and can change the API
+	if len(w.attrs) > 0 {
+		r.AddAttrs(w.attrs...)
+	}
+
+	err := w.handler.Handle(context.Background(), r)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "slog handler error: %v", err)
+	}
+}
+
+type msgArgs struct {
+	args []interface{}
+}
+
+func renderArgs(v ...interface{}) string {
+	return fmt.Sprint(v...)
+}
+
+func (m *msgArgs) String() string {
+	return renderArgs(m.args...)
+}
+
+type msgFormat struct {
+	format string
+	args   []interface{}
+}
+
+func renderFormat(format string, params ...interface{}) string {
+	return fmt.Sprintf(format, params...)
+}
+
+func (m *msgFormat) String() string {
+	return renderFormat(m.format, m.args...)
+}
+
+func newMsgArgs(v ...interface{}) fmt.Stringer {
+	return &msgArgs{args: v}
+}
+
+func newMsgFormat(format string, v ...interface{}) fmt.Stringer {
+	return &msgFormat{format: format, args: v}
+}
+
+// Trace formats message using the default formats for its operands
+// and writes to log with level = Trace
+func (w *Wrapper) Trace(v ...interface{}) {
+	w.handleLazy(types.TraceLvl, newMsgArgs(v...))
+}
+
+// Tracef formats message according to format specifier
+// and writes to log with level = Trace.
+func (w *Wrapper) Tracef(format string, params ...interface{}) {
+	w.handleLazy(types.TraceLvl, newMsgFormat(format, params...))
+}
+
+// Debug formats message using the default formats for its operands
+// and writes to log with level = Debug
+func (w *Wrapper) Debug(v ...interface{}) {
+	w.handleLazy(types.DebugLvl, newMsgArgs(v...))
+}
+
+// Debugf formats message according to format specifier
+// and writes to log with level = Debug.
+func (w *Wrapper) Debugf(format string, params ...interface{}) {
+	w.handleLazy(types.DebugLvl, newMsgFormat(format, params...))
+}
+
+// Info formats message using the default formats for its operands
+// and writes to log with level = Info
+func (w *Wrapper) Info(v ...interface{}) {
+	w.handleLazy(types.InfoLvl, newMsgArgs(v...))
+}
+
+// Infof formats message according to format specifier
+// and writes to log with level = Info.
+func (w *Wrapper) Infof(format string, params ...interface{}) {
+	w.handleLazy(types.InfoLvl, newMsgFormat(format, params...))
+}
+
+// Warn formats message using the default formats for its operands
+// and writes to log with level = Warn
+func (w *Wrapper) Warn(v ...interface{}) error {
+	return w.handleError(types.WarnLvl, renderArgs(v...))
+}
+
+// Warnf formats message according to format specifier
+// and writes to log with level = Warn.
+func (w *Wrapper) Warnf(format string, params ...interface{}) error {
+	return w.handleError(types.WarnLvl, renderFormat(format, params...))
+}
+
+// Error formats message using the default formats for its operands
+// and writes to log with level = Error
+func (w *Wrapper) Error(v ...interface{}) error {
+	return w.handleError(types.ErrorLvl, renderArgs(v...))
+}
+
+// Errorf formats message according to format specifier
+// and writes to log with level = Error.
+func (w *Wrapper) Errorf(format string, params ...interface{}) error {
+	return w.handleError(types.ErrorLvl, renderFormat(format, params...))
+}
+
+// Critical formats message using the default formats for its operands
+// and writes to log with level = Critical
+func (w *Wrapper) Critical(v ...interface{}) error {
+	return w.handleError(types.CriticalLvl, renderArgs(v...))
+}
+
+// Criticalf formats message according to format specifier
+// and writes to log with level = Critical.
+func (w *Wrapper) Criticalf(format string, params ...interface{}) error {
+	return w.handleError(types.CriticalLvl, renderFormat(format, params...))
+}
+
+// Close flushes all the messages in the logger and closes it. It cannot be used after this operation.
+func (w *Wrapper) Close() {
+	w.close()
+}
+
+// Flush flushes all the messages in the logger.
+func (w *Wrapper) Flush() {
+	w.flush()
+}
+
+// SetAdditionalStackDepth sets the additional number of frames to skip by runtime.Caller
+func (w *Wrapper) SetAdditionalStackDepth(depth int) error {
+	w.extraStackDepth = depth
+	return nil
+}
+
+// SetContext sets context which will be added to every log records
+func (w *Wrapper) SetContext(context interface{}) {
+	if context == nil {
+		w.attrs = nil
+		return
+	}
+
+	// See `extractContextString` in pkg/util/log/setup/log.go:
+	// the context is a slice of interface{}, it contains an even number of elements,
+	// and keys are strings.
+	//
+	// We can lift the restrictions and/or change the API later, but for now we want
+	// the exact same behavior as we have with seelog
+
+	ctx := context.([]interface{})
+	var attrs []slog.Attr
+	for i := 0; i < len(ctx); i += 2 {
+		key, val := ctx[i], ctx[i+1]
+		if keyStr, ok := key.(string); ok {
+			attrs = append(attrs, slog.Attr{Key: keyStr, Value: slog.AnyValue(val)})
+		}
+	}
+	w.attrs = attrs
+}

--- a/pkg/util/log/slog/wrapper_test.go
+++ b/pkg/util/log/slog/wrapper_test.go
@@ -1,0 +1,471 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/types"
+)
+
+// mockHandler is a simple slog.Handler that records log messages
+type mockHandler struct {
+	records   []slog.Record
+	enabled   bool
+	lastLevel slog.Level
+}
+
+func newMockHandler() *mockHandler {
+	return &mockHandler{
+		records: make([]slog.Record, 0),
+		enabled: true,
+	}
+}
+
+func (m *mockHandler) Enabled(_ context.Context, level slog.Level) bool {
+	m.lastLevel = level
+	return m.enabled
+}
+
+func (m *mockHandler) Handle(_ context.Context, record slog.Record) error {
+	m.records = append(m.records, record)
+	return nil
+}
+
+func (m *mockHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return m
+}
+
+func (m *mockHandler) WithGroup(_ string) slog.Handler {
+	return m
+}
+
+func (m *mockHandler) lastMessage() string {
+	if len(m.records) == 0 {
+		return ""
+	}
+	return m.records[len(m.records)-1].Message
+}
+
+func (m *mockHandler) lastRecord() slog.Record {
+	if len(m.records) == 0 {
+		return slog.Record{}
+	}
+	return m.records[len(m.records)-1]
+}
+
+func (m *mockHandler) reset() {
+	m.records = make([]slog.Record, 0)
+}
+
+func TestNewWrapper(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	assert.NotNil(t, wrapper)
+	assert.Equal(t, handler, wrapper.handler)
+	assert.NotNil(t, wrapper.flush)
+	assert.NotNil(t, wrapper.close)
+}
+
+func TestNewWrapperWithCloseAndFlush(t *testing.T) {
+	handler := newMockHandler()
+	flushCalled := false
+	closeCalled := false
+
+	flushFunc := func() { flushCalled = true }
+	closeFunc := func() { closeCalled = true }
+
+	wrapper := newWrapperWithCloseAndFlush(handler, flushFunc, closeFunc)
+
+	wrapper.Flush()
+	assert.True(t, flushCalled)
+
+	wrapper.Close()
+	assert.True(t, closeCalled)
+}
+
+func TestWrapperTrace(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	wrapper.Trace("test ", "message")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "test message", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.TraceLvl), handler.lastRecord().Level)
+}
+
+func TestWrapperTracef(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	wrapper.Tracef("test %s %d", "message", 42)
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "test message 42", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.TraceLvl), handler.lastRecord().Level)
+}
+
+func TestWrapperDebug(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	wrapper.Debug("debug ", "message")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "debug message", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.DebugLvl), handler.lastRecord().Level)
+}
+
+func TestWrapperDebugf(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	wrapper.Debugf("debug %s %d", "message", 123)
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "debug message 123", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.DebugLvl), handler.lastRecord().Level)
+}
+
+func TestWrapperInfo(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	wrapper.Info("info ", "message")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "info message", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.InfoLvl), handler.lastRecord().Level)
+}
+
+func TestWrapperInfof(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	wrapper.Infof("info %s", "message")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "info message", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.InfoLvl), handler.lastRecord().Level)
+}
+
+func TestWrapperWarn(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	err := wrapper.Warn("warn ", "message")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "warn message", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.WarnLvl), handler.lastRecord().Level)
+	assert.Error(t, err)
+	assert.Equal(t, "warn message", err.Error())
+}
+
+func TestWrapperWarnf(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	err := wrapper.Warnf("warn %s", "message")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "warn message", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.WarnLvl), handler.lastRecord().Level)
+	assert.Error(t, err)
+	assert.Equal(t, "warn message", err.Error())
+}
+
+func TestWrapperError(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	err := wrapper.Error("error ", "message")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "error message", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.ErrorLvl), handler.lastRecord().Level)
+	assert.Error(t, err)
+	assert.Equal(t, "error message", err.Error())
+}
+
+func TestWrapperErrorf(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	err := wrapper.Errorf("error %d", 404)
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "error 404", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.ErrorLvl), handler.lastRecord().Level)
+	assert.Error(t, err)
+	assert.Equal(t, "error 404", err.Error())
+}
+
+func TestWrapperCritical(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	err := wrapper.Critical("critical ", "message")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "critical message", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.CriticalLvl), handler.lastRecord().Level)
+	assert.Error(t, err)
+	assert.Equal(t, "critical message", err.Error())
+}
+
+func TestWrapperCriticalf(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	err := wrapper.Criticalf("critical %s", "failure")
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "critical failure", handler.lastMessage())
+	assert.Equal(t, slog.Level(types.CriticalLvl), handler.lastRecord().Level)
+	assert.Error(t, err)
+	assert.Equal(t, "critical failure", err.Error())
+}
+
+func TestWrapperSetAdditionalStackDepth(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	// Helper function that logs a message
+	logHelper := func() {
+		wrapper.Info("test message")
+	}
+
+	// Log without extra stack depth - should capture the anonymous function (func1) as the caller
+	logHelper()
+	assert.Equal(t, 1, len(handler.records))
+	record1 := handler.lastRecord()
+	frame1, _ := runtime.CallersFrames([]uintptr{record1.PC}).Next()
+	assert.Contains(t, frame1.Function, "TestWrapperSetAdditionalStackDepth.func1")
+
+	// Reset records
+	handler.reset()
+
+	// Set additional stack depth to skip one more frame (the helper function)
+	err := wrapper.SetAdditionalStackDepth(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, wrapper.extraStackDepth)
+
+	// Log again with extra stack depth - should now capture TestWrapperSetAdditionalStackDepth as the caller
+	logHelper()
+	assert.Equal(t, 1, len(handler.records))
+	record2 := handler.lastRecord()
+	frame2, _ := runtime.CallersFrames([]uintptr{record2.PC}).Next()
+	assert.True(t, strings.HasSuffix(frame2.Function, "TestWrapperSetAdditionalStackDepth"), frame2.Function)
+}
+
+func TestWrapperSetContext(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	// Test setting context
+	context := []interface{}{"key1", "value1", "key2", 42}
+	wrapper.SetContext(context)
+
+	// Test that context is added to log record
+	wrapper.Info("test")
+	record := handler.lastRecord()
+	attrs := getAttrs(record)
+	require.Equal(t, 2, len(attrs))
+	assert.Equal(t, "key1", attrs[0].Key)
+	assert.Equal(t, "value1", attrs[0].Value.String())
+	assert.Equal(t, "key2", attrs[1].Key)
+	assert.Equal(t, int64(42), attrs[1].Value.Int64())
+
+}
+
+func getAttrs(record slog.Record) []slog.Attr {
+	var attrs []slog.Attr
+	record.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a)
+		return true
+	})
+	return attrs
+}
+
+func TestWrapperSetContextNil(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	// Set context first
+	context := []interface{}{"key", "value"}
+	wrapper.SetContext(context)
+
+	// Log and verify context is present
+	wrapper.Info("test with context")
+	attrs1 := getAttrs(handler.lastRecord())
+	require.Equal(t, 1, len(attrs1))
+	assert.Equal(t, "key", attrs1[0].Key)
+	assert.Equal(t, "value", attrs1[0].Value.String())
+
+	// Clear context
+	handler.reset()
+	wrapper.SetContext(nil)
+
+	// Log and verify no context attributes are present
+	wrapper.Info("test without context")
+	record2 := handler.lastRecord()
+	attrs2 := getAttrs(record2)
+	assert.Empty(t, attrs2)
+}
+
+func TestWrapperSetContextSkipsNonStringKeys(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	// Context with non-string keys should be skipped
+	context := []interface{}{123, "value1", "key2", "value2"}
+	wrapper.SetContext(context)
+
+	// Only the second pair should be added
+	assert.Equal(t, 1, len(wrapper.attrs))
+	assert.Equal(t, "key2", wrapper.attrs[0].Key)
+}
+
+func TestRenderArgs(t *testing.T) {
+	result := renderArgs("hello", " ", "world")
+	assert.Equal(t, "hello world", result)
+}
+
+func TestRenderFormat(t *testing.T) {
+	result := renderFormat("hello %s %d", "world", 42)
+	assert.Equal(t, "hello world 42", result)
+}
+
+func TestMsgArgs(t *testing.T) {
+	msg := newMsgArgs("hello", " ", "world")
+	assert.Equal(t, "hello world", msg.String())
+}
+
+func TestMsgFormat(t *testing.T) {
+	msg := newMsgFormat("test %s %d", "value", 123)
+	assert.Equal(t, "test value 123", msg.String())
+}
+
+// Test that complex types are properly formatted
+func TestWrapperComplexTypes(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	type testStruct struct {
+		Field1 string
+		Field2 int
+	}
+
+	testObj := testStruct{Field1: "test", Field2: 42}
+
+	wrapper.Info("struct: ", testObj)
+	assert.Equal(t, 1, len(handler.records))
+	// The exact format may vary, but it should contain the struct representation
+	assert.Contains(t, handler.lastMessage(), "struct")
+}
+
+// Test multiple rapid log calls
+func TestWrapperMultipleCalls(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	for i := 0; i < 100; i++ {
+		wrapper.Info("message ", i)
+	}
+
+	assert.Equal(t, 100, len(handler.records))
+	assert.Equal(t, "message 99", handler.lastMessage())
+}
+
+// Test empty messages
+func TestWrapperEmptyMessage(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	wrapper.Info()
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "", strings.TrimSpace(handler.lastMessage()))
+}
+
+func TestWrapperFormatSpecifiers(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	wrapper.Infof("int: %d, string: %s, float: %.2f", 42, "test", 3.14159)
+	assert.Equal(t, "int: 42, string: test, float: 3.14", handler.lastMessage())
+}
+
+// TestTracefDoesNotBuildMessageWhenDisabled verifies that Tracef doesn't build
+// the message when the trace level is disabled, avoiding unnecessary formatting work
+func TestTracefDoesNotBuildMessageWhenDisabled(t *testing.T) {
+	handler := newMockHandler()
+	handler.enabled = false
+	wrapper := newWrapper(handler)
+
+	// Test that the fmt.Sprintf formatting is not called when level is disabled
+	// We do this by using handleLazy directly with a custom stringer
+	formatCalled := false
+	msg := &trackedStringer{
+		StringFunc: func() string {
+			formatCalled = true
+			return "formatted message"
+		},
+	}
+
+	// Call handleLazy directly with our tracked stringer
+	wrapper.Tracef("%s", msg)
+
+	// Verify String() was NOT called because the level was disabled
+	assert.False(t, formatCalled, "String() should not be called when level is disabled")
+	assert.Equal(t, 0, len(handler.records), "no record should be logged when level is disabled")
+
+	// Now test with level enabled to verify String() IS called
+	handler.enabled = true
+	handler.reset()
+
+	formatCalled = false
+	msg2 := &trackedStringer{
+		StringFunc: func() string {
+			formatCalled = true
+			return "formatted message"
+		},
+	}
+
+	wrapper.Tracef("%s", msg2)
+
+	// Verify String() WAS called because the level was enabled
+	assert.True(t, formatCalled, "String() should be called when level is enabled")
+	assert.Equal(t, 1, len(handler.records), "record should be logged when level is enabled")
+	assert.Equal(t, "formatted message", handler.lastMessage())
+}
+
+// Helper type for testing lazy evaluation
+type trackedStringer struct {
+	StringFunc func() string
+}
+
+func (t *trackedStringer) String() string {
+	return t.StringFunc()
+}
+
+func TestContextValuesNotRendered(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := newWrapper(handler)
+
+	// Create a context value with a tracked stringer to detect if it's evaluated
+	stringerCalled := false
+	expensiveValue := &trackedStringer{
+		StringFunc: func() string {
+			stringerCalled = true
+			return "expensive computation result"
+		},
+	}
+
+	// Set context with the expensive stringer value
+	wrapper.SetContext([]interface{}{"expensive_key", expensiveValue})
+	assert.False(t, stringerCalled, "String() should not be called during SetContext")
+
+	wrapper.Trace("test message")
+	assert.False(t, stringerCalled, "String() should not be called by the wrapper itself")
+}

--- a/pkg/util/log/types/types.go
+++ b/pkg/util/log/types/types.go
@@ -101,3 +101,35 @@ const (
 func (level LogLevel) String() string {
 	return seelog.LogLevel(level).String()
 }
+
+var capitalized = map[LogLevel]string{
+	TraceLvl:    "Trace",
+	DebugLvl:    "Debug",
+	InfoLvl:     "Info",
+	WarnLvl:     "Warn",
+	ErrorLvl:    "Error",
+	CriticalLvl: "Critical",
+	Off:         "Off",
+}
+
+var uppercased = map[LogLevel]string{
+	TraceLvl:    "TRACE",
+	DebugLvl:    "DEBUG",
+	InfoLvl:     "INFO",
+	WarnLvl:     "WARN",
+	ErrorLvl:    "ERROR",
+	CriticalLvl: "CRITICAL",
+	Off:         "OFF",
+}
+
+// Capitalized returns a capitalized string representation of the log level
+// Avoids allocations when logging.
+func (level LogLevel) Capitalized() string {
+	return capitalized[level]
+}
+
+// Uppercase returns an uppercase string representation of the log level
+// Avoids allocations when logging.
+func (level LogLevel) Uppercase() string {
+	return uppercased[level]
+}


### PR DESCRIPTION
### What does this PR do?
- [x] Add slog based implementation of `LoggerInterface` replacing seelog.
- [ ] Add an environment variable to pick which implementation to use, by default seelog is used so that there is no functional changes for users.

### Motivation
Eventually replace seelog with slog-based logger entirely.

Seelog is unmaintained for years, and doesn't provide many features that we need, forcing us to add layers and layers on top of it, making the code very complex.
This migration will hopefully allow us to significantly simplify the code later, and make it easier to add features.

### Describe how you validated your changes
- [x] Added many unit tests for the new code.
- [ ] Added unit tests for existing code in separate PR.
- [ ] Manual e2e testing for the more complex features (eg. syslog)

Once merged we will test the new implementation internally.

### Additional Notes
Replaces https://github.com/DataDog/datadog-agent/pull/39139, reusing a lot of the new code.

We need to use an environment variable and not a configuration because the log package is used before the configuration is read. Since even basic things like log level have different values between `slog` and `seelog`, we need to know from the very start which implementation we want to use.

- [ ] Some logic has been duplicated (eg. log formats, syslog, etc). I'll try to link to the original version to make the review easier.

We could use libraries for some of the logic, but it would be difficult to be sure we're 100% equivalent to the existing implementation, which is a requirement (in particular for the testing phase, as it makes the transition easier)
I do want to take a look at some of those later though.
- https://github.com/samber/slog-multi
- https://github.com/samber/slog-syslog
- https://github.com/samber/slog-formatter
- https://github.com/samber/slog-sampling
- https://github.com/samber/slog-zap