### PR TITLE
[NDMII-3668] Retry default device scan

### DIFF
--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -7,6 +7,7 @@ package snmpscanimpl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -37,9 +38,11 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 		Namespace:        namespace,
 	}
 	if err = s.sendPayload(inProgressStatusPayload); err != nil {
-		return fmt.Errorf("unable to send in progress status: %v", err)
+		return fmt.Errorf("unable to send in progress status: %w", err)
 	}
 	if err = snmp.Connect(); err != nil {
+		errs := []error{err}
+
 		// Send an error status if we can't connect to the agent
 		errorStatusPayload := metadata.NetworkDevicesMetadata{
 			DeviceScanStatus: &metadata.ScanStatusMetadata{
@@ -51,12 +54,17 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 			Namespace:        namespace,
 		}
 		if sendErr := s.sendPayload(errorStatusPayload); sendErr != nil {
-			return fmt.Errorf("unable to send error status: %v", sendErr)
+			errs = append(errs, fmt.Errorf("unable to send error status: %w", sendErr))
 		}
-		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
+		return gosnmplib.NewConnectionError(
+			fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w",
+				snmp.LocalAddr, snmp.Port, errors.Join(errs...)),
+		)
 	}
 	err = s.runDeviceScan(ctx, snmp, namespace, deviceID, scanParams.CallInterval)
 	if err != nil {
+		errs := []error{err}
+
 		// Send an error status if we can't scan the device
 		errorStatusPayload := metadata.NetworkDevicesMetadata{
 			DeviceScanStatus: &metadata.ScanStatusMetadata{
@@ -68,9 +76,9 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 			Namespace:        namespace,
 		}
 		if sendErr := s.sendPayload(errorStatusPayload); sendErr != nil {
-			return fmt.Errorf("unable to send error status: %v", sendErr)
+			errs = append(errs, fmt.Errorf("unable to send error status: %w", sendErr))
 		}
-		return fmt.Errorf("unable to perform device scan: %w", err)
+		return fmt.Errorf("unable to perform device scan: %w", errors.Join(errs...))
 	}
 	// Send a completed status if the scan was successful
 	completedStatusPayload := metadata.NetworkDevicesMetadata{
@@ -83,7 +91,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 		Namespace:        namespace,
 	}
 	if err = s.sendPayload(completedStatusPayload); err != nil {
-		return fmt.Errorf("unable to send completed status: %v", err)
+		return fmt.Errorf("unable to send completed status: %w", err)
 	}
 	return nil
 }

--- a/comp/snmpscanmanager/impl/devicescan.go
+++ b/comp/snmpscanmanager/impl/devicescan.go
@@ -15,17 +15,22 @@ type deviceScan struct {
 	DeviceIP   string     `json:"device_ip"`
 	ScanStatus scanStatus `json:"scan_status"`
 	ScanEndTs  time.Time  `json:"scan_end_ts"`
+	Failures   int        `json:"failures"`
 }
 
 type scanStatus string
 
 const (
-	successStatus scanStatus = "success"
-	failedStatus  scanStatus = "failed"
+	successScan scanStatus = "success"
+	failedScan  scanStatus = "failed"
 )
 
 func (ds *deviceScan) isSuccess() bool {
-	return ds.ScanStatus == successStatus
+	return ds.ScanStatus == successScan
+}
+
+func (ds *deviceScan) isFailed() bool {
+	return ds.ScanStatus == failedScan
 }
 
 type ipSet map[string]struct{}

