### PR TITLE
Simplify build seelog logger logic

### DIFF
--- a/pkg/util/log/setup/log.go
+++ b/pkg/util/log/setup/log.go
@@ -96,24 +96,24 @@ func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, sys
 	return nil
 }
 
-// BuildJMXLogger sets up a logger with JMX logger name and log level
+// BuildJMXLogger returns a logger with JMX logger name and log level
 // if a non empty logFile is provided, it will also log to the file
 // a non empty syslogURI will enable syslog, and format them following RFC 5424 if specified
 // you can also specify to log to the console and in JSON format
-func BuildJMXLogger(logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) (seelog.LoggerInterface, error) {
+func BuildJMXLogger(logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
 	// The JMX logger always logs at level "info", because JMXFetch does its
 	// own level filtering on and provides all messages to seelog at the info
 	// or error levels, via log.JMXInfo and log.JMXError.
 	return buildLogger(JMXLoggerName, log.InfoLvl, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
 }
 
-// SetupDogstatsdLogger sets up a logger with dogstatsd logger name and log level
+// SetupDogstatsdLogger returns a logger with dogstatsd logger name and log level
 // if a non empty logFile is provided, it will also log to the file
-func SetupDogstatsdLogger(logFile string, cfg pkgconfigmodel.Reader) (seelog.LoggerInterface, error) {
+func SetupDogstatsdLogger(logFile string, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
 	return buildDogstatsdLogger(DogstatsDLoggerName, log.InfoLvl, logFile, cfg)
 }
 
-func buildDogstatsdLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile string, cfg pkgconfigmodel.Reader) (seelog.LoggerInterface, error) {
+func buildDogstatsdLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile string, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
 	config := seelogCfg.NewSeelogConfig(string(loggerName), seelogLogLevel.String(), "common", "", buildCommonFormat(loggerName, cfg), false)
 
 	// Configuring max roll for log file, if dogstatsd_log_file_max_rolls env var is not set (or set improperly ) within datadog.yaml then default value is 3

--- a/pkg/util/log/setup/log_nix_test.go
+++ b/pkg/util/log/setup/log_nix_test.go
@@ -39,8 +39,7 @@ func TestGetSyslogURI(t *testing.T) {
 func TestSetupLoggingNowhere(t *testing.T) {
 	// setup logger so that it logs nowhere: i.e.  not to file, not to syslog, not to console
 	mockConfig := configmock.New(t)
-	seelogConfig, _ = buildLoggerConfig("agent", log.InfoLvl, "", "", false, false, false, mockConfig)
-	loggerInterface, err := GenerateLoggerInterface(seelogConfig)
+	loggerInterface, err := buildLogger("agent", log.InfoLvl, "", "", false, false, false, mockConfig)
 
 	assert.Nil(t, loggerInterface)
 	assert.NotNil(t, err)


### PR DESCRIPTION
### What does this PR do?
Overall simplify the logic to build `seelog` loggers:
- Have the `buildLogger`, `buildDogstatsdLogger`, and `BuildJMXLogger` functions directly return a `LoggerInterface` instead of a `seelog.LoggerInterface`
- Remove the 3 seelog config structs global variables
- Unexport `GenerateLoggerInterface`

### Motivation
Simplify the logic in order to not have to go through the config object when creating a logger.
It will make things simpler when introducing `slog`.

### Describe how you validated your changes
CI.
No functional changes expected.

### Additional Notes
