### PR TITLE
[CWS] Fix raw packet unmarshaller data race

### DIFF
--- a/pkg/security/secl/model/unmarshallers_pcap_linux.go
+++ b/pkg/security/secl/model/unmarshallers_pcap_linux.go
@@ -28,7 +28,7 @@ func (e *RawPacketEvent) UnmarshalBinary(data []byte) (int, error) {
 
 	e.Size = binary.NativeEndian.Uint32(data)
 	data = data[4:]
-	e.Data = data
+	e.Data = append([]byte(nil), data...)
 	e.CaptureInfo.InterfaceIndex = int(e.NetworkContext.Device.IfIndex)
 	e.CaptureInfo.Length = int(e.NetworkContext.Size)
 	e.CaptureInfo.CaptureLength = len(data)

--- a/pkg/security/secl/model/unmarshallers_pcap_linux.go
+++ b/pkg/security/secl/model/unmarshallers_pcap_linux.go
@@ -28,7 +28,7 @@ func (e *RawPacketEvent) UnmarshalBinary(data []byte) (int, error) {
 
 	e.Size = binary.NativeEndian.Uint32(data)
 	data = data[4:]
-	e.Data = append([]byte(nil), data...)
+	e.Data = slices.Clone(data)
 	e.CaptureInfo.InterfaceIndex = int(e.NetworkContext.Device.IfIndex)
 	e.CaptureInfo.Length = int(e.NetworkContext.Size)
 	e.CaptureInfo.CaptureLength = len(data)

--- a/pkg/security/secl/model/unmarshallers_pcap_linux.go
+++ b/pkg/security/secl/model/unmarshallers_pcap_linux.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"slices"
 )
 
 // UnmarshalBinary unmarshals a binary representation of itself


### PR DESCRIPTION
### What does this PR do?

Fix data race between JSON serialization of raw packet layers and ring buffer reuse by ensuring packet bytes no longer alias the ringbuf buffer

