### PR TITLE
Bump secret-generic-connector to 1.3.3

### DIFF
--- a/omnibus/config/software/secret-generic-connector.rb
+++ b/omnibus/config/software/secret-generic-connector.rb
@@ -16,7 +16,7 @@
 require './lib/ostools.rb'
 
 name "secret-generic-connector"
-default_version "1.3.2"
+default_version "1.3.3"
 
 # Define URLs for each platform
 secret_generic_urls = {
@@ -38,16 +38,16 @@ secret_generic_urls = {
 # Note: These should be updated for each version
 secret_generic_sha256 = {
   "linux" => {
-    "amd64" => "179c7e8a68feec89a08f7b7f694f7bf9f2319eb527dd1e1bec6fa84223213412",
-    "arm64" => "fe0d3e711ccd3083126ee8c352bc319201c45d055b4b98fdf001dfa21e6f4ad8"
+    "amd64" => "845efbf48b108981a9495a219af944194641fbcc13f1648cd953443d73a08754",
+    "arm64" => "2a972ec71d398bdaf574a30a5adcf26bcfce7e355bb8c1eb7fe9d0db4eb27e01"
   },
   "windows" => {
-    "amd64" => "0a79dba05ee1f736811df45436dc500367aef299fb7ff8811c54280ad021d97f",
-    "arm64" => "a33e8d59cd99207d2a91c222743d1a680b9d797bef65c354571427183355a179"
+    "amd64" => "2c7a9960abab52c2a3a1678bd91806842c5477805defea9099893b4d4cb09bad",
+    "arm64" => "0b26608f8a252a8133f499dafea9cb44f14a71fa8bb924b3a49c80336c0b660d"
   },
   "darwin" => {
-    "amd64" => "065fc3dcc083731abb5abeff38453d01254d1d46f218abd5c654836549f84478",
-    "arm64" => "2797bd609f18c863b9097aec0c3d8320f660ceb209660f910a0893687ef66612"
+    "amd64" => "ac92a4ec5432f841b27019e670e5fe3bdd8683ee0e6dfd378e907454f33f9779",
+    "arm64" => "f7cd78ff0baf47022749a8846a3ce9c722d058d287a94b975059233f8a1a27aa"
   },
 }
 


### PR DESCRIPTION
### What does this PR do?

Bump secret-generic-connector to 1.3.3

### Motivation

There was a problem with k8s authentication (https://dd.slack.com/archives/C9X24HRUZ/p1762285246175539)--this new release contains [a fix](https://github.com/DataDog/datadog-secret-backend/pull/223) for it.

### Describe how you validated your changes

### Additional Notes
