### PR TITLE
Replace disabled logger and introduce slog wrapper

### DIFF
--- a/pkg/util/log/slog/disabled.go
+++ b/pkg/util/log/slog/disabled.go
@@ -12,6 +12,6 @@ import (
 
 // Disabled returns a disabled logger.
 func Disabled() types.LoggerInterface {
-	disabledHandler := handlers.NewDisabledHandler()
+	disabledHandler := handlers.NewDisabled()
 	return NewWrapper(disabledHandler)
 }

--- a/pkg/util/log/slog/disabled.go
+++ b/pkg/util/log/slog/disabled.go
@@ -3,17 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package log
+package slog
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/log/slog"
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/handlers"
 	"github.com/DataDog/datadog-agent/pkg/util/log/types"
 )
 
-// LoggerInterface provides basic logging methods that can be used from outside the log package.
-type LoggerInterface = types.LoggerInterface
-
-// Disabled returns a disabled logger
-func Disabled() LoggerInterface {
-	return slog.Disabled()
+// Disabled returns a disabled logger.
+func Disabled() types.LoggerInterface {
+	disabledHandler := handlers.NewDisabledHandler()
+	return NewWrapper(disabledHandler)
 }

--- a/pkg/util/log/slog/handlers/disabled.go
+++ b/pkg/util/log/slog/handlers/disabled.go
@@ -14,11 +14,11 @@ var _ slog.Handler = disabled{}
 
 // disabled is a slog handler which never writes anything.
 //
-// This can be replaced by slog.Disabled once we update to Go 1.25
+// This can be replaced by slog.DiscardHandler once we update to Go 1.25
 type disabled struct{}
 
-// NewDisabledHandler returns a handler which never writes anything.
-func NewDisabledHandler() slog.Handler {
+// NewDisabled returns a handler which never writes anything.
+func NewDisabled() slog.Handler {
 	return disabled{}
 }
 

--- a/pkg/util/log/slog/handlers/disabled_handler.go
+++ b/pkg/util/log/slog/handlers/disabled_handler.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+)
+
+var _ slog.Handler = disabled{}
+
+// disabled is a slog handler which never writes anything.
+//
+// This can be replaced by slog.Disabled once we update to Go 1.25
+type disabled struct{}
+
+// NewDisabledHandler returns a handler which never writes anything.
+func NewDisabledHandler() slog.Handler {
+	return disabled{}
+}
+
+// Enabled returns false
+func (disabled) Enabled(context.Context, slog.Level) bool {
+	return false
+}
+
+// Handle does nothing
+func (disabled) Handle(context.Context, slog.Record) error {
+	return nil
+}
+
+// WithAttrs does nothing
+func (d disabled) WithAttrs([]slog.Attr) slog.Handler {
+	return d
+}
+
+// WithGroup does nothing
+func (d disabled) WithGroup(string) slog.Handler {
+	return d
+}

--- a/pkg/util/log/slog/handlers/disabled_handler_test.go
+++ b/pkg/util/log/slog/handlers/disabled_handler_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisabledHandlerEnabled(t *testing.T) {
+	handler := NewDisabledHandler()
+
+	// Should always return false for any level
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelInfo))
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestDisabledHandlerHandle(t *testing.T) {
+	handler := NewDisabledHandler()
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+	err := handler.Handle(context.Background(), record)
+	require.NoError(t, err)
+}

