### PR TITLE
Adds upload step for debian debug symbols during agent CI

### DIFF
--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -58,6 +58,64 @@
     fi
   - dd-pkg sign --key-id "${PIPELINE_KEY_ALIAS}" "${OMNIBUS_PACKAGE_DIR}"
 
+# Upload debug symbol packages to Datadog symbol server using datadog-ci to enable
+# remote symbolication when using ddprof (datadog's native profiler)
+.upload_debug_symbols: |
+  # Find debug symbol packages (dbgsym or -dbg packages)
+  DEBUG_PACKAGES=$(find $OMNIBUS_PACKAGE_DIR -name '*-dbg*.deb' 2>/dev/null || true)
+
+  if [ -n "$DEBUG_PACKAGES" ]; then
+    echo "Found debug symbol packages to upload:"
+    echo "$DEBUG_PACKAGES"
+
+    # Get Datadog API key for datadog-ci authentication
+    DATADOG_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?
+    export DATADOG_API_KEY
+
+    # Enable beta commands for elf-symbols upload
+    export DD_BETA_COMMANDS_ENABLED=1
+
+    # Verify datadog-ci is available
+    if ! command -v datadog-ci &> /dev/null; then
+      echo "WARNING: datadog-ci not found in PATH, skipping symbol upload"
+      exit 0
+    fi
+
+    # Upload each debug package using datadog-ci
+    for pkg in $DEBUG_PACKAGES; do
+      echo "Uploading symbols from: $(basename $pkg)"
+
+      # Extract package to temporary directory
+      EXTRACT_DIR=$(mktemp -d)
+      dpkg-deb -x "$pkg" "$EXTRACT_DIR" || {
+        echo "WARNING: Failed to extract package: $pkg"
+        rm -rf "$EXTRACT_DIR"
+        continue
+      }
+
+      # Upload debug symbols using datadog-ci elf-symbols upload
+      # This command scans recursively for ELF files and extracts build IDs automatically
+      DEBUG_DIR="$EXTRACT_DIR/opt/datadog-agent/.debug"
+      if [ -d "$DEBUG_DIR" ]; then
+        echo "Uploading symbols from $DEBUG_DIR"
+        datadog-ci elf-symbols upload "$DEBUG_DIR" || {
+          echo "WARNING: Symbol upload failed for $pkg (non-fatal)"
+        }
+      else
+        echo "WARNING: No .debug directory found in package at expected location"
+        echo "Searching for debug files in package:"
+        find "$EXTRACT_DIR" -type f \( -name "*.debug" -o -name "*.dbg" \) | head -10
+      fi
+
+      # Cleanup
+      rm -rf "$EXTRACT_DIR"
+    done
+
+    echo "Debug symbols upload process completed"
+  else
+    echo "No debug symbol packages matching '*-dbg*.deb' found in $OMNIBUS_PACKAGE_DIR"
+  fi
+
 # Login to docker with read-only credentials to avoid rate-limiting
 .login_to_docker_readonly:
   - DOCKER_LOGIN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $DOCKER_REGISTRY_RO user) || exit $?

--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -9,6 +9,7 @@ include:
     - !reference [.cache_omnibus_ruby_deps, setup]
     - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --target-project ${DD_PROJECT} ${OMNIBUS_EXTRA_ARGS}
     - !reference [.create_signature_and_lint_linux_packages]
+    - !reference [.upload_debug_symbols]
   after_script:
     - !reference [.static_quality_gate_package]
   artifacts:
@@ -140,6 +141,7 @@ installer_deb-arm64:
     - !reference [.cache_omnibus_ruby_deps, setup]
     - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --flavor iot
     - !reference [.create_signature_and_lint_linux_packages]
+    - !reference [.upload_debug_symbols]
   after_script:
     - !reference [.static_quality_gate_package]
   artifacts:


### PR DESCRIPTION
### What does this PR do?

Adds a step during Agent's CI to upload the debug symbols from linux debian
binaries to datadog.

### Motivation

`ddprof` can utilize these symbols to provide better profiling data

### Describe how you validated your changes

Testing in progress in SMP environment.
Once I get a container build here -> publish to dockerhub.

Then, using a dev build of SMP with `DD_PROFILING_REMOTE_SYMBOLIZATION` set to
true and compare this PR's artifacts vs last night's nightly build.

I would expect that I'll continue to see `DD_AGENT_1` for the baseline and real
symbols for this comparison.

#### Test 1
Running `aws-vault exec smp2 -- $HOME/dev/single-machine-performance/bin/submit_to_cluster --team-id 12344321 --baseline-repo datadog/agent-dev --comparison-repo datadog/agent-dev --baseline nightly-full-main-9f819c36-jmx --comparison scott-opell-debug-symbols-upload-2764aa32-full --path-to-experimen
ts $HOME/dev/single-machine-performance/experiments/regression/agent --tags 'purpose=validate-debug-symbols'`

and it started job_id: `e200c625-6262-4b72-a350-7057a3d915b8`

This is _NOT_ running with `DD_PROFILING_REMOTE_SYMBOLIZATION` set


#### Test 2
Running basically above but with `DD_PROFILING_REMOTE_SYMBOLIZATION` set, still [no profiles](https://app.datadoghq.com/profiling/comparison?compare_end_A=1764019831043&compare_end_B=1764019832422&compare_query_A=job_id%3A34f0164f-d2cb-42e2-814b-1adac625cadd%20variant%3Abaseline%20env%3Asingle-machine-performance%20language%3Anative&compare_query_B=job_id%3A34f0164f-d2cb-42e2-814b-1adac625cadd%20variant%3Acomparison%20env%3Asingle-machine-performance%20language%3Anative&compare_start_A=1763933431043&compare_start_B=1763933432422&compareValuesMode=absolute)

### Additional Notes
Generally you want the go profiler, which doesn't need these elf debug symbols.
This is specific to running the Agent under the native profiler.

[datadog-ci reference](https://github.com/DataDog/datadog-ci/blob/master/packages/datadog-ci/src/commands/elf-symbols/README.md)