--- a/comp/snmpscanmanager/impl/devicescan_test.go
+++ b/comp/snmpscanmanager/impl/devicescan_test.go
@@ -16,34 +16,70 @@ func Test_deviceScan_isSuccess(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
-		name           string
-		deviceScan     deviceScan
-		expectedResult bool
+		name              string
+		deviceScan        deviceScan
+		expectedIsSuccess bool
 	}{
 		{
 			name: "is not success",
 			deviceScan: deviceScan{
 				DeviceIP:   "10.0.0.1",
-				ScanStatus: failedStatus,
+				ScanStatus: failedScan,
 				ScanEndTs:  now,
 			},
-			expectedResult: false,
+			expectedIsSuccess: false,
 		},
 		{
 			name: "is success",
 			deviceScan: deviceScan{
 				DeviceIP:   "10.0.0.1",
-				ScanStatus: successStatus,
+				ScanStatus: successScan,
 				ScanEndTs:  now,
 			},
-			expectedResult: true,
+			expectedIsSuccess: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			isSuccess := test.deviceScan.isSuccess()
-			assert.Equal(t, test.expectedResult, isSuccess)
+			assert.Equal(t, test.expectedIsSuccess, isSuccess)
+		})
+	}
+}
+
+func Test_deviceScan_isFailed(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name             string
+		deviceScan       deviceScan
+		expectedIsFailed bool
+	}{
+		{
+			name: "is not failed",
+			deviceScan: deviceScan{
+				DeviceIP:   "10.0.0.1",
+				ScanStatus: successScan,
+				ScanEndTs:  now,
+			},
+			expectedIsFailed: false,
+		},
+		{
+			name: "is failed",
+			deviceScan: deviceScan{
+				DeviceIP:   "10.0.0.1",
+				ScanStatus: failedScan,
+				ScanEndTs:  now,
+			},
+			expectedIsFailed: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isFailed := test.deviceScan.isFailed()
+			assert.Equal(t, test.expectedIsFailed, isFailed)
 		})
 	}
 }

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -38,6 +38,16 @@ const (
 	cacheKey = "snmp_scanned_devices"
 )
 
+// scanRetryDelays defines how long to wait before retrying a failed scan.
+// Each duration represents the delay before the next retry attempt.
+var scanRetryDelays = []time.Duration{
+	1 * time.Hour,      // 1 hour
+	12 * time.Hour,     // 12 hours
+	24 * time.Hour,     // 1 day
+	3 * 24 * time.Hour, // 3 days
+	7 * 24 * time.Hour, // 1 week
+}
+
 // Requires defines the dependencies for the snmpscanmanager component
 type Requires struct {
 	compdef.In
@@ -178,13 +188,7 @@ func (m *snmpScanManagerImpl) scanWorker() {
 func (m *snmpScanManagerImpl) processScanRequest(req snmpscanmanager.ScanRequest) error {
 	snmpConfig, namespace, err := m.snmpConfigProvider.GetDeviceConfig(req.DeviceIP, m.agentConfig, m.httpClient)
 	if err != nil {
-		now := time.Now()
-		m.setDeviceScan(deviceScan{
-			DeviceIP:   req.DeviceIP,
-			ScanStatus: failedStatus,
-			ScanEndTs:  now,
-		})
-		m.writeCache()
+		m.onDeviceScanFailure(req, false)
 		return err
 	}
 
@@ -198,29 +202,62 @@ func (m *snmpScanManagerImpl) processScanRequest(req snmpscanmanager.ScanRequest
 			return nil
 		}
 
-		now := time.Now()
-		m.setDeviceScan(deviceScan{
-			DeviceIP:   req.DeviceIP,
-			ScanStatus: failedStatus,
-			ScanEndTs:  now,
-		})
-		m.writeCache()
+		m.onDeviceScanFailure(req, true)
 		return err
 	}
 
-	now := time.Now()
-	m.setDeviceScan(deviceScan{
-		DeviceIP:   req.DeviceIP,
-		ScanStatus: successStatus,
-		ScanEndTs:  now,
-	})
-	m.writeCache()
-
-	m.scheduleScanRefresh(req, now)
+	m.onDeviceScanSuccess(req)
 
 	m.log.Infof("Successfully processed default scan request for device '%s'", req.DeviceIP)
 
 	return nil
+}
+
+func (m *snmpScanManagerImpl) onDeviceScanFailure(req snmpscanmanager.ScanRequest, canRetry bool) {
+	now := time.Now()
+
+	m.mtx.Lock()
+	var failuresCount int
+	if !canRetry {
+		failuresCount = -1 // -1 means that it will not be retried
+	} else {
+		oldScan, exists := m.deviceScans[req.DeviceIP]
+		if !exists {
+			failuresCount = 1
+		} else {
+			failuresCount = max(oldScan.Failures+1, 1)
+		}
+	}
+	m.deviceScans[req.DeviceIP] = deviceScan{
+		DeviceIP:   req.DeviceIP,
+		ScanStatus: failedScan,
+		ScanEndTs:  now,
+		Failures:   failuresCount,
+	}
+	m.mtx.Unlock()
+
+	m.writeCache()
+
+	if canRetry {
+		m.scheduleScanRetry(req, now, failuresCount)
+	}
+}
+
+func (m *snmpScanManagerImpl) onDeviceScanSuccess(req snmpscanmanager.ScanRequest) {
+	now := time.Now()
+
+	m.mtx.Lock()
+	m.deviceScans[req.DeviceIP] = deviceScan{
+		DeviceIP:   req.DeviceIP,
+		ScanStatus: successScan,
+		ScanEndTs:  now,
+		Failures:   0,
+	}
+	m.mtx.Unlock()
+
+	m.writeCache()
+
+	m.scheduleScanRefresh(req, now)
 }
 
 func (m *snmpScanManagerImpl) loadCache() {
@@ -251,6 +288,12 @@ func (m *snmpScanManagerImpl) loadCache() {
 			m.scheduleScanRefresh(snmpscanmanager.ScanRequest{
 				DeviceIP: scan.DeviceIP,
 			}, scan.ScanEndTs)
+		}
+
+		if scan.isFailed() {
+			m.scheduleScanRetry(snmpscanmanager.ScanRequest{
+				DeviceIP: scan.DeviceIP,
+			}, scan.ScanEndTs, scan.Failures)
 		}
 	}
 }
