### PR TITLE
[EBPF] gpu: fix unit for timestamps in stateful collector

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -95,7 +95,7 @@ func processSample(device ddnvml.Device, metricName string, samplingType nvml.Sa
 
 // processUtilizationSample handles process utilization sampling logic
 func processUtilizationSample(device ddnvml.Device, lastTimestamp uint64, nsPidCache *NsPidCache) ([]Metric, uint64, error) {
-	currentTime := uint64(time.Now().Unix())
+	currentTime := uint64(time.Now().UnixMicro())
 	processSamples, err := device.GetProcessUtilization(lastTimestamp)
 
 	var allMetrics []Metric

--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -191,7 +191,7 @@ func newStatefulCollector(name CollectorName, device ddnvml.Device, apiCalls []a
 	}
 
 	// Initialize timestamps for sampling collectors
-	currentTime := uint64(time.Now().Unix())
+	currentTime := uint64(time.Now().UnixMicro())
 	for _, apiCall := range c.supportedAPIs {
 		c.lastTimestamps[apiCall.Name] = currentTime
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
@@ -273,9 +273,9 @@ func TestProcessUtilizationTimestampUpdate(t *testing.T) {
 			bc := collector.(*baseCollector)
 			bc.lastTimestamps["process_utilization"] = tt.initialTimestamp
 
-			timeBefore := uint64(time.Now().Unix())
+			timeBefore := uint64(time.Now().UnixMicro())
 			_, err = collector.Collect()
-			timeAfter := uint64(time.Now().Unix())
+			timeAfter := uint64(time.Now().UnixMicro())
 
 			// Timestamp should be updated to current time regardless of API success/failure
 			newTimestamp := bc.lastTimestamps["process_utilization"]

--- a/releasenotes/notes/gpu-sm-active-d2e4ec2e2d304e29.yaml
+++ b/releasenotes/notes/gpu-sm-active-d2e4ec2e2d304e29.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    gpu: fix a bug where the gpu.sm_active and
+    gpu.process.{sm_active,dram_active,encoder_utilization,decoder_utilization}
+    metrics were emitting values lower than expected.


### PR DESCRIPTION
### What does this PR do?

Fixes the unit used for the timestamps in the stateful collector, it was using seconds while the API expects microseconds 

https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1gb0ea5236f5e69e63bf53684a11c233bd

### Motivation

Fix a precision issue detected in https://datadoghq.atlassian.net/browse/GPUMON-512. It was affecting `gpu.sm_active` and `gpu.process.{sm_active,dram_active,encoder_utilization,decoder_utilization}` metrics.

### Describe how you validated your changes

Reproduced issue locally and validated the fix against that.

### Additional Notes