--- a/pkg/util/log/slog/handlers/disabled_test.go
+++ b/pkg/util/log/slog/handlers/disabled_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestDisabledHandlerEnabled(t *testing.T) {
-	handler := NewDisabledHandler()
+	handler := NewDisabled()
 
 	// Should always return false for any level
 	assert.False(t, handler.Enabled(context.Background(), slog.LevelDebug))
@@ -26,7 +26,7 @@ func TestDisabledHandlerEnabled(t *testing.T) {
 }
 
 func TestDisabledHandlerHandle(t *testing.T) {
-	handler := NewDisabledHandler()
+	handler := NewDisabled()
 
 	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
 	err := handler.Handle(context.Background(), record)

--- a/pkg/util/log/slog/handlers/docs.go
+++ b/pkg/util/log/slog/handlers/docs.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package handlers provides simple slog handlers
+package handlers

--- a/pkg/util/log/slog/wrapper.go
+++ b/pkg/util/log/slog/wrapper.go
@@ -46,9 +46,17 @@ func newWrapperWithCloseAndFlush(handler slog.Handler, flush func(), close func(
 	}
 }
 
-func (w *Wrapper) handleLazy(level types.LogLevel, message fmt.Stringer) {
+func (w *Wrapper) handleArgs(level types.LogLevel, v ...interface{}) {
 	if w.handler.Enabled(context.Background(), types.ToSlogLevel(level)) {
-		w.handle(level, message.String())
+		// rendering is only done if the level is enabled
+		w.handle(level, renderArgs(v...))
+	}
+}
+
+func (w *Wrapper) handleFormat(level types.LogLevel, format string, params ...interface{}) {
+	if w.handler.Enabled(context.Background(), types.ToSlogLevel(level)) {
+		// rendering is only done if the level is enabled
+		w.handle(level, renderFormat(format, params...))
 	}
 }
 
@@ -81,73 +89,48 @@ func (w *Wrapper) handle(level types.LogLevel, message string) {
 	}
 }
 
-type msgArgs struct {
-	args []interface{}
-}
-
 func renderArgs(v ...interface{}) string {
 	return fmt.Sprint(v...)
-}
-
-func (m *msgArgs) String() string {
-	return renderArgs(m.args...)
-}
-
-type msgFormat struct {
-	format string
-	args   []interface{}
 }
 
 func renderFormat(format string, params ...interface{}) string {
 	return fmt.Sprintf(format, params...)
 }
 
-func (m *msgFormat) String() string {
-	return renderFormat(m.format, m.args...)
-}
-
-func newMsgArgs(v ...interface{}) fmt.Stringer {
-	return &msgArgs{args: v}
-}
-
-func newMsgFormat(format string, v ...interface{}) fmt.Stringer {
-	return &msgFormat{format: format, args: v}
-}
-
 // Trace formats message using the default formats for its operands
 // and writes to log with level = Trace
 func (w *Wrapper) Trace(v ...interface{}) {
-	w.handleLazy(types.TraceLvl, newMsgArgs(v...))
+	w.handleArgs(types.TraceLvl, v...)
 }
 
 // Tracef formats message according to format specifier
 // and writes to log with level = Trace.
 func (w *Wrapper) Tracef(format string, params ...interface{}) {
-	w.handleLazy(types.TraceLvl, newMsgFormat(format, params...))
+	w.handleFormat(types.TraceLvl, format, params...)
 }
 
 // Debug formats message using the default formats for its operands
 // and writes to log with level = Debug
 func (w *Wrapper) Debug(v ...interface{}) {
-	w.handleLazy(types.DebugLvl, newMsgArgs(v...))
+	w.handleArgs(types.DebugLvl, v...)
 }
 
 // Debugf formats message according to format specifier
 // and writes to log with level = Debug.
 func (w *Wrapper) Debugf(format string, params ...interface{}) {
-	w.handleLazy(types.DebugLvl, newMsgFormat(format, params...))
+	w.handleFormat(types.DebugLvl, format, params...)
 }
 
 // Info formats message using the default formats for its operands
 // and writes to log with level = Info
 func (w *Wrapper) Info(v ...interface{}) {
-	w.handleLazy(types.InfoLvl, newMsgArgs(v...))
+	w.handleArgs(types.InfoLvl, v...)
 }
 
 // Infof formats message according to format specifier
 // and writes to log with level = Info.
 func (w *Wrapper) Infof(format string, params ...interface{}) {
-	w.handleLazy(types.InfoLvl, newMsgFormat(format, params...))
+	w.handleFormat(types.InfoLvl, format, params...)
 }
 
 // Warn formats message using the default formats for its operands

--- a/pkg/util/log/slog/wrapper.go
+++ b/pkg/util/log/slog/wrapper.go
@@ -1,0 +1,232 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package slog provides an slog implementation of the LoggerInterface interface.
+package slog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/types"
+)
+
+var _ types.LoggerInterface = (*Wrapper)(nil)
+
+const baseStackDepth = 4
+
+// Wrapper is a wrapper around the slog.Handler interface.
+// It implements the LoggerInterface interface.
+type Wrapper struct {
+	handler slog.Handler
+	flush   func()
+	close   func()
+
+	attrs           []slog.Attr
+	extraStackDepth int
+}
+
+// NewWrapper returns a new Wrapper implementing the LoggerInterface interface.
+func NewWrapper(handler slog.Handler) types.LoggerInterface {
+	return newWrapperWithCloseAndFlush(handler, nil, nil)
+}
+
+func newWrapperWithCloseAndFlush(handler slog.Handler, flush func(), close func()) types.LoggerInterface {
+	return &Wrapper{
+		handler: handler,
+		flush:   flush,
+		close:   close,
+	}
+}
+
+func (w *Wrapper) handleLazy(level types.LogLevel, message fmt.Stringer) {
+	if w.handler.Enabled(context.Background(), types.ToSlogLevel(level)) {
+		w.handle(level, message.String())
+	}
+}
+
+func (w *Wrapper) handleError(level types.LogLevel, message string) error {
+	if w.handler.Enabled(context.Background(), types.ToSlogLevel(level)) {
+		w.handle(level, message)
+	}
+	return errors.New(message)
+}
+
+func (w *Wrapper) handle(level types.LogLevel, message string) {
+	var pc [1]uintptr
+	runtime.Callers(baseStackDepth+w.extraStackDepth, pc[:])
+	r := slog.NewRecord(
+		time.Now().UTC(),
+		types.ToSlogLevel(level),
+		message,
+		pc[0],
+	)
+
+	// we only set a context to perform a single log, so adding them directly on the record is fine
+	// this can be optimized once we stop using seelog and can change the API
+	if len(w.attrs) > 0 {
+		r.AddAttrs(w.attrs...)
+	}
+
+	err := w.handler.Handle(context.Background(), r)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "slog handler error: %v", err)
+	}
+}
+
+type msgArgs struct {
+	args []interface{}
+}
+
+func renderArgs(v ...interface{}) string {
+	return fmt.Sprint(v...)
+}
+
+func (m *msgArgs) String() string {
+	return renderArgs(m.args...)
+}
+
+type msgFormat struct {
+	format string
+	args   []interface{}
+}
+
+func renderFormat(format string, params ...interface{}) string {
+	return fmt.Sprintf(format, params...)
+}
+
+func (m *msgFormat) String() string {
+	return renderFormat(m.format, m.args...)
+}
+
+func newMsgArgs(v ...interface{}) fmt.Stringer {
+	return &msgArgs{args: v}
+}
+
+func newMsgFormat(format string, v ...interface{}) fmt.Stringer {
+	return &msgFormat{format: format, args: v}
+}
+
+// Trace formats message using the default formats for its operands
+// and writes to log with level = Trace
+func (w *Wrapper) Trace(v ...interface{}) {
+	w.handleLazy(types.TraceLvl, newMsgArgs(v...))
+}
+
+// Tracef formats message according to format specifier
+// and writes to log with level = Trace.
+func (w *Wrapper) Tracef(format string, params ...interface{}) {
+	w.handleLazy(types.TraceLvl, newMsgFormat(format, params...))
+}
+
+// Debug formats message using the default formats for its operands
+// and writes to log with level = Debug
+func (w *Wrapper) Debug(v ...interface{}) {
+	w.handleLazy(types.DebugLvl, newMsgArgs(v...))
+}
+
+// Debugf formats message according to format specifier
+// and writes to log with level = Debug.
+func (w *Wrapper) Debugf(format string, params ...interface{}) {
+	w.handleLazy(types.DebugLvl, newMsgFormat(format, params...))
+}
+
+// Info formats message using the default formats for its operands
+// and writes to log with level = Info
+func (w *Wrapper) Info(v ...interface{}) {
+	w.handleLazy(types.InfoLvl, newMsgArgs(v...))
+}
+
+// Infof formats message according to format specifier
+// and writes to log with level = Info.
+func (w *Wrapper) Infof(format string, params ...interface{}) {
+	w.handleLazy(types.InfoLvl, newMsgFormat(format, params...))
+}
+
+// Warn formats message using the default formats for its operands
+// and writes to log with level = Warn
+func (w *Wrapper) Warn(v ...interface{}) error {
+	return w.handleError(types.WarnLvl, renderArgs(v...))
+}
+
+// Warnf formats message according to format specifier
+// and writes to log with level = Warn.
+func (w *Wrapper) Warnf(format string, params ...interface{}) error {
+	return w.handleError(types.WarnLvl, renderFormat(format, params...))
+}
+
+// Error formats message using the default formats for its operands
+// and writes to log with level = Error
+func (w *Wrapper) Error(v ...interface{}) error {
+	return w.handleError(types.ErrorLvl, renderArgs(v...))
+}
+
+// Errorf formats message according to format specifier
+// and writes to log with level = Error.
+func (w *Wrapper) Errorf(format string, params ...interface{}) error {
+	return w.handleError(types.ErrorLvl, renderFormat(format, params...))
+}
+
+// Critical formats message using the default formats for its operands
+// and writes to log with level = Critical
+func (w *Wrapper) Critical(v ...interface{}) error {
+	return w.handleError(types.CriticalLvl, renderArgs(v...))
+}
+
+// Criticalf formats message according to format specifier
+// and writes to log with level = Critical.
+func (w *Wrapper) Criticalf(format string, params ...interface{}) error {
+	return w.handleError(types.CriticalLvl, renderFormat(format, params...))
+}
+
+// Close flushes all the messages in the logger and closes it. It cannot be used after this operation.
+func (w *Wrapper) Close() {
+	if w.close != nil {
+		w.close()
+	}
+}
+
+// Flush flushes all the messages in the logger.
+func (w *Wrapper) Flush() {
+	if w.flush != nil {
+		w.flush()
+	}
+}
+
+// SetAdditionalStackDepth sets the additional number of frames to skip by runtime.Caller
+func (w *Wrapper) SetAdditionalStackDepth(depth int) error {
+	w.extraStackDepth = depth
+	return nil
+}
+
+// SetContext sets context which will be added to every log records
+func (w *Wrapper) SetContext(context interface{}) {
+	if context == nil {
+		w.attrs = nil
+		return
+	}
+
+	// See `extractContextString` in pkg/util/log/setup/log.go:
+	// the context is a slice of interface{}, it contains an even number of elements,
+	// and keys are strings.
+	//
+	// We can lift the restrictions and/or change the API later, but for now we want
+	// the exact same behavior as we have with seelog
+
+	ctx := context.([]interface{})
+	var attrs []slog.Attr
+	for i := 0; i < len(ctx); i += 2 {
+		key, val := ctx[i], ctx[i+1]
+		if keyStr, ok := key.(string); ok {
+			attrs = append(attrs, slog.Attr{Key: keyStr, Value: slog.AnyValue(val)})
+		}
+	}
+	w.attrs = attrs
+}

