### PR TITLE
APM: limit decoder buffer size from content length

### DIFF
--- a/releasenotes/notes/limit-trace-agent-buffers-9e7e4c9d54e7c237.yaml
+++ b/releasenotes/notes/limit-trace-agent-buffers-9e7e4c9d54e7c237.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Limit the size of the buffers used to decode the request body in the trace agent. This prevents the agent from allocating memory for requests that are too large.

--- a/releasenotes/notes/limit-trace-agent-buffers-9e7e4c9d54e7c237.yaml
+++ b/releasenotes/notes/limit-trace-agent-buffers-9e7e4c9d54e7c237.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Limit the size of the buffers used to decode the request body in the trace agent. This prevents the agent from allocating memory for requests that are too large.
+    APM: Limit the size of the buffers used to decode the request body in the Trace Agent. This prevents the Agent from allocating memory for requests that are too large.


### PR DESCRIPTION
### What does this PR do?
Limit buffer size to max payload size

### Motivation
There's a small bug here where we would grow a buffer to the content-length of an incoming request regardless of if the size was already too big for our max payload size. This could result in OOMs or too high memory usage when a tracer is sending payloads that are too large.

### Describe how you validated your changes
New unit test (written by cursor but checked by me)

### Additional Notes
