### PR TITLE
Move Default log function behind test build tag

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -31,7 +31,7 @@ func (d *dispatcher) getState(scrub bool) (types.StateResponse, error) {
 	if scrub {
 		scrubbedConf := make([]integration.Config, 0, len(danglingConf))
 		for _, config := range danglingConf {
-			scrubbedConf = append(scrubbedConf, integration.ScrubCheckConfig(config, log.Default()))
+			scrubbedConf = append(scrubbedConf, integration.ScrubCheckConfig(config, log.NewWrapper(1)))
 		}
 		danglingConf = scrubbedConf
 	}
@@ -46,7 +46,7 @@ func (d *dispatcher) getState(scrub bool) (types.StateResponse, error) {
 		if scrub {
 			scrubbedConf := make([]integration.Config, 0, len(configs))
 			for _, config := range configs {
-				scrubbedConf = append(scrubbedConf, integration.ScrubCheckConfig(config, log.Default()))
+				scrubbedConf = append(scrubbedConf, integration.ScrubCheckConfig(config, log.NewWrapper(1)))
 			}
 			configs = scrubbedConf
 		}

--- a/pkg/util/log/logger.go
+++ b/pkg/util/log/logger.go
@@ -14,11 +14,6 @@ import (
 // LoggerInterface provides basic logging methods that can be used from outside the log package.
 type LoggerInterface = types.LoggerInterface
 
-// Default returns a default logger
-func Default() LoggerInterface {
-	return seelog.Default
-}
-
 // Disabled returns a disabled logger
 func Disabled() LoggerInterface {
 	return seelog.Disabled

--- a/pkg/util/log/logger_test_utils.go
+++ b/pkg/util/log/logger_test_utils.go
@@ -13,6 +13,11 @@ import (
 	"github.com/cihub/seelog"
 )
 
+// Default returns a default logger
+func Default() LoggerInterface {
+	return seelog.Default
+}
+
 // loggerFromWriterWithMinLevelAndFormat creates a new logger from a writer, a minimum log level and a format.
 func loggerFromWriterWithMinLevelAndFormat(output io.Writer, minLevel LogLevel, format string) (LoggerInterface, error) {
 	return seelog.LoggerFromWriterWithMinLevelAndFormat(output, seelog.LogLevel(minLevel), format)


### PR DESCRIPTION
### What does this PR do?
Move `Default` log function behind test build tag.
Replace the one non-test use with `NewWrapper`, which returns a wrapper around `pkg/util/log`. 

### Motivation
`Default` return a basic logger printing to stdout.
It's only supposed to be used in tests, so it should be behind the test build tag.

### Describe how you validated your changes
CI

### Additional Notes