--- a/pkg/util/log/slog/wrapper_test.go
+++ b/pkg/util/log/slog/wrapper_test.go
@@ -1,0 +1,475 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log/types"
+)
+
+// mockHandler is a simple slog.Handler that records log messages
+type mockHandler struct {
+	records   []slog.Record
+	enabled   bool
+	lastLevel slog.Level
+}
+
+func newMockHandler() *mockHandler {
+	return &mockHandler{
+		records: make([]slog.Record, 0),
+		enabled: true,
+	}
+}
+
+func (m *mockHandler) Enabled(_ context.Context, level slog.Level) bool {
+	m.lastLevel = level
+	return m.enabled
+}
+
+func (m *mockHandler) Handle(_ context.Context, record slog.Record) error {
+	m.records = append(m.records, record)
+	return nil
+}
+
+func (m *mockHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return m
+}
+
+func (m *mockHandler) WithGroup(_ string) slog.Handler {
+	return m
+}
+
+func (m *mockHandler) lastMessage() string {
+	if len(m.records) == 0 {
+		return ""
+	}
+	return m.records[len(m.records)-1].Message
+}
+
+func (m *mockHandler) lastRecord() slog.Record {
+	if len(m.records) == 0 {
+		return slog.Record{}
+	}
+	return m.records[len(m.records)-1]
+}
+
+func (m *mockHandler) reset() {
+	m.records = make([]slog.Record, 0)
+}
+
+func TestNewWrapperWithCloseAndFlush(t *testing.T) {
+	handler := newMockHandler()
+	flushCalled := false
+	closeCalled := false
+
+	flushFunc := func() { flushCalled = true }
+	closeFunc := func() { closeCalled = true }
+
+	wrapper := newWrapperWithCloseAndFlush(handler, flushFunc, closeFunc)
+
+	wrapper.Flush()
+	assert.True(t, flushCalled)
+
+	wrapper.Close()
+	assert.True(t, closeCalled)
+}
+
+func TestWrapperBasicLogLevels(t *testing.T) {
+	tests := []struct {
+		name              string
+		logFunc           func(types.LoggerInterface, ...interface{})
+		logfFunc          func(types.LoggerInterface, string, ...interface{})
+		expectedLevel     types.LogLevel
+		argsInput         []interface{}
+		expectedArgsMsg   string
+		formatMsg         string
+		formatArgs        []interface{}
+		expectedFormatMsg string
+	}{
+		{
+			name:              "Trace",
+			logFunc:           types.LoggerInterface.Trace,
+			logfFunc:          types.LoggerInterface.Tracef,
+			expectedLevel:     types.TraceLvl,
+			argsInput:         []interface{}{"test ", "message"},
+			expectedArgsMsg:   "test message",
+			formatMsg:         "test %s %d",
+			formatArgs:        []interface{}{"message", 42},
+			expectedFormatMsg: "test message 42",
+		},
+		{
+			name:              "Debug",
+			logFunc:           types.LoggerInterface.Debug,
+			logfFunc:          types.LoggerInterface.Debugf,
+			expectedLevel:     types.DebugLvl,
+			argsInput:         []interface{}{"debug ", "message"},
+			expectedArgsMsg:   "debug message",
+			formatMsg:         "debug %s %d",
+			formatArgs:        []interface{}{"message", 123},
+			expectedFormatMsg: "debug message 123",
+		},
+		{
+			name:              "Info",
+			logFunc:           types.LoggerInterface.Info,
+			logfFunc:          types.LoggerInterface.Infof,
+			expectedLevel:     types.InfoLvl,
+			argsInput:         []interface{}{"info ", "message"},
+			expectedArgsMsg:   "info message",
+			formatMsg:         "info %s",
+			formatArgs:        []interface{}{"message"},
+			expectedFormatMsg: "info message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newMockHandler()
+			wrapper := NewWrapper(handler)
+
+			// Test args version
+			tt.logFunc(wrapper, tt.argsInput...)
+			assert.Equal(t, tt.expectedArgsMsg, handler.lastMessage())
+			require.Equal(t, 1, len(handler.records), handler.records)
+			assert.Equal(t, tt.expectedLevel, types.FromSlogLevel(handler.lastRecord().Level))
+
+			// Reset for format test
+			handler.reset()
+
+			// Test format version
+			tt.logfFunc(wrapper, tt.formatMsg, tt.formatArgs...)
+			assert.Equal(t, tt.expectedFormatMsg, handler.lastMessage())
+			require.Equal(t, 1, len(handler.records), handler.records)
+			assert.Equal(t, tt.expectedLevel, types.FromSlogLevel(handler.lastRecord().Level))
+		})
+	}
+}
+
+func TestWrapperErrorLogLevels(t *testing.T) {
+	tests := []struct {
+		name              string
+		logFunc           func(types.LoggerInterface, ...interface{}) error
+		logfFunc          func(types.LoggerInterface, string, ...interface{}) error
+		expectedLevel     types.LogLevel
+		argsInput         []interface{}
+		expectedArgsMsg   string
+		formatMsg         string
+		formatArgs        []interface{}
+		expectedFormatMsg string
+	}{
+		{
+			name:              "Warn",
+			logFunc:           types.LoggerInterface.Warn,
+			logfFunc:          types.LoggerInterface.Warnf,
+			expectedLevel:     types.WarnLvl,
+			argsInput:         []interface{}{"warn ", "message"},
+			expectedArgsMsg:   "warn message",
+			formatMsg:         "warn %s",
+			formatArgs:        []interface{}{"message"},
+			expectedFormatMsg: "warn message",
+		},
+		{
+			name:              "Error",
+			logFunc:           types.LoggerInterface.Error,
+			logfFunc:          types.LoggerInterface.Errorf,
+			expectedLevel:     types.ErrorLvl,
+			argsInput:         []interface{}{"error ", "message"},
+			expectedArgsMsg:   "error message",
+			formatMsg:         "error %d",
+			formatArgs:        []interface{}{404},
+			expectedFormatMsg: "error 404",
+		},
+		{
+			name:              "Critical",
+			logFunc:           types.LoggerInterface.Critical,
+			logfFunc:          types.LoggerInterface.Criticalf,
+			expectedLevel:     types.CriticalLvl,
+			argsInput:         []interface{}{"critical ", "message"},
+			expectedArgsMsg:   "critical message",
+			formatMsg:         "critical %s",
+			formatArgs:        []interface{}{"failure"},
+			expectedFormatMsg: "critical failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newMockHandler()
+			wrapper := NewWrapper(handler)
+
+			// Test args version
+			err := tt.logFunc(wrapper, tt.argsInput...)
+			require.Equal(t, 1, len(handler.records), handler.records)
+			assert.Equal(t, tt.expectedArgsMsg, handler.lastMessage())
+			assert.Equal(t, tt.expectedLevel, types.FromSlogLevel(handler.lastRecord().Level))
+			assert.Error(t, err)
+			assert.Equal(t, tt.expectedArgsMsg, err.Error())
+
+			// Reset for format test
+			handler.reset()
+
+			// Test format version
+			err = tt.logfFunc(wrapper, tt.formatMsg, tt.formatArgs...)
+			require.Equal(t, 1, len(handler.records), handler.records)
+			assert.Equal(t, tt.expectedFormatMsg, handler.lastMessage())
+			assert.Equal(t, tt.expectedLevel, types.FromSlogLevel(handler.lastRecord().Level))
+			assert.Error(t, err)
+			assert.Equal(t, tt.expectedFormatMsg, err.Error())
+		})
+	}
+}
+
+func TestWrapperSetAdditionalStackDepth(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	// Helper function that logs a message
+	logHelper := func() {
+		wrapper.Info("test message")
+	}
+
+	// Log without extra stack depth - should capture the anonymous function (func1) as the caller
+	logHelper()
+	require.Equal(t, 1, len(handler.records), handler.records)
+	record1 := handler.lastRecord()
+	frame1, _ := runtime.CallersFrames([]uintptr{record1.PC}).Next()
+	assert.Contains(t, frame1.Function, "TestWrapperSetAdditionalStackDepth.func1")
+
+	// Reset records
+	handler.reset()
+
+	// Set additional stack depth to skip one more frame (the helper function)
+	err := wrapper.SetAdditionalStackDepth(1)
+	require.NoError(t, err)
+
+	// Log again with extra stack depth - should now capture TestWrapperSetAdditionalStackDepth as the caller
+	logHelper()
+	require.Equal(t, 1, len(handler.records), handler.records)
+	record2 := handler.lastRecord()
+	frame2, _ := runtime.CallersFrames([]uintptr{record2.PC}).Next()
+	assert.True(t, strings.HasSuffix(frame2.Function, "TestWrapperSetAdditionalStackDepth"), frame2.Function)
+}
+
+func TestWrapperSetContext(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	// Test setting context
+	context := []interface{}{"key1", "value1", "key2", 42}
+	wrapper.SetContext(context)
+
+	// Test that context is added to log record
+	wrapper.Info("test")
+	record := handler.lastRecord()
+	attrs := getAttrs(record)
+	require.Equal(t, 2, len(attrs))
+	assert.Equal(t, "key1", attrs[0].Key)
+	assert.Equal(t, "value1", attrs[0].Value.String())
+	assert.Equal(t, "key2", attrs[1].Key)
+	assert.Equal(t, int64(42), attrs[1].Value.Int64())
+
+}
+
+func getAttrs(record slog.Record) []slog.Attr {
+	var attrs []slog.Attr
+	record.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a)
+		return true
+	})
+	return attrs
+}
+
+func TestWrapperSetContextNil(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	// Set context first
+	context := []interface{}{"key", "value"}
+	wrapper.SetContext(context)
+
+	// Log and verify context is present
+	wrapper.Info("test with context")
+	attrs1 := getAttrs(handler.lastRecord())
+	require.Equal(t, 1, len(attrs1))
+	assert.Equal(t, "key", attrs1[0].Key)
+	assert.Equal(t, "value", attrs1[0].Value.String())
+
+	// Clear context
+	handler.reset()
+	wrapper.SetContext(nil)
+
+	// Log and verify no context attributes are present
+	wrapper.Info("test without context")
+	record2 := handler.lastRecord()
+	attrs2 := getAttrs(record2)
+	assert.Empty(t, attrs2)
+}
+
+func TestWrapperSetContextSkipsNonStringKeys(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	// Context with non-string keys should be skipped
+	context := []interface{}{123, "value1", "key2", "value2"}
+	wrapper.SetContext(context)
+
+	wrapper.Info("test with context")
+	record := handler.lastRecord()
+	attrs := getAttrs(record)
+	require.Equal(t, 1, len(attrs))
+	assert.Equal(t, "key2", attrs[0].Key)
+	assert.Equal(t, "value2", attrs[0].Value.String())
+}
+
+func TestRenderArgs(t *testing.T) {
+	result := renderArgs("hello", " ", "world")
+	assert.Equal(t, "hello world", result)
+}
+
+func TestRenderFormat(t *testing.T) {
+	result := renderFormat("hello %s %d", "world", 42)
+	assert.Equal(t, "hello world 42", result)
+}
+
+func TestMsgArgs(t *testing.T) {
+	msg := newMsgArgs("hello", " ", "world")
+	assert.Equal(t, "hello world", msg.String())
+}
+
+func TestMsgFormat(t *testing.T) {
+	msg := newMsgFormat("test %s %d", "value", 123)
+	assert.Equal(t, "test value 123", msg.String())
+}
+
+// Test that complex types are properly formatted
+func TestWrapperComplexTypes(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	type testStruct struct {
+		Field1 string
+		Field2 int
+	}
+
+	testObj := testStruct{Field1: "test", Field2: 42}
+
+	wrapper.Info("struct: ", testObj)
+	require.Equal(t, 1, len(handler.records), handler.records)
+	// The exact format may vary, but it should contain the struct representation
+	assert.Contains(t, handler.lastMessage(), "struct")
+}
+
+// Test multiple rapid log calls
+func TestWrapperMultipleCalls(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	for i := 0; i < 100; i++ {
+		wrapper.Info("message ", i)
+	}
+
+	assert.Equal(t, 100, len(handler.records))
+	assert.Equal(t, "message 99", handler.lastMessage())
+}
+
+// Test empty messages
+func TestWrapperEmptyMessage(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	wrapper.Info()
+	assert.Equal(t, 1, len(handler.records))
+	assert.Equal(t, "", strings.TrimSpace(handler.lastMessage()))
+}
+
+func TestWrapperFormatSpecifiers(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	wrapper.Infof("int: %d, string: %s, float: %.2f", 42, "test", 3.14159)
+	assert.Equal(t, "int: 42, string: test, float: 3.14", handler.lastMessage())
+}
+
+// TestTracefDoesNotBuildMessageWhenDisabled verifies that Tracef doesn't build
+// the message when the trace level is disabled, avoiding unnecessary formatting work
+func TestTracefDoesNotBuildMessageWhenDisabled(t *testing.T) {
+	handler := newMockHandler()
+	handler.enabled = false
+	wrapper := NewWrapper(handler)
+
+	// Test that the fmt.Sprintf formatting is not called when level is disabled
+	// We do this by using handleLazy directly with a custom stringer
+	formatCalled := false
+	msg := &trackedStringer{
+		StringFunc: func() string {
+			formatCalled = true
+			return "formatted message"
+		},
+	}
+
+	// Call handleLazy directly with our tracked stringer
+	wrapper.Tracef("%s", msg)
+
+	// Verify String() was NOT called because the level was disabled
+	require.False(t, formatCalled, "String() should not be called when level is disabled")
+	require.Equal(t, 0, len(handler.records), "no record should be logged when level is disabled")
+
+	// Now test with level enabled to verify String() IS called
+	handler.enabled = true
+	handler.reset()
+
+	formatCalled = false
+	msg2 := &trackedStringer{
+		StringFunc: func() string {
+			formatCalled = true
+			return "formatted message"
+		},
+	}
+
+	wrapper.Tracef("%s", msg2)
+
+	// Verify String() WAS called because the level was enabled
+	assert.True(t, formatCalled, "String() should be called when level is enabled")
+	assert.Equal(t, 1, len(handler.records), "record should be logged when level is enabled")
+	assert.Equal(t, "formatted message", handler.lastMessage())
+}
+
+// Helper type for testing lazy evaluation
+type trackedStringer struct {
+	StringFunc func() string
+}
+
+func (t *trackedStringer) String() string {
+	return t.StringFunc()
+}
+
+func TestContextValuesNotRendered(t *testing.T) {
+	handler := newMockHandler()
+	wrapper := NewWrapper(handler)
+
+	// Create a context value with a tracked stringer to detect if it's evaluated
+	stringerCalled := false
+	expensiveValue := &trackedStringer{
+		StringFunc: func() string {
+			stringerCalled = true
+			return "expensive computation result"
+		},
+	}
+
+	// Set context with the expensive stringer value
+	wrapper.SetContext([]interface{}{"expensive_key", expensiveValue})
+	assert.False(t, stringerCalled, "String() should not be called during SetContext")
+
+	wrapper.Trace("test message")
+	assert.False(t, stringerCalled, "String() should not be called by the wrapper itself")
+}

