### PR TITLE
update serverless team from aws to azure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,9 +59,9 @@
 /.github/*_TEMPLATE.md                               @DataDog/agent-devx
 /.github/chainguard/**                               @DataDog/agent-devx
 /.github/dependabot.yaml                             @DataDog/agent-devx
-/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-azure
-/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-azure
-/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-azure
+/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-azure-gcp
+/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-azure-gcp
+/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-azure-gcp
 /.github/workflows/cws-btfhub-sync.yml               @DataDog/agent-security
 /.github/workflows/gohai.yml                         @DataDog/agent-configuration
 /.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes
@@ -132,7 +132,7 @@
 /.gitlab/binary_build/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-build
 /.gitlab/binary_build/cluster_agent.yml              @DataDog/container-integrations @DataDog/agent-build
 /.gitlab/binary_build/fakeintake.yml                 @DataDog/agent-devx
-/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-azure @DataDog/agent-build
+/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-azure-gcp @DataDog/agent-build
 /.gitlab/binary_build/otel_agent.yml                 @DataDog/opentelemetry-agent @DataDog/agent-build
 /.gitlab/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-build
 /.gitlab/binary_build/windows.yml                    @DataDog/agent-build @DataDog/windows-products
@@ -246,7 +246,7 @@
 /cmd/loader/                            @DataDog/agent-runtimes @DataDog/agent-apm
 /cmd/otel-agent/                        @DataDog/opentelemetry-agent
 /cmd/process-agent/                     @DataDog/container-experiences
-/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-azure
+/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-azure-gcp
 /cmd/serverless-init/                   @DataDog/serverless
 /cmd/sbomgen/                           @DataDog/agent-security
 /cmd/system-probe/                      @DataDog/ebpf-platform
@@ -419,7 +419,7 @@
 /pkg/metrics/metricsource.go            @DataDog/agent-metric-pipelines @DataDog/agent-integrations
 /pkg/serializer/                        @DataDog/agent-metric-pipelines
 /pkg/serializer/internal/metrics/origin_mapping.go  @DataDog/agent-metric-pipelines @DataDog/agent-integrations
-/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-azure
+/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-azure-gcp
 /pkg/serverless/appsec/                 @DataDog/asm-go
 /pkg/status/                            @DataDog/agent-configuration
 /pkg/status/health                      @DataDog/agent-runtimes
@@ -722,7 +722,7 @@
 /test/                                  @DataDog/agent-devx
 /test/benchmarks/                       @DataDog/agent-metric-pipelines
 /test/benchmarks/kubernetes_state/      @DataDog/container-integrations
-/test/integration/                      @DataDog/serverless @Datadog/serverless-azure
+/test/integration/                      @DataDog/serverless @Datadog/serverless-azure-gcp
 /test/integration/docker/               @DataDog/opentelemetry-agent
 /test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx
 /test/fakeintake/aggregator/ndmAggregator.go @DataDog/ndm-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,9 +59,9 @@
 /.github/*_TEMPLATE.md                               @DataDog/agent-devx
 /.github/chainguard/**                               @DataDog/agent-devx
 /.github/dependabot.yaml                             @DataDog/agent-devx
-/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-aws
-/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-aws
-/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-aws
+/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-azure
+/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-azure
+/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-azure
 /.github/workflows/cws-btfhub-sync.yml               @DataDog/agent-security
 /.github/workflows/gohai.yml                         @DataDog/agent-configuration
 /.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes
@@ -132,7 +132,7 @@
 /.gitlab/binary_build/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-build
 /.gitlab/binary_build/cluster_agent.yml              @DataDog/container-integrations @DataDog/agent-build
 /.gitlab/binary_build/fakeintake.yml                 @DataDog/agent-devx
-/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-aws @DataDog/agent-build
+/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-azure @DataDog/agent-build
 /.gitlab/binary_build/otel_agent.yml                 @DataDog/opentelemetry-agent @DataDog/agent-build
 /.gitlab/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-build
 /.gitlab/binary_build/windows.yml                    @DataDog/agent-build @DataDog/windows-products
@@ -246,7 +246,7 @@
 /cmd/loader/                            @DataDog/agent-runtimes @DataDog/agent-apm
 /cmd/otel-agent/                        @DataDog/opentelemetry-agent
 /cmd/process-agent/                     @DataDog/container-experiences
-/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-aws
+/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-azure
 /cmd/serverless-init/                   @DataDog/serverless
 /cmd/sbomgen/                           @DataDog/agent-security
 /cmd/system-probe/                      @DataDog/ebpf-platform
@@ -419,7 +419,7 @@
 /pkg/metrics/metricsource.go            @DataDog/agent-metric-pipelines @DataDog/agent-integrations
 /pkg/serializer/                        @DataDog/agent-metric-pipelines
 /pkg/serializer/internal/metrics/origin_mapping.go  @DataDog/agent-metric-pipelines @DataDog/agent-integrations
-/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-aws
+/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-azure
 /pkg/serverless/appsec/                 @DataDog/asm-go
 /pkg/status/                            @DataDog/agent-configuration
 /pkg/status/health                      @DataDog/agent-runtimes
@@ -722,7 +722,7 @@
 /test/                                  @DataDog/agent-devx
 /test/benchmarks/                       @DataDog/agent-metric-pipelines
 /test/benchmarks/kubernetes_state/      @DataDog/container-integrations
-/test/integration/                      @DataDog/serverless @Datadog/serverless-aws
+/test/integration/                      @DataDog/serverless @Datadog/serverless-azure
 /test/integration/docker/               @DataDog/opentelemetry-agent
 /test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx
 /test/fakeintake/aggregator/ndmAggregator.go @DataDog/ndm-core

--- a/tasks/libs/pipeline/github_slack_review_map.yaml
+++ b/tasks/libs/pipeline/github_slack_review_map.yaml
@@ -49,7 +49,7 @@
 '@datadog/remote-config': '#remote-config-monitoring'
 '@datadog/sdlc-security': '#sit'
 '@datadog/serverless': '#serverless-agent'
-'@datadog/serverless-aws': '#serverless-aws'
+'@datadog/serverless-azure': '#serverless-agent'
 '@datadog/single-machine-performance': '#single-machine-performance'
 '@datadog/universal-service-monitoring': '#universal-service-monitoring'
 '@datadog/windows-products': '#windows-products-reviews'

--- a/tasks/libs/pipeline/github_slack_review_map.yaml
+++ b/tasks/libs/pipeline/github_slack_review_map.yaml
@@ -49,7 +49,7 @@
 '@datadog/remote-config': '#remote-config-monitoring'
 '@datadog/sdlc-security': '#sit'
 '@datadog/serverless': '#serverless-agent'
-'@datadog/serverless-azure': '#serverless-agent'
+'@datadog/serverless-azure-gcp': '#serverless-azure-gcp-team'
 '@datadog/single-machine-performance': '#single-machine-performance'
 '@datadog/universal-service-monitoring': '#universal-service-monitoring'
 '@datadog/windows-products': '#windows-products-reviews'

--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -23,7 +23,7 @@ NON_RELEASING_TEAMS = {
     '@iglendd',  # Not a team but he's in the codeowners file
     'sdlc-security',
     'data-jobs-monitoring',
-    'serverless-azure',
+    'serverless-azure-gcp',
     'apm-ecosystems-performance',
 }
 

--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -23,7 +23,7 @@ NON_RELEASING_TEAMS = {
     '@iglendd',  # Not a team but he's in the codeowners file
     'sdlc-security',
     'data-jobs-monitoring',
-    'serverless-aws',
+    'serverless-azure',
     'apm-ecosystems-performance',
 }
 

--- a/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
+++ b/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
@@ -55,9 +55,9 @@
 /.github/CODEOWNERS                                  # do not notify anyone
 /.github/*_TEMPLATE.md                               @DataDog/agent-devx
 /.github/dependabot.yaml                             @DataDog/agent-devx
-/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-aws
-/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-aws
-/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-aws
+/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-azure
+/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-azure
+/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-azure
 /.github/workflows/cws-btfhub-sync.yml               @DataDog/agent-security
 /.github/workflows/gohai.yml                         @DataDog/agent-configuration
 /.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes
@@ -126,7 +126,7 @@
 /.gitlab/binary_build/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-build
 /.gitlab/binary_build/cluster_agent.yml              @DataDog/container-integrations @DataDog/agent-build
 /.gitlab/binary_build/fakeintake.yml                 @DataDog/agent-devx
-/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-aws @DataDog/agent-build
+/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-azure @DataDog/agent-build
 /.gitlab/binary_build/otel_agent.yml                 @DataDog/opentelemetry-agent @DataDog/agent-build
 /.gitlab/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-build
 /.gitlab/binary_build/windows.yml                    @DataDog/agent-build @DataDog/windows-products
@@ -238,7 +238,7 @@
 /cmd/dogstatsd/                         @DataDog/agent-metric-pipelines
 /cmd/otel-agent/                        @DataDog/opentelemetry-agent
 /cmd/process-agent/                     @DataDog/container-experiences
-/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-aws
+/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-azure
 /cmd/serverless-init/                   @DataDog/serverless
 /cmd/sbomgen/                           @DataDog/agent-security
 /cmd/system-probe/                      @DataDog/ebpf-platform
@@ -391,7 +391,7 @@
 /pkg/metrics/metricsource.go            @DataDog/agent-metric-pipelines @DataDog/agent-integrations
 /pkg/serializer/                        @DataDog/agent-metric-pipelines
 /pkg/serializer/internal/metrics/origin_mapping.go  @DataDog/agent-metric-pipelines @DataDog/agent-integrations
-/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-aws
+/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-azure
 /pkg/serverless/appsec/                 @DataDog/asm-go
 /pkg/status/                            @DataDog/agent-configuration
 /pkg/status/health                      @DataDog/agent-runtimes
@@ -680,7 +680,7 @@
 /test/                                  @DataDog/agent-devx
 /test/benchmarks/                       @DataDog/agent-metric-pipelines
 /test/benchmarks/kubernetes_state/      @DataDog/container-integrations
-/test/integration/                      @DataDog/serverless @Datadog/serverless-aws
+/test/integration/                      @DataDog/serverless @Datadog/serverless-azure
 /test/integration/docker/               @DataDog/opentelemetry-agent
 /test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx
 /test/fakeintake/aggregator/ndmAggregator.go @DataDog/ndm-core

--- a/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
+++ b/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
@@ -55,9 +55,9 @@
 /.github/CODEOWNERS                                  # do not notify anyone
 /.github/*_TEMPLATE.md                               @DataDog/agent-devx
 /.github/dependabot.yaml                             @DataDog/agent-devx
-/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-azure
-/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-azure
-/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-azure
+/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-azure-gcp
+/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-azure-gcp
+/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-azure-gcp
 /.github/workflows/cws-btfhub-sync.yml               @DataDog/agent-security
 /.github/workflows/gohai.yml                         @DataDog/agent-configuration
 /.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes
@@ -126,7 +126,7 @@
 /.gitlab/binary_build/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-build
 /.gitlab/binary_build/cluster_agent.yml              @DataDog/container-integrations @DataDog/agent-build
 /.gitlab/binary_build/fakeintake.yml                 @DataDog/agent-devx
-/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-azure @DataDog/agent-build
+/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-azure-gcp @DataDog/agent-build
 /.gitlab/binary_build/otel_agent.yml                 @DataDog/opentelemetry-agent @DataDog/agent-build
 /.gitlab/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-build
 /.gitlab/binary_build/windows.yml                    @DataDog/agent-build @DataDog/windows-products
@@ -238,7 +238,7 @@
 /cmd/dogstatsd/                         @DataDog/agent-metric-pipelines
 /cmd/otel-agent/                        @DataDog/opentelemetry-agent
 /cmd/process-agent/                     @DataDog/container-experiences
-/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-azure
+/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-azure-gcp
 /cmd/serverless-init/                   @DataDog/serverless
 /cmd/sbomgen/                           @DataDog/agent-security
 /cmd/system-probe/                      @DataDog/ebpf-platform
@@ -391,7 +391,7 @@
 /pkg/metrics/metricsource.go            @DataDog/agent-metric-pipelines @DataDog/agent-integrations
 /pkg/serializer/                        @DataDog/agent-metric-pipelines
 /pkg/serializer/internal/metrics/origin_mapping.go  @DataDog/agent-metric-pipelines @DataDog/agent-integrations
-/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-azure
+/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-azure-gcp
 /pkg/serverless/appsec/                 @DataDog/asm-go
 /pkg/status/                            @DataDog/agent-configuration
 /pkg/status/health                      @DataDog/agent-runtimes
@@ -680,7 +680,7 @@
 /test/                                  @DataDog/agent-devx
 /test/benchmarks/                       @DataDog/agent-metric-pipelines
 /test/benchmarks/kubernetes_state/      @DataDog/container-integrations
-/test/integration/                      @DataDog/serverless @Datadog/serverless-azure
+/test/integration/                      @DataDog/serverless @Datadog/serverless-azure-gcp
 /test/integration/docker/               @DataDog/opentelemetry-agent
 /test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx
 /test/fakeintake/aggregator/ndmAggregator.go @DataDog/ndm-core


### PR DESCRIPTION
### What does this PR do?
Re-assigns ownership for serverless.

### Motivation
The AWS Serverless team does not rely on this package. We want to stop getting tickets like [this](https://github.com/DataDog/datadog-agent/pull/new/update-serverless-team-ownership). Instead these notifications go to the GCP/Azure Serverless team since they are the only ones who use this package. 

Chatted with GCP/Azure Serverless about this in [thread](https://dd.slack.com/archives/GHQ114DRR/p1762523283527149)

I put the slack channel as #serverless-agent, not sure if there is a preferred one by GCP/Azure.

### Describe how you validated your changes

### Additional Notes
