### PR TITLE
Add chainguard to get GITHUB_TOKEN in deps_fetch job

### DIFF
--- a/.github/chainguard/self.gitlab.deps-fetch.sts.yaml
+++ b/.github/chainguard/self.gitlab.deps-fetch.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/.*"
+
+claim_pattern:
+  project_id: "4670"
+
+# This token is used by go_e2e_deps to make authenticated requests to download plugins
+# It doesn't even read from the datadog-agent repo but this is our only way to get a token
+permissions:
+  contents: read


### PR DESCRIPTION
### What does this PR do?

Add a sts policy to be able to retrieve a read only GITHUB_TOKEN. Needed to avoid rate limiting when downloading dependencies from Github

### Motivation

Will be required to dynamically download Pulumi plugins, so we can drop the test-infra-definitions image and rely only on the normal linux image

WIP in: https://github.com/DataDog/datadog-agent/pull/42832

### Describe how you validated your changes

### Additional Notes