@@ -308,9 +351,14 @@ func (m *snmpScanManagerImpl) scheduleScanRefresh(req snmpscanmanager.ScanReques
 	})
 }
 
-func (m *snmpScanManagerImpl) setDeviceScan(deviceScan deviceScan) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
+func (m *snmpScanManagerImpl) scheduleScanRetry(req snmpscanmanager.ScanRequest, lastScanTs time.Time, failuresCount int) {
+	idx := failuresCount - 1
+	if idx < 0 || idx >= len(scanRetryDelays) {
+		return
+	}
 
-	m.deviceScans[deviceScan.DeviceIP] = deviceScan
+	m.scanScheduler.QueueScanTask(scanTask{
+		req:        req,
+		nextScanTs: lastScanTs.Add(scanRetryDelays[idx]),
+	})
 }

--- a/pkg/snmp/gosnmplib/errors.go
+++ b/pkg/snmp/gosnmplib/errors.go
@@ -5,20 +5,24 @@
 
 package gosnmplib
 
+// ConnectionError represents a connection error to a device
 type ConnectionError struct {
 	err error
 }
 
+// NewConnectionError creates a new ConnectionError
 func NewConnectionError(err error) *ConnectionError {
 	return &ConnectionError{
 		err: err,
 	}
 }
 
+// Error returns the error message
 func (e *ConnectionError) Error() string {
 	return e.err.Error()
 }
 
+// Unwrap returns the underlying error
 func (e *ConnectionError) Unwrap() error {
 	return e.err
 }

--- a/pkg/snmp/gosnmplib/errors.go
+++ b/pkg/snmp/gosnmplib/errors.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package gosnmplib
+
+type ConnectionError struct {
+	err error
+}
+
+func NewConnectionError(err error) *ConnectionError {
+	return &ConnectionError{
+		err: err,
+	}
+}
+
+func (e *ConnectionError) Error() string {
+	return e.err.Error()
+}
+
+func (e *ConnectionError) Unwrap() error {
+	return e.err
+}

--- a/pkg/snmp/gosnmplib/walk.go
+++ b/pkg/snmp/gosnmplib/walk.go
@@ -67,7 +67,7 @@ RequestLoop:
 			response, err = session.GetNext([]string{oid})
 		}
 		if err != nil {
-			return err
+			return NewConnectionError(err)
 		}
 		if len(response.Variables) == 0 {
 			break RequestLoop


### PR DESCRIPTION
### What does this PR do?

This PR implements retrying the default device scan when it fails with an increasing interval between retries.
Only certain errors are retried, in this case, the errors when failing to connect to the device or failing getting an OID from the device are retried.

### Motivation

### Describe how you validated your changes

### Additional Notes