--- a/pkg/util/log/slog/wrapper_test.go
+++ b/pkg/util/log/slog/wrapper_test.go
@@ -341,16 +341,6 @@ func TestRenderFormat(t *testing.T) {
 	assert.Equal(t, "hello world 42", result)
 }
 
-func TestMsgArgs(t *testing.T) {
-	msg := newMsgArgs("hello", " ", "world")
-	assert.Equal(t, "hello world", msg.String())
-}
-
-func TestMsgFormat(t *testing.T) {
-	msg := newMsgFormat("test %s %d", "value", 123)
-	assert.Equal(t, "test value 123", msg.String())
-}
-
 // Test that complex types are properly formatted
 func TestWrapperComplexTypes(t *testing.T) {
 	handler := newMockHandler()

--- a/pkg/util/log/types/types.go
+++ b/pkg/util/log/types/types.go
@@ -6,7 +6,12 @@
 // Package types contains the types for the log package.
 package types
 
-import "github.com/cihub/seelog"
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cihub/seelog"
+)
 
 // LoggerInterface provides basic logging methods that can be used from outside the log package.
 type LoggerInterface interface {
@@ -100,4 +105,60 @@ const (
 
 func (level LogLevel) String() string {
 	return seelog.LogLevel(level).String()
+}
+
+const (
+	slogTraceLvl    slog.Level = slog.LevelDebug - 4
+	slogDebugLvl    slog.Level = slog.LevelDebug
+	slogInfoLvl     slog.Level = slog.LevelInfo
+	slogWarnLvl     slog.Level = slog.LevelWarn
+	slogErrorLvl    slog.Level = slog.LevelError
+	slogCriticalLvl slog.Level = slog.LevelError + 4
+	slogOff         slog.Level = slog.LevelError + 8
+)
+
+// ToSlogLevel converts a LogLevel to a slog.Level
+func ToSlogLevel(level LogLevel) slog.Level {
+	switch level {
+	case TraceLvl:
+		return slogTraceLvl
+	case DebugLvl:
+		return slogDebugLvl
+	case InfoLvl:
+		return slogInfoLvl
+	case WarnLvl:
+		return slogWarnLvl
+	case ErrorLvl:
+		return slogErrorLvl
+	case CriticalLvl:
+		return slogCriticalLvl
+	case Off:
+		return slogOff
+	default:
+		// unreachable
+		panic(fmt.Sprintf("unknown log level: %d", level))
+	}
+}
+
+// FromSlogLevel converts a slog.Level to a LogLevel
+func FromSlogLevel(level slog.Level) LogLevel {
+	switch level {
+	case slogTraceLvl:
+		return TraceLvl
+	case slogDebugLvl:
+		return DebugLvl
+	case slogInfoLvl:
+		return InfoLvl
+	case slogWarnLvl:
+		return WarnLvl
+	case slogErrorLvl:
+		return ErrorLvl
+	case slogCriticalLvl:
+		return CriticalLvl
+	case slogOff:
+		return Off
+	default:
+		// unreachable
+		panic(fmt.Sprintf("unknown slog log level: %d", level))
+	}
 }


### PR DESCRIPTION
### What does this PR do?
Replace `Disabled` logger implementation with `slog` based logger.

### Motivation
First step of actually introducing slog in `pkg/util/log`. Following PRs will build on top of this, in particular reusing `Wrapper`.

### Describe how you validated your changes
CI.

### Additional Notes
The current implementation might seem overkill (converting seelog levels to slog levels, or having a disabled handler and a `Wrapper` when we could just make a disabled impl directly), but it introduces the basic logic and structures which will be used by every following slog-based logger.