### PR TITLE
[K9VULN-9538] [CSPM] dbconfig: report the uid of the DB process

### DIFF
--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -11,6 +11,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"maps"
 	"os"
@@ -147,7 +148,11 @@ func LoadMongoDBConfig(ctx context.Context, hostroot string, proc *process.Proce
 	var result DBConfig
 	result.ProcessUser, _ = proc.UsernameWithContext(ctx)
 	result.ProcessName, _ = proc.NameWithContext(ctx)
-
+	if result.ProcessUser == "" {
+		if uids, _ := proc.UidsWithContext(ctx); len(uids) > 0 {
+			result.ProcessUser = fmt.Sprintf("uid:%d", uids[0]) // RUID
+		}
+	}
 	cmdline, _ := proc.CmdlineSlice()
 	for i, arg := range cmdline {
 		if arg == "--config" && i+1 < len(cmdline) {


### PR DESCRIPTION
### What does this PR do?

Handle the case when no user name can be looked up from /etc/passwd the RUID of the process. In the format `uid:%d`.

### Motivation

The username may not be defined, but we still want to report and handle it properly. The uid is sufficient for our usercases.
