### PR TITLE
pkg/dyninst/ir, irgen: generate ir for templates in ir.Program

### DIFF
--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -7,7 +7,11 @@
 
 package ir
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/exprlang"
+)
 
 // ProgramID is a ID corresponding to an instance of a Program.  It is used to
 // identify messages from this program as they are communicated over the ring
@@ -140,6 +144,47 @@ type Variable struct {
 // PCRange is the range of PC values that will be probed.
 type PCRange = [2]uint64
 
+// Template represents the concrete template structure for a probe.
+type Template struct {
+	// TemplateString is the complete template string.
+	TemplateString string
+	// Segments are the ordered parts of the template.
+	Segments []TemplateSegment
+}
+
+// TemplateSegment represents a concrete part of the template.
+type TemplateSegment interface {
+	templateSegment() // marker method
+}
+
+// StringSegment is a string literal in the template.
+type StringSegment string
+
+func (s StringSegment) templateSegment() {}
+
+// JSONSegment is an expression segment in the template.
+type JSONSegment struct {
+	// JSON is the AST of the DSL segment.
+	JSON exprlang.Expr
+	// DSL is the raw expression language segment.
+	DSL string
+	// EventKind is the kind of the event within the probe that corresponds to this segment (i.e. entry, return, line).
+	EventKind EventKind
+	// EventExpressionIndex is the index of the expression within the event.
+	EventExpressionIndex int
+}
+
+func (s JSONSegment) templateSegment() {}
+
+// InvalidSegment is a segment that represents an issue with the template.
+type InvalidSegment struct {
+	// Error is the error that occurred while parsing the segment.
+	Error string
+	DSL   string
+}
+
+func (s InvalidSegment) templateSegment() {}
+
 // Probe represents a probe from the config as it applies to the program.
 type Probe struct {
 	ProbeDefinition
@@ -147,8 +192,8 @@ type Probe struct {
 	Subprogram *Subprogram
 	// The events that trigger the probe.
 	Events []*Event
-	// TODO: Add template support:
-	//	TemplateSegments []TemplateSegment
+	// Template contains the concrete template structure for this probe.
+	Template *Template
 }
 
 // Event corresponds to an action that will occur when a PC is hit.

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -424,7 +424,7 @@ const (
 	RootExpressionKindLocal
 	// RootExpressionKindTemplateSegment means that this expression is part of a
 	// template segment.
-	// RootExpressionKindTemplateSegment
+	RootExpressionKindTemplateSegment
 )
 
 func (k RootExpressionKind) String() string {
@@ -433,6 +433,8 @@ func (k RootExpressionKind) String() string {
 		return "argument"
 	case RootExpressionKindLocal:
 		return "local"
+	case RootExpressionKindTemplateSegment:
+		return "template_segment"
 	default:
 		return fmt.Sprintf("RootExpressionKind(%d)", k)
 	}

--- a/pkg/dyninst/irgen/implementors_test.go
+++ b/pkg/dyninst/irgen/implementors_test.go
@@ -68,7 +68,7 @@ func TestImplementorIterator(t *testing.T) {
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	t.Run("in-memory", func(t *testing.T) {
 		factory := &inMemoryGoTypeIndexFactory{}
-		newFunction(t, cfgs[0], factory)
+		testImplementorIterator(t, cfgs[0], factory)
 	})
 	t.Run("on-disk", func(t *testing.T) {
 		diskCache, err := object.NewDiskCache(object.DiskCacheConfig{
@@ -77,12 +77,12 @@ func TestImplementorIterator(t *testing.T) {
 		})
 		require.NoError(t, err)
 		factory := &onDiskGoTypeIndexFactory{diskCache: diskCache}
-		newFunction(t, cfgs[0], factory)
+		testImplementorIterator(t, cfgs[0], factory)
 	})
 
 }
 
-func newFunction(t *testing.T, cfg testprogs.Config, factory goTypeIndexFactory) {
+func testImplementorIterator(t *testing.T, cfg testprogs.Config, factory goTypeIndexFactory) {
 	typeTab, interestingInterfaces, methodIndex := buildMethodIndex(
 		t, cfg, "sample", factory, interestingInterfaceNames,
 	)

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -46,6 +46,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/loclist"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/exprlang"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
@@ -361,13 +362,22 @@ func generateIR(
 		}
 	}
 
+	// Compute the set of expressions for the probes. This will populate
+	// the probe's Template field and resolve relevant variables etc.
+	probeExpressions := make([][]probeExpression, len(probes))
+	for i, p := range probes {
+		p.Template, probeExpressions[i] = processProbeExpressions(p)
+	}
+
 	// Finalize type information now that we have all referenced types.
 	if err := finalizeTypes(typeCatalog, materializedSubprograms); err != nil {
 		return nil, err
 	}
 
 	// Populate event root expressions for every probe.
-	probes, eventIssues := populateProbeEventsExpressions(probes, typeCatalog)
+	probes, eventIssues := populateProbeEventsExpressions(
+		probes, probeExpressions, typeCatalog,
+	)
 	issues = append(issues, eventIssues...)
 
 	// Detect probe definitions that did not match any symbol in the binary.
@@ -393,6 +403,192 @@ func generateIR(
 		GoModuledataInfo: processed.goModuledataInfo,
 		CommonTypes:      commonTypes,
 	}, nil
+}
+
+// probeExpression is an expression that applies to a probe.
+type probeExpression struct {
+	def exprlang.Expr
+	// As of writing, the only supported expressions reference a single
+	// variable. As this evolves, more variables may need to be supported.
+	relevantVariable *ir.Variable
+	// The kind of event at which this expression is evaluated.
+	eventKind ir.EventKind
+	// The kind of expression -- this is used to inform the deserialization
+	// code about how this expression should be displayed.
+	exprKind ir.RootExpressionKind
+	// If the exprKind is ir.RootExpressionTemplateSegment, this is the
+	// corresponding segment.
+	segment *ir.JSONSegment
+}
+
+// processProbeExpressions processes template segments and the snapshot
+// expressions for variables available at probe events. It computes the
+// ir.Template and the probeExpressions for the probe.
+func processProbeExpressions(
+	probe *ir.Probe,
+) (template *ir.Template, exprs []probeExpression) {
+	if td := probe.ProbeDefinition.GetTemplate(); td != nil {
+		template = newTemplate(td)
+	}
+	type jsonSegment struct {
+		*ir.JSONSegment
+		index int
+	}
+	var segmentRefs map[string][]jsonSegment
+	if template != nil {
+		segmentRefs = make(map[string][]jsonSegment)
+		for i, s := range template.Segments {
+			switch s := s.(type) {
+			case *ir.JSONSegment:
+				switch expr := s.JSON.(type) {
+				case *exprlang.RefExpr:
+					segmentRefs[expr.Ref] = append(segmentRefs[expr.Ref],
+						jsonSegment{JSONSegment: s, index: i})
+				}
+			}
+		}
+	}
+	isKind := func(kind ir.EventKind) func(*ir.Event) bool {
+		return func(ev *ir.Event) bool { return ev.Kind == kind }
+	}
+	haveEntry := slices.ContainsFunc(probe.Events, isKind(ir.EventKindEntry))
+	haveReturn := slices.ContainsFunc(probe.Events, isKind(ir.EventKindReturn))
+	variableIsAvailble := func(ips []ir.InjectionPoint, v *ir.Variable) bool {
+		locIdx := 0
+		var available bool
+		for _, ip := range ips {
+			for locIdx < len(v.Locations) && v.Locations[locIdx].Range[1] <= ip.PC {
+				locIdx++
+			}
+			available = locIdx < len(v.Locations) &&
+				ip.PC >= v.Locations[locIdx].Range[0]
+			if available {
+				return true
+			}
+		}
+		return false
+	}
+	for _, v := range probe.Subprogram.Variables {
+		var (
+			evKind   ir.EventKind
+			exprKind ir.RootExpressionKind
+		)
+		switch {
+
+		// The entry event for a method probe.
+		case haveEntry && v.Role == ir.VariableRoleParameter:
+			evKind, exprKind = ir.EventKindEntry, ir.RootExpressionKindArgument
+
+		// The return event for a method probe.
+		//
+		// TODO: We should return available locals from return probes, which
+		// would just require extending the next case to also be triggered for
+		// return variables.
+		case haveReturn && v.Role == ir.VariableRoleReturn:
+			evKind, exprKind = ir.EventKindReturn, ir.RootExpressionKindLocal
+
+		// The line-probe case:
+		case len(probe.Events) == 1 && probe.Events[0].Kind == ir.EventKindLine:
+			ips := probe.Events[0].InjectionPoints
+			if !variableIsAvailble(ips, v) {
+				continue
+			}
+			// TODO: the exprKind should be argument for available arguments.
+			evKind, exprKind = ir.EventKindLine, ir.RootExpressionKindLocal
+
+		default:
+			continue
+		}
+		exprs = append(exprs, probeExpression{
+			def:              &exprlang.RefExpr{Ref: v.Name},
+			relevantVariable: v,
+			eventKind:        evKind,
+			exprKind:         exprKind,
+		})
+
+		// Note: there's no risk of picking the wrong variable due to shadowing,
+		// but there should be! In materializePending we ensure that we only
+		// track a single variable with a given name. This is incorrect in cases
+		// of shadowing.  Instead we could record all shadowed variables and
+		// handle ambiguity of template resolution based on the specific return
+		// point (as that's all that matters for scoping in the case of
+		// shadowing) and come up with a naming scheme to describe the shadowed
+		// variables in snapshots.
+
+		segs, ok := segmentRefs[v.Name]
+		if !ok {
+			continue
+		}
+		for _, seg := range segs {
+			exprs = append(exprs, probeExpression{
+				def:              seg.JSON,
+				relevantVariable: v,
+				eventKind:        evKind,
+				exprKind:         ir.RootExpressionKindTemplateSegment,
+				segment:          seg.JSONSegment,
+			})
+		}
+		delete(segmentRefs, v.Name)
+	}
+	for name, segs := range segmentRefs {
+		for _, seg := range segs {
+			template.Segments[seg.index] = ir.InvalidSegment{
+				Error: fmt.Sprintf("failed to resolve reference %q", name),
+				DSL:   seg.DSL,
+			}
+		}
+	}
+	return template, exprs
+}
+
+// newTemplate creates a new template from a template definition.
+//
+// Note that the JSONSegment EventKind and EventExpressionIndex will be left
+// with zero values to be filled in later.
+func newTemplate(td ir.TemplateDefinition) *ir.Template {
+	var segments []ir.TemplateSegment
+	addSegment := func(s ir.TemplateSegment) {
+		segments = append(segments, s)
+	}
+	addInvalid := func(s ir.TemplateSegmentExpression, msg string) {
+		addSegment(ir.InvalidSegment{DSL: s.GetDSL(), Error: msg})
+	}
+	var i int
+	for segment := range td.GetSegments() {
+		switch segment := segment.(type) {
+		case ir.TemplateSegmentString:
+			addSegment(ir.StringSegment(segment.GetString()))
+		case ir.TemplateSegmentExpression:
+			expr, err := exprlang.Parse(segment.GetJSON())
+			if err != nil {
+				addInvalid(segment, err.Error())
+			} else {
+				switch expr := expr.(type) {
+				case *exprlang.RefExpr:
+					addSegment(&ir.JSONSegment{
+						DSL:  segment.GetDSL(),
+						JSON: expr,
+
+						// These will be filled in by populateProbeExpressions.
+						EventKind:            0,
+						EventExpressionIndex: 0,
+					})
+				case *exprlang.UnsupportedExpr:
+					msg := fmt.Sprintf("unsupported operation: %s", expr.Operation)
+					addInvalid(segment, msg)
+				default:
+					msg := fmt.Sprintf("unsupported expression: %T", expr)
+					addInvalid(segment, msg)
+				}
+			}
+		}
+		i++
+	}
+	t := &ir.Template{
+		TemplateString: td.GetTemplateString(),
+		Segments:       segments,
+	}
+	return t
 }
 
 // computeDepthBudgets returns the maximum reference depth per subprogram ID
@@ -715,6 +911,8 @@ func materializePending(
 		}
 		// First, create variables defined directly under the subprogram/abstract DIEs.
 		variableByOffset := make(map[dwarf.Offset]*ir.Variable, len(p.variables))
+		// TODO: In the future we should track variables by lexical block scope
+		// to be able to differentiate shadowing from malformed DWARF.
 		variableByName := make(map[string]*ir.Variable, len(p.variables))
 		for _, die := range p.variables {
 			parseLocs := !p.abstract
@@ -1722,10 +1920,11 @@ func completeGoSliceType(tc *typeCatalog, st *ir.StructureType) error {
 
 func populateProbeEventsExpressions(
 	probes []*ir.Probe,
+	exprs [][]probeExpression,
 	typeCatalog *typeCatalog,
 ) (successful []*ir.Probe, failed []ir.ProbeIssue) {
-	for _, probe := range probes {
-		if issue := populateProbeExpressions(probe, typeCatalog); !issue.IsNone() {
+	for i, probe := range probes {
+		if issue := populateProbeExpressions(probe, exprs[i], typeCatalog); !issue.IsNone() {
 			failed = append(failed, ir.ProbeIssue{
 				ProbeDefinition: probe.ProbeDefinition,
 				Issue:           issue,
@@ -1739,10 +1938,11 @@ func populateProbeEventsExpressions(
 
 func populateProbeExpressions(
 	probe *ir.Probe,
+	exprs []probeExpression,
 	typeCatalog *typeCatalog,
 ) ir.Issue {
 	for _, event := range probe.Events {
-		issue := populateEventExpressions(probe, event, typeCatalog)
+		issue := populateEventExpressions(probe, event, exprs, typeCatalog)
 		if !issue.IsNone() {
 			return issue
 		}
@@ -1753,63 +1953,36 @@ func populateProbeExpressions(
 func populateEventExpressions(
 	probe *ir.Probe,
 	event *ir.Event,
+	exprs []probeExpression,
 	typeCatalog *typeCatalog,
 ) ir.Issue {
 	id := typeCatalog.idAlloc.next()
 	var expressions []*ir.RootExpression
-	for _, variable := range probe.Subprogram.Variables {
-		var variableKind ir.RootExpressionKind
-		switch event.Kind {
-		case ir.EventKindEntry:
-			if variable.Role != ir.VariableRoleParameter {
-				continue
-			}
-			variableKind = ir.RootExpressionKindArgument
-		case ir.EventKindReturn:
-			if variable.Role != ir.VariableRoleReturn {
-				continue
-			}
-			variableKind = ir.RootExpressionKindLocal
-		case ir.EventKindLine:
-			// We capture any variable that is available at any of the injection points.
-			// We rely on both locations and injection points being sorted by PC to make
-			// this check linear. The location ranges might overlap, but this sweep is
-			// still correct.
-			available := false
-			locIdx := 0
-			for _, injectionPoint := range event.InjectionPoints {
-				for locIdx < len(variable.Locations) && variable.Locations[locIdx].Range[1] <= injectionPoint.PC {
-					locIdx++
-				}
-				if locIdx < len(variable.Locations) && injectionPoint.PC >= variable.Locations[locIdx].Range[0] {
-					available = true
-					break
-				}
-			}
-			if !available {
-				continue
-			}
-			variableKind = ir.RootExpressionKindLocal
-		default:
-			panic(fmt.Sprintf("unexpected event kind: %v", event.Kind))
+	for _, expr := range exprs {
+		if expr.eventKind != event.Kind {
+			continue
 		}
-		variableSize := variable.Type.GetByteSize()
-		expr := &ir.RootExpression{
-			Name:   variable.Name,
+		v := expr.relevantVariable
+		variableSize := v.Type.GetByteSize()
+		if seg := expr.segment; seg != nil {
+			seg.EventKind = expr.eventKind
+			seg.EventExpressionIndex = len(expressions)
+		}
+		expressions = append(expressions, &ir.RootExpression{
+			Name:   v.Name,
 			Offset: uint32(0),
-			Kind:   variableKind,
+			Kind:   expr.exprKind,
 			Expression: ir.Expression{
-				Type: variable.Type,
+				Type: v.Type,
 				Operations: []ir.ExpressionOp{
 					&ir.LocationOp{
-						Variable: variable,
+						Variable: v,
 						Offset:   0,
 						ByteSize: uint32(variableSize),
 					},
 				},
 			},
-		}
-		expressions = append(expressions, expr)
+		})
 	}
 	presenceBitsetSize := uint32((len(expressions) + 7) / 8)
 	byteSize := uint64(presenceBitsetSize)

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -5,17 +5,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: stackC
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1312 EventRootType Probe[main.stackC]
+          Type: 1322 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd0a46a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1313 EventRootType Probe[main.stackC]Return
+          Type: 1323 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd0a4a5", Frameless: false}]
           Condition: null
     - id: testAny
@@ -23,8 +23,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -41,8 +41,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -58,17 +58,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1294 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xd08f2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1295 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08fe2", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -76,8 +76,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -90,8 +90,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -104,8 +104,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -118,8 +118,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -132,8 +132,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -145,8 +145,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -159,8 +159,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -177,8 +177,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -191,8 +191,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -205,8 +205,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -219,8 +219,16 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{w}, {x}, {y}'
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -233,8 +241,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{t}'
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -247,8 +255,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -261,8 +269,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -275,8 +283,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -289,8 +297,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -303,8 +311,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -317,8 +325,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -331,13 +339,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testEmptySlice]
+          Type: 1311 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd0a000", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -345,13 +353,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1314 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -360,13 +373,13 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptyString]
+          Type: 1333 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -374,26 +387,26 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testEmptyStruct]
+          Type: 1339 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd0a9e0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1340 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd0aa00", Frameless: true}]
           Condition: null
     - id: testError
@@ -401,8 +414,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -415,8 +428,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -433,8 +446,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -451,8 +464,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -469,8 +482,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -490,8 +503,8 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -504,8 +517,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -522,8 +535,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -540,8 +558,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -558,13 +576,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBBB
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testInlinedBBB]
+          Type: 1344 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -572,8 +590,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBC
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -590,13 +608,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testInlinedBCA]
+          Type: 1345 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -607,13 +625,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Line
-          Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1346 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -621,13 +639,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testInlinedBCB]
+          Type: 1347 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -638,13 +656,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Line
-          Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1348 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -653,13 +671,13 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInlinedPrint]
+          Type: 1341 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0460a"
               Frameless: false
@@ -673,7 +691,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1342 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -684,13 +702,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Line
-          Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1343 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -708,13 +726,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testInlinedSq]
+          Type: 1349 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -725,13 +743,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1340 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1350 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -740,13 +758,13 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1351 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04b05"
               Frameless: false
@@ -758,8 +776,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -772,8 +790,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -786,8 +804,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -800,8 +818,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -814,8 +832,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -828,8 +846,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -841,17 +859,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1292 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xd08dae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1293 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08ef3", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -859,8 +877,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -876,8 +894,8 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -893,8 +911,8 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -910,8 +928,13 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a} and {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -923,17 +946,43 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1298 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xd09253", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1299 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xd09462", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -941,8 +990,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -955,8 +1004,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -969,8 +1018,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -983,8 +1032,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -997,8 +1046,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1011,8 +1060,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1025,8 +1074,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1039,8 +1088,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1053,8 +1102,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1067,8 +1118,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1081,8 +1134,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1095,8 +1148,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1109,8 +1162,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1123,8 +1176,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1137,8 +1190,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1151,8 +1204,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1165,8 +1218,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1179,8 +1232,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1193,8 +1246,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1207,8 +1260,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1221,13 +1276,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testMassiveString]
+          Type: 1330 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1236,81 +1291,117 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testMassiveString]
+          Type: 1331 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1300 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xd094f3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1301 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xd0972b", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1304 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xd0986e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1305 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xd09936", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
-      template: ""
-      segments: []
+      template: '{s1}, {s2}'
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1296 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xd0900e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1297 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xd0922a", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1250 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1251 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1318,8 +1409,22 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1331,8 +1436,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1344,13 +1449,41 @@ Probes:
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd08395", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      template: Parameter {i} * 2 = result {result}
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - Kind: Entry
+          Type: 1248 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd0832a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1249 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd08395", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}, {a}'
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1363,13 +1496,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1308 EventRootType Probe[main.testNilSlice]
+          Type: 1318 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1377,13 +1510,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1315 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1391,13 +1529,21 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {s}, {x}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1317 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1405,13 +1551,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1329 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd0a540", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1419,8 +1565,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1433,8 +1579,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1447,8 +1593,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1461,8 +1607,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1487,8 +1633,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}, {failed}'
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1512,102 +1663,102 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
-      template: ""
-      segments: []
+      template: testReturnsArray
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1260 EventRootType Probe[main.testReturnsArray]
+          Type: 1270 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xd0884a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1261 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1271 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xd088ad", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
-      template: ""
-      segments: []
+      template: testReturnsArrayOne
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1272 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xd088ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1273 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xd0890b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
-      template: ""
-      segments: []
+      template: testReturnsArrayZero
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1274 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xd0892a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1275 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xd08966", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
-      template: ""
-      segments: []
+      template: testReturnsBacktrackInt
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1278 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xd08a0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1279 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xd08a8a", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
-      template: ""
-      segments: []
+      template: testReturnsBoolAndUintptr
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1290 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xd08d4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1291 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xd08d90", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
-      template: ""
-      segments: []
+      template: testReturnsComplex
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1256 EventRootType Probe[main.testReturnsComplex]
+          Type: 1266 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xd0870a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1267 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xd08766", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1615,8 +1766,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{failed}'
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1636,8 +1787,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1653,8 +1804,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1670,8 +1821,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1688,8 +1839,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1709,153 +1860,153 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
-      template: ""
-      segments: []
+      template: testReturnsLargeStruct
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1268 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xd0878e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1269 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xd08813", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
-      template: ""
-      segments: []
+      template: testReturnsManyFloats
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1264 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xd0860e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1265 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xd086e5", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
-      template: ""
-      segments: []
+      template: testReturnsMixed
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1272 EventRootType Probe[main.testReturnsMixed]
+          Type: 1282 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xd08b6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1283 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xd08bcc", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
-      template: ""
-      segments: []
+      template: testReturnsMixedStruct
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1276 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xd0898a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1277 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xd089d8", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
-      template: ""
-      segments: []
+      template: testReturnsMultipleFloats
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1288 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xd08cca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1289 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xd08d16", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
-      template: ""
-      segments: []
+      template: testReturnsOnlyFloat
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1286 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xd08c6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1287 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xd08cae", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
-      template: ""
-      segments: []
+      template: testReturnsPrimitives
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1262 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xd0858a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1263 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xd085f1", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
-      template: ""
-      segments: []
+      template: testReturnsStructWithArray
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1284 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xd08bea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1285 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xd08c4d", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
-      template: ""
-      segments: []
+      template: testReturnsWideStruct
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1280 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xd08aae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1281 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xd08b34", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -1863,8 +2014,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -1872,13 +2023,44 @@ Probes:
           Type: 1125 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
+    - id: testSegmentsForParamsAndReturnsOutOfOrder
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{result2}{i}{result}{i}{i}{result2}{result}'
+      segments:
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result}
+          dsl: result
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1252 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1253 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Condition: null
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -1891,8 +2073,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -1905,8 +2087,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -1919,8 +2101,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -1933,8 +2115,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -1947,8 +2129,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -1961,8 +2143,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -1975,8 +2157,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -1989,8 +2171,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}{x}{x}
+      segments:
+        - 'parameter = '
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2003,8 +2192,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2017,13 +2206,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1314 EventRootType Probe[main.testSingleString]
+          Type: 1324 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd0a4c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2031,8 +2220,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2045,8 +2234,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2059,8 +2248,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2073,8 +2262,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2087,8 +2276,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2101,13 +2290,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1321 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2115,13 +2304,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1302 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1312 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2129,8 +2318,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2142,34 +2331,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1260 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd084ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1261 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0854e", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1302 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xd097ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1303 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xd0983c", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2177,8 +2366,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2191,8 +2380,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}'
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2205,13 +2394,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1306 EventRootType Probe[main.testStringSlice]
+          Type: 1316 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2219,8 +2408,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2233,8 +2422,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2247,17 +2436,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testStruct]
+          Type: 1337 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd0a860", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1328 EventRootType Probe[main.testStruct]Return
+          Type: 1338 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd0a882", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2265,13 +2454,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testStructSlice]
+          Type: 1313 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2279,8 +2473,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2292,47 +2486,47 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1306 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xd0996e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1307 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xd09a1a", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1335 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd0a720", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1336 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd0a73e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1334 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd0a700", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2340,8 +2534,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2349,18 +2543,85 @@ Probes:
           Type: 1197 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05540", Frameless: true}]
           Condition: null
+    - id: testTemplateWithNonexistantVariableName
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{nonexistentVariable}'
+      segments:
+        - json: {ref: nonexistentVariable}
+          dsl: nonexistentVariable
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1254 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1255 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedExpression
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{unsupportedExpression}'
+      segments:
+        - json: {foobar: unsupportedExpression}
+          dsl: unsupportedExpression
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1256 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedVariable
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: Executed main.testMultipleNamedReturn, it took {@duration}ms
+      segments:
+        - 'Executed main.testMultipleNamedReturn, it took '
+        - json: {ref: '@duration'}
+          dsl: '@duration'
+        - ms
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Condition: null
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}, {z}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testThreeStrings]
+          Type: 1325 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd0a4e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2368,17 +2629,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1326 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd0a500", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1327 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a51e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2386,13 +2647,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1328 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a520", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2400,8 +2661,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2414,8 +2675,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2428,8 +2689,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2442,8 +2703,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2456,8 +2717,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2470,8 +2731,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2484,8 +2745,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2498,13 +2759,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1300 EventRootType Probe[main.testUintSlice]
+          Type: 1310 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd09fe0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2512,13 +2773,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testUnitializedString]
+          Type: 1332 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2526,8 +2787,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2540,8 +2801,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2554,13 +2815,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1319 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2568,30 +2829,35 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1320 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1308 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xd09a4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1309 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09acc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -8744,10 +9010,10 @@ Types:
       GoKind: 22
       Pointee: 671 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1312
+      ID: 1322
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1313
+      ID: 1323
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8827,7 +9093,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1284
+      ID: 1294
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8843,7 +9109,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1285
+      ID: 1295
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9170,7 +9436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1304
+      ID: 1314
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9196,7 +9462,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1301
+      ID: 1311
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9212,7 +9478,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1323
+      ID: 1333
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9228,7 +9494,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1340
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9244,7 +9510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
+      ID: 1339
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9442,7 +9708,7 @@ Types:
       ID: 1182
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1334
+      ID: 1344
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1179
@@ -9474,16 +9740,16 @@ Types:
       ID: 1180
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1345
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1336
+      ID: 1346
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1337
+      ID: 1347
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1338
+      ID: 1348
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1183
@@ -9492,7 +9758,7 @@ Types:
       ID: 1184
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1341
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9508,7 +9774,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1343
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9524,10 +9790,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1342
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1349
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9543,7 +9809,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1350
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9559,7 +9825,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1351
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -9671,7 +9937,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1282
+      ID: 1292
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -9687,7 +9953,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1283
+      ID: 1293
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -9774,7 +10040,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1288
+      ID: 1298
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -9870,7 +10136,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1289
+      ID: 1299
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10206,7 +10472,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1330
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10222,7 +10488,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1321
+      ID: 1331
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10238,7 +10504,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1290
+      ID: 1300
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10334,7 +10600,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1291
+      ID: 1301
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10350,7 +10616,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1294
+      ID: 1304
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10376,7 +10642,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1295
+      ID: 1305
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10402,7 +10668,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1286
+      ID: 1296
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10428,7 +10694,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1287
+      ID: 1297
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10444,7 +10710,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1248
+      ID: 1250
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10460,7 +10726,175 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1252
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1254
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1256
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1258
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1251
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1253
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1255
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1257
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1259
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10558,7 +10992,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1247
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1249
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10600,7 +11066,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1315
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10626,7 +11092,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1317
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -10662,7 +11128,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1318
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10678,7 +11144,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1329
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10826,10 +11292,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1262
+      ID: 1272
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1263
+      ID: 1273
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10845,10 +11311,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1274
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1265
+      ID: 1275
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10864,10 +11330,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1260
+      ID: 1270
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1261
+      ID: 1271
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10883,10 +11349,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1268
+      ID: 1278
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1269
+      ID: 1279
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10982,10 +11448,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1280
+      ID: 1290
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1281
+      ID: 1291
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11011,10 +11477,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1266
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1257
+      ID: 1267
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11210,10 +11676,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1258
+      ID: 1268
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1259
+      ID: 1269
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11229,10 +11695,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1254
+      ID: 1264
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1255
+      ID: 1265
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11408,10 +11874,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1276
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1267
+      ID: 1277
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11427,10 +11893,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1272
+      ID: 1282
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1273
+      ID: 1283
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11486,10 +11952,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1278
+      ID: 1288
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1279
+      ID: 1289
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11515,10 +11981,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1276
+      ID: 1286
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1277
+      ID: 1287
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11534,10 +12000,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1262
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1253
+      ID: 1263
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -11623,10 +12089,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1274
+      ID: 1284
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1275
+      ID: 1285
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11642,10 +12108,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1270
+      ID: 1280
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1271
+      ID: 1281
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -11837,7 +12303,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1314
+      ID: 1324
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11933,7 +12399,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1321
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11949,7 +12415,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1302
+      ID: 1312
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11981,7 +12447,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1250
+      ID: 1260
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11997,7 +12463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1251
+      ID: 1261
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12033,7 +12499,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1292
+      ID: 1302
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12049,7 +12515,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1293
+      ID: 1303
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12117,7 +12583,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1316
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12165,7 +12631,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
+      ID: 1313
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12207,7 +12673,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1296
+      ID: 1306
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12223,7 +12689,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1297
+      ID: 1307
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12249,7 +12715,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1325
+      ID: 1335
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12265,10 +12731,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1326
+      ID: 1336
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1324
+      ID: 1334
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12300,7 +12766,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1337
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12316,10 +12782,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1328
+      ID: 1338
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1318
+      ID: 1328
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12335,7 +12801,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1326
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12351,10 +12817,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1317
+      ID: 1327
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1315
+      ID: 1325
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12502,7 +12968,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1300
+      ID: 1310
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12518,7 +12984,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1322
+      ID: 1332
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12566,7 +13032,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1309
+      ID: 1319
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12582,7 +13048,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1310
+      ID: 1320
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12598,7 +13064,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1298
+      ID: 1308
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12624,7 +13090,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1299
+      ID: 1309
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -19676,7 +20142,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1341
+MaxTypeID: 1351
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x175c760", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -18,6 +18,7 @@ Probes:
           Type: 1323 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd0a4a5", Frameless: false}]
           Condition: null
+      probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
       version: 0
       type: LOG_PROBE
@@ -36,6 +37,13 @@ Probes:
           Type: 1192 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xd04e25", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -54,6 +62,13 @@ Probes:
           Type: 1195 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xd04ebd", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -71,6 +86,13 @@ Probes:
           Type: 1295 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08fe2", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -85,6 +107,13 @@ Probes:
           Type: 1142 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -99,6 +128,13 @@ Probes:
           Type: 1138 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -113,6 +149,13 @@ Probes:
           Type: 1140 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd03000", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -127,6 +170,13 @@ Probes:
           Type: 1203 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd05600", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -141,6 +191,13 @@ Probes:
           Type: 1139 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -154,6 +211,13 @@ Probes:
           Type: 1141 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xd03020", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -172,6 +236,13 @@ Probes:
           Type: 1161 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xd0375e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -186,6 +257,13 @@ Probes:
           Type: 1127 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -200,6 +278,13 @@ Probes:
           Type: 1124 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -214,6 +299,13 @@ Probes:
           Type: 1223 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd07320", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{c}'
+        Segments:
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -236,6 +328,23 @@ Probes:
           Type: 1221 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd06f40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{w}, {x}, {y}'
+        Segments:
+            - JSON: {Ref: w}
+              DSL: w
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testCycle
       version: 0
       type: LOG_PROBE
@@ -250,6 +359,13 @@ Probes:
           Type: 1231 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{t}'
+        Segments:
+            - JSON: {Ref: t}
+              DSL: t
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -264,6 +380,13 @@ Probes:
           Type: 1166 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -278,6 +401,13 @@ Probes:
           Type: 1167 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -292,6 +422,13 @@ Probes:
           Type: 1162 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd03800", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -306,6 +443,13 @@ Probes:
           Type: 1163 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd03820", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -320,6 +464,13 @@ Probes:
           Type: 1164 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd039a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -334,6 +485,13 @@ Probes:
           Type: 1165 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd039c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -348,6 +506,13 @@ Probes:
           Type: 1311 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd0a000", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -367,6 +532,18 @@ Probes:
           Type: 1314 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -382,6 +559,13 @@ Probes:
           Type: 1333 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -396,6 +580,13 @@ Probes:
           Type: 1339 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd0a9e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -409,6 +600,13 @@ Probes:
           Type: 1340 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd0aa00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -423,6 +621,13 @@ Probes:
           Type: 1193 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04e60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -441,6 +646,13 @@ Probes:
           Type: 1176 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xd043ac", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -459,6 +671,13 @@ Probes:
           Type: 1174 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xd042db", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -477,6 +696,13 @@ Probes:
           Type: 1186 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xd04ac5", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -495,6 +721,13 @@ Probes:
           Type: 1188 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xd04b1d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -512,6 +745,13 @@ Probes:
           Type: 1189 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xd04ae8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -530,6 +770,13 @@ Probes:
           Type: 1178 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xd0480e", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -553,6 +800,18 @@ Probes:
           Type: 1180 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xd048de", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -571,6 +830,13 @@ Probes:
           Type: 1182 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xd0496b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -585,6 +851,9 @@ Probes:
           Type: 1344 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBBB
+        Segments: [testInlinedBBB]
     - id: testInlinedBC
       version: 0
       type: LOG_PROBE
@@ -603,6 +872,9 @@ Probes:
           Type: 1184 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xd04a9e", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBC
+        Segments: [testInlinedBC]
     - id: testInlinedBCA
       version: 0
       type: LOG_PROBE
@@ -617,6 +889,9 @@ Probes:
           Type: 1345 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCALine
       version: 0
       type: LOG_PROBE
@@ -634,6 +909,9 @@ Probes:
           Type: 1346 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCB
       version: 0
       type: LOG_PROBE
@@ -648,6 +926,9 @@ Probes:
           Type: 1347 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedBCBLine
       version: 0
       type: LOG_PROBE
@@ -665,6 +946,9 @@ Probes:
           Type: 1348 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -694,6 +978,13 @@ Probes:
           Type: 1342 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -721,6 +1012,13 @@ Probes:
             - PC: "0xd0492f"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -735,6 +1033,13 @@ Probes:
           Type: 1349 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -752,6 +1057,13 @@ Probes:
           Type: 1350 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -771,6 +1083,13 @@ Probes:
             - PC: "0xd04ba5"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -785,6 +1104,13 @@ Probes:
           Type: 1130 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -799,6 +1125,13 @@ Probes:
           Type: 1131 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -813,6 +1146,13 @@ Probes:
           Type: 1132 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -827,6 +1167,13 @@ Probes:
           Type: 1129 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -841,6 +1188,13 @@ Probes:
           Type: 1128 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -855,6 +1209,13 @@ Probes:
           Type: 1190 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04dc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -872,6 +1233,13 @@ Probes:
           Type: 1293 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08ef3", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -886,6 +1254,13 @@ Probes:
           Type: 1225 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd07500", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -903,6 +1278,9 @@ Probes:
           Type: 1170 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03bba", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineB
       version: 0
       type: LOG_PROBE
@@ -920,6 +1298,9 @@ Probes:
           Type: 1171 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03c6d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineC
       version: 0
       type: LOG_PROBE
@@ -942,6 +1323,18 @@ Probes:
           Type: 1172 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03d34", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a} and {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' and '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Line
+              EventExpressionIndex: 3
     - id: testManyArgsArrayReturn
       version: 0
       type: LOG_PROBE
@@ -985,6 +1378,53 @@ Probes:
           Type: 1299 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xd09462", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -999,6 +1439,13 @@ Probes:
           Type: 1201 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd055c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1013,6 +1460,13 @@ Probes:
           Type: 1208 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd05680", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1027,6 +1481,13 @@ Probes:
           Type: 1218 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xd057c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1041,6 +1502,13 @@ Probes:
           Type: 1220 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xd05800", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1055,6 +1523,13 @@ Probes:
           Type: 1219 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xd057e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1069,6 +1544,13 @@ Probes:
           Type: 1205 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd05640", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1083,6 +1565,13 @@ Probes:
           Type: 1217 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd057a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1097,6 +1586,13 @@ Probes:
           Type: 1216 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd05780", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1113,6 +1609,13 @@ Probes:
           Type: 1206 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1129,6 +1632,13 @@ Probes:
           Type: 1207 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1143,6 +1653,13 @@ Probes:
           Type: 1215 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd05760", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1157,6 +1674,13 @@ Probes:
           Type: 1214 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd05740", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1171,6 +1695,13 @@ Probes:
           Type: 1199 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd05580", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -1185,6 +1716,13 @@ Probes:
           Type: 1200 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd055a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -1199,6 +1737,13 @@ Probes:
           Type: 1198 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd05560", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -1213,6 +1758,13 @@ Probes:
           Type: 1209 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1227,6 +1779,13 @@ Probes:
           Type: 1212 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd05700", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -1241,6 +1800,13 @@ Probes:
           Type: 1213 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd05720", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -1255,6 +1821,13 @@ Probes:
           Type: 1210 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -1271,6 +1844,13 @@ Probes:
           Type: 1211 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -1285,6 +1865,13 @@ Probes:
           Type: 1330 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1300,6 +1887,13 @@ Probes:
           Type: 1331 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -1343,6 +1937,53 @@ Probes:
           Type: 1301 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xd0972b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -1365,6 +2006,18 @@ Probes:
           Type: 1305 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xd09936", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -1387,6 +2040,18 @@ Probes:
           Type: 1297 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xd0922a", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s1}, {s2}'
+        Segments:
+            - JSON: {Ref: s1}
+              DSL: s1
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s2}
+              DSL: s2
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1404,6 +2069,13 @@ Probes:
           Type: 1251 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -1432,6 +2104,33 @@ Probes:
           Type: 1222 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd07100", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1449,6 +2148,13 @@ Probes:
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd08395", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -1472,6 +2178,19 @@ Probes:
           Type: 1249 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd08395", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Parameter {i} * 2 = result {result}
+        Segments:
+            - 'Parameter '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ' * 2 = result '
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1491,6 +2210,18 @@ Probes:
           Type: 1230 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}, {a}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -1505,6 +2236,13 @@ Probes:
           Type: 1318 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -1524,6 +2262,18 @@ Probes:
           Type: 1315 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -1546,6 +2296,23 @@ Probes:
           Type: 1317 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {s}, {x}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -1560,6 +2327,13 @@ Probes:
           Type: 1329 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd0a540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -1574,6 +2348,13 @@ Probes:
           Type: 1226 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07520", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -1588,6 +2369,13 @@ Probes:
           Type: 1204 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -1602,6 +2390,13 @@ Probes:
           Type: 1224 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd074e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -1628,6 +2423,13 @@ Probes:
             - PC: "0xd0816c"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -1659,6 +2461,18 @@ Probes:
             - PC: "0xd07f59"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}, {failed}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -1676,6 +2490,9 @@ Probes:
           Type: 1271 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xd088ad", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArray
+        Segments: [testReturnsArray]
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
@@ -1693,6 +2510,9 @@ Probes:
           Type: 1273 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xd0890b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayOne
+        Segments: [testReturnsArrayOne]
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
@@ -1710,6 +2530,9 @@ Probes:
           Type: 1275 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xd08966", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayZero
+        Segments: [testReturnsArrayZero]
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
@@ -1727,6 +2550,9 @@ Probes:
           Type: 1279 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xd08a8a", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBacktrackInt
+        Segments: [testReturnsBacktrackInt]
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
@@ -1744,6 +2570,9 @@ Probes:
           Type: 1291 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xd08d90", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBoolAndUintptr
+        Segments: [testReturnsBoolAndUintptr]
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
@@ -1761,6 +2590,9 @@ Probes:
           Type: 1267 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xd08766", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsComplex
+        Segments: [testReturnsComplex]
     - id: testReturnsError
       version: 0
       type: LOG_PROBE
@@ -1783,6 +2615,13 @@ Probes:
             - PC: "0xd07e25"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{failed}'
+        Segments:
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -1800,6 +2639,13 @@ Probes:
           Type: 1233 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xd07c3b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -1817,6 +2663,13 @@ Probes:
           Type: 1237 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xd07dc4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -1834,6 +2687,13 @@ Probes:
           Type: 1235 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xd07cdb", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -1856,6 +2716,13 @@ Probes:
             - PC: "0xd0829b"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -1873,6 +2740,9 @@ Probes:
           Type: 1269 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xd08813", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsLargeStruct
+        Segments: [testReturnsLargeStruct]
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
@@ -1890,6 +2760,9 @@ Probes:
           Type: 1265 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xd086e5", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsManyFloats
+        Segments: [testReturnsManyFloats]
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
@@ -1907,6 +2780,9 @@ Probes:
           Type: 1283 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xd08bcc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixed
+        Segments: [testReturnsMixed]
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
@@ -1924,6 +2800,9 @@ Probes:
           Type: 1277 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xd089d8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixedStruct
+        Segments: [testReturnsMixedStruct]
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
@@ -1941,6 +2820,9 @@ Probes:
           Type: 1289 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xd08d16", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMultipleFloats
+        Segments: [testReturnsMultipleFloats]
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -1958,6 +2840,9 @@ Probes:
           Type: 1287 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xd08cae", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsOnlyFloat
+        Segments: [testReturnsOnlyFloat]
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
@@ -1975,6 +2860,9 @@ Probes:
           Type: 1263 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xd085f1", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsPrimitives
+        Segments: [testReturnsPrimitives]
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
@@ -1992,6 +2880,9 @@ Probes:
           Type: 1285 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xd08c4d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsStructWithArray
+        Segments: [testReturnsStructWithArray]
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
@@ -2009,6 +2900,9 @@ Probes:
           Type: 1281 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xd08b34", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsWideStruct
+        Segments: [testReturnsWideStruct]
     - id: testRuneArray
       version: 0
       type: LOG_PROBE
@@ -2023,6 +2917,13 @@ Probes:
           Type: 1125 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -2054,6 +2955,37 @@ Probes:
           Type: 1253 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
+        Segments:
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 4
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 5
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 2
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -2068,6 +3000,13 @@ Probes:
           Type: 1146 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -2082,6 +3021,13 @@ Probes:
           Type: 1144 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -2096,6 +3042,13 @@ Probes:
           Type: 1157 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat64
       version: 0
       type: LOG_PROBE
@@ -2110,6 +3063,13 @@ Probes:
           Type: 1158 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd035c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt
       version: 0
       type: LOG_PROBE
@@ -2124,6 +3084,13 @@ Probes:
           Type: 1147 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -2138,6 +3105,14 @@ Probes:
           Type: 1149 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -2152,6 +3127,13 @@ Probes:
           Type: 1150 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -2166,6 +3148,13 @@ Probes:
           Type: 1151 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -2187,6 +3176,22 @@ Probes:
           Type: 1148 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}{x}{x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -2201,6 +3206,13 @@ Probes:
           Type: 1145 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -2215,6 +3227,13 @@ Probes:
           Type: 1324 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd0a4c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -2229,6 +3248,13 @@ Probes:
           Type: 1152 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -2243,6 +3269,13 @@ Probes:
           Type: 1154 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -2257,6 +3290,13 @@ Probes:
           Type: 1155 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -2271,6 +3311,13 @@ Probes:
           Type: 1156 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -2285,6 +3332,13 @@ Probes:
           Type: 1153 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -2299,6 +3353,13 @@ Probes:
           Type: 1321 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -2313,6 +3374,13 @@ Probes:
           Type: 1312 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -2327,6 +3395,13 @@ Probes:
           Type: 1202 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2344,6 +3419,13 @@ Probes:
           Type: 1261 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0854e", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -2361,6 +3443,13 @@ Probes:
           Type: 1303 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xd0983c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -2375,6 +3464,13 @@ Probes:
           Type: 1126 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -2389,6 +3485,13 @@ Probes:
           Type: 1229 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd07660", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -2403,6 +3506,13 @@ Probes:
           Type: 1316 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -2417,6 +3527,13 @@ Probes:
           Type: 1168 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -2431,6 +3548,13 @@ Probes:
           Type: 1169 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -2449,6 +3573,13 @@ Probes:
           Type: 1338 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd0a882", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -2468,6 +3599,18 @@ Probes:
           Type: 1313 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -2482,6 +3625,13 @@ Probes:
           Type: 1196 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xd04ee0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -2499,6 +3649,13 @@ Probes:
           Type: 1307 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xd09a1a", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -2516,6 +3673,13 @@ Probes:
           Type: 1336 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd0a73e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -2529,6 +3693,13 @@ Probes:
           Type: 1334 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd0a700", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -2543,6 +3714,13 @@ Probes:
           Type: 1197 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -2562,6 +3740,11 @@ Probes:
           Type: 1255 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{nonexistentVariable}'
+        Segments:
+            - Error: failed to resolve reference "nonexistentVariable"
+              DSL: nonexistentVariable
     - id: testTemplateWithUnsupportedExpression
       version: 0
       type: LOG_PROBE
@@ -2581,6 +3764,11 @@ Probes:
           Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{unsupportedExpression}'
+        Segments:
+            - Error: 'unsupported operation: foobar'
+              DSL: unsupportedExpression
     - id: testTemplateWithUnsupportedVariable
       version: 0
       type: LOG_PROBE
@@ -2602,6 +3790,13 @@ Probes:
           Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
+        Segments:
+            - 'Executed main.testMultipleNamedReturn, it took '
+            - Error: failed to resolve reference "@duration"
+              DSL: '@duration'
+            - ms
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
@@ -2624,6 +3819,23 @@ Probes:
           Type: 1325 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd0a4e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}, {z}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -2642,6 +3854,13 @@ Probes:
           Type: 1327 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a51e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testThreeStringsInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2656,6 +3875,13 @@ Probes:
           Type: 1328 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a520", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -2670,6 +3896,13 @@ Probes:
           Type: 1159 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -2684,6 +3917,13 @@ Probes:
           Type: 1135 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -2698,6 +3938,13 @@ Probes:
           Type: 1136 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -2712,6 +3959,13 @@ Probes:
           Type: 1137 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -2726,6 +3980,13 @@ Probes:
           Type: 1134 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -2740,6 +4001,13 @@ Probes:
           Type: 1133 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -2754,6 +4022,13 @@ Probes:
           Type: 1228 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd07580", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -2768,6 +4043,13 @@ Probes:
           Type: 1310 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd09fe0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -2782,6 +4064,13 @@ Probes:
           Type: 1332 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -2796,6 +4085,13 @@ Probes:
           Type: 1227 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd07540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -2810,6 +4106,13 @@ Probes:
           Type: 1143 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03080", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -2824,6 +4127,13 @@ Probes:
           Type: 1319 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2838,6 +4148,13 @@ Probes:
           Type: 1320 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -2860,6 +4177,18 @@ Probes:
           Type: 1309 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09acc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -9031,12 +10360,22 @@ Types:
     - __kind: EventRootType
       ID: 1194
       Name: Probe[main.testAnyPtr]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 158 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 158 PointerType *interface {}
             Operations:
@@ -9063,12 +10402,22 @@ Types:
     - __kind: EventRootType
       ID: 1191
       Name: Probe[main.testAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -9095,12 +10444,22 @@ Types:
     - __kind: EventRootType
       ID: 1294
       Name: Probe[main.testArrayArgAndReturn]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -9140,10 +10499,20 @@ Types:
                   Variable: {subprogram: 19, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 117 ArrayType [2]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 19, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1140
       Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -9156,10 +10525,20 @@ Types:
                   Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
+        - Name: b
+          Offset: 65
+          Kind: template_segment
+          Expression:
+            Type: 114 ArrayType [2][2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 64
     - __kind: EventRootType
       ID: 1138
       Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9172,10 +10551,20 @@ Types:
                   Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 113 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 15, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1203
       Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -9188,10 +10577,20 @@ Types:
                   Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
+        - Name: m
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 186 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1139
       Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9204,10 +10603,20 @@ Types:
                   Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 104 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1141
       Name: Probe[main.testArrayOfStructs]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9220,15 +10629,35 @@ Types:
                   Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 115 ArrayType [2]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 1160
       Name: Probe[main.testBigStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 121 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: b
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 121 StructureType main.bigStruct
             Operations:
@@ -9242,7 +10671,7 @@ Types:
     - __kind: EventRootType
       ID: 1127
       Name: Probe[main.testBoolArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9255,15 +10684,35 @@ Types:
                   Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 105 ArrayType [2]bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1124
       Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 102 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -9287,10 +10736,20 @@ Types:
                   Variable: {subprogram: 85, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 238 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1221
       Name: Probe[main.testCombinedByte]
-      ByteSize: 7
+      ByteSize: 13
       PresenceBitsetSize: 1
       Expressions:
         - Name: w
@@ -9303,8 +10762,18 @@ Types:
                   Variable: {subprogram: 83, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
-        - Name: x
+        - Name: w
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -9313,9 +10782,29 @@ Types:
                   Variable: {subprogram: 83, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
         - Name: y
-          Offset: 3
+          Offset: 5
           Kind: argument
+          Expression:
+            Type: 16 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: y
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 16 BaseType float32
             Operations:
@@ -9326,7 +10815,7 @@ Types:
     - __kind: EventRootType
       ID: 1231
       Name: Probe[main.testCycle]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: t
@@ -9339,10 +10828,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
+        - Name: t
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 243 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1166
       Name: Probe[main.testDeepMap1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9355,10 +10854,20 @@ Types:
                   Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 136 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1167
       Name: Probe[main.testDeepMap7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9371,10 +10880,20 @@ Types:
                   Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 144 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1162
       Name: Probe[main.testDeepPtr1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9387,10 +10906,20 @@ Types:
                   Variable: {subprogram: 38, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 125 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1163
       Name: Probe[main.testDeepPtr7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9403,10 +10932,20 @@ Types:
                   Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 128 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1164
       Name: Probe[main.testDeepSlice1]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9419,10 +10958,20 @@ Types:
                   Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 130 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1165
       Name: Probe[main.testDeepSlice7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9435,10 +10984,20 @@ Types:
                   Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 134 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1314
       Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -9451,9 +11010,29 @@ Types:
                   Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9464,7 +11043,7 @@ Types:
     - __kind: EventRootType
       ID: 1311
       Name: Probe[main.testEmptySlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -9477,10 +11056,20 @@ Types:
                   Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 129, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1333
       Name: Probe[main.testEmptyString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9493,15 +11082,35 @@ Types:
                   Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 147, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1340
       Name: Probe[main.testEmptyStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 313 PointerType *main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 313 PointerType *main.emptyStruct
             Operations:
@@ -9525,10 +11134,20 @@ Types:
                   Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
+        - Name: e
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 312 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1193
       Name: Probe[main.testError]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
@@ -9541,15 +11160,35 @@ Types:
                   Variable: {subprogram: 57, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: e
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 57, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1175
       Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 154 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 154 PointerType *main.esotericHeap
             Operations:
@@ -9563,12 +11202,22 @@ Types:
     - __kind: EventRootType
       ID: 1173
       Name: Probe[main.testEsotericStack]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 150 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+        - Name: e
+          Offset: 65
+          Kind: template_segment
           Expression:
             Type: 150 StructureType main.esotericStack
             Operations:
@@ -9582,7 +11231,7 @@ Types:
     - __kind: EventRootType
       ID: 1187
       Name: Probe[main.testFramelessArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9595,10 +11244,20 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1189
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 49
+      ByteSize: 89
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9611,8 +11270,18 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-        - Name: ~r0
+        - Name: a
           Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 81
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -9640,12 +11309,22 @@ Types:
     - __kind: EventRootType
       ID: 1185
       Name: Probe[main.testFrameless]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9672,12 +11351,22 @@ Types:
     - __kind: EventRootType
       ID: 1177
       Name: Probe[main.testInlinedBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9691,12 +11380,22 @@ Types:
     - __kind: EventRootType
       ID: 1181
       Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9713,7 +11412,7 @@ Types:
     - __kind: EventRootType
       ID: 1179
       Name: Probe[main.testInlinedBB]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9726,9 +11425,29 @@ Types:
                   Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: y
+        - Name: x
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9760,7 +11479,7 @@ Types:
     - __kind: EventRootType
       ID: 1341
       Name: Probe[main.testInlinedPrint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9773,15 +11492,35 @@ Types:
                   Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1343
       Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9795,7 +11534,7 @@ Types:
     - __kind: EventRootType
       ID: 1349
       Name: Probe[main.testInlinedSq]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9808,10 +11547,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1350
       Name: Probe[main.testInlinedSq]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9824,10 +11573,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1351
       Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9840,10 +11599,20 @@ Types:
                   Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1130
       Name: Probe[main.testInt16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9856,10 +11625,20 @@ Types:
                   Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 108 ArrayType [2]int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1131
       Name: Probe[main.testInt32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9872,10 +11651,20 @@ Types:
                   Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 103 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1132
       Name: Probe[main.testInt64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9888,10 +11677,20 @@ Types:
                   Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 109 ArrayType [2]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1129
       Name: Probe[main.testInt8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9904,10 +11703,20 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 107 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1128
       Name: Probe[main.testIntArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9920,10 +11729,20 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1190
       Name: Probe[main.testInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -9936,15 +11755,35 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 157 GoInterfaceType main.behavior
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1292
       Name: Probe[main.testLargeArgAndReturn]
-      ByteSize: 81
+      ByteSize: 161
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: arg
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -9971,12 +11810,22 @@ Types:
     - __kind: EventRootType
       ID: 1225
       Name: Probe[main.testLinkedList]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 241 StructureType main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 241 StructureType main.node
             Operations:
@@ -10016,7 +11865,7 @@ Types:
     - __kind: EventRootType
       ID: 1172
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10029,9 +11878,29 @@ Types:
                   Variable: {subprogram: 46, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: a
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
           Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -10042,11 +11911,11 @@ Types:
     - __kind: EventRootType
       ID: 1298
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 74
-      PresenceBitsetSize: 2
+      ByteSize: 147
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10055,8 +11924,18 @@ Types:
                   Variable: {subprogram: 122, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10065,8 +11944,18 @@ Types:
                   Variable: {subprogram: 122, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10075,8 +11964,18 @@ Types:
                   Variable: {subprogram: 122, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10085,8 +11984,18 @@ Types:
                   Variable: {subprogram: 122, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10095,8 +12004,18 @@ Types:
                   Variable: {subprogram: 122, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10105,8 +12024,18 @@ Types:
                   Variable: {subprogram: 122, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10115,8 +12044,18 @@ Types:
                   Variable: {subprogram: 122, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10125,9 +12064,29 @@ Types:
                   Variable: {subprogram: 122, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 139
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -10154,7 +12113,7 @@ Types:
     - __kind: EventRootType
       ID: 1201
       Name: Probe[main.testMapArrayToArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10167,10 +12126,20 @@ Types:
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 181 GoMapType map[[4]string][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1208
       Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10183,10 +12152,20 @@ Types:
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1220
       Name: Probe[main.testMapEmptyKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10199,10 +12178,20 @@ Types:
                   Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 233 GoMapType map[struct {}]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 82, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1218
       Name: Probe[main.testMapEmptyKey]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10215,10 +12204,20 @@ Types:
                   Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 223 GoMapType map[struct {}]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1219
       Name: Probe[main.testMapEmptyValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10231,10 +12230,20 @@ Types:
                   Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 228 GoMapType map[int]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1205
       Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10247,10 +12256,20 @@ Types:
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 161 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 68, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1217
       Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10263,10 +12282,20 @@ Types:
                   Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 218 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1216
       Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10279,15 +12308,35 @@ Types:
                   Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 213 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1206
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -10298,7 +12347,7 @@ Types:
     - __kind: EventRootType
       ID: 1207
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10311,10 +12360,20 @@ Types:
                   Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1215
       Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10327,10 +12386,20 @@ Types:
                   Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1214
       Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10343,10 +12412,20 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1199
       Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10359,10 +12438,20 @@ Types:
                   Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1200
       Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10375,10 +12464,20 @@ Types:
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1198
       Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10391,10 +12490,20 @@ Types:
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 166 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1209
       Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10407,10 +12516,20 @@ Types:
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1213
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10423,10 +12542,20 @@ Types:
                   Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1212
       Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10439,10 +12568,20 @@ Types:
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 74, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1211
       Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10455,10 +12594,20 @@ Types:
                   Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1210
       Name: Probe[main.testMapWithSmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10471,15 +12620,35 @@ Types:
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1330
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -10490,7 +12659,7 @@ Types:
     - __kind: EventRootType
       ID: 1331
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10503,14 +12672,24 @@ Types:
                   Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1300
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 163
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10519,8 +12698,18 @@ Types:
                   Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10529,8 +12718,18 @@ Types:
                   Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10539,8 +12738,18 @@ Types:
                   Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10549,8 +12758,18 @@ Types:
                   Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10559,8 +12778,18 @@ Types:
                   Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10569,8 +12798,18 @@ Types:
                   Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10579,8 +12818,18 @@ Types:
                   Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10589,9 +12838,29 @@ Types:
                   Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: s
+          Offset: 147
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -10618,7 +12887,7 @@ Types:
     - __kind: EventRootType
       ID: 1304
       Name: Probe[main.testMultipleArrayArgs]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10631,9 +12900,29 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
-        - Name: b
+        - Name: a
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: b
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -10670,7 +12959,7 @@ Types:
     - __kind: EventRootType
       ID: 1296
       Name: Probe[main.testMultipleLargeArgs]
-      ByteSize: 161
+      ByteSize: 321
       PresenceBitsetSize: 1
       Expressions:
         - Name: s1
@@ -10683,9 +12972,29 @@ Types:
                   Variable: {subprogram: 121, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
-        - Name: s2
+        - Name: s1
           Offset: 81
+          Kind: template_segment
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 161
           Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 241
+          Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -10712,7 +13021,7 @@ Types:
     - __kind: EventRootType
       ID: 1250
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -10725,15 +13034,55 @@ Types:
                   Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1252
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -10818,7 +13167,7 @@ Types:
     - __kind: EventRootType
       ID: 1253
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -10831,9 +13180,49 @@ Types:
                   Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
+        - Name: result
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 25
           Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -10922,11 +13311,11 @@ Types:
     - __kind: EventRootType
       ID: 1222
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 62
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -10935,8 +13324,18 @@ Types:
                   Variable: {subprogram: 84, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
+        - Name: a
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
         - Name: b
-          Offset: 2
+          Offset: 4
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -10945,8 +13344,18 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
+        - Name: b
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
         - Name: c
-          Offset: 3
+          Offset: 6
           Kind: argument
           Expression:
             Type: 12 BaseType int32
@@ -10955,8 +13364,18 @@ Types:
                   Variable: {subprogram: 84, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
+        - Name: c
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
         - Name: d
-          Offset: 7
+          Offset: 14
           Kind: argument
           Expression:
             Type: 15 BaseType uint
@@ -10965,9 +13384,29 @@ Types:
                   Variable: {subprogram: 84, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 22
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 15
+          Offset: 30
           Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: e
+          Offset: 46
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -10978,7 +13417,7 @@ Types:
     - __kind: EventRootType
       ID: 1246
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -10991,15 +13430,35 @@ Types:
                   Variable: {subprogram: 101, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1248
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11026,7 +13485,7 @@ Types:
     - __kind: EventRootType
       ID: 1249
       Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11039,10 +13498,20 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
+        - Name: result
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1230
       Name: Probe[main.testNilPointer]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -11055,9 +13524,29 @@ Types:
                   Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: z
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 5 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 15 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -11068,7 +13557,7 @@ Types:
     - __kind: EventRootType
       ID: 1315
       Name: Probe[main.testNilSliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11081,9 +13570,29 @@ Types:
                   Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11094,7 +13603,7 @@ Types:
     - __kind: EventRootType
       ID: 1317
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 34
+      ByteSize: 67
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11107,8 +13616,18 @@ Types:
                   Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: s
+        - Name: a
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 3
           Kind: argument
           Expression:
             Type: 259 GoSliceHeaderType []bool
@@ -11117,9 +13636,29 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 259 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
-          Offset: 26
+          Offset: 51
           Kind: argument
+          Expression:
+            Type: 15 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 59
+          Kind: template_segment
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -11130,7 +13669,7 @@ Types:
     - __kind: EventRootType
       ID: 1318
       Name: Probe[main.testNilSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11143,10 +13682,20 @@ Types:
                   Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 260 GoSliceHeaderType []uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1329
       Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11159,10 +13708,20 @@ Types:
                   Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 265 PointerType *main.oneStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 144, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1226
       Name: Probe[main.testPointerLoop]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11175,10 +13734,20 @@ Types:
                   Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 242 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1204
       Name: Probe[main.testPointerToMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11191,10 +13760,20 @@ Types:
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 187 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 67, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1224
       Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11207,10 +13786,20 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 239 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1240
       Name: Probe[main.testReturnsAnyAndError]
-      ByteSize: 18
+      ByteSize: 35
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -11223,9 +13812,29 @@ Types:
                   Variable: {subprogram: 98, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
-        - Name: failed
+        - Name: v
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: failed
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11262,12 +13871,22 @@ Types:
     - __kind: EventRootType
       ID: 1242
       Name: Probe[main.testReturnsAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -11508,12 +14127,22 @@ Types:
     - __kind: EventRootType
       ID: 1238
       Name: Probe[main.testReturnsError]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: failed
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11540,12 +14169,22 @@ Types:
     - __kind: EventRootType
       ID: 1236
       Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11582,12 +14221,22 @@ Types:
     - __kind: EventRootType
       ID: 1234
       Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11614,12 +14263,22 @@ Types:
     - __kind: EventRootType
       ID: 1232
       Name: Probe[main.testReturnsInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11646,12 +14305,22 @@ Types:
     - __kind: EventRootType
       ID: 1244
       Name: Probe[main.testReturnsInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -12129,7 +14798,7 @@ Types:
     - __kind: EventRootType
       ID: 1125
       Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12142,10 +14811,20 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 103 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1146
       Name: Probe[main.testSingleBool]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12158,10 +14837,20 @@ Types:
                   Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1144
       Name: Probe[main.testSingleByte]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12174,10 +14863,20 @@ Types:
                   Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1157
       Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12190,10 +14889,20 @@ Types:
                   Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1158
       Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12206,10 +14915,20 @@ Types:
                   Variable: {subprogram: 35, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1149
       Name: Probe[main.testSingleInt16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12222,10 +14941,20 @@ Types:
                   Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 97 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1150
       Name: Probe[main.testSingleInt32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12238,10 +14967,20 @@ Types:
                   Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1151
       Name: Probe[main.testSingleInt64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12254,10 +14993,20 @@ Types:
                   Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 13 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1148
       Name: Probe[main.testSingleInt8]
-      ByteSize: 2
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12270,10 +15019,40 @@ Types:
                   Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1147
       Name: Probe[main.testSingleInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12286,10 +15065,20 @@ Types:
                   Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1145
       Name: Probe[main.testSingleRune]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12302,10 +15091,20 @@ Types:
                   Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1324
       Name: Probe[main.testSingleString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12318,10 +15117,20 @@ Types:
                   Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1154
       Name: Probe[main.testSingleUint16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12334,10 +15143,20 @@ Types:
                   Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1155
       Name: Probe[main.testSingleUint32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12350,10 +15169,20 @@ Types:
                   Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1156
       Name: Probe[main.testSingleUint64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12366,10 +15195,20 @@ Types:
                   Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1153
       Name: Probe[main.testSingleUint8]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12382,10 +15221,20 @@ Types:
                   Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1152
       Name: Probe[main.testSingleUint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12398,10 +15247,20 @@ Types:
                   Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1321
       Name: Probe[main.testSliceEmptyStructs]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -12414,10 +15273,20 @@ Types:
                   Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 261 GoSliceHeaderType []struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1312
       Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -12430,10 +15299,20 @@ Types:
                   Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 253 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1202
       Name: Probe[main.testSmallMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -12446,15 +15325,35 @@ Types:
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 65, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1260
       Name: Probe[main.testSomeNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12501,12 +15400,22 @@ Types:
     - __kind: EventRootType
       ID: 1302
       Name: Probe[main.testStackArgRegReturns]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: arg
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12553,7 +15462,7 @@ Types:
     - __kind: EventRootType
       ID: 1126
       Name: Probe[main.testStringArray]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12566,10 +15475,20 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
+        - Name: x
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 104 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1229
       Name: Probe[main.testStringPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -12582,10 +15501,20 @@ Types:
                   Variable: {subprogram: 91, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 88 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1316
       Name: Probe[main.testStringSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -12598,10 +15527,20 @@ Types:
                   Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1168
       Name: Probe[main.testStringType1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12614,10 +15553,20 @@ Types:
                   Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 146 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1169
       Name: Probe[main.testStringType2]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12630,10 +15579,20 @@ Types:
                   Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 148 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1313
       Name: Probe[main.testStructSlice]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -12646,9 +15605,29 @@ Types:
                   Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12659,7 +15638,7 @@ Types:
     - __kind: EventRootType
       ID: 1196
       Name: Probe[main.testStructWithAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -12672,15 +15651,35 @@ Types:
                   Variable: {subprogram: 59, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: s
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 159 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1306
       Name: Probe[main.testStructWithArrayArg]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 251 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 251 StructureType main.structWithArray
             Operations:
@@ -12717,12 +15716,22 @@ Types:
     - __kind: EventRootType
       ID: 1335
       Name: Probe[main.testStructWithCyclicMaps]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 280 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
@@ -12736,7 +15745,7 @@ Types:
     - __kind: EventRootType
       ID: 1334
       Name: Probe[main.testStructWithCyclicSlices]
-      ByteSize: 145
+      ByteSize: 289
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12749,10 +15758,20 @@ Types:
                   Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
+        - Name: a
+          Offset: 145
+          Kind: template_segment
+          Expression:
+            Type: 267 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 148, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
     - __kind: EventRootType
       ID: 1197
       Name: Probe[main.testStructWithMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -12765,15 +15784,35 @@ Types:
                   Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
+        - Name: s
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 160 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testStruct]
-      ByteSize: 57
+      ByteSize: 113
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 311 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 150, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+        - Name: x
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 311 StructureType main.aStruct
             Operations:
@@ -12787,7 +15826,7 @@ Types:
     - __kind: EventRootType
       ID: 1328
       Name: Probe[main.testThreeStringsInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12800,15 +15839,35 @@ Types:
                   Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 264 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 143, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1326
       Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 263 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 263 StructureType main.threeStringStruct
             Operations:
@@ -12822,7 +15881,7 @@ Types:
     - __kind: EventRootType
       ID: 1325
       Name: Probe[main.testThreeStrings]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12835,8 +15894,18 @@ Types:
                   Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-        - Name: y
+        - Name: x
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 33
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -12845,9 +15914,29 @@ Types:
                   Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
+        - Name: y
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
-          Offset: 33
+          Offset: 65
           Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 2, name: z}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: z
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -12858,7 +15947,7 @@ Types:
     - __kind: EventRootType
       ID: 1159
       Name: Probe[main.testTypeAlias]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12871,10 +15960,20 @@ Types:
                   Variable: {subprogram: 36, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 120 BaseType main.typeAlias
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1135
       Name: Probe[main.testUint16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12887,10 +15986,20 @@ Types:
                   Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1136
       Name: Probe[main.testUint32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12903,10 +16012,20 @@ Types:
                   Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 112 ArrayType [2]uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 13, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1137
       Name: Probe[main.testUint64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12919,10 +16038,20 @@ Types:
                   Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 52 ArrayType [2]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 14, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1134
       Name: Probe[main.testUint8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12935,10 +16064,20 @@ Types:
                   Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 102 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1133
       Name: Probe[main.testUintArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12951,10 +16090,20 @@ Types:
                   Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 110 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1228
       Name: Probe[main.testUintPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12967,10 +16116,20 @@ Types:
                   Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 100 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1310
       Name: Probe[main.testUintSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -12983,10 +16142,20 @@ Types:
                   Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1332
       Name: Probe[main.testUnitializedString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12999,10 +16168,20 @@ Types:
                   Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 146, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1227
       Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13015,10 +16194,20 @@ Types:
                   Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 19 VoidPointerType unsafe.Pointer
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1143
       Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
+      ByteSize: 1601
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13031,15 +16220,35 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
+        - Name: a
+          Offset: 801
+          Kind: template_segment
+          Expression:
+            Type: 119 ArrayType [100]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 20, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 800
     - __kind: EventRootType
       ID: 1319
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -13050,7 +16259,7 @@ Types:
     - __kind: EventRootType
       ID: 1320
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13063,10 +16272,20 @@ Types:
                   Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1308
       Name: Probe[main.testZeroSizeArgAndReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13079,9 +16298,29 @@ Types:
                   Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -5,17 +5,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: stackC
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.stackC]
+          Type: 1497 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcdb8aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.stackC]Return
+          Type: 1498 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcdb8e5", Frameless: false}]
           Condition: null
     - id: testAny
@@ -23,8 +23,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -41,8 +41,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -58,17 +58,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1469 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcda36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1470 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda422", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -76,8 +76,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -90,8 +90,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -104,8 +104,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -118,8 +118,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -132,8 +132,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -145,8 +145,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -159,8 +159,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -177,8 +177,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -191,8 +191,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -205,8 +205,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -219,8 +219,16 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{w}, {x}, {y}'
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -233,8 +241,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{t}'
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -247,8 +255,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -261,8 +269,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -275,8 +283,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -289,8 +297,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -303,8 +311,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -317,8 +325,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -331,13 +339,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testEmptySlice]
+          Type: 1486 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdb440", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -345,13 +353,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1489 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -360,13 +373,13 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptyString]
+          Type: 1508 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -374,26 +387,26 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testEmptyStruct]
+          Type: 1514 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcdbe20", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1515 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcdbe40", Frameless: true}]
           Condition: null
     - id: testError
@@ -401,8 +414,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -415,8 +428,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -433,8 +446,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -451,8 +464,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -469,8 +482,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -490,8 +503,8 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -504,8 +517,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -522,8 +535,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -540,8 +558,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -558,13 +576,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBBB
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testInlinedBBB]
+          Type: 1519 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -572,8 +590,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBC
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -590,13 +608,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testInlinedBCA]
+          Type: 1520 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -607,13 +625,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Line
-          Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1521 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -621,13 +639,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testInlinedBCB]
+          Type: 1522 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -638,13 +656,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Line
-          Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1523 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -653,13 +671,13 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.testInlinedPrint]
+          Type: 1516 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd592a"
               Frameless: false
@@ -673,7 +691,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1517 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -684,13 +702,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Line
-          Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1518 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -708,13 +726,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testInlinedSq]
+          Type: 1524 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -725,13 +743,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1515 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1525 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -740,13 +758,13 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1526 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5e25"
               Frameless: false
@@ -758,8 +776,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -772,8 +790,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -786,8 +804,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -800,8 +818,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -814,8 +832,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -828,8 +846,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -841,17 +859,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1467 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcda1ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1468 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda333", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -859,8 +877,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -876,8 +894,8 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -893,8 +911,8 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -910,8 +928,13 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a} and {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -923,17 +946,43 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1473 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcda693", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1474 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcda8a2", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -941,8 +990,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -955,8 +1004,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -969,8 +1018,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -983,8 +1032,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -997,8 +1046,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1011,8 +1060,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1025,8 +1074,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1039,8 +1088,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1053,8 +1102,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1067,8 +1118,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1081,8 +1134,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1095,8 +1148,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1109,8 +1162,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1123,8 +1176,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1137,8 +1190,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1151,8 +1204,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1165,8 +1218,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1179,8 +1232,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1193,8 +1246,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1207,8 +1260,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1221,13 +1276,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMassiveString]
+          Type: 1505 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1236,81 +1291,117 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testMassiveString]
+          Type: 1506 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1475 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcda933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1476 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdab6b", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1479 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdacae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1480 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdad7e", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
-      template: ""
-      segments: []
+      template: '{s1}, {s2}'
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1471 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1472 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcda66a", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1318,8 +1409,22 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1331,8 +1436,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1344,13 +1449,41 @@ Probes:
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      template: Parameter {i} * 2 = result {result}
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - Kind: Entry
+          Type: 1423 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd974a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1424 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}, {a}'
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1363,13 +1496,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testNilSlice]
+          Type: 1493 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1377,13 +1510,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1490 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1391,13 +1529,21 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {s}, {x}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1492 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1405,13 +1551,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1504 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdb980", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1419,8 +1565,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1433,8 +1579,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1447,8 +1593,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1461,8 +1607,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1487,8 +1633,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}, {failed}'
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1512,102 +1663,102 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
-      template: ""
-      segments: []
+      template: testReturnsArray
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsArray]
+          Type: 1445 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcd9c6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1446 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcd9ccd", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
-      template: ""
-      segments: []
+      template: testReturnsArrayOne
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1447 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcd9cea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1448 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcd9d2b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
-      template: ""
-      segments: []
+      template: testReturnsArrayZero
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1449 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcd9d4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1450 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcd9d86", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
-      template: ""
-      segments: []
+      template: testReturnsBacktrackInt
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1453 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcd9e2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1454 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcd9eaa", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
-      template: ""
-      segments: []
+      template: testReturnsBoolAndUintptr
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1465 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcda16a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1466 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcda1b0", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
-      template: ""
-      segments: []
+      template: testReturnsComplex
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsComplex]
+          Type: 1441 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcd9b2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1442 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1615,8 +1766,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{failed}'
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1636,8 +1787,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1653,8 +1804,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1670,8 +1821,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1688,8 +1839,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1709,153 +1860,153 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
-      template: ""
-      segments: []
+      template: testReturnsLargeStruct
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1443 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1444 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcd9c33", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
-      template: ""
-      segments: []
+      template: testReturnsManyFloats
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1439 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcd9a2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1440 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcd9b07", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
-      template: ""
-      segments: []
+      template: testReturnsMixed
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsMixed]
+          Type: 1457 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcd9f8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1458 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcd9fec", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
-      template: ""
-      segments: []
+      template: testReturnsMixedStruct
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1451 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcd9daa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1452 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcd9df8", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
-      template: ""
-      segments: []
+      template: testReturnsMultipleFloats
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1463 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcda0ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1464 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcda136", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
-      template: ""
-      segments: []
+      template: testReturnsOnlyFloat
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1461 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcda08a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1462 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcda0ce", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
-      template: ""
-      segments: []
+      template: testReturnsPrimitives
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1437 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcd99aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1438 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcd9a11", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
-      template: ""
-      segments: []
+      template: testReturnsStructWithArray
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1459 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcda00a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1460 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcda06d", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
-      template: ""
-      segments: []
+      template: testReturnsWideStruct
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1455 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcd9ece", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1456 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcd9f54", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -1863,8 +2014,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -1872,13 +2023,44 @@ Probes:
           Type: 1300 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
+    - id: testSegmentsForParamsAndReturnsOutOfOrder
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{result2}{i}{result}{i}{i}{result2}{result}'
+      segments:
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result}
+          dsl: result
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1427 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1428 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Condition: null
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -1891,8 +2073,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -1905,8 +2087,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -1919,8 +2101,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -1933,8 +2115,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -1947,8 +2129,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -1961,8 +2143,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -1975,8 +2157,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -1989,8 +2171,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}{x}{x}
+      segments:
+        - 'parameter = '
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2003,8 +2192,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2017,13 +2206,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testSingleString]
+          Type: 1499 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdb900", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2031,8 +2220,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2045,8 +2234,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2059,8 +2248,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2073,8 +2262,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2087,8 +2276,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2101,13 +2290,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1496 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2115,13 +2304,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1487 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2129,8 +2318,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2142,34 +2331,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1435 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd98ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1436 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd996b", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1477 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdac0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1478 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdac7c", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2177,8 +2366,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2191,8 +2380,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}'
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2205,13 +2394,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testStringSlice]
+          Type: 1491 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2219,8 +2408,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2233,8 +2422,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2247,17 +2436,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testStruct]
+          Type: 1512 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcdbca0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1503 EventRootType Probe[main.testStruct]Return
+          Type: 1513 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcdbcc2", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2265,13 +2454,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testStructSlice]
+          Type: 1488 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2279,8 +2473,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2292,47 +2486,47 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1481 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdadae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1482 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdae5a", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1510 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcdbb60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1511 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcdbb7e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1509 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcdbb40", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2340,8 +2534,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2349,18 +2543,85 @@ Probes:
           Type: 1372 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
           Condition: null
+    - id: testTemplateWithNonexistantVariableName
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{nonexistentVariable}'
+      segments:
+        - json: {ref: nonexistentVariable}
+          dsl: nonexistentVariable
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1429 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedExpression
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{unsupportedExpression}'
+      segments:
+        - json: {foobar: unsupportedExpression}
+          dsl: unsupportedExpression
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1431 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedVariable
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: Executed main.testMultipleNamedReturn, it took {@duration}ms
+      segments:
+        - 'Executed main.testMultipleNamedReturn, it took '
+        - json: {ref: '@duration'}
+          dsl: '@duration'
+        - ms
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Condition: null
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}, {z}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testThreeStrings]
+          Type: 1500 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdb920", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2368,17 +2629,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1501 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdb940", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1502 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdb95e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2386,13 +2647,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1503 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdb960", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2400,8 +2661,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2414,8 +2675,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2428,8 +2689,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2442,8 +2703,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2456,8 +2717,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2470,8 +2731,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2484,8 +2745,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2498,13 +2759,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testUintSlice]
+          Type: 1485 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdb420", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2512,13 +2773,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testUnitializedString]
+          Type: 1507 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2526,8 +2787,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2540,8 +2801,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2554,13 +2815,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1494 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2568,30 +2829,35 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1495 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1483 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdae8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1484 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdaf0c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9049,10 +9315,10 @@ Types:
       GoKind: 22
       Pointee: 808 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1487
+      ID: 1497
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1498
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9132,7 +9398,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1459
+      ID: 1469
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9148,7 +9414,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1460
+      ID: 1470
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9475,7 +9741,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1489
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9501,7 +9767,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1476
+      ID: 1486
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9517,7 +9783,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1508
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9533,7 +9799,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1515
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9549,7 +9815,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1504
+      ID: 1514
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9747,7 +10013,7 @@ Types:
       ID: 1357
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1519
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1354
@@ -9779,16 +10045,16 @@ Types:
       ID: 1355
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1520
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1511
+      ID: 1521
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1512
+      ID: 1522
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1513
+      ID: 1523
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1358
@@ -9797,7 +10063,7 @@ Types:
       ID: 1359
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1516
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9813,7 +10079,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1518
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9829,10 +10095,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1507
+      ID: 1517
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1524
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9848,7 +10114,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1525
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9864,7 +10130,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1526
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -9976,7 +10242,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1457
+      ID: 1467
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -9992,7 +10258,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1458
+      ID: 1468
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10079,7 +10345,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1473
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10175,7 +10441,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1474
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10511,7 +10777,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1505
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10527,7 +10793,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1496
+      ID: 1506
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10543,7 +10809,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1465
+      ID: 1475
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10639,7 +10905,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1466
+      ID: 1476
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10655,7 +10921,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1469
+      ID: 1479
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10681,7 +10947,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1470
+      ID: 1480
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10707,7 +10973,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1461
+      ID: 1471
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10733,7 +10999,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1462
+      ID: 1472
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10749,7 +11015,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10765,7 +11031,175 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1427
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1429
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1431
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1426
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1428
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1430
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1432
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1434
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10863,7 +11297,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1422
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1424
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10905,7 +11371,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1490
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10931,7 +11397,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1492
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -10967,7 +11433,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1493
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10983,7 +11449,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1504
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11131,10 +11597,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1437
+      ID: 1447
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1438
+      ID: 1448
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11150,10 +11616,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1449
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1450
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11169,10 +11635,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1435
+      ID: 1445
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1436
+      ID: 1446
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11188,10 +11654,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1443
+      ID: 1453
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1444
+      ID: 1454
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11287,10 +11753,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1455
+      ID: 1465
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1466
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11316,10 +11782,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1441
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1432
+      ID: 1442
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11515,10 +11981,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1433
+      ID: 1443
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1434
+      ID: 1444
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11534,10 +12000,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1429
+      ID: 1439
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1430
+      ID: 1440
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11713,10 +12179,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1451
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1442
+      ID: 1452
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11732,10 +12198,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1447
+      ID: 1457
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1448
+      ID: 1458
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11791,10 +12257,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1453
+      ID: 1463
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1454
+      ID: 1464
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11820,10 +12286,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1461
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1462
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11839,10 +12305,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1437
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1428
+      ID: 1438
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -11928,10 +12394,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1449
+      ID: 1459
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1450
+      ID: 1460
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11947,10 +12413,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1445
+      ID: 1455
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1446
+      ID: 1456
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12142,7 +12608,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1489
+      ID: 1499
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12238,7 +12704,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1496
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12254,7 +12720,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1477
+      ID: 1487
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12286,7 +12752,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1435
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12302,7 +12768,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1426
+      ID: 1436
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12338,7 +12804,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1467
+      ID: 1477
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12354,7 +12820,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1468
+      ID: 1478
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12422,7 +12888,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1481
+      ID: 1491
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12470,7 +12936,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1478
+      ID: 1488
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12512,7 +12978,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1481
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12528,7 +12994,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1472
+      ID: 1482
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12554,7 +13020,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1500
+      ID: 1510
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12570,10 +13036,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1501
+      ID: 1511
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1499
+      ID: 1509
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12605,7 +13071,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1512
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12621,10 +13087,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1503
+      ID: 1513
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1493
+      ID: 1503
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12640,7 +13106,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1501
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12656,10 +13122,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1492
+      ID: 1502
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1490
+      ID: 1500
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12807,7 +13273,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1485
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12823,7 +13289,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1497
+      ID: 1507
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12871,7 +13337,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1484
+      ID: 1494
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12887,7 +13353,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1495
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12903,7 +13369,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1473
+      ID: 1483
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12929,7 +13395,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1474
+      ID: 1484
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -21436,7 +21902,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1516
+MaxTypeID: 1526
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18003a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -18,6 +18,7 @@ Probes:
           Type: 1498 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcdb8e5", Frameless: false}]
           Condition: null
+      probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
       version: 0
       type: LOG_PROBE
@@ -36,6 +37,13 @@ Probes:
           Type: 1367 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcd6145", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -54,6 +62,13 @@ Probes:
           Type: 1370 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcd61dd", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -71,6 +86,13 @@ Probes:
           Type: 1470 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda422", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -85,6 +107,13 @@ Probes:
           Type: 1317 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -99,6 +128,13 @@ Probes:
           Type: 1313 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -113,6 +149,13 @@ Probes:
           Type: 1315 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -127,6 +170,13 @@ Probes:
           Type: 1378 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd6920", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -141,6 +191,13 @@ Probes:
           Type: 1314 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -154,6 +211,13 @@ Probes:
           Type: 1316 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -172,6 +236,13 @@ Probes:
           Type: 1336 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd4a7e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -186,6 +257,13 @@ Probes:
           Type: 1302 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -200,6 +278,13 @@ Probes:
           Type: 1299 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -214,6 +299,13 @@ Probes:
           Type: 1398 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{c}'
+        Segments:
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -236,6 +328,23 @@ Probes:
           Type: 1396 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{w}, {x}, {y}'
+        Segments:
+            - JSON: {Ref: w}
+              DSL: w
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testCycle
       version: 0
       type: LOG_PROBE
@@ -250,6 +359,13 @@ Probes:
           Type: 1406 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{t}'
+        Segments:
+            - JSON: {Ref: t}
+              DSL: t
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -264,6 +380,13 @@ Probes:
           Type: 1341 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -278,6 +401,13 @@ Probes:
           Type: 1342 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -292,6 +422,13 @@ Probes:
           Type: 1337 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4b20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -306,6 +443,13 @@ Probes:
           Type: 1338 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -320,6 +464,13 @@ Probes:
           Type: 1339 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4cc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -334,6 +485,13 @@ Probes:
           Type: 1340 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ce0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -348,6 +506,13 @@ Probes:
           Type: 1486 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdb440", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -367,6 +532,18 @@ Probes:
           Type: 1489 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -382,6 +559,13 @@ Probes:
           Type: 1508 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -396,6 +580,13 @@ Probes:
           Type: 1514 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcdbe20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -409,6 +600,13 @@ Probes:
           Type: 1515 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcdbe40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -423,6 +621,13 @@ Probes:
           Type: 1368 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd6180", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -441,6 +646,13 @@ Probes:
           Type: 1351 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd56cc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -459,6 +671,13 @@ Probes:
           Type: 1349 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd55fb", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -477,6 +696,13 @@ Probes:
           Type: 1361 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcd5de5", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -495,6 +721,13 @@ Probes:
           Type: 1363 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcd5e3d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -512,6 +745,13 @@ Probes:
           Type: 1364 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcd5e08", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -530,6 +770,13 @@ Probes:
           Type: 1353 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcd5b2e", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -553,6 +800,18 @@ Probes:
           Type: 1355 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcd5bfe", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -571,6 +830,13 @@ Probes:
           Type: 1357 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcd5c8b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -585,6 +851,9 @@ Probes:
           Type: 1519 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBBB
+        Segments: [testInlinedBBB]
     - id: testInlinedBC
       version: 0
       type: LOG_PROBE
@@ -603,6 +872,9 @@ Probes:
           Type: 1359 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcd5dbe", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBC
+        Segments: [testInlinedBC]
     - id: testInlinedBCA
       version: 0
       type: LOG_PROBE
@@ -617,6 +889,9 @@ Probes:
           Type: 1520 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCALine
       version: 0
       type: LOG_PROBE
@@ -634,6 +909,9 @@ Probes:
           Type: 1521 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCB
       version: 0
       type: LOG_PROBE
@@ -648,6 +926,9 @@ Probes:
           Type: 1522 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedBCBLine
       version: 0
       type: LOG_PROBE
@@ -665,6 +946,9 @@ Probes:
           Type: 1523 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -694,6 +978,13 @@ Probes:
           Type: 1517 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -721,6 +1012,13 @@ Probes:
             - PC: "0xcd5c4f"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -735,6 +1033,13 @@ Probes:
           Type: 1524 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -752,6 +1057,13 @@ Probes:
           Type: 1525 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -771,6 +1083,13 @@ Probes:
             - PC: "0xcd5ec5"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -785,6 +1104,13 @@ Probes:
           Type: 1305 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -799,6 +1125,13 @@ Probes:
           Type: 1306 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -813,6 +1146,13 @@ Probes:
           Type: 1307 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -827,6 +1167,13 @@ Probes:
           Type: 1304 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -841,6 +1188,13 @@ Probes:
           Type: 1303 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -855,6 +1209,13 @@ Probes:
           Type: 1365 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd60e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -872,6 +1233,13 @@ Probes:
           Type: 1468 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda333", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -886,6 +1254,13 @@ Probes:
           Type: 1400 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -903,6 +1278,9 @@ Probes:
           Type: 1345 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4eda", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineB
       version: 0
       type: LOG_PROBE
@@ -920,6 +1298,9 @@ Probes:
           Type: 1346 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4f8d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineC
       version: 0
       type: LOG_PROBE
@@ -942,6 +1323,18 @@ Probes:
           Type: 1347 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd5054", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a} and {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' and '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Line
+              EventExpressionIndex: 3
     - id: testManyArgsArrayReturn
       version: 0
       type: LOG_PROBE
@@ -985,6 +1378,53 @@ Probes:
           Type: 1474 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcda8a2", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -999,6 +1439,13 @@ Probes:
           Type: 1376 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1013,6 +1460,13 @@ Probes:
           Type: 1383 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1027,6 +1481,13 @@ Probes:
           Type: 1393 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xcd6ae0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1041,6 +1502,13 @@ Probes:
           Type: 1395 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xcd6b20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1055,6 +1523,13 @@ Probes:
           Type: 1394 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xcd6b00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1069,6 +1544,13 @@ Probes:
           Type: 1380 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd6960", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1083,6 +1565,13 @@ Probes:
           Type: 1392 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6ac0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1097,6 +1586,13 @@ Probes:
           Type: 1391 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd6aa0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1113,6 +1609,13 @@ Probes:
           Type: 1381 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1129,6 +1632,13 @@ Probes:
           Type: 1382 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1143,6 +1653,13 @@ Probes:
           Type: 1390 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1157,6 +1674,13 @@ Probes:
           Type: 1389 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1171,6 +1695,13 @@ Probes:
           Type: 1374 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd68a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -1185,6 +1716,13 @@ Probes:
           Type: 1375 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -1199,6 +1737,13 @@ Probes:
           Type: 1373 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd6880", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -1213,6 +1758,13 @@ Probes:
           Type: 1384 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1227,6 +1779,13 @@ Probes:
           Type: 1387 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -1241,6 +1800,13 @@ Probes:
           Type: 1388 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -1255,6 +1821,13 @@ Probes:
           Type: 1385 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -1271,6 +1844,13 @@ Probes:
           Type: 1386 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -1285,6 +1865,13 @@ Probes:
           Type: 1505 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1300,6 +1887,13 @@ Probes:
           Type: 1506 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -1343,6 +1937,53 @@ Probes:
           Type: 1476 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdab6b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -1365,6 +2006,18 @@ Probes:
           Type: 1480 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdad7e", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -1387,6 +2040,18 @@ Probes:
           Type: 1472 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcda66a", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s1}, {s2}'
+        Segments:
+            - JSON: {Ref: s1}
+              DSL: s1
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s2}
+              DSL: s2
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1404,6 +2069,13 @@ Probes:
           Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -1432,6 +2104,33 @@ Probes:
           Type: 1397 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd85e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1449,6 +2148,13 @@ Probes:
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -1472,6 +2178,19 @@ Probes:
           Type: 1424 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Parameter {i} * 2 = result {result}
+        Segments:
+            - 'Parameter '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ' * 2 = result '
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1491,6 +2210,18 @@ Probes:
           Type: 1405 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}, {a}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -1505,6 +2236,13 @@ Probes:
           Type: 1493 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -1524,6 +2262,18 @@ Probes:
           Type: 1490 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -1546,6 +2296,23 @@ Probes:
           Type: 1492 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {s}, {x}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -1560,6 +2327,13 @@ Probes:
           Type: 1504 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdb980", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -1574,6 +2348,13 @@ Probes:
           Type: 1401 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -1588,6 +2369,13 @@ Probes:
           Type: 1379 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -1602,6 +2390,13 @@ Probes:
           Type: 1399 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd89c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -1628,6 +2423,13 @@ Probes:
             - PC: "0xcd95ac"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -1659,6 +2461,18 @@ Probes:
             - PC: "0xcd9399"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}, {failed}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -1676,6 +2490,9 @@ Probes:
           Type: 1446 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcd9ccd", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArray
+        Segments: [testReturnsArray]
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
@@ -1693,6 +2510,9 @@ Probes:
           Type: 1448 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcd9d2b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayOne
+        Segments: [testReturnsArrayOne]
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
@@ -1710,6 +2530,9 @@ Probes:
           Type: 1450 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcd9d86", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayZero
+        Segments: [testReturnsArrayZero]
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
@@ -1727,6 +2550,9 @@ Probes:
           Type: 1454 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcd9eaa", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBacktrackInt
+        Segments: [testReturnsBacktrackInt]
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
@@ -1744,6 +2570,9 @@ Probes:
           Type: 1466 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcda1b0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBoolAndUintptr
+        Segments: [testReturnsBoolAndUintptr]
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
@@ -1761,6 +2590,9 @@ Probes:
           Type: 1442 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsComplex
+        Segments: [testReturnsComplex]
     - id: testReturnsError
       version: 0
       type: LOG_PROBE
@@ -1783,6 +2615,13 @@ Probes:
             - PC: "0xcd9265"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{failed}'
+        Segments:
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -1800,6 +2639,13 @@ Probes:
           Type: 1408 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcd907b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -1817,6 +2663,13 @@ Probes:
           Type: 1412 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcd9204", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -1834,6 +2687,13 @@ Probes:
           Type: 1410 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcd9114", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -1856,6 +2716,13 @@ Probes:
             - PC: "0xcd96d9"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -1873,6 +2740,9 @@ Probes:
           Type: 1444 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcd9c33", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsLargeStruct
+        Segments: [testReturnsLargeStruct]
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
@@ -1890,6 +2760,9 @@ Probes:
           Type: 1440 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcd9b07", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsManyFloats
+        Segments: [testReturnsManyFloats]
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
@@ -1907,6 +2780,9 @@ Probes:
           Type: 1458 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcd9fec", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixed
+        Segments: [testReturnsMixed]
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
@@ -1924,6 +2800,9 @@ Probes:
           Type: 1452 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcd9df8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixedStruct
+        Segments: [testReturnsMixedStruct]
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
@@ -1941,6 +2820,9 @@ Probes:
           Type: 1464 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcda136", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMultipleFloats
+        Segments: [testReturnsMultipleFloats]
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -1958,6 +2840,9 @@ Probes:
           Type: 1462 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcda0ce", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsOnlyFloat
+        Segments: [testReturnsOnlyFloat]
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
@@ -1975,6 +2860,9 @@ Probes:
           Type: 1438 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcd9a11", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsPrimitives
+        Segments: [testReturnsPrimitives]
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
@@ -1992,6 +2880,9 @@ Probes:
           Type: 1460 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcda06d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsStructWithArray
+        Segments: [testReturnsStructWithArray]
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
@@ -2009,6 +2900,9 @@ Probes:
           Type: 1456 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcd9f54", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsWideStruct
+        Segments: [testReturnsWideStruct]
     - id: testRuneArray
       version: 0
       type: LOG_PROBE
@@ -2023,6 +2917,13 @@ Probes:
           Type: 1300 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -2054,6 +2955,37 @@ Probes:
           Type: 1428 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
+        Segments:
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 4
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 5
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 2
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -2068,6 +3000,13 @@ Probes:
           Type: 1321 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -2082,6 +3021,13 @@ Probes:
           Type: 1319 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -2096,6 +3042,13 @@ Probes:
           Type: 1332 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat64
       version: 0
       type: LOG_PROBE
@@ -2110,6 +3063,13 @@ Probes:
           Type: 1333 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt
       version: 0
       type: LOG_PROBE
@@ -2124,6 +3084,13 @@ Probes:
           Type: 1322 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -2138,6 +3105,14 @@ Probes:
           Type: 1324 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -2152,6 +3127,13 @@ Probes:
           Type: 1325 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -2166,6 +3148,13 @@ Probes:
           Type: 1326 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -2187,6 +3176,22 @@ Probes:
           Type: 1323 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}{x}{x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -2201,6 +3206,13 @@ Probes:
           Type: 1320 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -2215,6 +3227,13 @@ Probes:
           Type: 1499 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdb900", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -2229,6 +3248,13 @@ Probes:
           Type: 1327 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -2243,6 +3269,13 @@ Probes:
           Type: 1329 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -2257,6 +3290,13 @@ Probes:
           Type: 1330 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -2271,6 +3311,13 @@ Probes:
           Type: 1331 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -2285,6 +3332,13 @@ Probes:
           Type: 1328 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -2299,6 +3353,13 @@ Probes:
           Type: 1496 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -2313,6 +3374,13 @@ Probes:
           Type: 1487 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -2327,6 +3395,13 @@ Probes:
           Type: 1377 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd6900", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2344,6 +3419,13 @@ Probes:
           Type: 1436 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd996b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -2361,6 +3443,13 @@ Probes:
           Type: 1478 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdac7c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -2375,6 +3464,13 @@ Probes:
           Type: 1301 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -2389,6 +3485,13 @@ Probes:
           Type: 1404 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -2403,6 +3506,13 @@ Probes:
           Type: 1491 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -2417,6 +3527,13 @@ Probes:
           Type: 1343 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -2431,6 +3548,13 @@ Probes:
           Type: 1344 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4ea0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -2449,6 +3573,13 @@ Probes:
           Type: 1513 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcdbcc2", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -2468,6 +3599,18 @@ Probes:
           Type: 1488 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -2482,6 +3625,13 @@ Probes:
           Type: 1371 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcd6200", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -2499,6 +3649,13 @@ Probes:
           Type: 1482 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdae5a", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -2516,6 +3673,13 @@ Probes:
           Type: 1511 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcdbb7e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -2529,6 +3693,13 @@ Probes:
           Type: 1509 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcdbb40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -2543,6 +3714,13 @@ Probes:
           Type: 1372 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -2562,6 +3740,11 @@ Probes:
           Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{nonexistentVariable}'
+        Segments:
+            - Error: failed to resolve reference "nonexistentVariable"
+              DSL: nonexistentVariable
     - id: testTemplateWithUnsupportedExpression
       version: 0
       type: LOG_PROBE
@@ -2581,6 +3764,11 @@ Probes:
           Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{unsupportedExpression}'
+        Segments:
+            - Error: 'unsupported operation: foobar'
+              DSL: unsupportedExpression
     - id: testTemplateWithUnsupportedVariable
       version: 0
       type: LOG_PROBE
@@ -2602,6 +3790,13 @@ Probes:
           Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
+        Segments:
+            - 'Executed main.testMultipleNamedReturn, it took '
+            - Error: failed to resolve reference "@duration"
+              DSL: '@duration'
+            - ms
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
@@ -2624,6 +3819,23 @@ Probes:
           Type: 1500 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdb920", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}, {z}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -2642,6 +3854,13 @@ Probes:
           Type: 1502 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdb95e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testThreeStringsInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2656,6 +3875,13 @@ Probes:
           Type: 1503 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdb960", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -2670,6 +3896,13 @@ Probes:
           Type: 1334 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd4900", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -2684,6 +3917,13 @@ Probes:
           Type: 1310 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -2698,6 +3938,13 @@ Probes:
           Type: 1311 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -2712,6 +3959,13 @@ Probes:
           Type: 1312 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -2726,6 +3980,13 @@ Probes:
           Type: 1309 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -2740,6 +4001,13 @@ Probes:
           Type: 1308 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -2754,6 +4022,13 @@ Probes:
           Type: 1403 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -2768,6 +4043,13 @@ Probes:
           Type: 1485 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdb420", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -2782,6 +4064,13 @@ Probes:
           Type: 1507 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -2796,6 +4085,13 @@ Probes:
           Type: 1402 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -2810,6 +4106,13 @@ Probes:
           Type: 1318 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -2824,6 +4127,13 @@ Probes:
           Type: 1494 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2838,6 +4148,13 @@ Probes:
           Type: 1495 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -2860,6 +4177,18 @@ Probes:
           Type: 1484 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdaf0c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -9336,12 +10665,22 @@ Types:
     - __kind: EventRootType
       ID: 1369
       Name: Probe[main.testAnyPtr]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 161 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 161 PointerType *interface {}
             Operations:
@@ -9368,12 +10707,22 @@ Types:
     - __kind: EventRootType
       ID: 1366
       Name: Probe[main.testAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -9400,12 +10749,22 @@ Types:
     - __kind: EventRootType
       ID: 1469
       Name: Probe[main.testArrayArgAndReturn]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -9445,10 +10804,20 @@ Types:
                   Variable: {subprogram: 19, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 122 ArrayType [2]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 19, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1315
       Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -9461,10 +10830,20 @@ Types:
                   Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
+        - Name: b
+          Offset: 65
+          Kind: template_segment
+          Expression:
+            Type: 119 ArrayType [2][2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 64
     - __kind: EventRootType
       ID: 1313
       Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9477,10 +10856,20 @@ Types:
                   Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 118 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 15, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1378
       Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -9493,10 +10882,20 @@ Types:
                   Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
+        - Name: m
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 189 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1314
       Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9509,10 +10908,20 @@ Types:
                   Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 109 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1316
       Name: Probe[main.testArrayOfStructs]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9525,15 +10934,35 @@ Types:
                   Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 120 ArrayType [2]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 1335
       Name: Probe[main.testBigStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 126 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: b
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 126 StructureType main.bigStruct
             Operations:
@@ -9547,7 +10976,7 @@ Types:
     - __kind: EventRootType
       ID: 1302
       Name: Probe[main.testBoolArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9560,15 +10989,35 @@ Types:
                   Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 110 ArrayType [2]bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1299
       Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 107 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -9592,10 +11041,20 @@ Types:
                   Variable: {subprogram: 85, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 241 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1396
       Name: Probe[main.testCombinedByte]
-      ByteSize: 7
+      ByteSize: 13
       PresenceBitsetSize: 1
       Expressions:
         - Name: w
@@ -9608,8 +11067,18 @@ Types:
                   Variable: {subprogram: 83, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
-        - Name: x
+        - Name: w
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -9618,9 +11087,29 @@ Types:
                   Variable: {subprogram: 83, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
         - Name: y
-          Offset: 3
+          Offset: 5
           Kind: argument
+          Expression:
+            Type: 17 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: y
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 17 BaseType float32
             Operations:
@@ -9631,7 +11120,7 @@ Types:
     - __kind: EventRootType
       ID: 1406
       Name: Probe[main.testCycle]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: t
@@ -9644,10 +11133,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
+        - Name: t
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 246 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1341
       Name: Probe[main.testDeepMap1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9660,10 +11159,20 @@ Types:
                   Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 141 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1342
       Name: Probe[main.testDeepMap7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9676,10 +11185,20 @@ Types:
                   Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 147 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testDeepPtr1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9692,10 +11211,20 @@ Types:
                   Variable: {subprogram: 38, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 130 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1338
       Name: Probe[main.testDeepPtr7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9708,10 +11237,20 @@ Types:
                   Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 133 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1339
       Name: Probe[main.testDeepSlice1]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9724,10 +11263,20 @@ Types:
                   Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 135 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1340
       Name: Probe[main.testDeepSlice7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9740,10 +11289,20 @@ Types:
                   Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 139 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1489
       Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -9756,9 +11315,29 @@ Types:
                   Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -9769,7 +11348,7 @@ Types:
     - __kind: EventRootType
       ID: 1486
       Name: Probe[main.testEmptySlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -9782,10 +11361,20 @@ Types:
                   Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 129, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1508
       Name: Probe[main.testEmptyString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9798,15 +11387,35 @@ Types:
                   Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 147, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1515
       Name: Probe[main.testEmptyStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 316 PointerType *main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 316 PointerType *main.emptyStruct
             Operations:
@@ -9830,10 +11439,20 @@ Types:
                   Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
+        - Name: e
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 315 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1368
       Name: Probe[main.testError]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
@@ -9846,15 +11465,35 @@ Types:
                   Variable: {subprogram: 57, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: e
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 57, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1350
       Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 157 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 157 PointerType *main.esotericHeap
             Operations:
@@ -9868,12 +11507,22 @@ Types:
     - __kind: EventRootType
       ID: 1348
       Name: Probe[main.testEsotericStack]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 153 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+        - Name: e
+          Offset: 65
+          Kind: template_segment
           Expression:
             Type: 153 StructureType main.esotericStack
             Operations:
@@ -9887,7 +11536,7 @@ Types:
     - __kind: EventRootType
       ID: 1362
       Name: Probe[main.testFramelessArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9900,10 +11549,20 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1364
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 49
+      ByteSize: 89
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9916,8 +11575,18 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-        - Name: ~r0
+        - Name: a
           Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 81
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -9945,12 +11614,22 @@ Types:
     - __kind: EventRootType
       ID: 1360
       Name: Probe[main.testFrameless]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -9977,12 +11656,22 @@ Types:
     - __kind: EventRootType
       ID: 1352
       Name: Probe[main.testInlinedBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -9996,12 +11685,22 @@ Types:
     - __kind: EventRootType
       ID: 1356
       Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10018,7 +11717,7 @@ Types:
     - __kind: EventRootType
       ID: 1354
       Name: Probe[main.testInlinedBB]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10031,9 +11730,29 @@ Types:
                   Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: y
+        - Name: x
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10065,7 +11784,7 @@ Types:
     - __kind: EventRootType
       ID: 1516
       Name: Probe[main.testInlinedPrint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10078,15 +11797,35 @@ Types:
                   Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1518
       Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10100,7 +11839,7 @@ Types:
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.testInlinedSq]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10113,10 +11852,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1525
       Name: Probe[main.testInlinedSq]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10129,10 +11878,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1526
       Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10145,10 +11904,20 @@ Types:
                   Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1305
       Name: Probe[main.testInt16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10161,10 +11930,20 @@ Types:
                   Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 113 ArrayType [2]int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1306
       Name: Probe[main.testInt32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10177,10 +11956,20 @@ Types:
                   Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 108 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1307
       Name: Probe[main.testInt64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10193,10 +11982,20 @@ Types:
                   Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 114 ArrayType [2]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1304
       Name: Probe[main.testInt8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10209,10 +12008,20 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 112 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1303
       Name: Probe[main.testIntArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10225,10 +12034,20 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1365
       Name: Probe[main.testInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -10241,15 +12060,35 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 160 GoInterfaceType main.behavior
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1467
       Name: Probe[main.testLargeArgAndReturn]
-      ByteSize: 81
+      ByteSize: 161
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: arg
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -10276,12 +12115,22 @@ Types:
     - __kind: EventRootType
       ID: 1400
       Name: Probe[main.testLinkedList]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 244 StructureType main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 244 StructureType main.node
             Operations:
@@ -10321,7 +12170,7 @@ Types:
     - __kind: EventRootType
       ID: 1347
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10334,9 +12183,29 @@ Types:
                   Variable: {subprogram: 46, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: a
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10347,11 +12216,11 @@ Types:
     - __kind: EventRootType
       ID: 1473
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 74
-      PresenceBitsetSize: 2
+      ByteSize: 147
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10360,8 +12229,18 @@ Types:
                   Variable: {subprogram: 122, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10370,8 +12249,18 @@ Types:
                   Variable: {subprogram: 122, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10380,8 +12269,18 @@ Types:
                   Variable: {subprogram: 122, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10390,8 +12289,18 @@ Types:
                   Variable: {subprogram: 122, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10400,8 +12309,18 @@ Types:
                   Variable: {subprogram: 122, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10410,8 +12329,18 @@ Types:
                   Variable: {subprogram: 122, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10420,8 +12349,18 @@ Types:
                   Variable: {subprogram: 122, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10430,9 +12369,29 @@ Types:
                   Variable: {subprogram: 122, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 139
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10459,7 +12418,7 @@ Types:
     - __kind: EventRootType
       ID: 1376
       Name: Probe[main.testMapArrayToArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10472,10 +12431,20 @@ Types:
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 184 GoMapType map[[4]string][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1383
       Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10488,10 +12457,20 @@ Types:
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1395
       Name: Probe[main.testMapEmptyKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10504,10 +12483,20 @@ Types:
                   Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 236 GoMapType map[struct {}]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 82, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1393
       Name: Probe[main.testMapEmptyKey]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10520,10 +12509,20 @@ Types:
                   Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 226 GoMapType map[struct {}]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1394
       Name: Probe[main.testMapEmptyValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10536,10 +12535,20 @@ Types:
                   Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 231 GoMapType map[int]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1380
       Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10552,10 +12561,20 @@ Types:
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 164 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 68, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1392
       Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10568,10 +12587,20 @@ Types:
                   Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 221 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1391
       Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10584,15 +12613,35 @@ Types:
                   Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 216 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1381
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -10603,7 +12652,7 @@ Types:
     - __kind: EventRootType
       ID: 1382
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10616,10 +12665,20 @@ Types:
                   Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1390
       Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10632,10 +12691,20 @@ Types:
                   Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 211 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1389
       Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10648,10 +12717,20 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1374
       Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10664,10 +12743,20 @@ Types:
                   Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 174 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1375
       Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10680,10 +12769,20 @@ Types:
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 179 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1373
       Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10696,10 +12795,20 @@ Types:
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 169 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1384
       Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10712,10 +12821,20 @@ Types:
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 196 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1388
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10728,10 +12847,20 @@ Types:
                   Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1387
       Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10744,10 +12873,20 @@ Types:
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 74, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1386
       Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10760,10 +12899,20 @@ Types:
                   Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 201 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1385
       Name: Probe[main.testMapWithSmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10776,15 +12925,35 @@ Types:
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 201 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -10795,7 +12964,7 @@ Types:
     - __kind: EventRootType
       ID: 1506
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10808,14 +12977,24 @@ Types:
                   Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1475
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 163
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10824,8 +13003,18 @@ Types:
                   Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10834,8 +13023,18 @@ Types:
                   Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10844,8 +13043,18 @@ Types:
                   Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10854,8 +13063,18 @@ Types:
                   Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10864,8 +13083,18 @@ Types:
                   Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10874,8 +13103,18 @@ Types:
                   Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10884,8 +13123,18 @@ Types:
                   Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10894,9 +13143,29 @@ Types:
                   Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: s
+          Offset: 147
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -10923,7 +13192,7 @@ Types:
     - __kind: EventRootType
       ID: 1479
       Name: Probe[main.testMultipleArrayArgs]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10936,9 +13205,29 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
-        - Name: b
+        - Name: a
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: b
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -10975,7 +13264,7 @@ Types:
     - __kind: EventRootType
       ID: 1471
       Name: Probe[main.testMultipleLargeArgs]
-      ByteSize: 161
+      ByteSize: 321
       PresenceBitsetSize: 1
       Expressions:
         - Name: s1
@@ -10988,9 +13277,29 @@ Types:
                   Variable: {subprogram: 121, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
-        - Name: s2
+        - Name: s1
           Offset: 81
+          Kind: template_segment
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 161
           Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 241
+          Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -11017,7 +13326,7 @@ Types:
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11030,15 +13339,55 @@ Types:
                   Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1427
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11123,7 +13472,7 @@ Types:
     - __kind: EventRootType
       ID: 1428
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11136,9 +13485,49 @@ Types:
                   Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
+        - Name: result
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 25
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11227,11 +13616,11 @@ Types:
     - __kind: EventRootType
       ID: 1397
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 62
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -11240,8 +13629,18 @@ Types:
                   Variable: {subprogram: 84, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
+        - Name: a
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
         - Name: b
-          Offset: 2
+          Offset: 4
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -11250,8 +13649,18 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
+        - Name: b
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
         - Name: c
-          Offset: 3
+          Offset: 6
           Kind: argument
           Expression:
             Type: 10 BaseType int32
@@ -11260,8 +13669,18 @@ Types:
                   Variable: {subprogram: 84, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
+        - Name: c
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
         - Name: d
-          Offset: 7
+          Offset: 14
           Kind: argument
           Expression:
             Type: 16 BaseType uint
@@ -11270,9 +13689,29 @@ Types:
                   Variable: {subprogram: 84, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 22
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 15
+          Offset: 30
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: e
+          Offset: 46
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -11283,7 +13722,7 @@ Types:
     - __kind: EventRootType
       ID: 1421
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11296,15 +13735,35 @@ Types:
                   Variable: {subprogram: 101, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1423
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11331,7 +13790,7 @@ Types:
     - __kind: EventRootType
       ID: 1424
       Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11344,10 +13803,20 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
+        - Name: result
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1405
       Name: Probe[main.testNilPointer]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -11360,9 +13829,29 @@ Types:
                   Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: z
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 16 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -11373,7 +13862,7 @@ Types:
     - __kind: EventRootType
       ID: 1490
       Name: Probe[main.testNilSliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11386,9 +13875,29 @@ Types:
                   Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11399,7 +13908,7 @@ Types:
     - __kind: EventRootType
       ID: 1492
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 34
+      ByteSize: 67
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11412,8 +13921,18 @@ Types:
                   Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: s
+        - Name: a
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 3
           Kind: argument
           Expression:
             Type: 262 GoSliceHeaderType []bool
@@ -11422,9 +13941,29 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 262 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
-          Offset: 26
+          Offset: 51
           Kind: argument
+          Expression:
+            Type: 16 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 59
+          Kind: template_segment
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -11435,7 +13974,7 @@ Types:
     - __kind: EventRootType
       ID: 1493
       Name: Probe[main.testNilSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11448,10 +13987,20 @@ Types:
                   Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 263 GoSliceHeaderType []uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1504
       Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11464,10 +14013,20 @@ Types:
                   Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 268 PointerType *main.oneStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 144, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1401
       Name: Probe[main.testPointerLoop]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11480,10 +14039,20 @@ Types:
                   Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 245 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1379
       Name: Probe[main.testPointerToMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11496,10 +14065,20 @@ Types:
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 190 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 67, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1399
       Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11512,10 +14091,20 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 242 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1415
       Name: Probe[main.testReturnsAnyAndError]
-      ByteSize: 18
+      ByteSize: 35
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -11528,9 +14117,29 @@ Types:
                   Variable: {subprogram: 98, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
-        - Name: failed
+        - Name: v
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: failed
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11567,12 +14176,22 @@ Types:
     - __kind: EventRootType
       ID: 1417
       Name: Probe[main.testReturnsAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -11813,12 +14432,22 @@ Types:
     - __kind: EventRootType
       ID: 1413
       Name: Probe[main.testReturnsError]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: failed
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11845,12 +14474,22 @@ Types:
     - __kind: EventRootType
       ID: 1411
       Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11887,12 +14526,22 @@ Types:
     - __kind: EventRootType
       ID: 1409
       Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11919,12 +14568,22 @@ Types:
     - __kind: EventRootType
       ID: 1407
       Name: Probe[main.testReturnsInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11951,12 +14610,22 @@ Types:
     - __kind: EventRootType
       ID: 1419
       Name: Probe[main.testReturnsInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -12434,7 +15103,7 @@ Types:
     - __kind: EventRootType
       ID: 1300
       Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12447,10 +15116,20 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 108 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1321
       Name: Probe[main.testSingleBool]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12463,10 +15142,20 @@ Types:
                   Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1319
       Name: Probe[main.testSingleByte]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12479,10 +15168,20 @@ Types:
                   Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1332
       Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12495,10 +15194,20 @@ Types:
                   Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1333
       Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12511,10 +15220,20 @@ Types:
                   Variable: {subprogram: 35, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1324
       Name: Probe[main.testSingleInt16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12527,10 +15246,20 @@ Types:
                   Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 102 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1325
       Name: Probe[main.testSingleInt32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12543,10 +15272,20 @@ Types:
                   Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1326
       Name: Probe[main.testSingleInt64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12559,10 +15298,20 @@ Types:
                   Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1323
       Name: Probe[main.testSingleInt8]
-      ByteSize: 2
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12575,10 +15324,40 @@ Types:
                   Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1322
       Name: Probe[main.testSingleInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12591,10 +15370,20 @@ Types:
                   Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1320
       Name: Probe[main.testSingleRune]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12607,10 +15396,20 @@ Types:
                   Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1499
       Name: Probe[main.testSingleString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12623,10 +15422,20 @@ Types:
                   Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1329
       Name: Probe[main.testSingleUint16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12639,10 +15448,20 @@ Types:
                   Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 6 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1330
       Name: Probe[main.testSingleUint32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12655,10 +15474,20 @@ Types:
                   Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1331
       Name: Probe[main.testSingleUint64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12671,10 +15500,20 @@ Types:
                   Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1328
       Name: Probe[main.testSingleUint8]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12687,10 +15526,20 @@ Types:
                   Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1327
       Name: Probe[main.testSingleUint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12703,10 +15552,20 @@ Types:
                   Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1496
       Name: Probe[main.testSliceEmptyStructs]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -12719,10 +15578,20 @@ Types:
                   Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 264 GoSliceHeaderType []struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1487
       Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -12735,10 +15604,20 @@ Types:
                   Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 256 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1377
       Name: Probe[main.testSmallMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -12751,15 +15630,35 @@ Types:
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 174 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 65, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1435
       Name: Probe[main.testSomeNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12806,12 +15705,22 @@ Types:
     - __kind: EventRootType
       ID: 1477
       Name: Probe[main.testStackArgRegReturns]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: arg
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12858,7 +15767,7 @@ Types:
     - __kind: EventRootType
       ID: 1301
       Name: Probe[main.testStringArray]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12871,10 +15780,20 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
+        - Name: x
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 109 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1404
       Name: Probe[main.testStringPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -12887,10 +15806,20 @@ Types:
                   Variable: {subprogram: 91, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 93 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1491
       Name: Probe[main.testStringSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -12903,10 +15832,20 @@ Types:
                   Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 261 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1343
       Name: Probe[main.testStringType1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12919,10 +15858,20 @@ Types:
                   Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 149 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1344
       Name: Probe[main.testStringType2]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12935,10 +15884,20 @@ Types:
                   Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 151 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1488
       Name: Probe[main.testStructSlice]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -12951,9 +15910,29 @@ Types:
                   Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12964,7 +15943,7 @@ Types:
     - __kind: EventRootType
       ID: 1371
       Name: Probe[main.testStructWithAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -12977,15 +15956,35 @@ Types:
                   Variable: {subprogram: 59, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: s
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 162 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1481
       Name: Probe[main.testStructWithArrayArg]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 254 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 254 StructureType main.structWithArray
             Operations:
@@ -13022,12 +16021,22 @@ Types:
     - __kind: EventRootType
       ID: 1510
       Name: Probe[main.testStructWithCyclicMaps]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 283 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
@@ -13041,7 +16050,7 @@ Types:
     - __kind: EventRootType
       ID: 1509
       Name: Probe[main.testStructWithCyclicSlices]
-      ByteSize: 145
+      ByteSize: 289
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13054,10 +16063,20 @@ Types:
                   Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
+        - Name: a
+          Offset: 145
+          Kind: template_segment
+          Expression:
+            Type: 270 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 148, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
     - __kind: EventRootType
       ID: 1372
       Name: Probe[main.testStructWithMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13070,15 +16089,35 @@ Types:
                   Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
+        - Name: s
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 163 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1512
       Name: Probe[main.testStruct]
-      ByteSize: 57
+      ByteSize: 113
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 314 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 150, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+        - Name: x
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 314 StructureType main.aStruct
             Operations:
@@ -13092,7 +16131,7 @@ Types:
     - __kind: EventRootType
       ID: 1503
       Name: Probe[main.testThreeStringsInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13105,15 +16144,35 @@ Types:
                   Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 267 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 143, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1501
       Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 266 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 266 StructureType main.threeStringStruct
             Operations:
@@ -13127,7 +16186,7 @@ Types:
     - __kind: EventRootType
       ID: 1500
       Name: Probe[main.testThreeStrings]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13140,8 +16199,18 @@ Types:
                   Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-        - Name: y
+        - Name: x
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 33
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -13150,9 +16219,29 @@ Types:
                   Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
+        - Name: y
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
-          Offset: 33
+          Offset: 65
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 2, name: z}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: z
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -13163,7 +16252,7 @@ Types:
     - __kind: EventRootType
       ID: 1334
       Name: Probe[main.testTypeAlias]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13176,10 +16265,20 @@ Types:
                   Variable: {subprogram: 36, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 125 BaseType main.typeAlias
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1310
       Name: Probe[main.testUint16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13192,10 +16291,20 @@ Types:
                   Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 116 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1311
       Name: Probe[main.testUint32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13208,10 +16317,20 @@ Types:
                   Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 117 ArrayType [2]uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 13, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1312
       Name: Probe[main.testUint64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13224,10 +16343,20 @@ Types:
                   Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 54 ArrayType [2]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 14, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1309
       Name: Probe[main.testUint8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13240,10 +16369,20 @@ Types:
                   Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 107 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1308
       Name: Probe[main.testUintArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13256,10 +16395,20 @@ Types:
                   Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 115 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1403
       Name: Probe[main.testUintPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13272,10 +16421,20 @@ Types:
                   Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 105 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1485
       Name: Probe[main.testUintSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -13288,10 +16447,20 @@ Types:
                   Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1507
       Name: Probe[main.testUnitializedString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13304,10 +16473,20 @@ Types:
                   Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 146, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1402
       Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13320,10 +16499,20 @@ Types:
                   Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 14 VoidPointerType unsafe.Pointer
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1318
       Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
+      ByteSize: 1601
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13336,15 +16525,35 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
+        - Name: a
+          Offset: 801
+          Kind: template_segment
+          Expression:
+            Type: 124 ArrayType [100]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 20, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 800
     - __kind: EventRootType
       ID: 1494
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -13355,7 +16564,7 @@ Types:
     - __kind: EventRootType
       ID: 1495
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13368,10 +16577,20 @@ Types:
                   Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1483
       Name: Probe[main.testZeroSizeArgAndReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13384,9 +16603,29 @@ Types:
                   Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -5,17 +5,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: stackC
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.stackC]
+          Type: 1516 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xce00ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1507 EventRootType Probe[main.stackC]Return
+          Type: 1517 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xce0105", Frameless: false}]
           Condition: null
     - id: testAny
@@ -23,8 +23,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -41,8 +41,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -58,17 +58,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1488 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcdebae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1489 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdec62", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -76,8 +76,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -90,8 +90,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -104,8 +104,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -118,8 +118,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -132,8 +132,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -145,8 +145,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -159,8 +159,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -177,8 +177,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -191,8 +191,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -205,8 +205,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -219,8 +219,16 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{w}, {x}, {y}'
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -233,8 +241,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{t}'
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -247,8 +255,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -261,8 +269,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -275,8 +283,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -289,8 +297,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -303,8 +311,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -317,8 +325,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -331,13 +339,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          Type: 1505 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -345,13 +353,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1508 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -360,13 +373,13 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptyString]
+          Type: 1527 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -374,26 +387,26 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testEmptyStruct]
+          Type: 1533 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xce0640", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1534 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xce0660", Frameless: true}]
           Condition: null
     - id: testError
@@ -401,8 +414,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -415,8 +428,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -433,8 +446,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -451,8 +464,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -469,8 +482,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -490,8 +503,8 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -504,8 +517,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -522,8 +535,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -540,8 +558,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -558,13 +576,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBBB
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testInlinedBBB]
+          Type: 1538 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -572,8 +590,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBC
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -590,13 +608,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testInlinedBCA]
+          Type: 1539 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -607,13 +625,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Line
-          Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1540 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -621,13 +639,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testInlinedBCB]
+          Type: 1541 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -638,13 +656,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Line
-          Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1542 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -653,13 +671,13 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testInlinedPrint]
+          Type: 1535 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda20a"
               Frameless: false
@@ -673,7 +691,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1536 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -684,13 +702,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Line
-          Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -708,13 +726,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testInlinedSq]
+          Type: 1543 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -725,13 +743,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1534 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1544 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -740,13 +758,13 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1545 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda705"
               Frameless: false
@@ -758,8 +776,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -772,8 +790,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -786,8 +804,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -800,8 +818,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -814,8 +832,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -828,8 +846,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -841,17 +859,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1486 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcdea0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1487 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdeb73", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -859,8 +877,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -876,8 +894,8 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -893,8 +911,8 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -910,8 +928,13 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a} and {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -923,17 +946,43 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1492 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcdeed3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1493 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcdf0e2", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -941,8 +990,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -955,8 +1004,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -969,8 +1018,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -983,8 +1032,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -997,8 +1046,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1011,8 +1060,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1025,8 +1074,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1039,8 +1088,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1053,8 +1102,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1067,8 +1118,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1081,8 +1134,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1095,8 +1148,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1109,8 +1162,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1123,8 +1176,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1137,8 +1190,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1151,8 +1204,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1165,8 +1218,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1179,8 +1232,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1193,8 +1246,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1207,8 +1260,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1221,13 +1276,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testMassiveString]
+          Type: 1524 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1236,81 +1291,117 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testMassiveString]
+          Type: 1525 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1494 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcdf173", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1495 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdf3ab", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1498 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdf4ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1499 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdf5bf", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
-      template: ""
-      segments: []
+      template: '{s1}, {s2}'
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1490 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcdec8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1491 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcdeeaa", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1444 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1445 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1318,8 +1409,22 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1331,8 +1436,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1344,13 +1449,41 @@ Probes:
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      template: Parameter {i} * 2 = result {result}
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - Kind: Entry
+          Type: 1442 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcddf8a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1443 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}, {a}'
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1363,13 +1496,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
+          Type: 1512 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1377,13 +1510,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1509 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1391,13 +1529,21 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {s}, {x}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1511 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1405,13 +1551,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1523 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xce01a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1419,8 +1565,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1433,8 +1579,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1447,8 +1593,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1461,8 +1607,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1487,8 +1633,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}, {failed}'
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1512,102 +1663,102 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
-      template: ""
-      segments: []
+      template: testReturnsArray
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          Type: 1464 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcde4aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1465 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcde50d", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
-      template: ""
-      segments: []
+      template: testReturnsArrayOne
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1466 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcde52a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1467 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcde56b", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
-      template: ""
-      segments: []
+      template: testReturnsArrayZero
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1468 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcde58a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1469 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcde5c6", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
-      template: ""
-      segments: []
+      template: testReturnsBacktrackInt
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1472 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcde66e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1473 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcde6ea", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
-      template: ""
-      segments: []
+      template: testReturnsBoolAndUintptr
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1484 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcde9aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1485 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcde9f0", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
-      template: ""
-      segments: []
+      template: testReturnsComplex
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          Type: 1460 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcde36a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1461 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcde3c6", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1615,8 +1766,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{failed}'
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1636,8 +1787,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1653,8 +1804,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1670,8 +1821,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1688,8 +1839,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1709,153 +1860,153 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
-      template: ""
-      segments: []
+      template: testReturnsLargeStruct
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1462 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcde3ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1463 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcde473", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
-      template: ""
-      segments: []
+      template: testReturnsManyFloats
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1458 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcde26e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1459 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcde347", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
-      template: ""
-      segments: []
+      template: testReturnsMixed
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          Type: 1476 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcde7ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1477 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcde82c", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
-      template: ""
-      segments: []
+      template: testReturnsMixedStruct
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1470 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcde5ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1471 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcde638", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
-      template: ""
-      segments: []
+      template: testReturnsMultipleFloats
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1482 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcde92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1483 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcde976", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
-      template: ""
-      segments: []
+      template: testReturnsOnlyFloat
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1480 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcde8ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1481 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcde90e", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
-      template: ""
-      segments: []
+      template: testReturnsPrimitives
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1456 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcde1ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1457 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcde251", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
-      template: ""
-      segments: []
+      template: testReturnsStructWithArray
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1478 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcde84a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1479 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcde8ad", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
-      template: ""
-      segments: []
+      template: testReturnsWideStruct
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1474 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcde70e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1475 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcde794", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -1863,8 +2014,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -1872,13 +2023,44 @@ Probes:
           Type: 1319 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
+    - id: testSegmentsForParamsAndReturnsOutOfOrder
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{result2}{i}{result}{i}{i}{result2}{result}'
+      segments:
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result}
+          dsl: result
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1446 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1447 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Condition: null
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -1891,8 +2073,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -1905,8 +2087,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -1919,8 +2101,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -1933,8 +2115,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -1947,8 +2129,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -1961,8 +2143,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -1975,8 +2157,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -1989,8 +2171,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}{x}{x}
+      segments:
+        - 'parameter = '
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2003,8 +2192,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2017,13 +2206,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1508 EventRootType Probe[main.testSingleString]
+          Type: 1518 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xce0120", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2031,8 +2220,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2045,8 +2234,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2059,8 +2248,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2073,8 +2262,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2087,8 +2276,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2101,13 +2290,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1515 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2115,13 +2304,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1506 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2129,8 +2318,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2142,34 +2331,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1454 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcde10e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1455 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcde1ad", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1496 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdf44a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1497 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdf4bc", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2177,8 +2366,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2191,8 +2380,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}'
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2205,13 +2394,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
+          Type: 1510 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2219,8 +2408,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2233,8 +2422,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2247,17 +2436,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testStruct]
+          Type: 1531 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xce04c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1522 EventRootType Probe[main.testStruct]Return
+          Type: 1532 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xce04e2", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2265,13 +2454,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
+          Type: 1507 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2279,8 +2473,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2292,47 +2486,47 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1500 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdf5ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1501 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdf69c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1529 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xce0380", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1530 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xce039e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1528 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xce0360", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2340,8 +2534,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2349,18 +2543,85 @@ Probes:
           Type: 1391 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
           Condition: null
+    - id: testTemplateWithNonexistantVariableName
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{nonexistentVariable}'
+      segments:
+        - json: {ref: nonexistentVariable}
+          dsl: nonexistentVariable
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1448 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1449 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedExpression
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{unsupportedExpression}'
+      segments:
+        - json: {foobar: unsupportedExpression}
+          dsl: unsupportedExpression
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1450 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedVariable
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: Executed main.testMultipleNamedReturn, it took {@duration}ms
+      segments:
+        - 'Executed main.testMultipleNamedReturn, it took '
+        - json: {ref: '@duration'}
+          dsl: '@duration'
+        - ms
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Condition: null
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}, {z}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStrings]
+          Type: 1519 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xce0140", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2368,17 +2629,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1520 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xce0160", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1521 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce017e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2386,13 +2647,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1522 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0180", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2400,8 +2661,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2414,8 +2675,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2428,8 +2689,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2442,8 +2703,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2456,8 +2717,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2470,8 +2731,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2484,8 +2745,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2498,13 +2759,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
+          Type: 1504 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2512,13 +2773,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testUnitializedString]
+          Type: 1526 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2526,8 +2787,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2540,8 +2801,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2554,13 +2815,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1513 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2568,30 +2829,35 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1514 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1502 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdf6ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1503 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdf74c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9116,10 +9382,10 @@ Types:
       GoKind: 22
       Pointee: 821 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1506
+      ID: 1516
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1507
+      ID: 1517
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9199,7 +9465,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1488
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9215,7 +9481,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1489
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9542,7 +9808,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1508
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9568,7 +9834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1505
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9584,7 +9850,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1527
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9600,7 +9866,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1534
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9616,7 +9882,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1523
+      ID: 1533
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9814,7 +10080,7 @@ Types:
       ID: 1376
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1528
+      ID: 1538
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1373
@@ -9846,16 +10112,16 @@ Types:
       ID: 1374
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1539
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1530
+      ID: 1540
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1531
+      ID: 1541
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1542
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1377
@@ -9864,7 +10130,7 @@ Types:
       ID: 1378
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1535
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9880,7 +10146,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1527
+      ID: 1537
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9896,10 +10162,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1536
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1543
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9915,7 +10181,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1544
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9931,7 +10197,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1545
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10043,7 +10309,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1486
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10059,7 +10325,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1487
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10146,7 +10412,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1492
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10242,7 +10508,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1493
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10578,7 +10844,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1524
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10594,7 +10860,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1525
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10610,7 +10876,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1494
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10706,7 +10972,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1495
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10722,7 +10988,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1498
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10748,7 +11014,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1499
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10774,7 +11040,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1490
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10800,7 +11066,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1491
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10816,7 +11082,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10832,7 +11098,175 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1446
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1448
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1445
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1449
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1451
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10930,7 +11364,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1441
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1443
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10972,7 +11438,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1509
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10998,7 +11464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1511
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11034,7 +11500,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1512
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11050,7 +11516,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1523
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11198,10 +11664,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1466
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1467
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11217,10 +11683,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1468
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1469
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11236,10 +11702,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1464
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1465
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11255,10 +11721,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1472
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1473
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11354,10 +11820,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1484
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1485
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11383,10 +11849,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1460
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1461
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11582,10 +12048,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1462
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1463
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11601,10 +12067,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1458
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1459
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11780,10 +12246,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1470
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1471
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11799,10 +12265,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1476
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1477
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11858,10 +12324,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1482
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1483
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11887,10 +12353,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1480
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1481
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11906,10 +12372,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1456
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1457
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -11995,10 +12461,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1478
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1479
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12014,10 +12480,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1474
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1475
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12209,7 +12675,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1508
+      ID: 1518
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12305,7 +12771,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1515
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12321,7 +12787,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1506
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12353,7 +12819,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1454
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12369,7 +12835,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1455
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12405,7 +12871,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1496
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12421,7 +12887,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1497
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12489,7 +12955,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1510
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12537,7 +13003,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1507
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12579,7 +13045,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1500
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12595,7 +13061,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1501
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12621,7 +13087,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1529
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12637,10 +13103,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1520
+      ID: 1530
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1518
+      ID: 1528
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12672,7 +13138,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1531
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12688,10 +13154,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1522
+      ID: 1532
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1512
+      ID: 1522
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12707,7 +13173,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1520
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12723,10 +13189,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1511
+      ID: 1521
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1519
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12874,7 +13340,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1504
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12890,7 +13356,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1516
+      ID: 1526
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12938,7 +13404,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
+      ID: 1513
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12954,7 +13420,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1514
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12970,7 +13436,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1502
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12996,7 +13462,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1503
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -21663,7 +22129,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1535
+MaxTypeID: 1545
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -18,6 +18,7 @@ Probes:
           Type: 1517 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xce0105", Frameless: false}]
           Condition: null
+      probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
       version: 0
       type: LOG_PROBE
@@ -36,6 +37,13 @@ Probes:
           Type: 1386 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcdaa25", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -54,6 +62,13 @@ Probes:
           Type: 1389 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcdaabd", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -71,6 +86,13 @@ Probes:
           Type: 1489 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdec62", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -85,6 +107,13 @@ Probes:
           Type: 1336 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -99,6 +128,13 @@ Probes:
           Type: 1332 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -113,6 +149,13 @@ Probes:
           Type: 1334 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -127,6 +170,13 @@ Probes:
           Type: 1397 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcdb1a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -141,6 +191,13 @@ Probes:
           Type: 1333 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -154,6 +211,13 @@ Probes:
           Type: 1335 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -172,6 +236,13 @@ Probes:
           Type: 1355 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd937e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -186,6 +257,13 @@ Probes:
           Type: 1321 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -200,6 +278,13 @@ Probes:
           Type: 1318 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -214,6 +299,13 @@ Probes:
           Type: 1417 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{c}'
+        Segments:
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -236,6 +328,23 @@ Probes:
           Type: 1415 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{w}, {x}, {y}'
+        Segments:
+            - JSON: {Ref: w}
+              DSL: w
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testCycle
       version: 0
       type: LOG_PROBE
@@ -250,6 +359,13 @@ Probes:
           Type: 1425 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{t}'
+        Segments:
+            - JSON: {Ref: t}
+              DSL: t
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -264,6 +380,13 @@ Probes:
           Type: 1360 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -278,6 +401,13 @@ Probes:
           Type: 1361 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -292,6 +422,13 @@ Probes:
           Type: 1356 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd9420", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -306,6 +443,13 @@ Probes:
           Type: 1357 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9440", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -320,6 +464,13 @@ Probes:
           Type: 1358 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -334,6 +485,13 @@ Probes:
           Type: 1359 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -348,6 +506,13 @@ Probes:
           Type: 1505 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -367,6 +532,18 @@ Probes:
           Type: 1508 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -382,6 +559,13 @@ Probes:
           Type: 1527 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -396,6 +580,13 @@ Probes:
           Type: 1533 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xce0640", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -409,6 +600,13 @@ Probes:
           Type: 1534 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xce0660", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -423,6 +621,13 @@ Probes:
           Type: 1387 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -441,6 +646,13 @@ Probes:
           Type: 1370 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd9fac", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -459,6 +671,13 @@ Probes:
           Type: 1368 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd9edb", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -477,6 +696,13 @@ Probes:
           Type: 1380 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcda6c5", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -495,6 +721,13 @@ Probes:
           Type: 1382 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcda71d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -512,6 +745,13 @@ Probes:
           Type: 1383 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcda6e8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -530,6 +770,13 @@ Probes:
           Type: 1372 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcda40e", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -553,6 +800,18 @@ Probes:
           Type: 1374 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcda4de", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -571,6 +830,13 @@ Probes:
           Type: 1376 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcda56b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -585,6 +851,9 @@ Probes:
           Type: 1538 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBBB
+        Segments: [testInlinedBBB]
     - id: testInlinedBC
       version: 0
       type: LOG_PROBE
@@ -603,6 +872,9 @@ Probes:
           Type: 1378 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcda693", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBC
+        Segments: [testInlinedBC]
     - id: testInlinedBCA
       version: 0
       type: LOG_PROBE
@@ -617,6 +889,9 @@ Probes:
           Type: 1539 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCALine
       version: 0
       type: LOG_PROBE
@@ -634,6 +909,9 @@ Probes:
           Type: 1540 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCB
       version: 0
       type: LOG_PROBE
@@ -648,6 +926,9 @@ Probes:
           Type: 1541 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedBCBLine
       version: 0
       type: LOG_PROBE
@@ -665,6 +946,9 @@ Probes:
           Type: 1542 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -694,6 +978,13 @@ Probes:
           Type: 1536 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -721,6 +1012,13 @@ Probes:
             - PC: "0xcda52f"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -735,6 +1033,13 @@ Probes:
           Type: 1543 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -752,6 +1057,13 @@ Probes:
           Type: 1544 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -771,6 +1083,13 @@ Probes:
             - PC: "0xcda7a5"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -785,6 +1104,13 @@ Probes:
           Type: 1324 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -799,6 +1125,13 @@ Probes:
           Type: 1325 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -813,6 +1146,13 @@ Probes:
           Type: 1326 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -827,6 +1167,13 @@ Probes:
           Type: 1323 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -841,6 +1188,13 @@ Probes:
           Type: 1322 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -855,6 +1209,13 @@ Probes:
           Type: 1384 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda9c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -872,6 +1233,13 @@ Probes:
           Type: 1487 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdeb73", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -886,6 +1254,13 @@ Probes:
           Type: 1419 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -903,6 +1278,9 @@ Probes:
           Type: 1364 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd97da", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineB
       version: 0
       type: LOG_PROBE
@@ -920,6 +1298,9 @@ Probes:
           Type: 1365 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd988d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineC
       version: 0
       type: LOG_PROBE
@@ -942,6 +1323,18 @@ Probes:
           Type: 1366 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd9954", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a} and {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' and '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Line
+              EventExpressionIndex: 3
     - id: testManyArgsArrayReturn
       version: 0
       type: LOG_PROBE
@@ -985,6 +1378,53 @@ Probes:
           Type: 1493 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcdf0e2", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -999,6 +1439,13 @@ Probes:
           Type: 1395 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1013,6 +1460,13 @@ Probes:
           Type: 1402 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1027,6 +1481,13 @@ Probes:
           Type: 1412 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xcdb360", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1041,6 +1502,13 @@ Probes:
           Type: 1414 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xcdb3a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1055,6 +1523,13 @@ Probes:
           Type: 1413 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xcdb380", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1069,6 +1544,13 @@ Probes:
           Type: 1399 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcdb1e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1083,6 +1565,13 @@ Probes:
           Type: 1411 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb340", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1097,6 +1586,13 @@ Probes:
           Type: 1410 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcdb320", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1113,6 +1609,13 @@ Probes:
           Type: 1400 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1129,6 +1632,13 @@ Probes:
           Type: 1401 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1143,6 +1653,13 @@ Probes:
           Type: 1409 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1157,6 +1674,13 @@ Probes:
           Type: 1408 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1171,6 +1695,13 @@ Probes:
           Type: 1393 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcdb120", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -1185,6 +1716,13 @@ Probes:
           Type: 1394 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcdb140", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -1199,6 +1737,13 @@ Probes:
           Type: 1392 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcdb100", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -1213,6 +1758,13 @@ Probes:
           Type: 1403 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1227,6 +1779,13 @@ Probes:
           Type: 1406 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -1241,6 +1800,13 @@ Probes:
           Type: 1407 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -1255,6 +1821,13 @@ Probes:
           Type: 1404 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -1271,6 +1844,13 @@ Probes:
           Type: 1405 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -1285,6 +1865,13 @@ Probes:
           Type: 1524 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1300,6 +1887,13 @@ Probes:
           Type: 1525 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -1343,6 +1937,53 @@ Probes:
           Type: 1495 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdf3ab", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -1365,6 +2006,18 @@ Probes:
           Type: 1499 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdf5bf", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -1387,6 +2040,18 @@ Probes:
           Type: 1491 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcdeeaa", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s1}, {s2}'
+        Segments:
+            - JSON: {Ref: s1}
+              DSL: s1
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s2}
+              DSL: s2
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1404,6 +2069,13 @@ Probes:
           Type: 1445 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -1432,6 +2104,33 @@ Probes:
           Type: 1416 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdce60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1449,6 +2148,13 @@ Probes:
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -1472,6 +2178,19 @@ Probes:
           Type: 1443 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Parameter {i} * 2 = result {result}
+        Segments:
+            - 'Parameter '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ' * 2 = result '
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1491,6 +2210,18 @@ Probes:
           Type: 1424 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}, {a}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -1505,6 +2236,13 @@ Probes:
           Type: 1512 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -1524,6 +2262,18 @@ Probes:
           Type: 1509 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -1546,6 +2296,23 @@ Probes:
           Type: 1511 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {s}, {x}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -1560,6 +2327,13 @@ Probes:
           Type: 1523 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xce01a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -1574,6 +2348,13 @@ Probes:
           Type: 1420 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -1588,6 +2369,13 @@ Probes:
           Type: 1398 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -1602,6 +2390,13 @@ Probes:
           Type: 1418 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdd220", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -1628,6 +2423,13 @@ Probes:
             - PC: "0xcdddea"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -1659,6 +2461,18 @@ Probes:
             - PC: "0xcddbd9"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}, {failed}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -1676,6 +2490,9 @@ Probes:
           Type: 1465 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcde50d", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArray
+        Segments: [testReturnsArray]
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
@@ -1693,6 +2510,9 @@ Probes:
           Type: 1467 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcde56b", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayOne
+        Segments: [testReturnsArrayOne]
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
@@ -1710,6 +2530,9 @@ Probes:
           Type: 1469 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcde5c6", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayZero
+        Segments: [testReturnsArrayZero]
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
@@ -1727,6 +2550,9 @@ Probes:
           Type: 1473 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcde6ea", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBacktrackInt
+        Segments: [testReturnsBacktrackInt]
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
@@ -1744,6 +2570,9 @@ Probes:
           Type: 1485 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcde9f0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBoolAndUintptr
+        Segments: [testReturnsBoolAndUintptr]
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
@@ -1761,6 +2590,9 @@ Probes:
           Type: 1461 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcde3c6", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsComplex
+        Segments: [testReturnsComplex]
     - id: testReturnsError
       version: 0
       type: LOG_PROBE
@@ -1783,6 +2615,13 @@ Probes:
             - PC: "0xcddaa5"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{failed}'
+        Segments:
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -1800,6 +2639,13 @@ Probes:
           Type: 1427 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcdd8bb", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -1817,6 +2663,13 @@ Probes:
           Type: 1431 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcdda44", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -1834,6 +2687,13 @@ Probes:
           Type: 1429 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcdd954", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -1856,6 +2716,13 @@ Probes:
             - PC: "0xcddf09"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -1873,6 +2740,9 @@ Probes:
           Type: 1463 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcde473", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsLargeStruct
+        Segments: [testReturnsLargeStruct]
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
@@ -1890,6 +2760,9 @@ Probes:
           Type: 1459 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcde347", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsManyFloats
+        Segments: [testReturnsManyFloats]
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
@@ -1907,6 +2780,9 @@ Probes:
           Type: 1477 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcde82c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixed
+        Segments: [testReturnsMixed]
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
@@ -1924,6 +2800,9 @@ Probes:
           Type: 1471 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcde638", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixedStruct
+        Segments: [testReturnsMixedStruct]
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
@@ -1941,6 +2820,9 @@ Probes:
           Type: 1483 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcde976", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMultipleFloats
+        Segments: [testReturnsMultipleFloats]
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -1958,6 +2840,9 @@ Probes:
           Type: 1481 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcde90e", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsOnlyFloat
+        Segments: [testReturnsOnlyFloat]
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
@@ -1975,6 +2860,9 @@ Probes:
           Type: 1457 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcde251", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsPrimitives
+        Segments: [testReturnsPrimitives]
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
@@ -1992,6 +2880,9 @@ Probes:
           Type: 1479 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcde8ad", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsStructWithArray
+        Segments: [testReturnsStructWithArray]
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
@@ -2009,6 +2900,9 @@ Probes:
           Type: 1475 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcde794", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsWideStruct
+        Segments: [testReturnsWideStruct]
     - id: testRuneArray
       version: 0
       type: LOG_PROBE
@@ -2023,6 +2917,13 @@ Probes:
           Type: 1319 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -2054,6 +2955,37 @@ Probes:
           Type: 1447 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
+        Segments:
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 4
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 5
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 2
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -2068,6 +3000,13 @@ Probes:
           Type: 1340 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -2082,6 +3021,13 @@ Probes:
           Type: 1338 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -2096,6 +3042,13 @@ Probes:
           Type: 1351 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat64
       version: 0
       type: LOG_PROBE
@@ -2110,6 +3063,13 @@ Probes:
           Type: 1352 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt
       version: 0
       type: LOG_PROBE
@@ -2124,6 +3084,13 @@ Probes:
           Type: 1341 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -2138,6 +3105,14 @@ Probes:
           Type: 1343 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -2152,6 +3127,13 @@ Probes:
           Type: 1344 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -2166,6 +3148,13 @@ Probes:
           Type: 1345 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -2187,6 +3176,22 @@ Probes:
           Type: 1342 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}{x}{x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -2201,6 +3206,13 @@ Probes:
           Type: 1339 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -2215,6 +3227,13 @@ Probes:
           Type: 1518 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xce0120", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -2229,6 +3248,13 @@ Probes:
           Type: 1346 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -2243,6 +3269,13 @@ Probes:
           Type: 1348 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -2257,6 +3290,13 @@ Probes:
           Type: 1349 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -2271,6 +3311,13 @@ Probes:
           Type: 1350 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -2285,6 +3332,13 @@ Probes:
           Type: 1347 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -2299,6 +3353,13 @@ Probes:
           Type: 1515 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -2313,6 +3374,13 @@ Probes:
           Type: 1506 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -2327,6 +3395,13 @@ Probes:
           Type: 1396 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2344,6 +3419,13 @@ Probes:
           Type: 1455 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcde1ad", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -2361,6 +3443,13 @@ Probes:
           Type: 1497 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdf4bc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -2375,6 +3464,13 @@ Probes:
           Type: 1320 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -2389,6 +3485,13 @@ Probes:
           Type: 1423 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -2403,6 +3506,13 @@ Probes:
           Type: 1510 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -2417,6 +3527,13 @@ Probes:
           Type: 1362 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -2431,6 +3548,13 @@ Probes:
           Type: 1363 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -2449,6 +3573,13 @@ Probes:
           Type: 1532 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xce04e2", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -2468,6 +3599,18 @@ Probes:
           Type: 1507 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -2482,6 +3625,13 @@ Probes:
           Type: 1390 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -2499,6 +3649,13 @@ Probes:
           Type: 1501 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdf69c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -2516,6 +3673,13 @@ Probes:
           Type: 1530 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xce039e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -2529,6 +3693,13 @@ Probes:
           Type: 1528 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xce0360", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -2543,6 +3714,13 @@ Probes:
           Type: 1391 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -2562,6 +3740,11 @@ Probes:
           Type: 1449 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{nonexistentVariable}'
+        Segments:
+            - Error: failed to resolve reference "nonexistentVariable"
+              DSL: nonexistentVariable
     - id: testTemplateWithUnsupportedExpression
       version: 0
       type: LOG_PROBE
@@ -2581,6 +3764,11 @@ Probes:
           Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{unsupportedExpression}'
+        Segments:
+            - Error: 'unsupported operation: foobar'
+              DSL: unsupportedExpression
     - id: testTemplateWithUnsupportedVariable
       version: 0
       type: LOG_PROBE
@@ -2602,6 +3790,13 @@ Probes:
           Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
+        Segments:
+            - 'Executed main.testMultipleNamedReturn, it took '
+            - Error: failed to resolve reference "@duration"
+              DSL: '@duration'
+            - ms
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
@@ -2624,6 +3819,23 @@ Probes:
           Type: 1519 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xce0140", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}, {z}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -2642,6 +3854,13 @@ Probes:
           Type: 1521 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce017e", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testThreeStringsInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2656,6 +3875,13 @@ Probes:
           Type: 1522 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0180", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -2670,6 +3896,13 @@ Probes:
           Type: 1353 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd9200", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -2684,6 +3917,13 @@ Probes:
           Type: 1329 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -2698,6 +3938,13 @@ Probes:
           Type: 1330 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -2712,6 +3959,13 @@ Probes:
           Type: 1331 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -2726,6 +3980,13 @@ Probes:
           Type: 1328 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -2740,6 +4001,13 @@ Probes:
           Type: 1327 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -2754,6 +4022,13 @@ Probes:
           Type: 1422 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -2768,6 +4043,13 @@ Probes:
           Type: 1504 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -2782,6 +4064,13 @@ Probes:
           Type: 1526 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -2796,6 +4085,13 @@ Probes:
           Type: 1421 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -2810,6 +4106,13 @@ Probes:
           Type: 1337 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -2824,6 +4127,13 @@ Probes:
           Type: 1513 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2838,6 +4148,13 @@ Probes:
           Type: 1514 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -2860,6 +4177,18 @@ Probes:
           Type: 1503 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdf74c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -9403,12 +10732,22 @@ Types:
     - __kind: EventRootType
       ID: 1388
       Name: Probe[main.testAnyPtr]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 163 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 163 PointerType *interface {}
             Operations:
@@ -9435,12 +10774,22 @@ Types:
     - __kind: EventRootType
       ID: 1385
       Name: Probe[main.testAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -9467,12 +10816,22 @@ Types:
     - __kind: EventRootType
       ID: 1488
       Name: Probe[main.testArrayArgAndReturn]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -9512,10 +10871,20 @@ Types:
                   Variable: {subprogram: 19, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 124 ArrayType [2]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 19, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1334
       Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -9528,10 +10897,20 @@ Types:
                   Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
+        - Name: b
+          Offset: 65
+          Kind: template_segment
+          Expression:
+            Type: 121 ArrayType [2][2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 64
     - __kind: EventRootType
       ID: 1332
       Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9544,10 +10923,20 @@ Types:
                   Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 120 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 15, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1397
       Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -9560,10 +10949,20 @@ Types:
                   Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
+        - Name: m
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 191 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1333
       Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9576,10 +10975,20 @@ Types:
                   Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1335
       Name: Probe[main.testArrayOfStructs]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9592,15 +11001,35 @@ Types:
                   Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 122 ArrayType [2]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 1354
       Name: Probe[main.testBigStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 128 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: b
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 128 StructureType main.bigStruct
             Operations:
@@ -9614,7 +11043,7 @@ Types:
     - __kind: EventRootType
       ID: 1321
       Name: Probe[main.testBoolArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9627,15 +11056,35 @@ Types:
                   Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 112 ArrayType [2]bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1318
       Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 109 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -9659,10 +11108,20 @@ Types:
                   Variable: {subprogram: 85, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 243 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1415
       Name: Probe[main.testCombinedByte]
-      ByteSize: 7
+      ByteSize: 13
       PresenceBitsetSize: 1
       Expressions:
         - Name: w
@@ -9675,8 +11134,18 @@ Types:
                   Variable: {subprogram: 83, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
-        - Name: x
+        - Name: w
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -9685,9 +11154,29 @@ Types:
                   Variable: {subprogram: 83, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
         - Name: y
-          Offset: 3
+          Offset: 5
           Kind: argument
+          Expression:
+            Type: 18 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: y
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 18 BaseType float32
             Operations:
@@ -9698,7 +11187,7 @@ Types:
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testCycle]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: t
@@ -9711,10 +11200,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
+        - Name: t
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 248 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1360
       Name: Probe[main.testDeepMap1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9727,10 +11226,20 @@ Types:
                   Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 143 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1361
       Name: Probe[main.testDeepMap7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9743,10 +11252,20 @@ Types:
                   Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 149 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1356
       Name: Probe[main.testDeepPtr1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9759,10 +11278,20 @@ Types:
                   Variable: {subprogram: 38, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 132 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1357
       Name: Probe[main.testDeepPtr7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9775,10 +11304,20 @@ Types:
                   Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 135 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1358
       Name: Probe[main.testDeepSlice1]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9791,10 +11330,20 @@ Types:
                   Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 137 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1359
       Name: Probe[main.testDeepSlice7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9807,10 +11356,20 @@ Types:
                   Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 141 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1508
       Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -9823,9 +11382,29 @@ Types:
                   Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -9836,7 +11415,7 @@ Types:
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.testEmptySlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -9849,10 +11428,20 @@ Types:
                   Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 129, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1527
       Name: Probe[main.testEmptyString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9865,15 +11454,35 @@ Types:
                   Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 147, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1534
       Name: Probe[main.testEmptyStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 318 PointerType *main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 318 PointerType *main.emptyStruct
             Operations:
@@ -9897,10 +11506,20 @@ Types:
                   Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
+        - Name: e
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 317 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1387
       Name: Probe[main.testError]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
@@ -9913,15 +11532,35 @@ Types:
                   Variable: {subprogram: 57, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: e
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 57, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1369
       Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 159 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 159 PointerType *main.esotericHeap
             Operations:
@@ -9935,12 +11574,22 @@ Types:
     - __kind: EventRootType
       ID: 1367
       Name: Probe[main.testEsotericStack]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 155 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+        - Name: e
+          Offset: 65
+          Kind: template_segment
           Expression:
             Type: 155 StructureType main.esotericStack
             Operations:
@@ -9954,7 +11603,7 @@ Types:
     - __kind: EventRootType
       ID: 1381
       Name: Probe[main.testFramelessArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9967,10 +11616,20 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1383
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 49
+      ByteSize: 89
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9983,8 +11642,18 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-        - Name: ~r0
+        - Name: a
           Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 81
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -10012,12 +11681,22 @@ Types:
     - __kind: EventRootType
       ID: 1379
       Name: Probe[main.testFrameless]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10044,12 +11723,22 @@ Types:
     - __kind: EventRootType
       ID: 1371
       Name: Probe[main.testInlinedBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10063,12 +11752,22 @@ Types:
     - __kind: EventRootType
       ID: 1375
       Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10085,7 +11784,7 @@ Types:
     - __kind: EventRootType
       ID: 1373
       Name: Probe[main.testInlinedBB]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10098,9 +11797,29 @@ Types:
                   Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: y
+        - Name: x
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10132,7 +11851,7 @@ Types:
     - __kind: EventRootType
       ID: 1535
       Name: Probe[main.testInlinedPrint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10145,15 +11864,35 @@ Types:
                   Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1537
       Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10167,7 +11906,7 @@ Types:
     - __kind: EventRootType
       ID: 1543
       Name: Probe[main.testInlinedSq]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10180,10 +11919,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1544
       Name: Probe[main.testInlinedSq]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10196,10 +11945,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1545
       Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10212,10 +11971,20 @@ Types:
                   Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1324
       Name: Probe[main.testInt16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10228,10 +11997,20 @@ Types:
                   Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 115 ArrayType [2]int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1325
       Name: Probe[main.testInt32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10244,10 +12023,20 @@ Types:
                   Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 110 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1326
       Name: Probe[main.testInt64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10260,10 +12049,20 @@ Types:
                   Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 116 ArrayType [2]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1323
       Name: Probe[main.testInt8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10276,10 +12075,20 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 114 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1322
       Name: Probe[main.testIntArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10292,10 +12101,20 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1384
       Name: Probe[main.testInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -10308,15 +12127,35 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 162 GoInterfaceType main.behavior
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1486
       Name: Probe[main.testLargeArgAndReturn]
-      ByteSize: 81
+      ByteSize: 161
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: arg
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -10343,12 +12182,22 @@ Types:
     - __kind: EventRootType
       ID: 1419
       Name: Probe[main.testLinkedList]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 246 StructureType main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 246 StructureType main.node
             Operations:
@@ -10388,7 +12237,7 @@ Types:
     - __kind: EventRootType
       ID: 1366
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10401,9 +12250,29 @@ Types:
                   Variable: {subprogram: 46, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: a
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10414,11 +12283,11 @@ Types:
     - __kind: EventRootType
       ID: 1492
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 74
-      PresenceBitsetSize: 2
+      ByteSize: 147
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10427,8 +12296,18 @@ Types:
                   Variable: {subprogram: 122, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10437,8 +12316,18 @@ Types:
                   Variable: {subprogram: 122, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10447,8 +12336,18 @@ Types:
                   Variable: {subprogram: 122, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10457,8 +12356,18 @@ Types:
                   Variable: {subprogram: 122, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10467,8 +12376,18 @@ Types:
                   Variable: {subprogram: 122, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10477,8 +12396,18 @@ Types:
                   Variable: {subprogram: 122, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10487,8 +12416,18 @@ Types:
                   Variable: {subprogram: 122, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10497,9 +12436,29 @@ Types:
                   Variable: {subprogram: 122, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 139
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10526,7 +12485,7 @@ Types:
     - __kind: EventRootType
       ID: 1395
       Name: Probe[main.testMapArrayToArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10539,10 +12498,20 @@ Types:
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 186 GoMapType map[[4]string][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1402
       Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10555,10 +12524,20 @@ Types:
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1414
       Name: Probe[main.testMapEmptyKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10571,10 +12550,20 @@ Types:
                   Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 238 GoMapType map[struct {}]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 82, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1412
       Name: Probe[main.testMapEmptyKey]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10587,10 +12576,20 @@ Types:
                   Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 228 GoMapType map[struct {}]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1413
       Name: Probe[main.testMapEmptyValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10603,10 +12602,20 @@ Types:
                   Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 233 GoMapType map[int]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1399
       Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10619,10 +12628,20 @@ Types:
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 166 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 68, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1411
       Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10635,10 +12654,20 @@ Types:
                   Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 223 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1410
       Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10651,15 +12680,35 @@ Types:
                   Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 218 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1400
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -10670,7 +12719,7 @@ Types:
     - __kind: EventRootType
       ID: 1401
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10683,10 +12732,20 @@ Types:
                   Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1409
       Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10699,10 +12758,20 @@ Types:
                   Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 213 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1408
       Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10715,10 +12784,20 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1393
       Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10731,10 +12810,20 @@ Types:
                   Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1394
       Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10747,10 +12836,20 @@ Types:
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 181 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1392
       Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10763,10 +12862,20 @@ Types:
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1403
       Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10779,10 +12888,20 @@ Types:
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1407
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10795,10 +12914,20 @@ Types:
                   Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1406
       Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10811,10 +12940,20 @@ Types:
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 74, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1405
       Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10827,10 +12966,20 @@ Types:
                   Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1404
       Name: Probe[main.testMapWithSmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10843,15 +12992,35 @@ Types:
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -10862,7 +13031,7 @@ Types:
     - __kind: EventRootType
       ID: 1525
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10875,14 +13044,24 @@ Types:
                   Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1494
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 163
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10891,8 +13070,18 @@ Types:
                   Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10901,8 +13090,18 @@ Types:
                   Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10911,8 +13110,18 @@ Types:
                   Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10921,8 +13130,18 @@ Types:
                   Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10931,8 +13150,18 @@ Types:
                   Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10941,8 +13170,18 @@ Types:
                   Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10951,8 +13190,18 @@ Types:
                   Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10961,9 +13210,29 @@ Types:
                   Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: s
+          Offset: 147
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -10990,7 +13259,7 @@ Types:
     - __kind: EventRootType
       ID: 1498
       Name: Probe[main.testMultipleArrayArgs]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11003,9 +13272,29 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
-        - Name: b
+        - Name: a
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: b
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -11042,7 +13331,7 @@ Types:
     - __kind: EventRootType
       ID: 1490
       Name: Probe[main.testMultipleLargeArgs]
-      ByteSize: 161
+      ByteSize: 321
       PresenceBitsetSize: 1
       Expressions:
         - Name: s1
@@ -11055,9 +13344,29 @@ Types:
                   Variable: {subprogram: 121, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
-        - Name: s2
+        - Name: s1
           Offset: 81
+          Kind: template_segment
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 161
           Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 241
+          Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -11084,7 +13393,7 @@ Types:
     - __kind: EventRootType
       ID: 1444
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11097,15 +13406,55 @@ Types:
                   Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1446
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11190,7 +13539,7 @@ Types:
     - __kind: EventRootType
       ID: 1447
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11203,9 +13552,49 @@ Types:
                   Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
+        - Name: result
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 25
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11294,11 +13683,11 @@ Types:
     - __kind: EventRootType
       ID: 1416
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 62
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -11307,8 +13696,18 @@ Types:
                   Variable: {subprogram: 84, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
+        - Name: a
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
         - Name: b
-          Offset: 2
+          Offset: 4
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -11317,8 +13716,18 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
+        - Name: b
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
         - Name: c
-          Offset: 3
+          Offset: 6
           Kind: argument
           Expression:
             Type: 10 BaseType int32
@@ -11327,8 +13736,18 @@ Types:
                   Variable: {subprogram: 84, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
+        - Name: c
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
         - Name: d
-          Offset: 7
+          Offset: 14
           Kind: argument
           Expression:
             Type: 17 BaseType uint
@@ -11337,9 +13756,29 @@ Types:
                   Variable: {subprogram: 84, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 22
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 15
+          Offset: 30
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: e
+          Offset: 46
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -11350,7 +13789,7 @@ Types:
     - __kind: EventRootType
       ID: 1440
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11363,15 +13802,35 @@ Types:
                   Variable: {subprogram: 101, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1442
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11398,7 +13857,7 @@ Types:
     - __kind: EventRootType
       ID: 1443
       Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11411,10 +13870,20 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
+        - Name: result
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1424
       Name: Probe[main.testNilPointer]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -11427,9 +13896,29 @@ Types:
                   Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: z
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 17 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -11440,7 +13929,7 @@ Types:
     - __kind: EventRootType
       ID: 1509
       Name: Probe[main.testNilSliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11453,9 +13942,29 @@ Types:
                   Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11466,7 +13975,7 @@ Types:
     - __kind: EventRootType
       ID: 1511
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 34
+      ByteSize: 67
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11479,8 +13988,18 @@ Types:
                   Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: s
+        - Name: a
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 3
           Kind: argument
           Expression:
             Type: 264 GoSliceHeaderType []bool
@@ -11489,9 +14008,29 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 264 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
-          Offset: 26
+          Offset: 51
           Kind: argument
+          Expression:
+            Type: 17 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 59
+          Kind: template_segment
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -11502,7 +14041,7 @@ Types:
     - __kind: EventRootType
       ID: 1512
       Name: Probe[main.testNilSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11515,10 +14054,20 @@ Types:
                   Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 265 GoSliceHeaderType []uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1523
       Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11531,10 +14080,20 @@ Types:
                   Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 270 PointerType *main.oneStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 144, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1420
       Name: Probe[main.testPointerLoop]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11547,10 +14106,20 @@ Types:
                   Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 247 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1398
       Name: Probe[main.testPointerToMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11563,10 +14132,20 @@ Types:
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 192 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 67, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1418
       Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11579,10 +14158,20 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 244 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1434
       Name: Probe[main.testReturnsAnyAndError]
-      ByteSize: 18
+      ByteSize: 35
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -11595,9 +14184,29 @@ Types:
                   Variable: {subprogram: 98, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
-        - Name: failed
+        - Name: v
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: failed
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11634,12 +14243,22 @@ Types:
     - __kind: EventRootType
       ID: 1436
       Name: Probe[main.testReturnsAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -11880,12 +14499,22 @@ Types:
     - __kind: EventRootType
       ID: 1432
       Name: Probe[main.testReturnsError]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: failed
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11912,12 +14541,22 @@ Types:
     - __kind: EventRootType
       ID: 1430
       Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11954,12 +14593,22 @@ Types:
     - __kind: EventRootType
       ID: 1428
       Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11986,12 +14635,22 @@ Types:
     - __kind: EventRootType
       ID: 1426
       Name: Probe[main.testReturnsInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12018,12 +14677,22 @@ Types:
     - __kind: EventRootType
       ID: 1438
       Name: Probe[main.testReturnsInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -12501,7 +15170,7 @@ Types:
     - __kind: EventRootType
       ID: 1319
       Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12514,10 +15183,20 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 110 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1340
       Name: Probe[main.testSingleBool]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12530,10 +15209,20 @@ Types:
                   Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1338
       Name: Probe[main.testSingleByte]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12546,10 +15235,20 @@ Types:
                   Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1351
       Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12562,10 +15261,20 @@ Types:
                   Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 18 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1352
       Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12578,10 +15287,20 @@ Types:
                   Variable: {subprogram: 35, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1343
       Name: Probe[main.testSingleInt16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12594,10 +15313,20 @@ Types:
                   Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 104 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1344
       Name: Probe[main.testSingleInt32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12610,10 +15339,20 @@ Types:
                   Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1345
       Name: Probe[main.testSingleInt64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12626,10 +15365,20 @@ Types:
                   Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1342
       Name: Probe[main.testSingleInt8]
-      ByteSize: 2
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12642,10 +15391,40 @@ Types:
                   Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1341
       Name: Probe[main.testSingleInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12658,10 +15437,20 @@ Types:
                   Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1339
       Name: Probe[main.testSingleRune]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12674,10 +15463,20 @@ Types:
                   Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1518
       Name: Probe[main.testSingleString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12690,10 +15489,20 @@ Types:
                   Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1348
       Name: Probe[main.testSingleUint16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12706,10 +15515,20 @@ Types:
                   Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 6 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1349
       Name: Probe[main.testSingleUint32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12722,10 +15541,20 @@ Types:
                   Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1350
       Name: Probe[main.testSingleUint64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12738,10 +15567,20 @@ Types:
                   Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1347
       Name: Probe[main.testSingleUint8]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12754,10 +15593,20 @@ Types:
                   Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1346
       Name: Probe[main.testSingleUint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12770,10 +15619,20 @@ Types:
                   Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1515
       Name: Probe[main.testSliceEmptyStructs]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -12786,10 +15645,20 @@ Types:
                   Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 266 GoSliceHeaderType []struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1506
       Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -12802,10 +15671,20 @@ Types:
                   Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1396
       Name: Probe[main.testSmallMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -12818,15 +15697,35 @@ Types:
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 65, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1454
       Name: Probe[main.testSomeNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12873,12 +15772,22 @@ Types:
     - __kind: EventRootType
       ID: 1496
       Name: Probe[main.testStackArgRegReturns]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: arg
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12925,7 +15834,7 @@ Types:
     - __kind: EventRootType
       ID: 1320
       Name: Probe[main.testStringArray]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12938,10 +15847,20 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
+        - Name: x
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1423
       Name: Probe[main.testStringPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -12954,10 +15873,20 @@ Types:
                   Variable: {subprogram: 91, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 95 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1510
       Name: Probe[main.testStringSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -12970,10 +15899,20 @@ Types:
                   Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 263 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1362
       Name: Probe[main.testStringType1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12986,10 +15925,20 @@ Types:
                   Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 151 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1363
       Name: Probe[main.testStringType2]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13002,10 +15951,20 @@ Types:
                   Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 153 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1507
       Name: Probe[main.testStructSlice]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13018,9 +15977,29 @@ Types:
                   Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13031,7 +16010,7 @@ Types:
     - __kind: EventRootType
       ID: 1390
       Name: Probe[main.testStructWithAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13044,15 +16023,35 @@ Types:
                   Variable: {subprogram: 59, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: s
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 164 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1500
       Name: Probe[main.testStructWithArrayArg]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 256 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 256 StructureType main.structWithArray
             Operations:
@@ -13089,12 +16088,22 @@ Types:
     - __kind: EventRootType
       ID: 1529
       Name: Probe[main.testStructWithCyclicMaps]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 285 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
@@ -13108,7 +16117,7 @@ Types:
     - __kind: EventRootType
       ID: 1528
       Name: Probe[main.testStructWithCyclicSlices]
-      ByteSize: 145
+      ByteSize: 289
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13121,10 +16130,20 @@ Types:
                   Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
+        - Name: a
+          Offset: 145
+          Kind: template_segment
+          Expression:
+            Type: 272 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 148, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
     - __kind: EventRootType
       ID: 1391
       Name: Probe[main.testStructWithMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13137,15 +16156,35 @@ Types:
                   Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
+        - Name: s
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 165 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testStruct]
-      ByteSize: 57
+      ByteSize: 113
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 316 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 150, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+        - Name: x
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 316 StructureType main.aStruct
             Operations:
@@ -13159,7 +16198,7 @@ Types:
     - __kind: EventRootType
       ID: 1522
       Name: Probe[main.testThreeStringsInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13172,15 +16211,35 @@ Types:
                   Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 269 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 143, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1520
       Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 268 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 268 StructureType main.threeStringStruct
             Operations:
@@ -13194,7 +16253,7 @@ Types:
     - __kind: EventRootType
       ID: 1519
       Name: Probe[main.testThreeStrings]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13207,8 +16266,18 @@ Types:
                   Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-        - Name: y
+        - Name: x
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 33
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -13217,9 +16286,29 @@ Types:
                   Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
+        - Name: y
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
-          Offset: 33
+          Offset: 65
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 2, name: z}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: z
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -13230,7 +16319,7 @@ Types:
     - __kind: EventRootType
       ID: 1353
       Name: Probe[main.testTypeAlias]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13243,10 +16332,20 @@ Types:
                   Variable: {subprogram: 36, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 127 BaseType main.typeAlias
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1329
       Name: Probe[main.testUint16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13259,10 +16358,20 @@ Types:
                   Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 118 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1330
       Name: Probe[main.testUint32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13275,10 +16384,20 @@ Types:
                   Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 119 ArrayType [2]uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 13, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1331
       Name: Probe[main.testUint64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13291,10 +16410,20 @@ Types:
                   Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 54 ArrayType [2]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 14, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1328
       Name: Probe[main.testUint8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13307,10 +16436,20 @@ Types:
                   Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 109 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1327
       Name: Probe[main.testUintArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13323,10 +16462,20 @@ Types:
                   Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 117 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1422
       Name: Probe[main.testUintPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13339,10 +16488,20 @@ Types:
                   Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 107 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1504
       Name: Probe[main.testUintSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -13355,10 +16514,20 @@ Types:
                   Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1526
       Name: Probe[main.testUnitializedString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13371,10 +16540,20 @@ Types:
                   Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 146, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1421
       Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13387,10 +16566,20 @@ Types:
                   Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 14 VoidPointerType unsafe.Pointer
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
+      ByteSize: 1601
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13403,15 +16592,35 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
+        - Name: a
+          Offset: 801
+          Kind: template_segment
+          Expression:
+            Type: 126 ArrayType [100]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 20, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 800
     - __kind: EventRootType
       ID: 1513
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -13422,7 +16631,7 @@ Types:
     - __kind: EventRootType
       ID: 1514
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13435,10 +16644,20 @@ Types:
                   Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1502
       Name: Probe[main.testZeroSizeArgAndReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13451,9 +16670,29 @@ Types:
                   Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -18,6 +18,7 @@ Probes:
           Type: 1323 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x89288c", Frameless: false}]
           Condition: null
+      probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
       version: 0
       type: LOG_PROBE
@@ -36,6 +37,13 @@ Probes:
           Type: 1192 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x88dd84", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -54,6 +62,13 @@ Probes:
           Type: 1195 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x88de04", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -71,6 +86,13 @@ Probes:
           Type: 1295 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x8916a4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -85,6 +107,13 @@ Probes:
           Type: 1142 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -99,6 +128,13 @@ Probes:
           Type: 1138 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -113,6 +149,13 @@ Probes:
           Type: 1140 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -127,6 +170,13 @@ Probes:
           Type: 1203 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88e440", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -141,6 +191,13 @@ Probes:
           Type: 1139 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -154,6 +211,13 @@ Probes:
           Type: 1141 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -172,6 +236,13 @@ Probes:
           Type: 1161 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x88c8c8", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -186,6 +257,13 @@ Probes:
           Type: 1127 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -200,6 +278,13 @@ Probes:
           Type: 1124 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -214,6 +299,13 @@ Probes:
           Type: 1223 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88fb30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{c}'
+        Segments:
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -236,6 +328,23 @@ Probes:
           Type: 1221 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88f8b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{w}, {x}, {y}'
+        Segments:
+            - JSON: {Ref: w}
+              DSL: w
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testCycle
       version: 0
       type: LOG_PROBE
@@ -250,6 +359,13 @@ Probes:
           Type: 1231 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fdd0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{t}'
+        Segments:
+            - JSON: {Ref: t}
+              DSL: t
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -264,6 +380,13 @@ Probes:
           Type: 1166 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -278,6 +401,13 @@ Probes:
           Type: 1167 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -292,6 +422,13 @@ Probes:
           Type: 1162 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c980", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -306,6 +443,13 @@ Probes:
           Type: 1163 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c990", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -320,6 +464,13 @@ Probes:
           Type: 1164 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -334,6 +485,13 @@ Probes:
           Type: 1165 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -348,6 +506,13 @@ Probes:
           Type: 1311 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x8924d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -367,6 +532,18 @@ Probes:
           Type: 1314 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x892500", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -382,6 +559,13 @@ Probes:
           Type: 1333 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x892930", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -396,6 +580,13 @@ Probes:
           Type: 1339 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x892c80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -409,6 +600,13 @@ Probes:
           Type: 1340 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x892c90", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -423,6 +621,13 @@ Probes:
           Type: 1193 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88ddb0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -441,6 +646,13 @@ Probes:
           Type: 1176 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x88d394", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -459,6 +671,13 @@ Probes:
           Type: 1174 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x88d2dc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -477,6 +696,13 @@ Probes:
           Type: 1186 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x88da88", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -495,6 +721,13 @@ Probes:
           Type: 1188 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x88dad8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -512,6 +745,13 @@ Probes:
           Type: 1189 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x88da9c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -530,6 +770,13 @@ Probes:
           Type: 1178 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x88d7f0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -553,6 +800,18 @@ Probes:
           Type: 1180 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x88d8b0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -571,6 +830,13 @@ Probes:
           Type: 1182 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x88d934", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -585,6 +851,9 @@ Probes:
           Type: 1344 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d878", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBBB
+        Segments: [testInlinedBBB]
     - id: testInlinedBC
       version: 0
       type: LOG_PROBE
@@ -603,6 +872,9 @@ Probes:
           Type: 1184 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x88da68", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBC
+        Segments: [testInlinedBC]
     - id: testInlinedBCA
       version: 0
       type: LOG_PROBE
@@ -617,6 +889,9 @@ Probes:
           Type: 1345 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCALine
       version: 0
       type: LOG_PROBE
@@ -634,6 +909,9 @@ Probes:
           Type: 1346 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCB
       version: 0
       type: LOG_PROBE
@@ -648,6 +926,9 @@ Probes:
           Type: 1347 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedBCBLine
       version: 0
       type: LOG_PROBE
@@ -665,6 +946,9 @@ Probes:
           Type: 1348 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -694,6 +978,13 @@ Probes:
           Type: 1342 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d630", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -721,6 +1012,13 @@ Probes:
             - PC: "0x88d8fc"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -735,6 +1033,13 @@ Probes:
           Type: 1349 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -752,6 +1057,13 @@ Probes:
           Type: 1350 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -771,6 +1083,13 @@ Probes:
             - PC: "0x88db4c"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -785,6 +1104,13 @@ Probes:
           Type: 1130 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -799,6 +1125,13 @@ Probes:
           Type: 1131 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -813,6 +1146,13 @@ Probes:
           Type: 1132 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -827,6 +1167,13 @@ Probes:
           Type: 1129 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -841,6 +1188,13 @@ Probes:
           Type: 1128 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -855,6 +1209,13 @@ Probes:
           Type: 1190 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88dd30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -872,6 +1233,13 @@ Probes:
           Type: 1293 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x891588", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -886,6 +1254,13 @@ Probes:
           Type: 1225 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88fce0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -903,6 +1278,9 @@ Probes:
           Type: 1170 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ccec", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineB
       version: 0
       type: LOG_PROBE
@@ -920,6 +1298,9 @@ Probes:
           Type: 1171 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88cd80", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineC
       version: 0
       type: LOG_PROBE
@@ -942,6 +1323,18 @@ Probes:
           Type: 1172 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ce2c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a} and {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' and '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Line
+              EventExpressionIndex: 3
     - id: testManyArgsArrayReturn
       version: 0
       type: LOG_PROBE
@@ -985,6 +1378,53 @@ Probes:
           Type: 1299 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x891aac", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -999,6 +1439,13 @@ Probes:
           Type: 1201 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88e420", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1013,6 +1460,13 @@ Probes:
           Type: 1208 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1027,6 +1481,13 @@ Probes:
           Type: 1218 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x88e520", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1041,6 +1502,13 @@ Probes:
           Type: 1220 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x88e540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1055,6 +1523,13 @@ Probes:
           Type: 1219 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x88e530", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1069,6 +1544,13 @@ Probes:
           Type: 1205 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88e460", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1083,6 +1565,13 @@ Probes:
           Type: 1217 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88e510", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1097,6 +1586,13 @@ Probes:
           Type: 1216 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88e500", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1113,6 +1609,13 @@ Probes:
           Type: 1206 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1129,6 +1632,13 @@ Probes:
           Type: 1207 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1143,6 +1653,13 @@ Probes:
           Type: 1215 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1157,6 +1674,13 @@ Probes:
           Type: 1214 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1171,6 +1695,13 @@ Probes:
           Type: 1199 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88e400", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -1185,6 +1716,13 @@ Probes:
           Type: 1200 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88e410", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -1199,6 +1737,13 @@ Probes:
           Type: 1198 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -1213,6 +1758,13 @@ Probes:
           Type: 1209 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88e490", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1227,6 +1779,13 @@ Probes:
           Type: 1212 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -1241,6 +1800,13 @@ Probes:
           Type: 1213 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -1255,6 +1821,13 @@ Probes:
           Type: 1210 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -1271,6 +1844,13 @@ Probes:
           Type: 1211 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -1285,6 +1865,13 @@ Probes:
           Type: 1330 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1300,6 +1887,13 @@ Probes:
           Type: 1331 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -1343,6 +1937,53 @@ Probes:
           Type: 1301 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x891ce0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -1365,6 +2006,18 @@ Probes:
           Type: 1305 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x891eb0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -1387,6 +2040,18 @@ Probes:
           Type: 1297 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x8918b0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s1}, {s2}'
+        Segments:
+            - JSON: {Ref: s1}
+              DSL: s1
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s2}
+              DSL: s2
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1404,6 +2069,13 @@ Probes:
           Type: 1251 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -1432,6 +2104,33 @@ Probes:
           Type: 1222 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f990", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1449,6 +2148,13 @@ Probes:
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -1472,6 +2178,19 @@ Probes:
           Type: 1249 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Parameter {i} * 2 = result {result}
+        Segments:
+            - 'Parameter '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ' * 2 = result '
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1491,6 +2210,18 @@ Probes:
           Type: 1230 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fdb0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}, {a}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -1505,6 +2236,13 @@ Probes:
           Type: 1318 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -1524,6 +2262,18 @@ Probes:
           Type: 1315 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x892510", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -1546,6 +2296,23 @@ Probes:
           Type: 1317 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {s}, {x}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -1560,6 +2327,13 @@ Probes:
           Type: 1329 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x892900", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -1574,6 +2348,13 @@ Probes:
           Type: 1226 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88fcf0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -1588,6 +2369,13 @@ Probes:
           Type: 1204 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -1602,6 +2390,13 @@ Probes:
           Type: 1224 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88fcd0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -1628,6 +2423,13 @@ Probes:
             - PC: "0x8907a8"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -1659,6 +2461,18 @@ Probes:
             - PC: "0x8905a0"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}, {failed}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -1676,6 +2490,9 @@ Probes:
           Type: 1271 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x890e90", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArray
+        Segments: [testReturnsArray]
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
@@ -1693,6 +2510,9 @@ Probes:
           Type: 1273 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x890f04", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayOne
+        Segments: [testReturnsArrayOne]
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
@@ -1710,6 +2530,9 @@ Probes:
           Type: 1275 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x890f70", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayZero
+        Segments: [testReturnsArrayZero]
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
@@ -1727,6 +2550,9 @@ Probes:
           Type: 1279 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x89108c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBacktrackInt
+        Segments: [testReturnsBacktrackInt]
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
@@ -1744,6 +2570,9 @@ Probes:
           Type: 1291 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x8913f8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBoolAndUintptr
+        Segments: [testReturnsBoolAndUintptr]
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
@@ -1761,6 +2590,9 @@ Probes:
           Type: 1267 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x890d34", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsComplex
+        Segments: [testReturnsComplex]
     - id: testReturnsError
       version: 0
       type: LOG_PROBE
@@ -1783,6 +2615,13 @@ Probes:
             - PC: "0x89042c"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{failed}'
+        Segments:
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -1800,6 +2639,13 @@ Probes:
           Type: 1233 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x89023c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -1817,6 +2663,13 @@ Probes:
           Type: 1237 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x8903b0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -1834,6 +2687,13 @@ Probes:
           Type: 1235 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x8902dc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -1856,6 +2716,13 @@ Probes:
             - PC: "0x8908cc"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -1873,6 +2740,9 @@ Probes:
           Type: 1269 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x890e04", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsLargeStruct
+        Segments: [testReturnsLargeStruct]
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
@@ -1890,6 +2760,9 @@ Probes:
           Type: 1265 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x890cac", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsManyFloats
+        Segments: [testReturnsManyFloats]
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
@@ -1907,6 +2780,9 @@ Probes:
           Type: 1283 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x891200", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixed
+        Segments: [testReturnsMixed]
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
@@ -1924,6 +2800,9 @@ Probes:
           Type: 1277 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x890ff0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixedStruct
+        Segments: [testReturnsMixedStruct]
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
@@ -1941,6 +2820,9 @@ Probes:
           Type: 1289 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x89137c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMultipleFloats
+        Segments: [testReturnsMultipleFloats]
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -1958,6 +2840,9 @@ Probes:
           Type: 1287 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x891308", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsOnlyFloat
+        Segments: [testReturnsOnlyFloat]
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
@@ -1975,6 +2860,9 @@ Probes:
           Type: 1263 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x890bf0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsPrimitives
+        Segments: [testReturnsPrimitives]
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
@@ -1992,6 +2880,9 @@ Probes:
           Type: 1285 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x891290", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsStructWithArray
+        Segments: [testReturnsStructWithArray]
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
@@ -2009,6 +2900,9 @@ Probes:
           Type: 1281 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x891174", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsWideStruct
+        Segments: [testReturnsWideStruct]
     - id: testRuneArray
       version: 0
       type: LOG_PROBE
@@ -2023,6 +2917,13 @@ Probes:
           Type: 1125 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -2054,6 +2955,37 @@ Probes:
           Type: 1253 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
+        Segments:
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 4
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 5
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 2
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -2068,6 +3000,13 @@ Probes:
           Type: 1146 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -2082,6 +3021,13 @@ Probes:
           Type: 1144 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -2096,6 +3042,13 @@ Probes:
           Type: 1157 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat64
       version: 0
       type: LOG_PROBE
@@ -2110,6 +3063,13 @@ Probes:
           Type: 1158 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c790", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt
       version: 0
       type: LOG_PROBE
@@ -2124,6 +3084,13 @@ Probes:
           Type: 1147 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -2138,6 +3105,14 @@ Probes:
           Type: 1149 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -2152,6 +3127,13 @@ Probes:
           Type: 1150 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -2166,6 +3148,13 @@ Probes:
           Type: 1151 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -2187,6 +3176,22 @@ Probes:
           Type: 1148 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}{x}{x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -2201,6 +3206,13 @@ Probes:
           Type: 1145 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -2215,6 +3227,13 @@ Probes:
           Type: 1324 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x8928b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -2229,6 +3248,13 @@ Probes:
           Type: 1152 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -2243,6 +3269,13 @@ Probes:
           Type: 1154 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -2257,6 +3290,13 @@ Probes:
           Type: 1155 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -2271,6 +3311,13 @@ Probes:
           Type: 1156 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -2285,6 +3332,13 @@ Probes:
           Type: 1153 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -2299,6 +3353,13 @@ Probes:
           Type: 1321 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -2313,6 +3374,13 @@ Probes:
           Type: 1312 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x8924e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -2327,6 +3395,13 @@ Probes:
           Type: 1202 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88e430", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2344,6 +3419,13 @@ Probes:
           Type: 1261 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890b54", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -2361,6 +3443,13 @@ Probes:
           Type: 1303 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -2375,6 +3464,13 @@ Probes:
           Type: 1126 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -2389,6 +3485,13 @@ Probes:
           Type: 1229 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fd90", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -2403,6 +3506,13 @@ Probes:
           Type: 1316 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -2417,6 +3527,13 @@ Probes:
           Type: 1168 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88ccb0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -2431,6 +3548,13 @@ Probes:
           Type: 1169 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88ccc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -2449,6 +3573,13 @@ Probes:
           Type: 1338 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x892b9c", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -2468,6 +3599,18 @@ Probes:
           Type: 1313 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x8924f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -2482,6 +3625,13 @@ Probes:
           Type: 1196 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x88de30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -2499,6 +3649,13 @@ Probes:
           Type: 1307 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x891f7c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -2516,6 +3673,13 @@ Probes:
           Type: 1336 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x892aa8", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -2529,6 +3693,13 @@ Probes:
           Type: 1334 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x892a80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -2543,6 +3714,13 @@ Probes:
           Type: 1197 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e3e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -2562,6 +3740,11 @@ Probes:
           Type: 1255 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{nonexistentVariable}'
+        Segments:
+            - Error: failed to resolve reference "nonexistentVariable"
+              DSL: nonexistentVariable
     - id: testTemplateWithUnsupportedExpression
       version: 0
       type: LOG_PROBE
@@ -2581,6 +3764,11 @@ Probes:
           Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{unsupportedExpression}'
+        Segments:
+            - Error: 'unsupported operation: foobar'
+              DSL: unsupportedExpression
     - id: testTemplateWithUnsupportedVariable
       version: 0
       type: LOG_PROBE
@@ -2602,6 +3790,13 @@ Probes:
           Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
+        Segments:
+            - 'Executed main.testMultipleNamedReturn, it took '
+            - Error: failed to resolve reference "@duration"
+              DSL: '@duration'
+            - ms
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
@@ -2624,6 +3819,23 @@ Probes:
           Type: 1325 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x8928c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}, {z}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -2642,6 +3854,13 @@ Probes:
           Type: 1327 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x8928e8", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testThreeStringsInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2656,6 +3875,13 @@ Probes:
           Type: 1328 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8928f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -2670,6 +3896,13 @@ Probes:
           Type: 1159 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c7a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -2684,6 +3917,13 @@ Probes:
           Type: 1135 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -2698,6 +3938,13 @@ Probes:
           Type: 1136 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -2712,6 +3959,13 @@ Probes:
           Type: 1137 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -2726,6 +3980,13 @@ Probes:
           Type: 1134 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -2740,6 +4001,13 @@ Probes:
           Type: 1133 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -2754,6 +4022,13 @@ Probes:
           Type: 1228 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -2768,6 +4043,13 @@ Probes:
           Type: 1310 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x8924c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -2782,6 +4064,13 @@ Probes:
           Type: 1332 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x892920", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -2796,6 +4085,13 @@ Probes:
           Type: 1227 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88fd00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -2810,6 +4106,13 @@ Probes:
           Type: 1143 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c380", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -2824,6 +4127,13 @@ Probes:
           Type: 1319 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2838,6 +4148,13 @@ Probes:
           Type: 1320 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -2860,6 +4177,18 @@ Probes:
           Type: 1309 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x892024", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -9267,12 +10596,22 @@ Types:
     - __kind: EventRootType
       ID: 1194
       Name: Probe[main.testAnyPtr]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 158 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 158 PointerType *interface {}
             Operations:
@@ -9299,12 +10638,22 @@ Types:
     - __kind: EventRootType
       ID: 1191
       Name: Probe[main.testAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -9331,12 +10680,22 @@ Types:
     - __kind: EventRootType
       ID: 1294
       Name: Probe[main.testArrayArgAndReturn]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -9376,10 +10735,20 @@ Types:
                   Variable: {subprogram: 19, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 117 ArrayType [2]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 19, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1140
       Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -9392,10 +10761,20 @@ Types:
                   Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
+        - Name: b
+          Offset: 65
+          Kind: template_segment
+          Expression:
+            Type: 114 ArrayType [2][2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 64
     - __kind: EventRootType
       ID: 1138
       Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9408,10 +10787,20 @@ Types:
                   Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 113 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 15, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1203
       Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -9424,10 +10813,20 @@ Types:
                   Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
+        - Name: m
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 186 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1139
       Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9440,10 +10839,20 @@ Types:
                   Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 104 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1141
       Name: Probe[main.testArrayOfStructs]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9456,15 +10865,35 @@ Types:
                   Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 115 ArrayType [2]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 1160
       Name: Probe[main.testBigStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 121 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: b
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 121 StructureType main.bigStruct
             Operations:
@@ -9478,7 +10907,7 @@ Types:
     - __kind: EventRootType
       ID: 1127
       Name: Probe[main.testBoolArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9491,15 +10920,35 @@ Types:
                   Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 105 ArrayType [2]bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1124
       Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 102 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -9523,10 +10972,20 @@ Types:
                   Variable: {subprogram: 85, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 238 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1221
       Name: Probe[main.testCombinedByte]
-      ByteSize: 7
+      ByteSize: 13
       PresenceBitsetSize: 1
       Expressions:
         - Name: w
@@ -9539,8 +10998,18 @@ Types:
                   Variable: {subprogram: 83, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
-        - Name: x
+        - Name: w
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -9549,9 +11018,29 @@ Types:
                   Variable: {subprogram: 83, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
         - Name: y
-          Offset: 3
+          Offset: 5
           Kind: argument
+          Expression:
+            Type: 16 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: y
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 16 BaseType float32
             Operations:
@@ -9562,7 +11051,7 @@ Types:
     - __kind: EventRootType
       ID: 1231
       Name: Probe[main.testCycle]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: t
@@ -9575,10 +11064,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
+        - Name: t
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 243 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1166
       Name: Probe[main.testDeepMap1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9591,10 +11090,20 @@ Types:
                   Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 136 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1167
       Name: Probe[main.testDeepMap7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9607,10 +11116,20 @@ Types:
                   Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 144 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1162
       Name: Probe[main.testDeepPtr1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9623,10 +11142,20 @@ Types:
                   Variable: {subprogram: 38, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 125 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1163
       Name: Probe[main.testDeepPtr7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9639,10 +11168,20 @@ Types:
                   Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 128 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1164
       Name: Probe[main.testDeepSlice1]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9655,10 +11194,20 @@ Types:
                   Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 130 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1165
       Name: Probe[main.testDeepSlice7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9671,10 +11220,20 @@ Types:
                   Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 134 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1314
       Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -9687,9 +11246,29 @@ Types:
                   Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9700,7 +11279,7 @@ Types:
     - __kind: EventRootType
       ID: 1311
       Name: Probe[main.testEmptySlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -9713,10 +11292,20 @@ Types:
                   Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 129, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1333
       Name: Probe[main.testEmptyString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9729,15 +11318,35 @@ Types:
                   Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 147, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1340
       Name: Probe[main.testEmptyStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 313 PointerType *main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 313 PointerType *main.emptyStruct
             Operations:
@@ -9761,10 +11370,20 @@ Types:
                   Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
+        - Name: e
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 312 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1193
       Name: Probe[main.testError]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
@@ -9777,15 +11396,35 @@ Types:
                   Variable: {subprogram: 57, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: e
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 57, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1175
       Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 154 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 154 PointerType *main.esotericHeap
             Operations:
@@ -9799,12 +11438,22 @@ Types:
     - __kind: EventRootType
       ID: 1173
       Name: Probe[main.testEsotericStack]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 150 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+        - Name: e
+          Offset: 65
+          Kind: template_segment
           Expression:
             Type: 150 StructureType main.esotericStack
             Operations:
@@ -9818,7 +11467,7 @@ Types:
     - __kind: EventRootType
       ID: 1187
       Name: Probe[main.testFramelessArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9831,10 +11480,20 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1189
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 49
+      ByteSize: 89
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9847,8 +11506,18 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-        - Name: ~r0
+        - Name: a
           Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 81
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -9876,12 +11545,22 @@ Types:
     - __kind: EventRootType
       ID: 1185
       Name: Probe[main.testFrameless]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9908,12 +11587,22 @@ Types:
     - __kind: EventRootType
       ID: 1177
       Name: Probe[main.testInlinedBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9927,12 +11616,22 @@ Types:
     - __kind: EventRootType
       ID: 1181
       Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9949,7 +11648,7 @@ Types:
     - __kind: EventRootType
       ID: 1179
       Name: Probe[main.testInlinedBB]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9962,9 +11661,29 @@ Types:
                   Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: y
+        - Name: x
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -9996,7 +11715,7 @@ Types:
     - __kind: EventRootType
       ID: 1341
       Name: Probe[main.testInlinedPrint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10009,15 +11728,35 @@ Types:
                   Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1343
       Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -10031,7 +11770,7 @@ Types:
     - __kind: EventRootType
       ID: 1349
       Name: Probe[main.testInlinedSq]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10044,10 +11783,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1350
       Name: Probe[main.testInlinedSq]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10060,10 +11809,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1351
       Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10076,10 +11835,20 @@ Types:
                   Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1130
       Name: Probe[main.testInt16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10092,10 +11861,20 @@ Types:
                   Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 108 ArrayType [2]int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1131
       Name: Probe[main.testInt32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10108,10 +11887,20 @@ Types:
                   Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 103 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1132
       Name: Probe[main.testInt64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10124,10 +11913,20 @@ Types:
                   Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 109 ArrayType [2]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1129
       Name: Probe[main.testInt8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10140,10 +11939,20 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 107 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1128
       Name: Probe[main.testIntArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10156,10 +11965,20 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1190
       Name: Probe[main.testInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -10172,15 +11991,35 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 157 GoInterfaceType main.behavior
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1292
       Name: Probe[main.testLargeArgAndReturn]
-      ByteSize: 81
+      ByteSize: 161
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: arg
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -10207,12 +12046,22 @@ Types:
     - __kind: EventRootType
       ID: 1225
       Name: Probe[main.testLinkedList]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 241 StructureType main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 241 StructureType main.node
             Operations:
@@ -10252,7 +12101,7 @@ Types:
     - __kind: EventRootType
       ID: 1172
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10265,9 +12114,29 @@ Types:
                   Variable: {subprogram: 46, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: a
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
           Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -10278,11 +12147,11 @@ Types:
     - __kind: EventRootType
       ID: 1298
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 74
-      PresenceBitsetSize: 2
+      ByteSize: 147
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10291,8 +12160,18 @@ Types:
                   Variable: {subprogram: 122, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10301,8 +12180,18 @@ Types:
                   Variable: {subprogram: 122, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10311,8 +12200,18 @@ Types:
                   Variable: {subprogram: 122, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10321,8 +12220,18 @@ Types:
                   Variable: {subprogram: 122, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10331,8 +12240,18 @@ Types:
                   Variable: {subprogram: 122, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10341,8 +12260,18 @@ Types:
                   Variable: {subprogram: 122, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10351,8 +12280,18 @@ Types:
                   Variable: {subprogram: 122, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10361,9 +12300,29 @@ Types:
                   Variable: {subprogram: 122, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 139
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -10390,7 +12349,7 @@ Types:
     - __kind: EventRootType
       ID: 1201
       Name: Probe[main.testMapArrayToArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10403,10 +12362,20 @@ Types:
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 181 GoMapType map[[4]string][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1208
       Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10419,10 +12388,20 @@ Types:
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1220
       Name: Probe[main.testMapEmptyKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10435,10 +12414,20 @@ Types:
                   Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 233 GoMapType map[struct {}]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 82, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1218
       Name: Probe[main.testMapEmptyKey]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10451,10 +12440,20 @@ Types:
                   Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 223 GoMapType map[struct {}]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1219
       Name: Probe[main.testMapEmptyValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10467,10 +12466,20 @@ Types:
                   Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 228 GoMapType map[int]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1205
       Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10483,10 +12492,20 @@ Types:
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 161 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 68, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1217
       Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10499,10 +12518,20 @@ Types:
                   Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 218 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1216
       Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10515,15 +12544,35 @@ Types:
                   Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 213 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1206
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -10534,7 +12583,7 @@ Types:
     - __kind: EventRootType
       ID: 1207
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10547,10 +12596,20 @@ Types:
                   Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 188 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1215
       Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10563,10 +12622,20 @@ Types:
                   Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1214
       Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10579,10 +12648,20 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1199
       Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10595,10 +12674,20 @@ Types:
                   Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1200
       Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10611,10 +12700,20 @@ Types:
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1198
       Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10627,10 +12726,20 @@ Types:
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 166 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1209
       Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10643,10 +12752,20 @@ Types:
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1213
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10659,10 +12778,20 @@ Types:
                   Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1212
       Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10675,10 +12804,20 @@ Types:
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 74, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1211
       Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10691,10 +12830,20 @@ Types:
                   Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1210
       Name: Probe[main.testMapWithSmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10707,15 +12856,35 @@ Types:
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1330
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -10726,7 +12895,7 @@ Types:
     - __kind: EventRootType
       ID: 1331
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10739,14 +12908,24 @@ Types:
                   Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1300
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 163
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10755,8 +12934,18 @@ Types:
                   Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10765,8 +12954,18 @@ Types:
                   Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10775,8 +12974,18 @@ Types:
                   Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10785,8 +12994,18 @@ Types:
                   Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10795,8 +13014,18 @@ Types:
                   Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10805,8 +13034,18 @@ Types:
                   Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10815,8 +13054,18 @@ Types:
                   Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -10825,9 +13074,29 @@ Types:
                   Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: s
+          Offset: 147
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -10854,7 +13123,7 @@ Types:
     - __kind: EventRootType
       ID: 1304
       Name: Probe[main.testMultipleArrayArgs]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10867,9 +13136,29 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
-        - Name: b
+        - Name: a
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: b
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -10906,7 +13195,7 @@ Types:
     - __kind: EventRootType
       ID: 1296
       Name: Probe[main.testMultipleLargeArgs]
-      ByteSize: 161
+      ByteSize: 321
       PresenceBitsetSize: 1
       Expressions:
         - Name: s1
@@ -10919,9 +13208,29 @@ Types:
                   Variable: {subprogram: 121, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
-        - Name: s2
+        - Name: s1
           Offset: 81
+          Kind: template_segment
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 161
           Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 241
+          Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -10948,7 +13257,7 @@ Types:
     - __kind: EventRootType
       ID: 1250
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -10961,15 +13270,55 @@ Types:
                   Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1252
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11054,7 +13403,7 @@ Types:
     - __kind: EventRootType
       ID: 1253
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11067,9 +13416,49 @@ Types:
                   Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
+        - Name: result
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 25
           Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11158,11 +13547,11 @@ Types:
     - __kind: EventRootType
       ID: 1222
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 62
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -11171,8 +13560,18 @@ Types:
                   Variable: {subprogram: 84, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
+        - Name: a
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
         - Name: b
-          Offset: 2
+          Offset: 4
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -11181,8 +13580,18 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
+        - Name: b
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
         - Name: c
-          Offset: 3
+          Offset: 6
           Kind: argument
           Expression:
             Type: 13 BaseType int32
@@ -11191,8 +13600,18 @@ Types:
                   Variable: {subprogram: 84, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
+        - Name: c
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 13 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
         - Name: d
-          Offset: 7
+          Offset: 14
           Kind: argument
           Expression:
             Type: 12 BaseType uint
@@ -11201,9 +13620,29 @@ Types:
                   Variable: {subprogram: 84, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 22
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 15
+          Offset: 30
           Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: e
+          Offset: 46
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -11214,7 +13653,7 @@ Types:
     - __kind: EventRootType
       ID: 1246
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11227,15 +13666,35 @@ Types:
                   Variable: {subprogram: 101, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1248
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11262,7 +13721,7 @@ Types:
     - __kind: EventRootType
       ID: 1249
       Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11275,10 +13734,20 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
+        - Name: result
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1230
       Name: Probe[main.testNilPointer]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -11291,9 +13760,29 @@ Types:
                   Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: z
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 5 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 12 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -11304,7 +13793,7 @@ Types:
     - __kind: EventRootType
       ID: 1315
       Name: Probe[main.testNilSliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11317,9 +13806,29 @@ Types:
                   Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11330,7 +13839,7 @@ Types:
     - __kind: EventRootType
       ID: 1317
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 34
+      ByteSize: 67
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11343,8 +13852,18 @@ Types:
                   Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: s
+        - Name: a
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 3
           Kind: argument
           Expression:
             Type: 259 GoSliceHeaderType []bool
@@ -11353,9 +13872,29 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 259 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
-          Offset: 26
+          Offset: 51
           Kind: argument
+          Expression:
+            Type: 12 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 59
+          Kind: template_segment
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -11366,7 +13905,7 @@ Types:
     - __kind: EventRootType
       ID: 1318
       Name: Probe[main.testNilSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11379,10 +13918,20 @@ Types:
                   Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 260 GoSliceHeaderType []uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1329
       Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11395,10 +13944,20 @@ Types:
                   Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 265 PointerType *main.oneStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 144, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1226
       Name: Probe[main.testPointerLoop]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11411,10 +13970,20 @@ Types:
                   Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 242 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1204
       Name: Probe[main.testPointerToMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11427,10 +13996,20 @@ Types:
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 187 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 67, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1224
       Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11443,10 +14022,20 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 239 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1240
       Name: Probe[main.testReturnsAnyAndError]
-      ByteSize: 18
+      ByteSize: 35
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -11459,9 +14048,29 @@ Types:
                   Variable: {subprogram: 98, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
-        - Name: failed
+        - Name: v
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: failed
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11498,12 +14107,22 @@ Types:
     - __kind: EventRootType
       ID: 1242
       Name: Probe[main.testReturnsAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -11744,12 +14363,22 @@ Types:
     - __kind: EventRootType
       ID: 1238
       Name: Probe[main.testReturnsError]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: failed
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11776,12 +14405,22 @@ Types:
     - __kind: EventRootType
       ID: 1236
       Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11818,12 +14457,22 @@ Types:
     - __kind: EventRootType
       ID: 1234
       Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11850,12 +14499,22 @@ Types:
     - __kind: EventRootType
       ID: 1232
       Name: Probe[main.testReturnsInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11882,12 +14541,22 @@ Types:
     - __kind: EventRootType
       ID: 1244
       Name: Probe[main.testReturnsInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -12365,7 +15034,7 @@ Types:
     - __kind: EventRootType
       ID: 1125
       Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12378,10 +15047,20 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 103 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1146
       Name: Probe[main.testSingleBool]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12394,10 +15073,20 @@ Types:
                   Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1144
       Name: Probe[main.testSingleByte]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12410,10 +15099,20 @@ Types:
                   Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1157
       Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12426,10 +15125,20 @@ Types:
                   Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1158
       Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12442,10 +15151,20 @@ Types:
                   Variable: {subprogram: 35, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1149
       Name: Probe[main.testSingleInt16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12458,10 +15177,20 @@ Types:
                   Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 89 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1150
       Name: Probe[main.testSingleInt32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12474,10 +15203,20 @@ Types:
                   Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 13 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1151
       Name: Probe[main.testSingleInt64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12490,10 +15229,20 @@ Types:
                   Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 14 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1148
       Name: Probe[main.testSingleInt8]
-      ByteSize: 2
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12506,10 +15255,40 @@ Types:
                   Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1147
       Name: Probe[main.testSingleInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12522,10 +15301,20 @@ Types:
                   Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1145
       Name: Probe[main.testSingleRune]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12538,10 +15327,20 @@ Types:
                   Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 13 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1324
       Name: Probe[main.testSingleString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12554,10 +15353,20 @@ Types:
                   Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1154
       Name: Probe[main.testSingleUint16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12570,10 +15379,20 @@ Types:
                   Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1155
       Name: Probe[main.testSingleUint32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12586,10 +15405,20 @@ Types:
                   Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1156
       Name: Probe[main.testSingleUint64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12602,10 +15431,20 @@ Types:
                   Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1153
       Name: Probe[main.testSingleUint8]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12618,10 +15457,20 @@ Types:
                   Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1152
       Name: Probe[main.testSingleUint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12634,10 +15483,20 @@ Types:
                   Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1321
       Name: Probe[main.testSliceEmptyStructs]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -12650,10 +15509,20 @@ Types:
                   Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 261 GoSliceHeaderType []struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1312
       Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -12666,10 +15535,20 @@ Types:
                   Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 253 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1202
       Name: Probe[main.testSmallMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -12682,15 +15561,35 @@ Types:
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 65, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1260
       Name: Probe[main.testSomeNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12737,12 +15636,22 @@ Types:
     - __kind: EventRootType
       ID: 1302
       Name: Probe[main.testStackArgRegReturns]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: arg
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12789,7 +15698,7 @@ Types:
     - __kind: EventRootType
       ID: 1126
       Name: Probe[main.testStringArray]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12802,10 +15711,20 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
+        - Name: x
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 104 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1229
       Name: Probe[main.testStringPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -12818,10 +15737,20 @@ Types:
                   Variable: {subprogram: 91, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 88 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1316
       Name: Probe[main.testStringSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -12834,10 +15763,20 @@ Types:
                   Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1168
       Name: Probe[main.testStringType1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12850,10 +15789,20 @@ Types:
                   Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 146 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1169
       Name: Probe[main.testStringType2]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12866,10 +15815,20 @@ Types:
                   Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 148 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1313
       Name: Probe[main.testStructSlice]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -12882,9 +15841,29 @@ Types:
                   Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12895,7 +15874,7 @@ Types:
     - __kind: EventRootType
       ID: 1196
       Name: Probe[main.testStructWithAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -12908,15 +15887,35 @@ Types:
                   Variable: {subprogram: 59, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: s
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 159 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1306
       Name: Probe[main.testStructWithArrayArg]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 251 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 251 StructureType main.structWithArray
             Operations:
@@ -12953,12 +15952,22 @@ Types:
     - __kind: EventRootType
       ID: 1335
       Name: Probe[main.testStructWithCyclicMaps]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 280 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
@@ -12972,7 +15981,7 @@ Types:
     - __kind: EventRootType
       ID: 1334
       Name: Probe[main.testStructWithCyclicSlices]
-      ByteSize: 145
+      ByteSize: 289
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -12985,10 +15994,20 @@ Types:
                   Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
+        - Name: a
+          Offset: 145
+          Kind: template_segment
+          Expression:
+            Type: 267 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 148, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
     - __kind: EventRootType
       ID: 1197
       Name: Probe[main.testStructWithMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13001,15 +16020,35 @@ Types:
                   Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
+        - Name: s
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 160 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testStruct]
-      ByteSize: 57
+      ByteSize: 113
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 311 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 150, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+        - Name: x
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 311 StructureType main.aStruct
             Operations:
@@ -13023,7 +16062,7 @@ Types:
     - __kind: EventRootType
       ID: 1328
       Name: Probe[main.testThreeStringsInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13036,15 +16075,35 @@ Types:
                   Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 264 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 143, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1326
       Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 263 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 263 StructureType main.threeStringStruct
             Operations:
@@ -13058,7 +16117,7 @@ Types:
     - __kind: EventRootType
       ID: 1325
       Name: Probe[main.testThreeStrings]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13071,8 +16130,18 @@ Types:
                   Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-        - Name: y
+        - Name: x
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 33
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -13081,9 +16150,29 @@ Types:
                   Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
+        - Name: y
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
-          Offset: 33
+          Offset: 65
           Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 2, name: z}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: z
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13094,7 +16183,7 @@ Types:
     - __kind: EventRootType
       ID: 1159
       Name: Probe[main.testTypeAlias]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13107,10 +16196,20 @@ Types:
                   Variable: {subprogram: 36, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 120 BaseType main.typeAlias
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1135
       Name: Probe[main.testUint16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13123,10 +16222,20 @@ Types:
                   Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1136
       Name: Probe[main.testUint32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13139,10 +16248,20 @@ Types:
                   Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 112 ArrayType [2]uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 13, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1137
       Name: Probe[main.testUint64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13155,10 +16274,20 @@ Types:
                   Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 52 ArrayType [2]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 14, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1134
       Name: Probe[main.testUint8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13171,10 +16300,20 @@ Types:
                   Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 102 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1133
       Name: Probe[main.testUintArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13187,10 +16326,20 @@ Types:
                   Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 110 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1228
       Name: Probe[main.testUintPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13203,10 +16352,20 @@ Types:
                   Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 100 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1310
       Name: Probe[main.testUintSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -13219,10 +16378,20 @@ Types:
                   Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1332
       Name: Probe[main.testUnitializedString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13235,10 +16404,20 @@ Types:
                   Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 146, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1227
       Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13251,10 +16430,20 @@ Types:
                   Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 19 VoidPointerType unsafe.Pointer
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1143
       Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
+      ByteSize: 1601
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13267,15 +16456,35 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
+        - Name: a
+          Offset: 801
+          Kind: template_segment
+          Expression:
+            Type: 119 ArrayType [100]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 20, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 800
     - __kind: EventRootType
       ID: 1319
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -13286,7 +16495,7 @@ Types:
     - __kind: EventRootType
       ID: 1320
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13299,10 +16508,20 @@ Types:
                   Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1308
       Name: Probe[main.testZeroSizeArgAndReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13315,9 +16534,29 @@ Types:
                   Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -5,17 +5,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: stackC
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1312 EventRootType Probe[main.stackC]
+          Type: 1322 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x892858", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1313 EventRootType Probe[main.stackC]Return
+          Type: 1323 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x89288c", Frameless: false}]
           Condition: null
     - id: testAny
@@ -23,8 +23,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -41,8 +41,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -58,17 +58,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1294 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x89160c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1295 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x8916a4", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -76,8 +76,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -90,8 +90,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -104,8 +104,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -118,8 +118,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -132,8 +132,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -145,8 +145,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -159,8 +159,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -177,8 +177,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -191,8 +191,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -205,8 +205,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -219,8 +219,16 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{w}, {x}, {y}'
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -233,8 +241,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{t}'
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -247,8 +255,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -261,8 +269,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -275,8 +283,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -289,8 +297,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -303,8 +311,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -317,8 +325,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -331,13 +339,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testEmptySlice]
+          Type: 1311 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x8924d0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -345,13 +353,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1314 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x892500", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -360,13 +373,13 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testEmptyString]
+          Type: 1333 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x892930", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -374,26 +387,26 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testEmptyStruct]
+          Type: 1339 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x892c80", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1340 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x892c90", Frameless: true}]
           Condition: null
     - id: testError
@@ -401,8 +414,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -415,8 +428,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -433,8 +446,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -451,8 +464,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -469,8 +482,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -490,8 +503,8 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -504,8 +517,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -522,8 +535,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -540,8 +558,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -558,13 +576,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBBB
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testInlinedBBB]
+          Type: 1344 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d878", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -572,8 +590,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBC
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -590,13 +608,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1335 EventRootType Probe[main.testInlinedBCA]
+          Type: 1345 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -607,13 +625,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Line
-          Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1346 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -621,13 +639,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testInlinedBCB]
+          Type: 1347 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -638,13 +656,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Line
-          Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1348 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -653,13 +671,13 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testInlinedPrint]
+          Type: 1341 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -673,7 +691,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1342 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d630", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -684,13 +702,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Line
-          Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1343 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -708,13 +726,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testInlinedSq]
+          Type: 1349 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -725,13 +743,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1340 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1350 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -740,13 +758,13 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1351 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88dab4"
               Frameless: false
@@ -758,8 +776,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -772,8 +790,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -786,8 +804,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -800,8 +818,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -814,8 +832,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -828,8 +846,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -841,17 +859,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1292 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x891430", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1293 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x891588", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -859,8 +877,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -876,8 +894,8 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -893,8 +911,8 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -910,8 +928,13 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a} and {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -923,17 +946,43 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1298 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x89193c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1299 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x891aac", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -941,8 +990,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -955,8 +1004,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -969,8 +1018,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -983,8 +1032,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -997,8 +1046,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1011,8 +1060,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1025,8 +1074,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1039,8 +1088,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1053,8 +1102,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1067,8 +1118,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1081,8 +1134,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1095,8 +1148,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1109,8 +1162,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1123,8 +1176,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1137,8 +1190,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1151,8 +1204,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1165,8 +1218,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1179,8 +1232,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1193,8 +1246,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1207,8 +1260,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1221,13 +1276,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testMassiveString]
+          Type: 1330 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1236,81 +1291,117 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testMassiveString]
+          Type: 1331 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1300 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x891b30", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1301 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x891ce0", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1304 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x891e0c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1305 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x891eb0", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
-      template: ""
-      segments: []
+      template: '{s1}, {s2}'
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1296 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x8916e0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1297 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x8918b0", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1250 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1251 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1318,8 +1409,22 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1331,8 +1436,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1344,13 +1449,41 @@ Probes:
           Type: 1247 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      template: Parameter {i} * 2 = result {result}
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - Kind: Entry
+          Type: 1248 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x890958", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1249 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}, {a}'
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1363,13 +1496,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1308 EventRootType Probe[main.testNilSlice]
+          Type: 1318 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1377,13 +1510,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1315 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x892510", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1391,13 +1529,21 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {s}, {x}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1317 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1405,13 +1551,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1329 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x892900", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1419,8 +1565,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1433,8 +1579,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1447,8 +1593,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1461,8 +1607,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1487,8 +1633,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}, {failed}'
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1512,102 +1663,102 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
-      template: ""
-      segments: []
+      template: testReturnsArray
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1260 EventRootType Probe[main.testReturnsArray]
+          Type: 1270 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x890e3c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1261 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1271 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x890e90", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
-      template: ""
-      segments: []
+      template: testReturnsArrayOne
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1272 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x890ec8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1273 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x890f04", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
-      template: ""
-      segments: []
+      template: testReturnsArrayZero
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1274 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x890f38", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1275 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x890f70", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
-      template: ""
-      segments: []
+      template: testReturnsBacktrackInt
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1278 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x891028", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1279 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x89108c", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
-      template: ""
-      segments: []
+      template: testReturnsBoolAndUintptr
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1290 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x8913b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1291 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x8913f8", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
-      template: ""
-      segments: []
+      template: testReturnsComplex
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1256 EventRootType Probe[main.testReturnsComplex]
+          Type: 1266 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x890ce8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1267 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x890d34", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1615,8 +1766,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{failed}'
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1636,8 +1787,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1653,8 +1804,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1670,8 +1821,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1688,8 +1839,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1709,153 +1860,153 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
-      template: ""
-      segments: []
+      template: testReturnsLargeStruct
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1268 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x890d70", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1269 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x890e04", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
-      template: ""
-      segments: []
+      template: testReturnsManyFloats
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1264 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x890c28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1265 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x890cac", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
-      template: ""
-      segments: []
+      template: testReturnsMixed
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1272 EventRootType Probe[main.testReturnsMixed]
+          Type: 1282 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x8911a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1283 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x891200", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
-      template: ""
-      segments: []
+      template: testReturnsMixedStruct
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1276 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x890fa8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1277 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x890ff0", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
-      template: ""
-      segments: []
+      template: testReturnsMultipleFloats
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1288 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x891338", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1289 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x89137c", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
-      template: ""
-      segments: []
+      template: testReturnsOnlyFloat
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1286 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x8912c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1287 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x891308", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
-      template: ""
-      segments: []
+      template: testReturnsPrimitives
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1262 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x890b98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1263 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x890bf0", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
-      template: ""
-      segments: []
+      template: testReturnsStructWithArray
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1284 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x89123c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1285 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x891290", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
-      template: ""
-      segments: []
+      template: testReturnsWideStruct
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1280 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x8910d0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1281 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x891174", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -1863,8 +2014,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -1872,13 +2023,44 @@ Probes:
           Type: 1125 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
+    - id: testSegmentsForParamsAndReturnsOutOfOrder
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{result2}{i}{result}{i}{i}{result2}{result}'
+      segments:
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result}
+          dsl: result
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1252 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1253 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Condition: null
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -1891,8 +2073,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -1905,8 +2087,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -1919,8 +2101,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -1933,8 +2115,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -1947,8 +2129,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -1961,8 +2143,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -1975,8 +2157,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -1989,8 +2171,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}{x}{x}
+      segments:
+        - 'parameter = '
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2003,8 +2192,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2017,13 +2206,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1314 EventRootType Probe[main.testSingleString]
+          Type: 1324 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x8928b0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2031,8 +2220,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2045,8 +2234,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2059,8 +2248,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2073,8 +2262,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2087,8 +2276,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2101,13 +2290,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1321 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2115,13 +2304,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1302 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1312 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x8924e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2129,8 +2318,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2142,34 +2331,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1260 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x890ac8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1261 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890b54", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1302 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x891d68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1303 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2177,8 +2366,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2191,8 +2380,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}'
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2205,13 +2394,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1306 EventRootType Probe[main.testStringSlice]
+          Type: 1316 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2219,8 +2408,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2233,8 +2422,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2247,17 +2436,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testStruct]
+          Type: 1337 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x892b80", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1328 EventRootType Probe[main.testStruct]Return
+          Type: 1338 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x892b9c", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2265,13 +2454,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testStructSlice]
+          Type: 1313 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x8924f0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2279,8 +2473,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2292,47 +2486,47 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1306 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x891eec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1307 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x891f7c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1335 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x892a90", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1336 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x892aa8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1334 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x892a80", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2340,8 +2534,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2349,18 +2543,85 @@ Probes:
           Type: 1197 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e3e0", Frameless: true}]
           Condition: null
+    - id: testTemplateWithNonexistantVariableName
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{nonexistentVariable}'
+      segments:
+        - json: {ref: nonexistentVariable}
+          dsl: nonexistentVariable
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1254 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1255 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedExpression
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{unsupportedExpression}'
+      segments:
+        - json: {foobar: unsupportedExpression}
+          dsl: unsupportedExpression
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1256 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedVariable
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: Executed main.testMultipleNamedReturn, it took {@duration}ms
+      segments:
+        - 'Executed main.testMultipleNamedReturn, it took '
+        - json: {ref: '@duration'}
+          dsl: '@duration'
+        - ms
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Condition: null
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}, {z}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testThreeStrings]
+          Type: 1325 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x8928c0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2368,17 +2629,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1326 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x8928d0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1327 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x8928e8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2386,13 +2647,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1328 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8928f0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2400,8 +2661,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2414,8 +2675,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2428,8 +2689,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2442,8 +2703,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2456,8 +2717,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2470,8 +2731,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2484,8 +2745,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2498,13 +2759,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1300 EventRootType Probe[main.testUintSlice]
+          Type: 1310 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x8924c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2512,13 +2773,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testUnitializedString]
+          Type: 1332 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x892920", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2526,8 +2787,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2540,8 +2801,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2554,13 +2815,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1319 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2568,30 +2829,35 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1320 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1308 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x891fb8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1309 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x892024", Frameless: false}]
           Condition: null
 Subprograms:
@@ -8980,10 +9246,10 @@ Types:
       GoKind: 22
       Pointee: 671 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1312
+      ID: 1322
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1313
+      ID: 1323
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9063,7 +9329,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1284
+      ID: 1294
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9079,7 +9345,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1285
+      ID: 1295
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9406,7 +9672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1304
+      ID: 1314
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9432,7 +9698,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1301
+      ID: 1311
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9448,7 +9714,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1323
+      ID: 1333
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9464,7 +9730,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1340
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9480,7 +9746,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
+      ID: 1339
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9678,7 +9944,7 @@ Types:
       ID: 1182
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1334
+      ID: 1344
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1179
@@ -9710,16 +9976,16 @@ Types:
       ID: 1180
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1335
+      ID: 1345
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1336
+      ID: 1346
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1337
+      ID: 1347
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1338
+      ID: 1348
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1183
@@ -9728,7 +9994,7 @@ Types:
       ID: 1184
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1341
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9744,7 +10010,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1343
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9760,10 +10026,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1342
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1339
+      ID: 1349
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9779,7 +10045,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1350
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9795,7 +10061,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1351
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -9907,7 +10173,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1282
+      ID: 1292
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -9923,7 +10189,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1283
+      ID: 1293
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10010,7 +10276,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1288
+      ID: 1298
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10106,7 +10372,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1289
+      ID: 1299
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10442,7 +10708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1330
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10458,7 +10724,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1321
+      ID: 1331
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10474,7 +10740,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1290
+      ID: 1300
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10570,7 +10836,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1291
+      ID: 1301
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10586,7 +10852,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1294
+      ID: 1304
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10612,7 +10878,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1295
+      ID: 1305
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10638,7 +10904,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1286
+      ID: 1296
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10664,7 +10930,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1287
+      ID: 1297
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10680,7 +10946,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1248
+      ID: 1250
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10696,7 +10962,175 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1252
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1254
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1256
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1258
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1251
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1253
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1255
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1257
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1259
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10794,7 +11228,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1247
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1249
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10836,7 +11302,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1315
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10862,7 +11328,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1317
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -10898,7 +11364,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1308
+      ID: 1318
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10914,7 +11380,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1329
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11062,10 +11528,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1262
+      ID: 1272
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1263
+      ID: 1273
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11081,10 +11547,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1264
+      ID: 1274
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1265
+      ID: 1275
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11100,10 +11566,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1260
+      ID: 1270
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1261
+      ID: 1271
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11119,10 +11585,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1268
+      ID: 1278
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1269
+      ID: 1279
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11218,10 +11684,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1280
+      ID: 1290
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1281
+      ID: 1291
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11247,10 +11713,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1266
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1257
+      ID: 1267
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11446,10 +11912,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1258
+      ID: 1268
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1259
+      ID: 1269
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11465,10 +11931,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1254
+      ID: 1264
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1255
+      ID: 1265
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11644,10 +12110,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1276
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1267
+      ID: 1277
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11663,10 +12129,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1272
+      ID: 1282
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1273
+      ID: 1283
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11722,10 +12188,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1278
+      ID: 1288
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1279
+      ID: 1289
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -11751,10 +12217,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1276
+      ID: 1286
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1277
+      ID: 1287
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11770,10 +12236,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1262
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1253
+      ID: 1263
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -11859,10 +12325,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1274
+      ID: 1284
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1275
+      ID: 1285
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11878,10 +12344,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1270
+      ID: 1280
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1271
+      ID: 1281
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12073,7 +12539,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1314
+      ID: 1324
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12169,7 +12635,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1321
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12185,7 +12651,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1302
+      ID: 1312
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12217,7 +12683,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1250
+      ID: 1260
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12233,7 +12699,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1251
+      ID: 1261
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12269,7 +12735,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1292
+      ID: 1302
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12285,7 +12751,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1293
+      ID: 1303
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12353,7 +12819,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1316
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12401,7 +12867,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
+      ID: 1313
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12443,7 +12909,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1296
+      ID: 1306
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12459,7 +12925,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1297
+      ID: 1307
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12485,7 +12951,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1325
+      ID: 1335
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12501,10 +12967,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1326
+      ID: 1336
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1324
+      ID: 1334
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12536,7 +13002,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1337
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12552,10 +13018,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1328
+      ID: 1338
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1318
+      ID: 1328
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12571,7 +13037,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1326
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12587,10 +13053,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1317
+      ID: 1327
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1315
+      ID: 1325
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12738,7 +13204,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1300
+      ID: 1310
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12754,7 +13220,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1322
+      ID: 1332
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12802,7 +13268,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1309
+      ID: 1319
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12818,7 +13284,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1310
+      ID: 1320
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12834,7 +13300,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1298
+      ID: 1308
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12860,7 +13326,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1299
+      ID: 1309
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -19912,7 +20378,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1341
+MaxTypeID: 1351
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -18,6 +18,7 @@ Probes:
           Type: 1498 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84fe8c", Frameless: false}]
           Condition: null
+      probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
       version: 0
       type: LOG_PROBE
@@ -36,6 +37,13 @@ Probes:
           Type: 1367 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x84b484", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -54,6 +62,13 @@ Probes:
           Type: 1370 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x84b504", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -71,6 +86,13 @@ Probes:
           Type: 1470 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ed44", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -85,6 +107,13 @@ Probes:
           Type: 1317 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -99,6 +128,13 @@ Probes:
           Type: 1313 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -113,6 +149,13 @@ Probes:
           Type: 1315 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -127,6 +170,13 @@ Probes:
           Type: 1378 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -141,6 +191,13 @@ Probes:
           Type: 1314 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -154,6 +211,13 @@ Probes:
           Type: 1316 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x849a90", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -172,6 +236,13 @@ Probes:
           Type: 1336 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x84a008", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -186,6 +257,13 @@ Probes:
           Type: 1302 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -200,6 +278,13 @@ Probes:
           Type: 1299 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -214,6 +299,13 @@ Probes:
           Type: 1398 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84d2e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{c}'
+        Segments:
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -236,6 +328,23 @@ Probes:
           Type: 1396 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84d060", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{w}, {x}, {y}'
+        Segments:
+            - JSON: {Ref: w}
+              DSL: w
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testCycle
       version: 0
       type: LOG_PROBE
@@ -250,6 +359,13 @@ Probes:
           Type: 1406 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d580", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{t}'
+        Segments:
+            - JSON: {Ref: t}
+              DSL: t
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -264,6 +380,13 @@ Probes:
           Type: 1341 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -278,6 +401,13 @@ Probes:
           Type: 1342 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -292,6 +422,13 @@ Probes:
           Type: 1337 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -306,6 +443,13 @@ Probes:
           Type: 1338 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -320,6 +464,13 @@ Probes:
           Type: 1339 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a270", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -334,6 +485,13 @@ Probes:
           Type: 1340 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a280", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -348,6 +506,13 @@ Probes:
           Type: 1486 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84fad0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -367,6 +532,18 @@ Probes:
           Type: 1489 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84fb00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -382,6 +559,13 @@ Probes:
           Type: 1508 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ff30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -396,6 +580,13 @@ Probes:
           Type: 1514 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x850280", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -409,6 +600,13 @@ Probes:
           Type: 1515 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x850290", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -423,6 +621,13 @@ Probes:
           Type: 1368 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b4b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -441,6 +646,13 @@ Probes:
           Type: 1351 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x84aab4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -459,6 +671,13 @@ Probes:
           Type: 1349 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x84aa1c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -477,6 +696,13 @@ Probes:
           Type: 1361 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x84b198", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -495,6 +721,13 @@ Probes:
           Type: 1363 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x84b1e8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -512,6 +745,13 @@ Probes:
           Type: 1364 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -530,6 +770,13 @@ Probes:
           Type: 1353 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x84af10", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -553,6 +800,18 @@ Probes:
           Type: 1355 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x84afd0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -571,6 +830,13 @@ Probes:
           Type: 1357 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x84b044", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -585,6 +851,9 @@ Probes:
           Type: 1519 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBBB
+        Segments: [testInlinedBBB]
     - id: testInlinedBC
       version: 0
       type: LOG_PROBE
@@ -603,6 +872,9 @@ Probes:
           Type: 1359 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x84b178", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBC
+        Segments: [testInlinedBC]
     - id: testInlinedBCA
       version: 0
       type: LOG_PROBE
@@ -617,6 +889,9 @@ Probes:
           Type: 1520 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCALine
       version: 0
       type: LOG_PROBE
@@ -634,6 +909,9 @@ Probes:
           Type: 1521 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCB
       version: 0
       type: LOG_PROBE
@@ -648,6 +926,9 @@ Probes:
           Type: 1522 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedBCBLine
       version: 0
       type: LOG_PROBE
@@ -665,6 +946,9 @@ Probes:
           Type: 1523 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -694,6 +978,13 @@ Probes:
           Type: 1517 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -721,6 +1012,13 @@ Probes:
             - PC: "0x84b00c"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -735,6 +1033,13 @@ Probes:
           Type: 1524 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -752,6 +1057,13 @@ Probes:
           Type: 1525 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -771,6 +1083,13 @@ Probes:
             - PC: "0x84b25c"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -785,6 +1104,13 @@ Probes:
           Type: 1305 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -799,6 +1125,13 @@ Probes:
           Type: 1306 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -813,6 +1146,13 @@ Probes:
           Type: 1307 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -827,6 +1167,13 @@ Probes:
           Type: 1304 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -841,6 +1188,13 @@ Probes:
           Type: 1303 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -855,6 +1209,13 @@ Probes:
           Type: 1365 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b430", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -872,6 +1233,13 @@ Probes:
           Type: 1468 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ec48", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -886,6 +1254,13 @@ Probes:
           Type: 1400 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d490", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -903,6 +1278,9 @@ Probes:
           Type: 1345 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a42c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineB
       version: 0
       type: LOG_PROBE
@@ -920,6 +1298,9 @@ Probes:
           Type: 1346 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a4bc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineC
       version: 0
       type: LOG_PROBE
@@ -942,6 +1323,18 @@ Probes:
           Type: 1347 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a564", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a} and {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' and '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Line
+              EventExpressionIndex: 3
     - id: testManyArgsArrayReturn
       version: 0
       type: LOG_PROBE
@@ -985,6 +1378,53 @@ Probes:
           Type: 1474 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x84f118", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -999,6 +1439,13 @@ Probes:
           Type: 1376 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84bb20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1013,6 +1460,13 @@ Probes:
           Type: 1383 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84bb80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1027,6 +1481,13 @@ Probes:
           Type: 1393 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x84bc20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1041,6 +1502,13 @@ Probes:
           Type: 1395 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x84bc40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1055,6 +1523,13 @@ Probes:
           Type: 1394 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x84bc30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1069,6 +1544,13 @@ Probes:
           Type: 1380 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84bb60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1083,6 +1565,13 @@ Probes:
           Type: 1392 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84bc10", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1097,6 +1586,13 @@ Probes:
           Type: 1391 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84bc00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1113,6 +1609,13 @@ Probes:
           Type: 1381 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1129,6 +1632,13 @@ Probes:
           Type: 1382 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1143,6 +1653,13 @@ Probes:
           Type: 1390 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84bbf0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1157,6 +1674,13 @@ Probes:
           Type: 1389 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84bbe0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1171,6 +1695,13 @@ Probes:
           Type: 1374 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84bb00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -1185,6 +1716,13 @@ Probes:
           Type: 1375 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84bb10", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -1199,6 +1737,13 @@ Probes:
           Type: 1373 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84baf0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -1213,6 +1758,13 @@ Probes:
           Type: 1384 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84bb90", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1227,6 +1779,13 @@ Probes:
           Type: 1387 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -1241,6 +1800,13 @@ Probes:
           Type: 1388 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84bbd0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -1255,6 +1821,13 @@ Probes:
           Type: 1385 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84bba0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -1271,6 +1844,13 @@ Probes:
           Type: 1386 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -1285,6 +1865,13 @@ Probes:
           Type: 1505 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1300,6 +1887,13 @@ Probes:
           Type: 1506 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -1343,6 +1937,53 @@ Probes:
           Type: 1476 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x84f32c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -1365,6 +2006,18 @@ Probes:
           Type: 1480 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x84f4d4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -1387,6 +2040,18 @@ Probes:
           Type: 1472 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x84ef50", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s1}, {s2}'
+        Segments:
+            - JSON: {Ref: s1}
+              DSL: s1
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s2}
+              DSL: s2
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1404,6 +2069,13 @@ Probes:
           Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -1432,6 +2104,33 @@ Probes:
           Type: 1397 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84d140", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1449,6 +2148,13 @@ Probes:
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e088", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -1472,6 +2178,19 @@ Probes:
           Type: 1424 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e088", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Parameter {i} * 2 = result {result}
+        Segments:
+            - 'Parameter '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ' * 2 = result '
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1491,6 +2210,18 @@ Probes:
           Type: 1405 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d560", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}, {a}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -1505,6 +2236,13 @@ Probes:
           Type: 1493 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -1524,6 +2262,18 @@ Probes:
           Type: 1490 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -1546,6 +2296,23 @@ Probes:
           Type: 1492 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {s}, {x}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -1560,6 +2327,13 @@ Probes:
           Type: 1504 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ff00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -1574,6 +2348,13 @@ Probes:
           Type: 1401 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d4a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -1588,6 +2369,13 @@ Probes:
           Type: 1379 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -1602,6 +2390,13 @@ Probes:
           Type: 1399 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d480", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -1628,6 +2423,13 @@ Probes:
             - PC: "0x84de84"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -1659,6 +2461,18 @@ Probes:
             - PC: "0x84dc80"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}, {failed}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -1676,6 +2490,9 @@ Probes:
           Type: 1446 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x84e550", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArray
+        Segments: [testReturnsArray]
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
@@ -1693,6 +2510,9 @@ Probes:
           Type: 1448 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x84e5c4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayOne
+        Segments: [testReturnsArrayOne]
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
@@ -1710,6 +2530,9 @@ Probes:
           Type: 1450 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x84e630", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayZero
+        Segments: [testReturnsArrayZero]
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
@@ -1727,6 +2550,9 @@ Probes:
           Type: 1454 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x84e74c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBacktrackInt
+        Segments: [testReturnsBacktrackInt]
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
@@ -1744,6 +2570,9 @@ Probes:
           Type: 1466 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x84eab8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBoolAndUintptr
+        Segments: [testReturnsBoolAndUintptr]
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
@@ -1761,6 +2590,9 @@ Probes:
           Type: 1442 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x84e3f4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsComplex
+        Segments: [testReturnsComplex]
     - id: testReturnsError
       version: 0
       type: LOG_PROBE
@@ -1783,6 +2615,13 @@ Probes:
             - PC: "0x84db0c"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{failed}'
+        Segments:
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -1800,6 +2639,13 @@ Probes:
           Type: 1408 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x84d91c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -1817,6 +2663,13 @@ Probes:
           Type: 1412 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x84da90", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -1834,6 +2687,13 @@ Probes:
           Type: 1410 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x84d9b8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -1856,6 +2716,13 @@ Probes:
             - PC: "0x84dfa8"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -1873,6 +2740,9 @@ Probes:
           Type: 1444 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x84e4c4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsLargeStruct
+        Segments: [testReturnsLargeStruct]
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
@@ -1890,6 +2760,9 @@ Probes:
           Type: 1440 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x84e36c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsManyFloats
+        Segments: [testReturnsManyFloats]
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
@@ -1907,6 +2780,9 @@ Probes:
           Type: 1458 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x84e8c0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixed
+        Segments: [testReturnsMixed]
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
@@ -1924,6 +2800,9 @@ Probes:
           Type: 1452 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x84e6b0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixedStruct
+        Segments: [testReturnsMixedStruct]
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
@@ -1941,6 +2820,9 @@ Probes:
           Type: 1464 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x84ea3c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMultipleFloats
+        Segments: [testReturnsMultipleFloats]
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -1958,6 +2840,9 @@ Probes:
           Type: 1462 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x84e9c8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsOnlyFloat
+        Segments: [testReturnsOnlyFloat]
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
@@ -1975,6 +2860,9 @@ Probes:
           Type: 1438 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x84e2b0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsPrimitives
+        Segments: [testReturnsPrimitives]
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
@@ -1992,6 +2880,9 @@ Probes:
           Type: 1460 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x84e950", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsStructWithArray
+        Segments: [testReturnsStructWithArray]
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
@@ -2009,6 +2900,9 @@ Probes:
           Type: 1456 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x84e834", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsWideStruct
+        Segments: [testReturnsWideStruct]
     - id: testRuneArray
       version: 0
       type: LOG_PROBE
@@ -2023,6 +2917,13 @@ Probes:
           Type: 1300 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -2054,6 +2955,37 @@ Probes:
           Type: 1428 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
+        Segments:
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 4
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 5
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 2
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -2068,6 +3000,13 @@ Probes:
           Type: 1321 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -2082,6 +3021,13 @@ Probes:
           Type: 1319 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -2096,6 +3042,13 @@ Probes:
           Type: 1332 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat64
       version: 0
       type: LOG_PROBE
@@ -2110,6 +3063,13 @@ Probes:
           Type: 1333 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849ed0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt
       version: 0
       type: LOG_PROBE
@@ -2124,6 +3084,13 @@ Probes:
           Type: 1322 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -2138,6 +3105,14 @@ Probes:
           Type: 1324 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -2152,6 +3127,13 @@ Probes:
           Type: 1325 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -2166,6 +3148,13 @@ Probes:
           Type: 1326 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -2187,6 +3176,22 @@ Probes:
           Type: 1323 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}{x}{x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -2201,6 +3206,13 @@ Probes:
           Type: 1320 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -2215,6 +3227,13 @@ Probes:
           Type: 1499 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84feb0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -2229,6 +3248,13 @@ Probes:
           Type: 1327 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -2243,6 +3269,13 @@ Probes:
           Type: 1329 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -2257,6 +3290,13 @@ Probes:
           Type: 1330 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -2271,6 +3311,13 @@ Probes:
           Type: 1331 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -2285,6 +3332,13 @@ Probes:
           Type: 1328 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -2299,6 +3353,13 @@ Probes:
           Type: 1496 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -2313,6 +3374,13 @@ Probes:
           Type: 1487 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84fae0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -2327,6 +3395,13 @@ Probes:
           Type: 1377 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84bb30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2344,6 +3419,13 @@ Probes:
           Type: 1436 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84e220", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -2361,6 +3443,13 @@ Probes:
           Type: 1478 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x84f3ec", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -2375,6 +3464,13 @@ Probes:
           Type: 1301 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -2389,6 +3485,13 @@ Probes:
           Type: 1404 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d540", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -2403,6 +3506,13 @@ Probes:
           Type: 1491 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -2417,6 +3527,13 @@ Probes:
           Type: 1343 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -2431,6 +3548,13 @@ Probes:
           Type: 1344 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a400", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -2449,6 +3573,13 @@ Probes:
           Type: 1513 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x85019c", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -2468,6 +3599,18 @@ Probes:
           Type: 1488 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84faf0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -2482,6 +3625,13 @@ Probes:
           Type: 1371 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x84b530", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -2499,6 +3649,13 @@ Probes:
           Type: 1482 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x84f59c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -2516,6 +3673,13 @@ Probes:
           Type: 1511 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x8500a8", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -2529,6 +3693,13 @@ Probes:
           Type: 1509 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x850080", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -2543,6 +3714,13 @@ Probes:
           Type: 1372 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -2562,6 +3740,11 @@ Probes:
           Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{nonexistentVariable}'
+        Segments:
+            - Error: failed to resolve reference "nonexistentVariable"
+              DSL: nonexistentVariable
     - id: testTemplateWithUnsupportedExpression
       version: 0
       type: LOG_PROBE
@@ -2581,6 +3764,11 @@ Probes:
           Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{unsupportedExpression}'
+        Segments:
+            - Error: 'unsupported operation: foobar'
+              DSL: unsupportedExpression
     - id: testTemplateWithUnsupportedVariable
       version: 0
       type: LOG_PROBE
@@ -2602,6 +3790,13 @@ Probes:
           Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
+        Segments:
+            - 'Executed main.testMultipleNamedReturn, it took '
+            - Error: failed to resolve reference "@duration"
+              DSL: '@duration'
+            - ms
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
@@ -2624,6 +3819,23 @@ Probes:
           Type: 1500 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84fec0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}, {z}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -2642,6 +3854,13 @@ Probes:
           Type: 1502 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84fee8", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testThreeStringsInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2656,6 +3875,13 @@ Probes:
           Type: 1503 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84fef0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -2670,6 +3896,13 @@ Probes:
           Type: 1334 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ee0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -2684,6 +3917,13 @@ Probes:
           Type: 1310 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -2698,6 +3938,13 @@ Probes:
           Type: 1311 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -2712,6 +3959,13 @@ Probes:
           Type: 1312 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -2726,6 +3980,13 @@ Probes:
           Type: 1309 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -2740,6 +4001,13 @@ Probes:
           Type: 1308 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -2754,6 +4022,13 @@ Probes:
           Type: 1403 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -2768,6 +4043,13 @@ Probes:
           Type: 1485 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84fac0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -2782,6 +4064,13 @@ Probes:
           Type: 1507 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ff20", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -2796,6 +4085,13 @@ Probes:
           Type: 1402 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d4b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -2810,6 +4106,13 @@ Probes:
           Type: 1318 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849ac0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -2824,6 +4127,13 @@ Probes:
           Type: 1494 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2838,6 +4148,13 @@ Probes:
           Type: 1495 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -2860,6 +4177,18 @@ Probes:
           Type: 1484 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84f640", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -9572,12 +10901,22 @@ Types:
     - __kind: EventRootType
       ID: 1369
       Name: Probe[main.testAnyPtr]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 161 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 161 PointerType *interface {}
             Operations:
@@ -9604,12 +10943,22 @@ Types:
     - __kind: EventRootType
       ID: 1366
       Name: Probe[main.testAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -9636,12 +10985,22 @@ Types:
     - __kind: EventRootType
       ID: 1469
       Name: Probe[main.testArrayArgAndReturn]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -9681,10 +11040,20 @@ Types:
                   Variable: {subprogram: 19, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 122 ArrayType [2]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 19, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1315
       Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -9697,10 +11066,20 @@ Types:
                   Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
+        - Name: b
+          Offset: 65
+          Kind: template_segment
+          Expression:
+            Type: 119 ArrayType [2][2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 64
     - __kind: EventRootType
       ID: 1313
       Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9713,10 +11092,20 @@ Types:
                   Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 118 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 15, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1378
       Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -9729,10 +11118,20 @@ Types:
                   Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
+        - Name: m
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 189 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1314
       Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9745,10 +11144,20 @@ Types:
                   Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 109 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1316
       Name: Probe[main.testArrayOfStructs]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9761,15 +11170,35 @@ Types:
                   Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 120 ArrayType [2]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 1335
       Name: Probe[main.testBigStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 126 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: b
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 126 StructureType main.bigStruct
             Operations:
@@ -9783,7 +11212,7 @@ Types:
     - __kind: EventRootType
       ID: 1302
       Name: Probe[main.testBoolArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9796,15 +11225,35 @@ Types:
                   Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 110 ArrayType [2]bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1299
       Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 107 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -9828,10 +11277,20 @@ Types:
                   Variable: {subprogram: 85, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 241 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1396
       Name: Probe[main.testCombinedByte]
-      ByteSize: 7
+      ByteSize: 13
       PresenceBitsetSize: 1
       Expressions:
         - Name: w
@@ -9844,8 +11303,18 @@ Types:
                   Variable: {subprogram: 83, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
-        - Name: x
+        - Name: w
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -9854,9 +11323,29 @@ Types:
                   Variable: {subprogram: 83, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
         - Name: y
-          Offset: 3
+          Offset: 5
           Kind: argument
+          Expression:
+            Type: 17 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: y
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 17 BaseType float32
             Operations:
@@ -9867,7 +11356,7 @@ Types:
     - __kind: EventRootType
       ID: 1406
       Name: Probe[main.testCycle]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: t
@@ -9880,10 +11369,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
+        - Name: t
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 246 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1341
       Name: Probe[main.testDeepMap1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9896,10 +11395,20 @@ Types:
                   Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 141 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1342
       Name: Probe[main.testDeepMap7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9912,10 +11421,20 @@ Types:
                   Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 147 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testDeepPtr1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9928,10 +11447,20 @@ Types:
                   Variable: {subprogram: 38, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 130 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1338
       Name: Probe[main.testDeepPtr7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9944,10 +11473,20 @@ Types:
                   Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 133 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1339
       Name: Probe[main.testDeepSlice1]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9960,10 +11499,20 @@ Types:
                   Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 135 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1340
       Name: Probe[main.testDeepSlice7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9976,10 +11525,20 @@ Types:
                   Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 139 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1489
       Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -9992,9 +11551,29 @@ Types:
                   Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10005,7 +11584,7 @@ Types:
     - __kind: EventRootType
       ID: 1486
       Name: Probe[main.testEmptySlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -10018,10 +11597,20 @@ Types:
                   Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 129, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1508
       Name: Probe[main.testEmptyString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10034,15 +11623,35 @@ Types:
                   Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 147, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1515
       Name: Probe[main.testEmptyStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 316 PointerType *main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 316 PointerType *main.emptyStruct
             Operations:
@@ -10066,10 +11675,20 @@ Types:
                   Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
+        - Name: e
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 315 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1368
       Name: Probe[main.testError]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
@@ -10082,15 +11701,35 @@ Types:
                   Variable: {subprogram: 57, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: e
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 57, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1350
       Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 157 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 157 PointerType *main.esotericHeap
             Operations:
@@ -10104,12 +11743,22 @@ Types:
     - __kind: EventRootType
       ID: 1348
       Name: Probe[main.testEsotericStack]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 153 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+        - Name: e
+          Offset: 65
+          Kind: template_segment
           Expression:
             Type: 153 StructureType main.esotericStack
             Operations:
@@ -10123,7 +11772,7 @@ Types:
     - __kind: EventRootType
       ID: 1362
       Name: Probe[main.testFramelessArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10136,10 +11785,20 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1364
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 49
+      ByteSize: 89
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10152,8 +11811,18 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-        - Name: ~r0
+        - Name: a
           Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 81
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -10181,12 +11850,22 @@ Types:
     - __kind: EventRootType
       ID: 1360
       Name: Probe[main.testFrameless]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10213,12 +11892,22 @@ Types:
     - __kind: EventRootType
       ID: 1352
       Name: Probe[main.testInlinedBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10232,12 +11921,22 @@ Types:
     - __kind: EventRootType
       ID: 1356
       Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10254,7 +11953,7 @@ Types:
     - __kind: EventRootType
       ID: 1354
       Name: Probe[main.testInlinedBB]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10267,9 +11966,29 @@ Types:
                   Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: y
+        - Name: x
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10301,7 +12020,7 @@ Types:
     - __kind: EventRootType
       ID: 1516
       Name: Probe[main.testInlinedPrint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10314,15 +12033,35 @@ Types:
                   Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1518
       Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10336,7 +12075,7 @@ Types:
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.testInlinedSq]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10349,10 +12088,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1525
       Name: Probe[main.testInlinedSq]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10365,10 +12114,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1526
       Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10381,10 +12140,20 @@ Types:
                   Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1305
       Name: Probe[main.testInt16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10397,10 +12166,20 @@ Types:
                   Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 113 ArrayType [2]int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1306
       Name: Probe[main.testInt32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10413,10 +12192,20 @@ Types:
                   Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 108 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1307
       Name: Probe[main.testInt64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10429,10 +12218,20 @@ Types:
                   Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 114 ArrayType [2]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1304
       Name: Probe[main.testInt8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10445,10 +12244,20 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 112 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1303
       Name: Probe[main.testIntArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10461,10 +12270,20 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1365
       Name: Probe[main.testInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -10477,15 +12296,35 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 160 GoInterfaceType main.behavior
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1467
       Name: Probe[main.testLargeArgAndReturn]
-      ByteSize: 81
+      ByteSize: 161
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: arg
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -10512,12 +12351,22 @@ Types:
     - __kind: EventRootType
       ID: 1400
       Name: Probe[main.testLinkedList]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 244 StructureType main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 244 StructureType main.node
             Operations:
@@ -10557,7 +12406,7 @@ Types:
     - __kind: EventRootType
       ID: 1347
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10570,9 +12419,29 @@ Types:
                   Variable: {subprogram: 46, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: a
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10583,11 +12452,11 @@ Types:
     - __kind: EventRootType
       ID: 1473
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 74
-      PresenceBitsetSize: 2
+      ByteSize: 147
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10596,8 +12465,18 @@ Types:
                   Variable: {subprogram: 122, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10606,8 +12485,18 @@ Types:
                   Variable: {subprogram: 122, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10616,8 +12505,18 @@ Types:
                   Variable: {subprogram: 122, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10626,8 +12525,18 @@ Types:
                   Variable: {subprogram: 122, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10636,8 +12545,18 @@ Types:
                   Variable: {subprogram: 122, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10646,8 +12565,18 @@ Types:
                   Variable: {subprogram: 122, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10656,8 +12585,18 @@ Types:
                   Variable: {subprogram: 122, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10666,9 +12605,29 @@ Types:
                   Variable: {subprogram: 122, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 139
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10695,7 +12654,7 @@ Types:
     - __kind: EventRootType
       ID: 1376
       Name: Probe[main.testMapArrayToArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10708,10 +12667,20 @@ Types:
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 184 GoMapType map[[4]string][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1383
       Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10724,10 +12693,20 @@ Types:
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1395
       Name: Probe[main.testMapEmptyKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10740,10 +12719,20 @@ Types:
                   Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 236 GoMapType map[struct {}]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 82, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1393
       Name: Probe[main.testMapEmptyKey]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10756,10 +12745,20 @@ Types:
                   Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 226 GoMapType map[struct {}]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1394
       Name: Probe[main.testMapEmptyValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10772,10 +12771,20 @@ Types:
                   Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 231 GoMapType map[int]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1380
       Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10788,10 +12797,20 @@ Types:
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 164 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 68, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1392
       Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10804,10 +12823,20 @@ Types:
                   Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 221 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1391
       Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10820,15 +12849,35 @@ Types:
                   Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 216 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1381
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -10839,7 +12888,7 @@ Types:
     - __kind: EventRootType
       ID: 1382
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10852,10 +12901,20 @@ Types:
                   Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 191 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1390
       Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10868,10 +12927,20 @@ Types:
                   Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 211 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1389
       Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10884,10 +12953,20 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1374
       Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10900,10 +12979,20 @@ Types:
                   Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 174 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1375
       Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10916,10 +13005,20 @@ Types:
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 179 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1373
       Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10932,10 +13031,20 @@ Types:
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 169 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1384
       Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10948,10 +13057,20 @@ Types:
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 196 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1388
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10964,10 +13083,20 @@ Types:
                   Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1387
       Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10980,10 +13109,20 @@ Types:
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 206 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 74, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1386
       Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10996,10 +13135,20 @@ Types:
                   Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 201 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1385
       Name: Probe[main.testMapWithSmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11012,15 +13161,35 @@ Types:
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 201 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -11031,7 +13200,7 @@ Types:
     - __kind: EventRootType
       ID: 1506
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -11044,14 +13213,24 @@ Types:
                   Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1475
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 163
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11060,8 +13239,18 @@ Types:
                   Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11070,8 +13259,18 @@ Types:
                   Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11080,8 +13279,18 @@ Types:
                   Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11090,8 +13299,18 @@ Types:
                   Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11100,8 +13319,18 @@ Types:
                   Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11110,8 +13339,18 @@ Types:
                   Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11120,8 +13359,18 @@ Types:
                   Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11130,9 +13379,29 @@ Types:
                   Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: s
+          Offset: 147
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -11159,7 +13428,7 @@ Types:
     - __kind: EventRootType
       ID: 1479
       Name: Probe[main.testMultipleArrayArgs]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11172,9 +13441,29 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
-        - Name: b
+        - Name: a
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: b
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -11211,7 +13500,7 @@ Types:
     - __kind: EventRootType
       ID: 1471
       Name: Probe[main.testMultipleLargeArgs]
-      ByteSize: 161
+      ByteSize: 321
       PresenceBitsetSize: 1
       Expressions:
         - Name: s1
@@ -11224,9 +13513,29 @@ Types:
                   Variable: {subprogram: 121, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
-        - Name: s2
+        - Name: s1
           Offset: 81
+          Kind: template_segment
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 161
           Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 241
+          Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -11253,7 +13562,7 @@ Types:
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11266,15 +13575,55 @@ Types:
                   Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1427
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11359,7 +13708,7 @@ Types:
     - __kind: EventRootType
       ID: 1428
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11372,9 +13721,49 @@ Types:
                   Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
+        - Name: result
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 25
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11463,11 +13852,11 @@ Types:
     - __kind: EventRootType
       ID: 1397
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 62
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -11476,8 +13865,18 @@ Types:
                   Variable: {subprogram: 84, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
+        - Name: a
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
         - Name: b
-          Offset: 2
+          Offset: 4
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -11486,8 +13885,18 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
+        - Name: b
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
         - Name: c
-          Offset: 3
+          Offset: 6
           Kind: argument
           Expression:
             Type: 12 BaseType int32
@@ -11496,8 +13905,18 @@ Types:
                   Variable: {subprogram: 84, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
+        - Name: c
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
         - Name: d
-          Offset: 7
+          Offset: 14
           Kind: argument
           Expression:
             Type: 10 BaseType uint
@@ -11506,9 +13925,29 @@ Types:
                   Variable: {subprogram: 84, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 22
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 15
+          Offset: 30
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: e
+          Offset: 46
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -11519,7 +13958,7 @@ Types:
     - __kind: EventRootType
       ID: 1421
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11532,15 +13971,35 @@ Types:
                   Variable: {subprogram: 101, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1423
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11567,7 +14026,7 @@ Types:
     - __kind: EventRootType
       ID: 1424
       Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11580,10 +14039,20 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
+        - Name: result
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1405
       Name: Probe[main.testNilPointer]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -11596,9 +14065,29 @@ Types:
                   Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: z
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -11609,7 +14098,7 @@ Types:
     - __kind: EventRootType
       ID: 1490
       Name: Probe[main.testNilSliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11622,9 +14111,29 @@ Types:
                   Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11635,7 +14144,7 @@ Types:
     - __kind: EventRootType
       ID: 1492
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 34
+      ByteSize: 67
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11648,8 +14157,18 @@ Types:
                   Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: s
+        - Name: a
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 3
           Kind: argument
           Expression:
             Type: 262 GoSliceHeaderType []bool
@@ -11658,9 +14177,29 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 262 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
-          Offset: 26
+          Offset: 51
           Kind: argument
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 59
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -11671,7 +14210,7 @@ Types:
     - __kind: EventRootType
       ID: 1493
       Name: Probe[main.testNilSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11684,10 +14223,20 @@ Types:
                   Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 263 GoSliceHeaderType []uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1504
       Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11700,10 +14249,20 @@ Types:
                   Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 268 PointerType *main.oneStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 144, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1401
       Name: Probe[main.testPointerLoop]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11716,10 +14275,20 @@ Types:
                   Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 245 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1379
       Name: Probe[main.testPointerToMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11732,10 +14301,20 @@ Types:
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 190 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 67, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1399
       Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11748,10 +14327,20 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 242 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1415
       Name: Probe[main.testReturnsAnyAndError]
-      ByteSize: 18
+      ByteSize: 35
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -11764,9 +14353,29 @@ Types:
                   Variable: {subprogram: 98, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
-        - Name: failed
+        - Name: v
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: failed
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11803,12 +14412,22 @@ Types:
     - __kind: EventRootType
       ID: 1417
       Name: Probe[main.testReturnsAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -12049,12 +14668,22 @@ Types:
     - __kind: EventRootType
       ID: 1413
       Name: Probe[main.testReturnsError]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: failed
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -12081,12 +14710,22 @@ Types:
     - __kind: EventRootType
       ID: 1411
       Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12123,12 +14762,22 @@ Types:
     - __kind: EventRootType
       ID: 1409
       Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12155,12 +14804,22 @@ Types:
     - __kind: EventRootType
       ID: 1407
       Name: Probe[main.testReturnsInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12187,12 +14846,22 @@ Types:
     - __kind: EventRootType
       ID: 1419
       Name: Probe[main.testReturnsInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -12670,7 +15339,7 @@ Types:
     - __kind: EventRootType
       ID: 1300
       Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12683,10 +15352,20 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 108 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1321
       Name: Probe[main.testSingleBool]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12699,10 +15378,20 @@ Types:
                   Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1319
       Name: Probe[main.testSingleByte]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12715,10 +15404,20 @@ Types:
                   Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1332
       Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12731,10 +15430,20 @@ Types:
                   Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1333
       Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12747,10 +15456,20 @@ Types:
                   Variable: {subprogram: 35, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1324
       Name: Probe[main.testSingleInt16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12763,10 +15482,20 @@ Types:
                   Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 94 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1325
       Name: Probe[main.testSingleInt32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12779,10 +15508,20 @@ Types:
                   Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1326
       Name: Probe[main.testSingleInt64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12795,10 +15534,20 @@ Types:
                   Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 13 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1323
       Name: Probe[main.testSingleInt8]
-      ByteSize: 2
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12811,10 +15560,40 @@ Types:
                   Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1322
       Name: Probe[main.testSingleInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12827,10 +15606,20 @@ Types:
                   Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1320
       Name: Probe[main.testSingleRune]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12843,10 +15632,20 @@ Types:
                   Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1499
       Name: Probe[main.testSingleString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12859,10 +15658,20 @@ Types:
                   Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1329
       Name: Probe[main.testSingleUint16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12875,10 +15684,20 @@ Types:
                   Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 6 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1330
       Name: Probe[main.testSingleUint32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12891,10 +15710,20 @@ Types:
                   Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1331
       Name: Probe[main.testSingleUint64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12907,10 +15736,20 @@ Types:
                   Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1328
       Name: Probe[main.testSingleUint8]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12923,10 +15762,20 @@ Types:
                   Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1327
       Name: Probe[main.testSingleUint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12939,10 +15788,20 @@ Types:
                   Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1496
       Name: Probe[main.testSliceEmptyStructs]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -12955,10 +15814,20 @@ Types:
                   Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 264 GoSliceHeaderType []struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1487
       Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -12971,10 +15840,20 @@ Types:
                   Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 256 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1377
       Name: Probe[main.testSmallMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -12987,15 +15866,35 @@ Types:
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 174 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 65, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1435
       Name: Probe[main.testSomeNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13042,12 +15941,22 @@ Types:
     - __kind: EventRootType
       ID: 1477
       Name: Probe[main.testStackArgRegReturns]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: arg
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -13094,7 +16003,7 @@ Types:
     - __kind: EventRootType
       ID: 1301
       Name: Probe[main.testStringArray]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13107,10 +16016,20 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
+        - Name: x
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 109 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1404
       Name: Probe[main.testStringPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -13123,10 +16042,20 @@ Types:
                   Variable: {subprogram: 91, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 93 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1491
       Name: Probe[main.testStringSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13139,10 +16068,20 @@ Types:
                   Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 261 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1343
       Name: Probe[main.testStringType1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13155,10 +16094,20 @@ Types:
                   Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 149 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1344
       Name: Probe[main.testStringType2]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13171,10 +16120,20 @@ Types:
                   Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 151 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1488
       Name: Probe[main.testStructSlice]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13187,9 +16146,29 @@ Types:
                   Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13200,7 +16179,7 @@ Types:
     - __kind: EventRootType
       ID: 1371
       Name: Probe[main.testStructWithAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13213,15 +16192,35 @@ Types:
                   Variable: {subprogram: 59, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: s
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 162 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1481
       Name: Probe[main.testStructWithArrayArg]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 254 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 254 StructureType main.structWithArray
             Operations:
@@ -13258,12 +16257,22 @@ Types:
     - __kind: EventRootType
       ID: 1510
       Name: Probe[main.testStructWithCyclicMaps]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 283 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
@@ -13277,7 +16286,7 @@ Types:
     - __kind: EventRootType
       ID: 1509
       Name: Probe[main.testStructWithCyclicSlices]
-      ByteSize: 145
+      ByteSize: 289
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13290,10 +16299,20 @@ Types:
                   Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
+        - Name: a
+          Offset: 145
+          Kind: template_segment
+          Expression:
+            Type: 270 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 148, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
     - __kind: EventRootType
       ID: 1372
       Name: Probe[main.testStructWithMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13306,15 +16325,35 @@ Types:
                   Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
+        - Name: s
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 163 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1512
       Name: Probe[main.testStruct]
-      ByteSize: 57
+      ByteSize: 113
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 314 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 150, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+        - Name: x
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 314 StructureType main.aStruct
             Operations:
@@ -13328,7 +16367,7 @@ Types:
     - __kind: EventRootType
       ID: 1503
       Name: Probe[main.testThreeStringsInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13341,15 +16380,35 @@ Types:
                   Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 267 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 143, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1501
       Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 266 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 266 StructureType main.threeStringStruct
             Operations:
@@ -13363,7 +16422,7 @@ Types:
     - __kind: EventRootType
       ID: 1500
       Name: Probe[main.testThreeStrings]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13376,8 +16435,18 @@ Types:
                   Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-        - Name: y
+        - Name: x
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 33
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -13386,9 +16455,29 @@ Types:
                   Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
+        - Name: y
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
-          Offset: 33
+          Offset: 65
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 2, name: z}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: z
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -13399,7 +16488,7 @@ Types:
     - __kind: EventRootType
       ID: 1334
       Name: Probe[main.testTypeAlias]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13412,10 +16501,20 @@ Types:
                   Variable: {subprogram: 36, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 125 BaseType main.typeAlias
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1310
       Name: Probe[main.testUint16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13428,10 +16527,20 @@ Types:
                   Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 116 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1311
       Name: Probe[main.testUint32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13444,10 +16553,20 @@ Types:
                   Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 117 ArrayType [2]uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 13, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1312
       Name: Probe[main.testUint64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13460,10 +16579,20 @@ Types:
                   Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 54 ArrayType [2]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 14, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1309
       Name: Probe[main.testUint8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13476,10 +16605,20 @@ Types:
                   Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 107 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1308
       Name: Probe[main.testUintArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13492,10 +16631,20 @@ Types:
                   Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 115 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1403
       Name: Probe[main.testUintPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13508,10 +16657,20 @@ Types:
                   Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 105 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1485
       Name: Probe[main.testUintSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -13524,10 +16683,20 @@ Types:
                   Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1507
       Name: Probe[main.testUnitializedString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13540,10 +16709,20 @@ Types:
                   Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 146, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1402
       Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13556,10 +16735,20 @@ Types:
                   Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 15 VoidPointerType unsafe.Pointer
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1318
       Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
+      ByteSize: 1601
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13572,15 +16761,35 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
+        - Name: a
+          Offset: 801
+          Kind: template_segment
+          Expression:
+            Type: 124 ArrayType [100]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 20, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 800
     - __kind: EventRootType
       ID: 1494
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -13591,7 +16800,7 @@ Types:
     - __kind: EventRootType
       ID: 1495
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13604,10 +16813,20 @@ Types:
                   Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1483
       Name: Probe[main.testZeroSizeArgAndReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13620,9 +16839,29 @@ Types:
                   Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -5,17 +5,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: stackC
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.stackC]
+          Type: 1497 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84fe58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.stackC]Return
+          Type: 1498 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84fe8c", Frameless: false}]
           Condition: null
     - id: testAny
@@ -23,8 +23,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -41,8 +41,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -58,17 +58,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1469 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x84ecac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1470 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ed44", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -76,8 +76,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -90,8 +90,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -104,8 +104,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -118,8 +118,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -132,8 +132,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -145,8 +145,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -159,8 +159,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -177,8 +177,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -191,8 +191,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -205,8 +205,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -219,8 +219,16 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{w}, {x}, {y}'
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -233,8 +241,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{t}'
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -247,8 +255,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -261,8 +269,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -275,8 +283,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -289,8 +297,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -303,8 +311,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -317,8 +325,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -331,13 +339,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testEmptySlice]
+          Type: 1486 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84fad0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -345,13 +353,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1489 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84fb00", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -360,13 +373,13 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptyString]
+          Type: 1508 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ff30", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -374,26 +387,26 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testEmptyStruct]
+          Type: 1514 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x850280", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1515 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x850290", Frameless: true}]
           Condition: null
     - id: testError
@@ -401,8 +414,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -415,8 +428,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -433,8 +446,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -451,8 +464,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -469,8 +482,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -490,8 +503,8 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -504,8 +517,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -522,8 +535,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -540,8 +558,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -558,13 +576,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBBB
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testInlinedBBB]
+          Type: 1519 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -572,8 +590,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBC
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -590,13 +608,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testInlinedBCA]
+          Type: 1520 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -607,13 +625,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Line
-          Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1521 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -621,13 +639,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testInlinedBCB]
+          Type: 1522 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -638,13 +656,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Line
-          Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1523 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -653,13 +671,13 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.testInlinedPrint]
+          Type: 1516 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -673,7 +691,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1517 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -684,13 +702,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Line
-          Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1518 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -708,13 +726,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testInlinedSq]
+          Type: 1524 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -725,13 +743,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1515 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1525 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -740,13 +758,13 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1526 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1c4"
               Frameless: false
@@ -758,8 +776,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -772,8 +790,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -786,8 +804,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -800,8 +818,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -814,8 +832,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -828,8 +846,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -841,17 +859,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1467 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x84eaf0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1468 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ec48", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -859,8 +877,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -876,8 +894,8 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -893,8 +911,8 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -910,8 +928,13 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a} and {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -923,17 +946,43 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1473 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x84efac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1474 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x84f118", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -941,8 +990,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -955,8 +1004,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -969,8 +1018,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -983,8 +1032,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -997,8 +1046,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1011,8 +1060,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1025,8 +1074,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1039,8 +1088,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1053,8 +1102,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1067,8 +1118,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1081,8 +1134,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1095,8 +1148,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1109,8 +1162,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1123,8 +1176,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1137,8 +1190,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1151,8 +1204,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1165,8 +1218,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1179,8 +1232,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1193,8 +1246,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1207,8 +1260,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1221,13 +1276,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMassiveString]
+          Type: 1505 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1236,81 +1291,117 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testMassiveString]
+          Type: 1506 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1475 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x84f180", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1476 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x84f32c", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1479 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1480 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x84f4d4", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
-      template: ""
-      segments: []
+      template: '{s1}, {s2}'
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1471 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x84ed80", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1472 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x84ef50", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1425 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1426 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1318,8 +1409,22 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1331,8 +1436,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1344,13 +1449,41 @@ Probes:
           Type: 1422 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e088", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      template: Parameter {i} * 2 = result {result}
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - Kind: Entry
+          Type: 1423 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84e028", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1424 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e088", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}, {a}'
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1363,13 +1496,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testNilSlice]
+          Type: 1493 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1377,13 +1510,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1490 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1391,13 +1529,21 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {s}, {x}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1492 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1405,13 +1551,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1504 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ff00", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1419,8 +1565,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1433,8 +1579,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1447,8 +1593,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1461,8 +1607,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1487,8 +1633,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}, {failed}'
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1512,102 +1663,102 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
-      template: ""
-      segments: []
+      template: testReturnsArray
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsArray]
+          Type: 1445 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x84e4fc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1446 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x84e550", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
-      template: ""
-      segments: []
+      template: testReturnsArrayOne
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1447 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x84e588", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1448 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x84e5c4", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
-      template: ""
-      segments: []
+      template: testReturnsArrayZero
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1449 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x84e5f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1450 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x84e630", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
-      template: ""
-      segments: []
+      template: testReturnsBacktrackInt
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1453 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x84e6e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1454 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x84e74c", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
-      template: ""
-      segments: []
+      template: testReturnsBoolAndUintptr
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1465 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x84ea78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1466 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x84eab8", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
-      template: ""
-      segments: []
+      template: testReturnsComplex
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsComplex]
+          Type: 1441 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x84e3a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1442 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x84e3f4", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1615,8 +1766,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{failed}'
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1636,8 +1787,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1653,8 +1804,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1670,8 +1821,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1688,8 +1839,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1709,153 +1860,153 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
-      template: ""
-      segments: []
+      template: testReturnsLargeStruct
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1443 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x84e430", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1444 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x84e4c4", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
-      template: ""
-      segments: []
+      template: testReturnsManyFloats
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1439 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x84e2e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1440 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x84e36c", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
-      template: ""
-      segments: []
+      template: testReturnsMixed
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testReturnsMixed]
+          Type: 1457 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x84e868", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1458 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x84e8c0", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
-      template: ""
-      segments: []
+      template: testReturnsMixedStruct
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1451 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x84e668", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1452 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x84e6b0", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
-      template: ""
-      segments: []
+      template: testReturnsMultipleFloats
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1463 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x84e9f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1464 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x84ea3c", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
-      template: ""
-      segments: []
+      template: testReturnsOnlyFloat
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1461 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x84e988", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1462 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x84e9c8", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
-      template: ""
-      segments: []
+      template: testReturnsPrimitives
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1437 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x84e258", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1438 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x84e2b0", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
-      template: ""
-      segments: []
+      template: testReturnsStructWithArray
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1459 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x84e8fc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1460 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x84e950", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
-      template: ""
-      segments: []
+      template: testReturnsWideStruct
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1455 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x84e790", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1456 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x84e834", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -1863,8 +2014,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -1872,13 +2023,44 @@ Probes:
           Type: 1300 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
+    - id: testSegmentsForParamsAndReturnsOutOfOrder
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{result2}{i}{result}{i}{i}{result2}{result}'
+      segments:
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result}
+          dsl: result
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1427 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1428 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Condition: null
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -1891,8 +2073,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -1905,8 +2087,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -1919,8 +2101,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -1933,8 +2115,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -1947,8 +2129,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -1961,8 +2143,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -1975,8 +2157,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -1989,8 +2171,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}{x}{x}
+      segments:
+        - 'parameter = '
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2003,8 +2192,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2017,13 +2206,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testSingleString]
+          Type: 1499 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84feb0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2031,8 +2220,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2045,8 +2234,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2059,8 +2248,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2073,8 +2262,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2087,8 +2276,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2101,13 +2290,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1496 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2115,13 +2304,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1487 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84fae0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2129,8 +2318,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2142,34 +2331,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1435 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84e198", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1436 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84e220", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1477 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x84f388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1478 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x84f3ec", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2177,8 +2366,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2191,8 +2380,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}'
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2205,13 +2394,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testStringSlice]
+          Type: 1491 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2219,8 +2408,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2233,8 +2422,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2247,17 +2436,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testStruct]
+          Type: 1512 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x850180", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1503 EventRootType Probe[main.testStruct]Return
+          Type: 1513 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x85019c", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2265,13 +2454,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testStructSlice]
+          Type: 1488 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84faf0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2279,8 +2473,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2292,47 +2486,47 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1481 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x84f50c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1482 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x84f59c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1510 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x850090", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1511 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x8500a8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1509 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x850080", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2340,8 +2534,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2349,18 +2543,85 @@ Probes:
           Type: 1372 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
           Condition: null
+    - id: testTemplateWithNonexistantVariableName
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{nonexistentVariable}'
+      segments:
+        - json: {ref: nonexistentVariable}
+          dsl: nonexistentVariable
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1429 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedExpression
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{unsupportedExpression}'
+      segments:
+        - json: {foobar: unsupportedExpression}
+          dsl: unsupportedExpression
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1431 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedVariable
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: Executed main.testMultipleNamedReturn, it took {@duration}ms
+      segments:
+        - 'Executed main.testMultipleNamedReturn, it took '
+        - json: {ref: '@duration'}
+          dsl: '@duration'
+        - ms
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Condition: null
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}, {z}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testThreeStrings]
+          Type: 1500 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84fec0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2368,17 +2629,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1501 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84fed0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1502 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84fee8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2386,13 +2647,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1503 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84fef0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2400,8 +2661,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2414,8 +2675,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2428,8 +2689,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2442,8 +2703,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2456,8 +2717,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2470,8 +2731,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2484,8 +2745,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2498,13 +2759,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testUintSlice]
+          Type: 1485 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84fac0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2512,13 +2773,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testUnitializedString]
+          Type: 1507 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ff20", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2526,8 +2787,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2540,8 +2801,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2554,13 +2815,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1494 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2568,30 +2829,35 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1495 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1483 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1484 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84f640", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9285,10 +9551,10 @@ Types:
       GoKind: 22
       Pointee: 808 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1487
+      ID: 1497
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1498
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9368,7 +9634,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1459
+      ID: 1469
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9384,7 +9650,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1460
+      ID: 1470
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9711,7 +9977,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1489
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9737,7 +10003,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1476
+      ID: 1486
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9753,7 +10019,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1498
+      ID: 1508
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9769,7 +10035,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1515
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9785,7 +10051,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1504
+      ID: 1514
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -9983,7 +10249,7 @@ Types:
       ID: 1357
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1519
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1354
@@ -10015,16 +10281,16 @@ Types:
       ID: 1355
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1510
+      ID: 1520
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1511
+      ID: 1521
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1512
+      ID: 1522
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1513
+      ID: 1523
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1358
@@ -10033,7 +10299,7 @@ Types:
       ID: 1359
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1516
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10049,7 +10315,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1518
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10065,10 +10331,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1507
+      ID: 1517
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1514
+      ID: 1524
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10084,7 +10350,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1525
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10100,7 +10366,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1526
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10212,7 +10478,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1457
+      ID: 1467
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10228,7 +10494,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1458
+      ID: 1468
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10315,7 +10581,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1473
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10411,7 +10677,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1474
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10747,7 +11013,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1505
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10763,7 +11029,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1496
+      ID: 1506
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10779,7 +11045,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1465
+      ID: 1475
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10875,7 +11141,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1466
+      ID: 1476
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10891,7 +11157,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1469
+      ID: 1479
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10917,7 +11183,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1470
+      ID: 1480
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10943,7 +11209,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1461
+      ID: 1471
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -10969,7 +11235,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1462
+      ID: 1472
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10985,7 +11251,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11001,7 +11267,175 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1427
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1429
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1431
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1426
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1428
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1430
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1432
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1434
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11099,7 +11533,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1422
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1424
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11141,7 +11607,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1490
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11167,7 +11633,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1492
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11203,7 +11669,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1493
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11219,7 +11685,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1504
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11367,10 +11833,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1437
+      ID: 1447
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1438
+      ID: 1448
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11386,10 +11852,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1449
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1450
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11405,10 +11871,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1435
+      ID: 1445
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1436
+      ID: 1446
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11424,10 +11890,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1443
+      ID: 1453
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1444
+      ID: 1454
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11523,10 +11989,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1455
+      ID: 1465
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1466
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11552,10 +12018,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1441
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1432
+      ID: 1442
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11751,10 +12217,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1433
+      ID: 1443
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1434
+      ID: 1444
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11770,10 +12236,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1429
+      ID: 1439
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1430
+      ID: 1440
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -11949,10 +12415,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1451
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1442
+      ID: 1452
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11968,10 +12434,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1447
+      ID: 1457
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1448
+      ID: 1458
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12027,10 +12493,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1453
+      ID: 1463
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1454
+      ID: 1464
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12056,10 +12522,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1461
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1462
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12075,10 +12541,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1437
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1428
+      ID: 1438
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12164,10 +12630,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1449
+      ID: 1459
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1450
+      ID: 1460
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12183,10 +12649,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1445
+      ID: 1455
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1446
+      ID: 1456
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12378,7 +12844,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1489
+      ID: 1499
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12474,7 +12940,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1496
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12490,7 +12956,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1477
+      ID: 1487
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12522,7 +12988,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1435
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12538,7 +13004,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1426
+      ID: 1436
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12574,7 +13040,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1467
+      ID: 1477
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12590,7 +13056,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1468
+      ID: 1478
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12658,7 +13124,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1481
+      ID: 1491
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12706,7 +13172,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1478
+      ID: 1488
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12748,7 +13214,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1471
+      ID: 1481
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12764,7 +13230,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1472
+      ID: 1482
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12790,7 +13256,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1500
+      ID: 1510
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12806,10 +13272,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1501
+      ID: 1511
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1499
+      ID: 1509
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12841,7 +13307,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1512
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12857,10 +13323,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1503
+      ID: 1513
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1493
+      ID: 1503
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12876,7 +13342,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1501
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12892,10 +13358,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1492
+      ID: 1502
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1490
+      ID: 1500
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13043,7 +13509,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1485
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13059,7 +13525,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1497
+      ID: 1507
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13107,7 +13573,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1484
+      ID: 1494
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13123,7 +13589,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1495
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13139,7 +13605,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1473
+      ID: 1483
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13165,7 +13631,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1474
+      ID: 1484
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -21672,7 +22138,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1516
+MaxTypeID: 1526
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -18,6 +18,7 @@ Probes:
           Type: 1517 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80c318", Frameless: false}]
           Condition: null
+      probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
       version: 0
       type: LOG_PROBE
@@ -36,6 +37,13 @@ Probes:
           Type: 1386 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x807c40", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -54,6 +62,13 @@ Probes:
           Type: 1389 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x807cb0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -71,6 +86,13 @@ Probes:
           Type: 1489 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b2d8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -85,6 +107,13 @@ Probes:
           Type: 1336 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -99,6 +128,13 @@ Probes:
           Type: 1332 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -113,6 +149,13 @@ Probes:
           Type: 1334 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806390", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -127,6 +170,13 @@ Probes:
           Type: 1397 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x808280", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -141,6 +191,13 @@ Probes:
           Type: 1333 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -154,6 +211,13 @@ Probes:
           Type: 1335 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -172,6 +236,13 @@ Probes:
           Type: 1355 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x8068fc", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -186,6 +257,13 @@ Probes:
           Type: 1321 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -200,6 +278,13 @@ Probes:
           Type: 1318 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -214,6 +299,13 @@ Probes:
           Type: 1417 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{c}'
+        Segments:
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -236,6 +328,23 @@ Probes:
           Type: 1415 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x809750", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{w}, {x}, {y}'
+        Segments:
+            - JSON: {Ref: w}
+              DSL: w
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testCycle
       version: 0
       type: LOG_PROBE
@@ -250,6 +359,13 @@ Probes:
           Type: 1425 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x809c50", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{t}'
+        Segments:
+            - JSON: {Ref: t}
+              DSL: t
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -264,6 +380,13 @@ Probes:
           Type: 1360 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -278,6 +401,13 @@ Probes:
           Type: 1361 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -292,6 +422,13 @@ Probes:
           Type: 1356 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x8069b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -306,6 +443,13 @@ Probes:
           Type: 1357 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -320,6 +464,13 @@ Probes:
           Type: 1358 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -334,6 +485,13 @@ Probes:
           Type: 1359 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b40", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -348,6 +506,13 @@ Probes:
           Type: 1505 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80bf90", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -367,6 +532,18 @@ Probes:
           Type: 1508 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80bfc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -382,6 +559,13 @@ Probes:
           Type: 1527 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -396,6 +580,13 @@ Probes:
           Type: 1533 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -409,6 +600,13 @@ Probes:
           Type: 1534 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -423,6 +621,13 @@ Probes:
           Type: 1387 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807c60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -441,6 +646,13 @@ Probes:
           Type: 1370 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x8072f0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -459,6 +671,13 @@ Probes:
           Type: 1368 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x807258", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{e}'
+        Segments:
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -477,6 +696,13 @@ Probes:
           Type: 1380 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x807988", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -495,6 +721,13 @@ Probes:
           Type: 1382 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x8079d0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -512,6 +745,13 @@ Probes:
           Type: 1383 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x80799c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -530,6 +770,13 @@ Probes:
           Type: 1372 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x80771c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -553,6 +800,18 @@ Probes:
           Type: 1374 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -571,6 +830,13 @@ Probes:
           Type: 1376 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x807850", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -585,6 +851,9 @@ Probes:
           Type: 1538 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBBB
+        Segments: [testInlinedBBB]
     - id: testInlinedBC
       version: 0
       type: LOG_PROBE
@@ -603,6 +872,9 @@ Probes:
           Type: 1378 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x807964", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBC
+        Segments: [testInlinedBC]
     - id: testInlinedBCA
       version: 0
       type: LOG_PROBE
@@ -617,6 +889,9 @@ Probes:
           Type: 1539 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCALine
       version: 0
       type: LOG_PROBE
@@ -634,6 +909,9 @@ Probes:
           Type: 1540 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCA
+        Segments: [testInlinedBCA]
     - id: testInlinedBCB
       version: 0
       type: LOG_PROBE
@@ -648,6 +926,9 @@ Probes:
           Type: 1541 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedBCBLine
       version: 0
       type: LOG_PROBE
@@ -665,6 +946,9 @@ Probes:
           Type: 1542 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testInlinedBCB
+        Segments: [testInlinedBCB]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -694,6 +978,13 @@ Probes:
           Type: 1536 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -721,6 +1012,13 @@ Probes:
             - PC: "0x80781c"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -735,6 +1033,13 @@ Probes:
           Type: 1543 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -752,6 +1057,13 @@ Probes:
           Type: 1544 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 1
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -771,6 +1083,13 @@ Probes:
             - PC: "0x807a3c"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -785,6 +1104,13 @@ Probes:
           Type: 1324 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -799,6 +1125,13 @@ Probes:
           Type: 1325 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -813,6 +1146,13 @@ Probes:
           Type: 1326 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -827,6 +1167,13 @@ Probes:
           Type: 1323 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -841,6 +1188,13 @@ Probes:
           Type: 1322 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -855,6 +1209,13 @@ Probes:
           Type: 1384 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x807bf0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{b}'
+        Segments:
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -872,6 +1233,13 @@ Probes:
           Type: 1487 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b1e8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -886,6 +1254,13 @@ Probes:
           Type: 1419 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x809b60", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -903,6 +1278,9 @@ Probes:
           Type: 1364 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806cec", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineB
       version: 0
       type: LOG_PROBE
@@ -920,6 +1298,9 @@ Probes:
           Type: 1365 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806d70", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testLongFunctionWithChangingState
+        Segments: [testLongFunctionWithChangingState]
     - id: testLongFunctionWithChangingStateLineC
       version: 0
       type: LOG_PROBE
@@ -942,6 +1323,18 @@ Probes:
           Type: 1366 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806e0c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a} and {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Line
+              EventExpressionIndex: 1
+            - ' and '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Line
+              EventExpressionIndex: 3
     - id: testManyArgsArrayReturn
       version: 0
       type: LOG_PROBE
@@ -985,6 +1378,53 @@ Probes:
           Type: 1493 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x80b65c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -999,6 +1439,13 @@ Probes:
           Type: 1395 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x808260", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1013,6 +1460,13 @@ Probes:
           Type: 1402 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1027,6 +1481,13 @@ Probes:
           Type: 1412 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x808360", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1041,6 +1502,13 @@ Probes:
           Type: 1414 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x808380", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1055,6 +1523,13 @@ Probes:
           Type: 1413 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x808370", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1069,6 +1544,13 @@ Probes:
           Type: 1399 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1083,6 +1565,13 @@ Probes:
           Type: 1411 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x808350", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1097,6 +1586,13 @@ Probes:
           Type: 1410 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x808340", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1113,6 +1609,13 @@ Probes:
           Type: 1400 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1129,6 +1632,13 @@ Probes:
           Type: 1401 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1143,6 +1653,13 @@ Probes:
           Type: 1409 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x808330", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1157,6 +1674,13 @@ Probes:
           Type: 1408 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x808320", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1171,6 +1695,13 @@ Probes:
           Type: 1393 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x808240", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -1185,6 +1716,13 @@ Probes:
           Type: 1394 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x808250", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -1199,6 +1737,13 @@ Probes:
           Type: 1392 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x808230", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -1213,6 +1758,13 @@ Probes:
           Type: 1403 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1227,6 +1779,13 @@ Probes:
           Type: 1406 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x808300", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -1241,6 +1800,13 @@ Probes:
           Type: 1407 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x808310", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -1255,6 +1821,13 @@ Probes:
           Type: 1404 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -1271,6 +1844,13 @@ Probes:
           Type: 1405 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{redactMyEntries}'
+        Segments:
+            - JSON: {Ref: redactMyEntries}
+              DSL: redactMyEntries
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -1285,6 +1865,13 @@ Probes:
           Type: 1524 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1300,6 +1887,13 @@ Probes:
           Type: 1525 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -1343,6 +1937,53 @@ Probes:
           Type: 1495 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x80b848", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
+            - ', '
+            - JSON: {Ref: f}
+              DSL: f
+              EventKind: Entry
+              EventExpressionIndex: 11
+            - ', '
+            - JSON: {Ref: g}
+              DSL: g
+              EventKind: Entry
+              EventExpressionIndex: 13
+            - ', '
+            - JSON: {Ref: h}
+              DSL: h
+              EventKind: Entry
+              EventExpressionIndex: 15
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 17
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -1365,6 +2006,18 @@ Probes:
           Type: 1499 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x80b9d4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -1387,6 +2040,18 @@ Probes:
           Type: 1491 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x80b4b4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s1}, {s2}'
+        Segments:
+            - JSON: {Ref: s1}
+              DSL: s1
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s2}
+              DSL: s2
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1404,6 +2069,13 @@ Probes:
           Type: 1445 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -1432,6 +2104,33 @@ Probes:
           Type: 1416 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x809830", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}, {c}, {d}, {e}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: c}
+              DSL: c
+              EventKind: Entry
+              EventExpressionIndex: 5
+            - ', '
+            - JSON: {Ref: d}
+              DSL: d
+              EventKind: Entry
+              EventExpressionIndex: 7
+            - ', '
+            - JSON: {Ref: e}
+              DSL: e
+              EventKind: Entry
+              EventExpressionIndex: 9
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -1449,6 +2148,13 @@ Probes:
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -1472,6 +2178,19 @@ Probes:
           Type: 1443 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Parameter {i} * 2 = result {result}
+        Segments:
+            - 'Parameter '
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ' * 2 = result '
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
@@ -1491,6 +2210,18 @@ Probes:
           Type: 1424 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x809c30", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}, {a}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -1505,6 +2236,13 @@ Probes:
           Type: 1512 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -1524,6 +2262,18 @@ Probes:
           Type: 1509 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -1546,6 +2296,23 @@ Probes:
           Type: 1511 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {s}, {x}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -1560,6 +2327,13 @@ Probes:
           Type: 1523 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80c370", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -1574,6 +2348,13 @@ Probes:
           Type: 1420 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x809b70", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -1588,6 +2369,13 @@ Probes:
           Type: 1398 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -1602,6 +2390,13 @@ Probes:
           Type: 1418 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x809b50", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -1628,6 +2423,13 @@ Probes:
             - PC: "0x80a4f8"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -1659,6 +2461,18 @@ Probes:
             - PC: "0x80a314"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}, {failed}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -1676,6 +2490,9 @@ Probes:
           Type: 1465 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x80ab68", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArray
+        Segments: [testReturnsArray]
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
@@ -1693,6 +2510,9 @@ Probes:
           Type: 1467 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x80abd0", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayOne
+        Segments: [testReturnsArrayOne]
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
@@ -1710,6 +2530,9 @@ Probes:
           Type: 1469 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x80ac3c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsArrayZero
+        Segments: [testReturnsArrayZero]
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
@@ -1727,6 +2550,9 @@ Probes:
           Type: 1473 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBacktrackInt
+        Segments: [testReturnsBacktrackInt]
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
@@ -1744,6 +2570,9 @@ Probes:
           Type: 1485 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x80b084", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsBoolAndUintptr
+        Segments: [testReturnsBoolAndUintptr]
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
@@ -1761,6 +2590,9 @@ Probes:
           Type: 1461 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x80aa20", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsComplex
+        Segments: [testReturnsComplex]
     - id: testReturnsError
       version: 0
       type: LOG_PROBE
@@ -1783,6 +2615,13 @@ Probes:
             - PC: "0x80a1a8"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{failed}'
+        Segments:
+            - JSON: {Ref: failed}
+              DSL: failed
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -1800,6 +2639,13 @@ Probes:
           Type: 1427 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x809fb8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -1817,6 +2663,13 @@ Probes:
           Type: 1431 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x80a124", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -1834,6 +2687,13 @@ Probes:
           Type: 1429 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x80a054", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -1856,6 +2716,13 @@ Probes:
             - PC: "0x80a604"
               Frameless: false
           Condition: null
+      probeTemplate:
+        TemplateString: '{v}'
+        Segments:
+            - JSON: {Ref: v}
+              DSL: v
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -1873,6 +2740,9 @@ Probes:
           Type: 1463 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x80aadc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsLargeStruct
+        Segments: [testReturnsLargeStruct]
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
@@ -1890,6 +2760,9 @@ Probes:
           Type: 1459 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x80a9a8", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsManyFloats
+        Segments: [testReturnsManyFloats]
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
@@ -1907,6 +2780,9 @@ Probes:
           Type: 1477 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80aeac", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixed
+        Segments: [testReturnsMixed]
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
@@ -1924,6 +2800,9 @@ Probes:
           Type: 1471 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80acbc", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMixedStruct
+        Segments: [testReturnsMixedStruct]
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
@@ -1941,6 +2820,9 @@ Probes:
           Type: 1483 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x80b018", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsMultipleFloats
+        Segments: [testReturnsMultipleFloats]
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -1958,6 +2840,9 @@ Probes:
           Type: 1481 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x80afa4", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsOnlyFloat
+        Segments: [testReturnsOnlyFloat]
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
@@ -1975,6 +2860,9 @@ Probes:
           Type: 1457 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80a8ec", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsPrimitives
+        Segments: [testReturnsPrimitives]
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
@@ -1992,6 +2880,9 @@ Probes:
           Type: 1479 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x80af38", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsStructWithArray
+        Segments: [testReturnsStructWithArray]
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
@@ -2009,6 +2900,9 @@ Probes:
           Type: 1475 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x80ae1c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: testReturnsWideStruct
+        Segments: [testReturnsWideStruct]
     - id: testRuneArray
       version: 0
       type: LOG_PROBE
@@ -2023,6 +2917,13 @@ Probes:
           Type: 1319 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -2054,6 +2955,37 @@ Probes:
           Type: 1447 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
+        Segments:
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 4
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 1
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - JSON: {Ref: result2}
+              DSL: result2
+              EventKind: Return
+              EventExpressionIndex: 5
+            - JSON: {Ref: result}
+              DSL: result
+              EventKind: Return
+              EventExpressionIndex: 2
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -2068,6 +3000,13 @@ Probes:
           Type: 1340 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -2082,6 +3021,13 @@ Probes:
           Type: 1338 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -2096,6 +3042,13 @@ Probes:
           Type: 1351 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleFloat64
       version: 0
       type: LOG_PROBE
@@ -2110,6 +3063,13 @@ Probes:
           Type: 1352 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt
       version: 0
       type: LOG_PROBE
@@ -2124,6 +3084,13 @@ Probes:
           Type: 1341 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -2138,6 +3105,14 @@ Probes:
           Type: 1343 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -2152,6 +3127,13 @@ Probes:
           Type: 1344 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -2166,6 +3148,13 @@ Probes:
           Type: 1345 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -2187,6 +3176,22 @@ Probes:
           Type: 1342 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: parameter = {x}{x}{x}
+        Segments:
+            - 'parameter = '
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 2
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -2201,6 +3206,13 @@ Probes:
           Type: 1339 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -2215,6 +3227,13 @@ Probes:
           Type: 1518 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80c330", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -2229,6 +3248,13 @@ Probes:
           Type: 1346 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -2243,6 +3269,13 @@ Probes:
           Type: 1348 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -2257,6 +3290,13 @@ Probes:
           Type: 1349 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -2271,6 +3311,13 @@ Probes:
           Type: 1350 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -2285,6 +3332,13 @@ Probes:
           Type: 1347 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -2299,6 +3353,13 @@ Probes:
           Type: 1515 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -2313,6 +3374,13 @@ Probes:
           Type: 1506 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80bfa0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -2327,6 +3395,13 @@ Probes:
           Type: 1396 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x808270", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{m}'
+        Segments:
+            - JSON: {Ref: m}
+              DSL: m
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2344,6 +3419,13 @@ Probes:
           Type: 1455 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a85c", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{i}'
+        Segments:
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -2361,6 +3443,13 @@ Probes:
           Type: 1497 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x80b900", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -2375,6 +3464,13 @@ Probes:
           Type: 1320 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -2389,6 +3485,13 @@ Probes:
           Type: 1423 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809c10", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{z}'
+        Segments:
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -2403,6 +3506,13 @@ Probes:
           Type: 1510 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -2417,6 +3527,13 @@ Probes:
           Type: 1362 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806cb0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -2431,6 +3548,13 @@ Probes:
           Type: 1363 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806cc0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -2449,6 +3573,13 @@ Probes:
           Type: 1532 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -2468,6 +3599,18 @@ Probes:
           Type: 1507 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80bfb0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}, {a}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 3
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -2482,6 +3625,13 @@ Probes:
           Type: 1390 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x807cd0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -2499,6 +3649,13 @@ Probes:
           Type: 1501 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x80ba90", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{arg}'
+        Segments:
+            - JSON: {Ref: arg}
+              DSL: arg
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -2516,6 +3673,13 @@ Probes:
           Type: 1530 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80c4fc", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -2529,6 +3693,13 @@ Probes:
           Type: 1528 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80c4e0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -2543,6 +3714,13 @@ Probes:
           Type: 1391 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808220", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{s}'
+        Segments:
+            - JSON: {Ref: s}
+              DSL: s
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -2562,6 +3740,11 @@ Probes:
           Type: 1449 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{nonexistentVariable}'
+        Segments:
+            - Error: failed to resolve reference "nonexistentVariable"
+              DSL: nonexistentVariable
     - id: testTemplateWithUnsupportedExpression
       version: 0
       type: LOG_PROBE
@@ -2581,6 +3764,11 @@ Probes:
           Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{unsupportedExpression}'
+        Segments:
+            - Error: 'unsupported operation: foobar'
+              DSL: unsupportedExpression
     - id: testTemplateWithUnsupportedVariable
       version: 0
       type: LOG_PROBE
@@ -2602,6 +3790,13 @@ Probes:
           Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
+        Segments:
+            - 'Executed main.testMultipleNamedReturn, it took '
+            - Error: failed to resolve reference "@duration"
+              DSL: '@duration'
+            - ms
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
@@ -2624,6 +3819,23 @@ Probes:
           Type: 1519 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80c340", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}, {y}, {z}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: y}
+              DSL: y
+              EventKind: Entry
+              EventExpressionIndex: 3
+            - ', '
+            - JSON: {Ref: z}
+              DSL: z
+              EventKind: Entry
+              EventExpressionIndex: 5
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -2642,6 +3854,13 @@ Probes:
           Type: 1521 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c35c", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testThreeStringsInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2656,6 +3875,13 @@ Probes:
           Type: 1522 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c360", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testTypeAlias
       version: 0
       type: LOG_PROBE
@@ -2670,6 +3896,13 @@ Probes:
           Type: 1353 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067f0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -2684,6 +3917,13 @@ Probes:
           Type: 1329 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -2698,6 +3938,13 @@ Probes:
           Type: 1330 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -2712,6 +3959,13 @@ Probes:
           Type: 1331 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -2726,6 +3980,13 @@ Probes:
           Type: 1328 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -2740,6 +4001,13 @@ Probes:
           Type: 1327 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -2754,6 +4022,13 @@ Probes:
           Type: 1422 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -2768,6 +4043,13 @@ Probes:
           Type: 1504 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80bf80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{u}'
+        Segments:
+            - JSON: {Ref: u}
+              DSL: u
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -2782,6 +4064,13 @@ Probes:
           Type: 1526 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80c390", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -2796,6 +4085,13 @@ Probes:
           Type: 1421 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809b80", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -2810,6 +4106,13 @@ Probes:
           Type: 1337 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -2824,6 +4127,13 @@ Probes:
           Type: 1513 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2838,6 +4148,13 @@ Probes:
           Type: 1514 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{xs}'
+        Segments:
+            - JSON: {Ref: xs}
+              DSL: xs
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -2860,6 +4177,18 @@ Probes:
           Type: 1503 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80bb28", Frameless: false}]
           Condition: null
+      probeTemplate:
+        TemplateString: '{a}, {b}'
+        Segments:
+            - JSON: {Ref: a}
+              DSL: a
+              EventKind: Entry
+              EventExpressionIndex: 1
+            - ', '
+            - JSON: {Ref: b}
+              DSL: b
+              EventKind: Entry
+              EventExpressionIndex: 3
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -9673,12 +11002,22 @@ Types:
     - __kind: EventRootType
       ID: 1388
       Name: Probe[main.testAnyPtr]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 163 PointerType *interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 163 PointerType *interface {}
             Operations:
@@ -9705,12 +11044,22 @@ Types:
     - __kind: EventRootType
       ID: 1385
       Name: Probe[main.testAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -9737,12 +11086,22 @@ Types:
     - __kind: EventRootType
       ID: 1488
       Name: Probe[main.testArrayArgAndReturn]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -9782,10 +11141,20 @@ Types:
                   Variable: {subprogram: 19, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 124 ArrayType [2]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 19, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1334
       Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -9798,10 +11167,20 @@ Types:
                   Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
+        - Name: b
+          Offset: 65
+          Kind: template_segment
+          Expression:
+            Type: 121 ArrayType [2][2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 64
     - __kind: EventRootType
       ID: 1332
       Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9814,10 +11193,20 @@ Types:
                   Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 120 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 15, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1397
       Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -9830,10 +11219,20 @@ Types:
                   Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
+        - Name: m
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 191 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1333
       Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9846,10 +11245,20 @@ Types:
                   Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+        - Name: a
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1335
       Name: Probe[main.testArrayOfStructs]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9862,15 +11271,35 @@ Types:
                   Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 122 ArrayType [2]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 1354
       Name: Probe[main.testBigStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 128 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: b
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 128 StructureType main.bigStruct
             Operations:
@@ -9884,7 +11313,7 @@ Types:
     - __kind: EventRootType
       ID: 1321
       Name: Probe[main.testBoolArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -9897,15 +11326,35 @@ Types:
                   Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 112 ArrayType [2]bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1318
       Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 109 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -9929,10 +11378,20 @@ Types:
                   Variable: {subprogram: 85, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
+        - Name: c
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 243 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1415
       Name: Probe[main.testCombinedByte]
-      ByteSize: 7
+      ByteSize: 13
       PresenceBitsetSize: 1
       Expressions:
         - Name: w
@@ -9945,8 +11404,18 @@ Types:
                   Variable: {subprogram: 83, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
-        - Name: x
+        - Name: w
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -9955,9 +11424,29 @@ Types:
                   Variable: {subprogram: 83, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
         - Name: y
-          Offset: 3
+          Offset: 5
           Kind: argument
+          Expression:
+            Type: 18 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: y
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 18 BaseType float32
             Operations:
@@ -9968,7 +11457,7 @@ Types:
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testCycle]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: t
@@ -9981,10 +11470,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
+        - Name: t
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 248 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1360
       Name: Probe[main.testDeepMap1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -9997,10 +11496,20 @@ Types:
                   Variable: {subprogram: 42, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 143 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1361
       Name: Probe[main.testDeepMap7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10013,10 +11522,20 @@ Types:
                   Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 149 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1356
       Name: Probe[main.testDeepPtr1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10029,10 +11548,20 @@ Types:
                   Variable: {subprogram: 38, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 132 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1357
       Name: Probe[main.testDeepPtr7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10045,10 +11574,20 @@ Types:
                   Variable: {subprogram: 39, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 135 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1358
       Name: Probe[main.testDeepSlice1]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10061,10 +11600,20 @@ Types:
                   Variable: {subprogram: 40, index: 0, name: a}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 137 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1359
       Name: Probe[main.testDeepSlice7]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10077,10 +11626,20 @@ Types:
                   Variable: {subprogram: 41, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 141 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1508
       Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -10093,9 +11652,29 @@ Types:
                   Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 132, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10106,7 +11685,7 @@ Types:
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.testEmptySlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -10119,10 +11698,20 @@ Types:
                   Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 129, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1527
       Name: Probe[main.testEmptyString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10135,15 +11724,35 @@ Types:
                   Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 147, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1534
       Name: Probe[main.testEmptyStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 318 PointerType *main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 318 PointerType *main.emptyStruct
             Operations:
@@ -10167,10 +11776,20 @@ Types:
                   Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
+        - Name: e
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 317 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
     - __kind: EventRootType
       ID: 1387
       Name: Probe[main.testError]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
@@ -10183,15 +11802,35 @@ Types:
                   Variable: {subprogram: 57, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: e
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 57, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1369
       Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 159 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 159 PointerType *main.esotericHeap
             Operations:
@@ -10205,12 +11844,22 @@ Types:
     - __kind: EventRootType
       ID: 1367
       Name: Probe[main.testEsotericStack]
-      ByteSize: 65
+      ByteSize: 129
       PresenceBitsetSize: 1
       Expressions:
         - Name: e
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 155 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 47, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+        - Name: e
+          Offset: 65
+          Kind: template_segment
           Expression:
             Type: 155 StructureType main.esotericStack
             Operations:
@@ -10224,7 +11873,7 @@ Types:
     - __kind: EventRootType
       ID: 1381
       Name: Probe[main.testFramelessArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10237,10 +11886,20 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1383
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 49
+      ByteSize: 89
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10253,8 +11912,18 @@ Types:
                   Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-        - Name: ~r0
+        - Name: a
           Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 81
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -10282,12 +11951,22 @@ Types:
     - __kind: EventRootType
       ID: 1379
       Name: Probe[main.testFrameless]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10314,12 +11993,22 @@ Types:
     - __kind: EventRootType
       ID: 1371
       Name: Probe[main.testInlinedBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10333,12 +12022,22 @@ Types:
     - __kind: EventRootType
       ID: 1375
       Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10355,7 +12054,7 @@ Types:
     - __kind: EventRootType
       ID: 1373
       Name: Probe[main.testInlinedBB]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10368,9 +12067,29 @@ Types:
                   Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: y
+        - Name: x
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10402,7 +12121,7 @@ Types:
     - __kind: EventRootType
       ID: 1535
       Name: Probe[main.testInlinedPrint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10415,15 +12134,35 @@ Types:
                   Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1537
       Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 153, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10437,7 +12176,7 @@ Types:
     - __kind: EventRootType
       ID: 1543
       Name: Probe[main.testInlinedSq]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10450,10 +12189,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1544
       Name: Probe[main.testInlinedSq]Line
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10466,10 +12215,20 @@ Types:
                   Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 157, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1545
       Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10482,10 +12241,20 @@ Types:
                   Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
+        - Name: a
+          Offset: 41
+          Kind: template_segment
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 1324
       Name: Probe[main.testInt16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10498,10 +12267,20 @@ Types:
                   Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 115 ArrayType [2]int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1325
       Name: Probe[main.testInt32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10514,10 +12293,20 @@ Types:
                   Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 110 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1326
       Name: Probe[main.testInt64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10530,10 +12319,20 @@ Types:
                   Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 116 ArrayType [2]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1323
       Name: Probe[main.testInt8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10546,10 +12345,20 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 114 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1322
       Name: Probe[main.testIntArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -10562,10 +12371,20 @@ Types:
                   Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1384
       Name: Probe[main.testInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: b
@@ -10578,15 +12397,35 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 162 GoInterfaceType main.behavior
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1486
       Name: Probe[main.testLargeArgAndReturn]
-      ByteSize: 81
+      ByteSize: 161
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: arg
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -10613,12 +12452,22 @@ Types:
     - __kind: EventRootType
       ID: 1419
       Name: Probe[main.testLinkedList]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 246 StructureType main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: a
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 246 StructureType main.node
             Operations:
@@ -10658,7 +12507,7 @@ Types:
     - __kind: EventRootType
       ID: 1366
       Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -10671,9 +12520,29 @@ Types:
                   Variable: {subprogram: 46, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: a
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 17
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10684,11 +12553,11 @@ Types:
     - __kind: EventRootType
       ID: 1492
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 74
-      PresenceBitsetSize: 2
+      ByteSize: 147
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10697,8 +12566,18 @@ Types:
                   Variable: {subprogram: 122, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10707,8 +12586,18 @@ Types:
                   Variable: {subprogram: 122, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10717,8 +12606,18 @@ Types:
                   Variable: {subprogram: 122, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10727,8 +12626,18 @@ Types:
                   Variable: {subprogram: 122, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10737,8 +12646,18 @@ Types:
                   Variable: {subprogram: 122, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10747,8 +12666,18 @@ Types:
                   Variable: {subprogram: 122, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10757,8 +12686,18 @@ Types:
                   Variable: {subprogram: 122, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -10767,9 +12706,29 @@ Types:
                   Variable: {subprogram: 122, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 139
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -10796,7 +12755,7 @@ Types:
     - __kind: EventRootType
       ID: 1395
       Name: Probe[main.testMapArrayToArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10809,10 +12768,20 @@ Types:
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 186 GoMapType map[[4]string][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1402
       Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10825,10 +12794,20 @@ Types:
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1414
       Name: Probe[main.testMapEmptyKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10841,10 +12820,20 @@ Types:
                   Variable: {subprogram: 82, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 238 GoMapType map[struct {}]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 82, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1412
       Name: Probe[main.testMapEmptyKey]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10857,10 +12846,20 @@ Types:
                   Variable: {subprogram: 80, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 228 GoMapType map[struct {}]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1413
       Name: Probe[main.testMapEmptyValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10873,10 +12872,20 @@ Types:
                   Variable: {subprogram: 81, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 233 GoMapType map[int]struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1399
       Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10889,10 +12898,20 @@ Types:
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 166 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 68, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1411
       Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10905,10 +12924,20 @@ Types:
                   Variable: {subprogram: 79, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 223 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1410
       Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10921,15 +12950,35 @@ Types:
                   Variable: {subprogram: 78, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 218 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1400
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -10940,7 +12989,7 @@ Types:
     - __kind: EventRootType
       ID: 1401
       Name: Probe[main.testMapMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -10953,10 +13002,20 @@ Types:
                   Variable: {subprogram: 69, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 193 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1409
       Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10969,10 +13028,20 @@ Types:
                   Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 213 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1408
       Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -10985,10 +13054,20 @@ Types:
                   Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1393
       Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11001,10 +13080,20 @@ Types:
                   Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1394
       Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11017,10 +13106,20 @@ Types:
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 181 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1392
       Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11033,10 +13132,20 @@ Types:
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 171 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1403
       Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11049,10 +13158,20 @@ Types:
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 198 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1407
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11065,10 +13184,20 @@ Types:
                   Variable: {subprogram: 75, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1406
       Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11081,10 +13210,20 @@ Types:
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 208 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 74, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1405
       Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: redactMyEntries
@@ -11097,10 +13236,20 @@ Types:
                   Variable: {subprogram: 73, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
+        - Name: redactMyEntries
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1404
       Name: Probe[main.testMapWithSmallValue]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11113,15 +13262,35 @@ Types:
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 203 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -11132,7 +13301,7 @@ Types:
     - __kind: EventRootType
       ID: 1525
       Name: Probe[main.testMassiveString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -11145,14 +13314,24 @@ Types:
                   Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1494
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 163
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11161,8 +13340,18 @@ Types:
                   Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 11
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
         - Name: b
-          Offset: 10
+          Offset: 19
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11171,8 +13360,18 @@ Types:
                   Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: b
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
         - Name: c
-          Offset: 18
+          Offset: 35
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11181,8 +13380,18 @@ Types:
                   Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
+        - Name: c
+          Offset: 43
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
         - Name: d
-          Offset: 26
+          Offset: 51
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11191,8 +13400,18 @@ Types:
                   Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 59
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 34
+          Offset: 67
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11201,8 +13420,18 @@ Types:
                   Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
+        - Name: e
+          Offset: 75
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
         - Name: f
-          Offset: 42
+          Offset: 83
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11211,8 +13440,18 @@ Types:
                   Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
+        - Name: f
+          Offset: 91
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
         - Name: g
-          Offset: 50
+          Offset: 99
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11221,8 +13460,18 @@ Types:
                   Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
+        - Name: g
+          Offset: 107
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
         - Name: h
-          Offset: 58
+          Offset: 115
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -11231,9 +13480,29 @@ Types:
                   Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
+        - Name: h
+          Offset: 123
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
-          Offset: 66
+          Offset: 131
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: s
+          Offset: 147
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -11260,7 +13529,7 @@ Types:
     - __kind: EventRootType
       ID: 1498
       Name: Probe[main.testMultipleArrayArgs]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11273,9 +13542,29 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
-        - Name: b
+        - Name: a
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: b
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -11312,7 +13601,7 @@ Types:
     - __kind: EventRootType
       ID: 1490
       Name: Probe[main.testMultipleLargeArgs]
-      ByteSize: 161
+      ByteSize: 321
       PresenceBitsetSize: 1
       Expressions:
         - Name: s1
@@ -11325,9 +13614,29 @@ Types:
                   Variable: {subprogram: 121, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
-        - Name: s2
+        - Name: s1
           Offset: 81
+          Kind: template_segment
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 161
           Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 241
+          Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -11354,7 +13663,7 @@ Types:
     - __kind: EventRootType
       ID: 1444
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11367,15 +13676,55 @@ Types:
                   Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1446
       Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11460,7 +13809,7 @@ Types:
     - __kind: EventRootType
       ID: 1447
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11473,9 +13822,49 @@ Types:
                   Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
+        - Name: result
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 25
           Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11564,11 +13953,11 @@ Types:
     - __kind: EventRootType
       ID: 1416
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 62
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -11577,8 +13966,18 @@ Types:
                   Variable: {subprogram: 84, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
+        - Name: a
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
         - Name: b
-          Offset: 2
+          Offset: 4
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -11587,8 +13986,18 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
+        - Name: b
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
         - Name: c
-          Offset: 3
+          Offset: 6
           Kind: argument
           Expression:
             Type: 12 BaseType int32
@@ -11597,8 +14006,18 @@ Types:
                   Variable: {subprogram: 84, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
+        - Name: c
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
         - Name: d
-          Offset: 7
+          Offset: 14
           Kind: argument
           Expression:
             Type: 10 BaseType uint
@@ -11607,9 +14026,29 @@ Types:
                   Variable: {subprogram: 84, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
+        - Name: d
+          Offset: 22
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
-          Offset: 15
+          Offset: 30
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: e
+          Offset: 46
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -11620,7 +14059,7 @@ Types:
     - __kind: EventRootType
       ID: 1440
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
@@ -11633,15 +14072,35 @@ Types:
                   Variable: {subprogram: 101, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1442
       Name: Probe[main.testNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11668,7 +14127,7 @@ Types:
     - __kind: EventRootType
       ID: 1443
       Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -11681,10 +14140,20 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
+        - Name: result
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1424
       Name: Probe[main.testNilPointer]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -11697,9 +14166,29 @@ Types:
                   Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: z
           Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 17
           Kind: argument
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -11710,7 +14199,7 @@ Types:
     - __kind: EventRootType
       ID: 1509
       Name: Probe[main.testNilSliceOfStructs]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11723,9 +14212,29 @@ Types:
                   Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 133, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -11736,7 +14245,7 @@ Types:
     - __kind: EventRootType
       ID: 1511
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 34
+      ByteSize: 67
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11749,8 +14258,18 @@ Types:
                   Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: s
+        - Name: a
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 3
           Kind: argument
           Expression:
             Type: 264 GoSliceHeaderType []bool
@@ -11759,9 +14278,29 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 27
+          Kind: template_segment
+          Expression:
+            Type: 264 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
-          Offset: 26
+          Offset: 51
           Kind: argument
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 59
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -11772,7 +14311,7 @@ Types:
     - __kind: EventRootType
       ID: 1512
       Name: Probe[main.testNilSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -11785,10 +14324,20 @@ Types:
                   Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 265 GoSliceHeaderType []uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1523
       Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11801,10 +14350,20 @@ Types:
                   Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 270 PointerType *main.oneStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 144, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1420
       Name: Probe[main.testPointerLoop]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11817,10 +14376,20 @@ Types:
                   Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 247 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1398
       Name: Probe[main.testPointerToMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -11833,10 +14402,20 @@ Types:
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 192 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 67, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1418
       Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -11849,10 +14428,20 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 244 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1434
       Name: Probe[main.testReturnsAnyAndError]
-      ByteSize: 18
+      ByteSize: 35
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -11865,9 +14454,29 @@ Types:
                   Variable: {subprogram: 98, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
-        - Name: failed
+        - Name: v
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: failed
+          Offset: 33
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -11904,12 +14513,22 @@ Types:
     - __kind: EventRootType
       ID: 1436
       Name: Probe[main.testReturnsAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -12150,12 +14769,22 @@ Types:
     - __kind: EventRootType
       ID: 1432
       Name: Probe[main.testReturnsError]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: failed
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -12182,12 +14811,22 @@ Types:
     - __kind: EventRootType
       ID: 1430
       Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12224,12 +14863,22 @@ Types:
     - __kind: EventRootType
       ID: 1428
       Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12256,12 +14905,22 @@ Types:
     - __kind: EventRootType
       ID: 1426
       Name: Probe[main.testReturnsInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12288,12 +14947,22 @@ Types:
     - __kind: EventRootType
       ID: 1438
       Name: Probe[main.testReturnsInterface]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -12771,7 +15440,7 @@ Types:
     - __kind: EventRootType
       ID: 1319
       Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12784,10 +15453,20 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 110 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1340
       Name: Probe[main.testSingleBool]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12800,10 +15479,20 @@ Types:
                   Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1338
       Name: Probe[main.testSingleByte]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12816,10 +15505,20 @@ Types:
                   Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1351
       Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12832,10 +15531,20 @@ Types:
                   Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 18 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1352
       Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12848,10 +15557,20 @@ Types:
                   Variable: {subprogram: 35, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1343
       Name: Probe[main.testSingleInt16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12864,10 +15583,20 @@ Types:
                   Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 96 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1344
       Name: Probe[main.testSingleInt32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12880,10 +15609,20 @@ Types:
                   Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1345
       Name: Probe[main.testSingleInt64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12896,10 +15635,20 @@ Types:
                   Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 13 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1342
       Name: Probe[main.testSingleInt8]
-      ByteSize: 2
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12912,10 +15661,40 @@ Types:
                   Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 4
+          Kind: template_segment
+          Expression:
+            Type: 17 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1341
       Name: Probe[main.testSingleInt]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12928,10 +15707,20 @@ Types:
                   Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1339
       Name: Probe[main.testSingleRune]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12944,10 +15733,20 @@ Types:
                   Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1518
       Name: Probe[main.testSingleString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12960,10 +15759,20 @@ Types:
                   Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 140, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1348
       Name: Probe[main.testSingleUint16]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12976,10 +15785,20 @@ Types:
                   Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 6 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1349
       Name: Probe[main.testSingleUint32]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -12992,10 +15811,20 @@ Types:
                   Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1350
       Name: Probe[main.testSingleUint64]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13008,10 +15837,20 @@ Types:
                   Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1347
       Name: Probe[main.testSingleUint8]
-      ByteSize: 2
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13024,10 +15863,20 @@ Types:
                   Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: x
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
       ID: 1346
       Name: Probe[main.testSingleUint]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13040,10 +15889,20 @@ Types:
                   Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1515
       Name: Probe[main.testSliceEmptyStructs]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13056,10 +15915,20 @@ Types:
                   Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 266 GoSliceHeaderType []struct {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1506
       Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -13072,10 +15941,20 @@ Types:
                   Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 258 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1396
       Name: Probe[main.testSmallMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
@@ -13088,15 +15967,35 @@ Types:
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+        - Name: m
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 176 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 65, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1454
       Name: Probe[main.testSomeNamedReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: i
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13143,12 +16042,22 @@ Types:
     - __kind: EventRootType
       ID: 1496
       Name: Probe[main.testStackArgRegReturns]
-      ByteSize: 41
+      ByteSize: 81
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: arg
+          Offset: 41
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -13195,7 +16104,7 @@ Types:
     - __kind: EventRootType
       ID: 1320
       Name: Probe[main.testStringArray]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13208,10 +16117,20 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
+        - Name: x
+          Offset: 33
+          Kind: template_segment
+          Expression:
+            Type: 111 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
     - __kind: EventRootType
       ID: 1423
       Name: Probe[main.testStringPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: z
@@ -13224,10 +16143,20 @@ Types:
                   Variable: {subprogram: 91, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 95 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1510
       Name: Probe[main.testStringSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13240,10 +16169,20 @@ Types:
                   Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
+        - Name: s
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 263 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1362
       Name: Probe[main.testStringType1]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13256,10 +16195,20 @@ Types:
                   Variable: {subprogram: 44, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 151 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1363
       Name: Probe[main.testStringType2]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13272,10 +16221,20 @@ Types:
                   Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 153 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1507
       Name: Probe[main.testStructSlice]
-      ByteSize: 33
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13288,9 +16247,29 @@ Types:
                   Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
-        - Name: a
+        - Name: xs
           Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 49
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 131, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13301,7 +16280,7 @@ Types:
     - __kind: EventRootType
       ID: 1390
       Name: Probe[main.testStructWithAny]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13314,15 +16293,35 @@ Types:
                   Variable: {subprogram: 59, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: s
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 164 StructureType main.structWithAny
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1500
       Name: Probe[main.testStructWithArrayArg]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: arg
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 256 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: arg
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 256 StructureType main.structWithArray
             Operations:
@@ -13359,12 +16358,22 @@ Types:
     - __kind: EventRootType
       ID: 1529
       Name: Probe[main.testStructWithCyclicMaps]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 285 StructureType main.structWithCyclicMaps
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 149, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
@@ -13378,7 +16387,7 @@ Types:
     - __kind: EventRootType
       ID: 1528
       Name: Probe[main.testStructWithCyclicSlices]
-      ByteSize: 145
+      ByteSize: 289
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13391,10 +16400,20 @@ Types:
                   Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
+        - Name: a
+          Offset: 145
+          Kind: template_segment
+          Expression:
+            Type: 272 StructureType main.structWithCyclicSlices
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 148, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 144
     - __kind: EventRootType
       ID: 1391
       Name: Probe[main.testStructWithMap]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: s
@@ -13407,15 +16426,35 @@ Types:
                   Variable: {subprogram: 60, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
+        - Name: s
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 165 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testStruct]
-      ByteSize: 57
+      ByteSize: 113
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 316 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 150, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+        - Name: x
+          Offset: 57
+          Kind: template_segment
           Expression:
             Type: 316 StructureType main.aStruct
             Operations:
@@ -13429,7 +16468,7 @@ Types:
     - __kind: EventRootType
       ID: 1522
       Name: Probe[main.testThreeStringsInStructPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13442,15 +16481,35 @@ Types:
                   Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 269 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 143, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1520
       Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 268 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+        - Name: a
+          Offset: 49
+          Kind: template_segment
           Expression:
             Type: 268 StructureType main.threeStringStruct
             Operations:
@@ -13464,7 +16523,7 @@ Types:
     - __kind: EventRootType
       ID: 1519
       Name: Probe[main.testThreeStrings]
-      ByteSize: 49
+      ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13477,8 +16536,18 @@ Types:
                   Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-        - Name: y
+        - Name: x
           Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 33
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -13487,9 +16556,29 @@ Types:
                   Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
+        - Name: y
+          Offset: 49
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
-          Offset: 33
+          Offset: 65
           Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 141, index: 2, name: z}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: z
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -13500,7 +16589,7 @@ Types:
     - __kind: EventRootType
       ID: 1353
       Name: Probe[main.testTypeAlias]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13513,10 +16602,20 @@ Types:
                   Variable: {subprogram: 36, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 127 BaseType main.typeAlias
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1329
       Name: Probe[main.testUint16Array]
-      ByteSize: 5
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13529,10 +16628,20 @@ Types:
                   Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
+        - Name: x
+          Offset: 5
+          Kind: template_segment
+          Expression:
+            Type: 118 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 1330
       Name: Probe[main.testUint32Array]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13545,10 +16654,20 @@ Types:
                   Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 119 ArrayType [2]uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 13, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1331
       Name: Probe[main.testUint64Array]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13561,10 +16680,20 @@ Types:
                   Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 54 ArrayType [2]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 14, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1328
       Name: Probe[main.testUint8Array]
-      ByteSize: 3
+      ByteSize: 5
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13577,10 +16706,20 @@ Types:
                   Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+        - Name: x
+          Offset: 3
+          Kind: template_segment
+          Expression:
+            Type: 109 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
     - __kind: EventRootType
       ID: 1327
       Name: Probe[main.testUintArray]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13593,10 +16732,20 @@ Types:
                   Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 117 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1422
       Name: Probe[main.testUintPointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13609,10 +16758,20 @@ Types:
                   Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 107 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1504
       Name: Probe[main.testUintSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: u
@@ -13625,10 +16784,20 @@ Types:
                   Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
+        - Name: u
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1526
       Name: Probe[main.testUnitializedString]
-      ByteSize: 17
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13641,10 +16810,20 @@ Types:
                   Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 146, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 1421
       Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -13657,10 +16836,20 @@ Types:
                   Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 15 VoidPointerType unsafe.Pointer
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
+      ByteSize: 1601
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13673,15 +16862,35 @@ Types:
                   Variable: {subprogram: 20, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
+        - Name: a
+          Offset: 801
+          Kind: template_segment
+          Expression:
+            Type: 126 ArrayType [100]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 20, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 800
     - __kind: EventRootType
       ID: 1513
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -13692,7 +16901,7 @@ Types:
     - __kind: EventRootType
       ID: 1514
       Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: xs
@@ -13705,10 +16914,20 @@ Types:
                   Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+        - Name: xs
+          Offset: 25
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 1502
       Name: Probe[main.testZeroSizeArgAndReturn]
-      ByteSize: 9
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
@@ -13721,9 +16940,29 @@ Types:
                   Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
+        - Name: a
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 1
           Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -5,17 +5,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.stackC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: stackC
+      segments: [stackC]
       captureSnapshot: true
       subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.stackC]
+          Type: 1516 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80c2e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1507 EventRootType Probe[main.stackC]Return
+          Type: 1517 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80c318", Frameless: false}]
           Condition: null
     - id: testAny
@@ -23,8 +23,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 56}
       events:
@@ -41,8 +41,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testAnyPtr}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 58}
       events:
@@ -58,17 +58,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1488 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x80b24c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1489 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b2d8", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
@@ -76,8 +76,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 19}
       events:
@@ -90,8 +90,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 15}
       events:
@@ -104,8 +104,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfArraysOfArrays}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 17}
       events:
@@ -118,8 +118,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 66}
       events:
@@ -132,8 +132,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 16}
       events:
@@ -145,8 +145,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testArrayOfStructs}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 18}
       events:
@@ -159,8 +159,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBigStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 37}
       events:
@@ -177,8 +177,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testBoolArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
@@ -191,8 +191,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testByteArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
@@ -205,8 +205,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testChannel}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{c}'
+      segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
       subprogram: {subprogram: 85}
       events:
@@ -219,8 +219,16 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCombinedByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{w}, {x}, {y}'
+      segments:
+        - json: {ref: w}
+          dsl: w
+        - ', '
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 83}
       events:
@@ -233,8 +241,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testCycle}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{t}'
+      segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
@@ -247,8 +255,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 42}
       events:
@@ -261,8 +269,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepMap7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 43}
       events:
@@ -275,8 +283,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 38}
       events:
@@ -289,8 +297,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepPtr7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 39}
       events:
@@ -303,8 +311,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 40}
       events:
@@ -317,8 +325,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testDeepSlice7}
       capture: {maxReferenceDepth: 5}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 41}
       events:
@@ -331,13 +339,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          Type: 1505 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80bf90", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -345,13 +353,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptySliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1508 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80bfc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -360,13 +373,13 @@ Probes:
       where: {methodName: main.testEmptyString}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptyString]
+          Type: 1527 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -374,26 +387,26 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEmptyStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testEmptyStruct]
+          Type: 1533 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testEmptyStructPointer}
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1534 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
     - id: testError
@@ -401,8 +414,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testError}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 57}
       events:
@@ -415,8 +428,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericHeap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
@@ -433,8 +446,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testEsotericStack}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{e}'
+      segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
@@ -451,8 +464,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFrameless}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
@@ -469,8 +482,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testFramelessArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -490,8 +503,8 @@ Probes:
         sourceFile: inlined.go
         lines: ["93"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 54}
       events:
@@ -504,8 +517,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
@@ -522,8 +535,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
@@ -540,8 +558,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
@@ -558,13 +576,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBBB
+      segments: [testInlinedBBB]
       captureSnapshot: true
       subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testInlinedBBB]
+          Type: 1538 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -572,8 +590,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBC}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBC
+      segments: [testInlinedBC]
       captureSnapshot: true
       subprogram: {subprogram: 52}
       events:
@@ -590,13 +608,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCA}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testInlinedBCA]
+          Type: 1539 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -607,13 +625,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["63"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCA
+      segments: [testInlinedBCA]
       captureSnapshot: true
       subprogram: {subprogram: 155}
       events:
         - Kind: Line
-          Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1540 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -621,13 +639,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedBCB}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testInlinedBCB]
+          Type: 1541 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -638,13 +656,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["67"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testInlinedBCB
+      segments: [testInlinedBCB]
       captureSnapshot: true
       subprogram: {subprogram: 156}
       events:
         - Kind: Line
-          Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1542 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -653,13 +671,13 @@ Probes:
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testInlinedPrint]
+          Type: 1535 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -673,7 +691,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1536 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -684,13 +702,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["14"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 153}
       events:
         - Kind: Line
-          Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -708,13 +726,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInlinedSq}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testInlinedSq]
+          Type: 1543 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -725,13 +743,13 @@ Probes:
         sourceFile: inlined.go
         lines: ["75"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1534 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1544 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -740,13 +758,13 @@ Probes:
       where: {methodName: main.testInlinedSumArray}
       tags: ['foo:bar']
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1545 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8079b4"
               Frameless: false
@@ -758,8 +776,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 7}
       events:
@@ -772,8 +790,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
@@ -786,8 +804,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
@@ -800,8 +818,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInt8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
@@ -814,8 +832,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testIntArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
@@ -828,8 +846,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{b}'
+      segments: [{json: {ref: b}, dsl: b}]
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
@@ -841,17 +859,17 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testLargeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1486 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x80b0c0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1487 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b1e8", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -859,8 +877,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 87}
       events:
@@ -876,8 +894,8 @@ Probes:
         sourceFile: complex.go
         lines: ["208"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -893,8 +911,8 @@ Probes:
         sourceFile: complex.go
         lines: ["215"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: testLongFunctionWithChangingState
+      segments: [testLongFunctionWithChangingState]
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -910,8 +928,13 @@ Probes:
         sourceFile: complex.go
         lines: ["220"]
       sampling: {snapshotsPerSecond: 100}
-      template: ""
-      segments: []
+      template: '{a} and {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ' and '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
@@ -923,17 +946,43 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testManyArgsArrayReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: i}
+          dsl: i
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1492 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x80b51c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1493 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x80b65c", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -941,8 +990,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapArrayToArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 64}
       events:
@@ -955,8 +1004,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmbeddedMaps}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 70}
       events:
@@ -969,8 +1018,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKey}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 80}
       events:
@@ -983,8 +1032,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 82}
       events:
@@ -997,8 +1046,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapEmptyValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 81}
       events:
@@ -1011,8 +1060,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapIntToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 68}
       events:
@@ -1025,8 +1074,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 79}
       events:
@@ -1039,8 +1088,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapLargeKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 78}
       events:
@@ -1053,8 +1102,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1067,8 +1118,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 69}
       events:
@@ -1081,8 +1134,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeyLargeValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 77}
       events:
@@ -1095,8 +1148,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapSmallKeySmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 76}
       events:
@@ -1109,8 +1162,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 62}
       events:
@@ -1123,8 +1176,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 63}
       events:
@@ -1137,8 +1190,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapStringToStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 61}
       events:
@@ -1151,8 +1204,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithLinkedList}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 71}
       events:
@@ -1165,8 +1218,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 74}
       events:
@@ -1179,8 +1232,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallKeyAndValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 75}
       events:
@@ -1193,8 +1246,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValue}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 72}
       events:
@@ -1207,8 +1260,10 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMapWithSmallValueMassive}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{redactMyEntries}'
+      segments:
+        - json: {ref: redactMyEntries}
+          dsl: redactMyEntries
       captureSnapshot: true
       subprogram: {subprogram: 73}
       events:
@@ -1221,13 +1276,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testMassiveString]
+          Type: 1524 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
@@ -1236,81 +1291,117 @@ Probes:
       where: {methodName: main.testMassiveString}
       tags: ['foo:bar']
       capture: {maxLength: 11}
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testMassiveString]
+          Type: 1525 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMixedArgsStackReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
+        - ', '
+        - json: {ref: f}
+          dsl: f
+        - ', '
+        - json: {ref: g}
+          dsl: g
+        - ', '
+        - json: {ref: h}
+          dsl: h
+        - ', '
+        - json: {ref: s}
+          dsl: s
       captureSnapshot: true
       subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1494 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x80b6c0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1495 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x80b848", Frameless: false}]
           Condition: null
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleArrayArgs}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1498 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x80b93c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1499 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x80b9d4", Frameless: false}]
           Condition: null
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleLargeArgs}
-      template: ""
-      segments: []
+      template: '{s1}, {s2}'
+      segments:
+        - json: {ref: s1}
+          dsl: s1
+        - ', '
+        - json: {ref: s2}
+          dsl: s2
       captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1490 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x80b310", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1491 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x80b4b4", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testMultipleNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1444 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a718", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1445 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -1318,8 +1409,22 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testMultipleSimpleParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {b}, {c}, {d}, {e}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
+        - ', '
+        - json: {ref: c}
+          dsl: c
+        - ', '
+        - json: {ref: d}
+          dsl: d
+        - ', '
+        - json: {ref: e}
+          dsl: e
       captureSnapshot: true
       subprogram: {subprogram: 84}
       events:
@@ -1331,8 +1436,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 101}
       events:
@@ -1344,13 +1449,41 @@ Probes:
           Type: 1441 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
           Condition: null
+    - id: testNamedReturnWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNamedReturn}
+      template: Parameter {i} * 2 = result {result}
+      segments:
+        - 'Parameter '
+        - json: {ref: i}
+          dsl: i
+        - ' * 2 = result '
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - Kind: Entry
+          Type: 1442 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a688", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1443 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
+          Condition: null
     - id: testNilPointer
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testNilPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}, {a}'
+      segments:
+        - json: {ref: z}
+          dsl: z
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
@@ -1363,13 +1496,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testNilSlice]
+          Type: 1512 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -1377,13 +1510,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceOfStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1509 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -1391,13 +1529,21 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testNilSliceWithOtherParams}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}, {s}, {x}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: s}
+          dsl: s
+        - ', '
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1511 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -1405,13 +1551,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testOneStringInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1523 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80c370", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -1419,8 +1565,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerLoop}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
@@ -1433,8 +1579,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 67}
       events:
@@ -1447,8 +1593,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testPointerToSimpleStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 86}
       events:
@@ -1461,8 +1607,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAny}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 99}
       events:
@@ -1487,8 +1633,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsAnyAndError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}, {failed}'
+      segments:
+        - json: {ref: v}
+          dsl: v
+        - ', '
+        - json: {ref: failed}
+          dsl: failed
       captureSnapshot: true
       subprogram: {subprogram: 98}
       events:
@@ -1512,102 +1663,102 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArray}
-      template: ""
-      segments: []
+      template: testReturnsArray
+      segments: [testReturnsArray]
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          Type: 1464 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x80ab1c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1465 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x80ab68", Frameless: false}]
           Condition: null
     - id: testReturnsArrayOne
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayOne}
-      template: ""
-      segments: []
+      template: testReturnsArrayOne
+      segments: [testReturnsArrayOne]
       captureSnapshot: true
       subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1466 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x80ab98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1467 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x80abd0", Frameless: false}]
           Condition: null
     - id: testReturnsArrayZero
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsArrayZero}
-      template: ""
-      segments: []
+      template: testReturnsArrayZero
+      segments: [testReturnsArrayZero]
       captureSnapshot: true
       subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1468 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x80ac08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1469 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x80ac3c", Frameless: false}]
           Condition: null
     - id: testReturnsBacktrackInt
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBacktrackInt}
-      template: ""
-      segments: []
+      template: testReturnsBacktrackInt
+      segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1472 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x80acf8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1473 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
           Condition: null
     - id: testReturnsBoolAndUintptr
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsBoolAndUintptr}
-      template: ""
-      segments: []
+      template: testReturnsBoolAndUintptr
+      segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1484 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x80b048", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1485 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x80b084", Frameless: false}]
           Condition: null
     - id: testReturnsComplex
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsComplex}
-      template: ""
-      segments: []
+      template: testReturnsComplex
+      segments: [testReturnsComplex]
       captureSnapshot: true
       subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          Type: 1460 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x80a9d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1461 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x80aa20", Frameless: false}]
           Condition: null
     - id: testReturnsError
@@ -1615,8 +1766,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsError}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{failed}'
+      segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
@@ -1636,8 +1787,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsInt}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
@@ -1653,8 +1804,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntAndFloat}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
@@ -1670,8 +1821,8 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsIntPointer}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
@@ -1688,8 +1839,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testReturnsInterface}
       sampling: {snapshotsPerSecond: 10}
-      template: ""
-      segments: []
+      template: '{v}'
+      segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
       subprogram: {subprogram: 100}
       events:
@@ -1709,153 +1860,153 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsLargeStruct}
-      template: ""
-      segments: []
+      template: testReturnsLargeStruct
+      segments: [testReturnsLargeStruct]
       captureSnapshot: true
       subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1462 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x80aa60", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1463 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x80aadc", Frameless: false}]
           Condition: null
     - id: testReturnsManyFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsManyFloats}
-      template: ""
-      segments: []
+      template: testReturnsManyFloats
+      segments: [testReturnsManyFloats]
       captureSnapshot: true
       subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1458 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x80a928", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1459 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x80a9a8", Frameless: false}]
           Condition: null
     - id: testReturnsMixed
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixed}
-      template: ""
-      segments: []
+      template: testReturnsMixed
+      segments: [testReturnsMixed]
       captureSnapshot: true
       subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          Type: 1476 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1477 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80aeac", Frameless: false}]
           Condition: null
     - id: testReturnsMixedStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMixedStruct}
-      template: ""
-      segments: []
+      template: testReturnsMixedStruct
+      segments: [testReturnsMixedStruct]
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1470 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x80ac78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1471 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80acbc", Frameless: false}]
           Condition: null
     - id: testReturnsMultipleFloats
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsMultipleFloats}
-      template: ""
-      segments: []
+      template: testReturnsMultipleFloats
+      segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1482 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x80afd8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1483 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x80b018", Frameless: false}]
           Condition: null
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsOnlyFloat}
-      template: ""
-      segments: []
+      template: testReturnsOnlyFloat
+      segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1480 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x80af68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1481 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x80afa4", Frameless: false}]
           Condition: null
     - id: testReturnsPrimitives
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsPrimitives}
-      template: ""
-      segments: []
+      template: testReturnsPrimitives
+      segments: [testReturnsPrimitives]
       captureSnapshot: true
       subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1456 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x80a898", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1457 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80a8ec", Frameless: false}]
           Condition: null
     - id: testReturnsStructWithArray
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsStructWithArray}
-      template: ""
-      segments: []
+      template: testReturnsStructWithArray
+      segments: [testReturnsStructWithArray]
       captureSnapshot: true
       subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1478 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x80aeec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1479 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x80af38", Frameless: false}]
           Condition: null
     - id: testReturnsWideStruct
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testReturnsWideStruct}
-      template: ""
-      segments: []
+      template: testReturnsWideStruct
+      segments: [testReturnsWideStruct]
       captureSnapshot: true
       subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1474 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x80ad90", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1475 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x80ae1c", Frameless: false}]
           Condition: null
     - id: testRuneArray
@@ -1863,8 +2014,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testRuneArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
@@ -1872,13 +2023,44 @@ Probes:
           Type: 1319 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
+    - id: testSegmentsForParamsAndReturnsOutOfOrder
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{result2}{i}{result}{i}{i}{result2}{result}'
+      segments:
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result}
+          dsl: result
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: i}
+          dsl: i
+        - json: {ref: result2}
+          dsl: result2
+        - json: {ref: result}
+          dsl: result
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1446 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1447 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Condition: null
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSingleBool}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 23}
       events:
@@ -1891,8 +2073,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleByte}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 21}
       events:
@@ -1905,8 +2087,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 34}
       events:
@@ -1919,8 +2101,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleFloat64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
@@ -1933,8 +2115,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 24}
       events:
@@ -1947,8 +2129,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}
+      segments: ['parameter = ', {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 26}
       events:
@@ -1961,8 +2143,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 27}
       events:
@@ -1975,8 +2157,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 28}
       events:
@@ -1989,8 +2171,15 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleInt8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: parameter = {x}{x}{x}
+      segments:
+        - 'parameter = '
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
+        - json: {ref: x}
+          dsl: x
       captureSnapshot: true
       subprogram: {subprogram: 25}
       events:
@@ -2003,8 +2192,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleRune}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 22}
       events:
@@ -2017,13 +2206,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1508 EventRootType Probe[main.testSingleString]
+          Type: 1518 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80c330", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -2031,8 +2220,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 29}
       events:
@@ -2045,8 +2234,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint16}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 31}
       events:
@@ -2059,8 +2248,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint32}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 32}
       events:
@@ -2073,8 +2262,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint64}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 33}
       events:
@@ -2087,8 +2276,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSingleUint8}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 30}
       events:
@@ -2101,13 +2290,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceEmptyStructs}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1515 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -2115,13 +2304,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSliceOfSlices}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1506 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80bfa0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -2129,8 +2318,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testSmallMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{m}'
+      segments: [{json: {ref: m}, dsl: m}]
       captureSnapshot: true
       subprogram: {subprogram: 65}
       events:
@@ -2142,34 +2331,34 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testSomeNamedReturn}
-      template: ""
-      segments: []
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
       subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1454 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a7d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1455 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a85c", Frameless: false}]
           Condition: null
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStackArgRegReturns}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1496 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x80b8a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1497 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x80b900", Frameless: false}]
           Condition: null
     - id: testStringArray
@@ -2177,8 +2366,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
@@ -2191,8 +2380,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{z}'
+      segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
@@ -2205,13 +2394,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testStringSlice]
+          Type: 1510 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
     - id: testStringType1
@@ -2219,8 +2408,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType1}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
@@ -2233,8 +2422,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStringType2}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
@@ -2247,17 +2436,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testStruct]
+          Type: 1531 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1522 EventRootType Probe[main.testStruct]Return
+          Type: 1532 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -2265,13 +2454,18 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}, {a}'
+      segments:
+        - json: {ref: xs}
+          dsl: xs
+        - ', '
+        - json: {ref: a}
+          dsl: a
       captureSnapshot: true
       subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testStructSlice]
+          Type: 1507 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80bfb0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
@@ -2279,8 +2473,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithAny}
       capture: {maxReferenceDepth: 1}
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 59}
       events:
@@ -2292,47 +2486,47 @@ Probes:
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithArrayArg}
-      template: ""
-      segments: []
+      template: '{arg}'
+      segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1500 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x80ba0c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1501 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x80ba90", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicMaps}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1529 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80c4f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1530 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80c4fc", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testStructWithCyclicSlices}
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1528 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80c4e0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -2340,8 +2534,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testStructWithMap}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{s}'
+      segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       subprogram: {subprogram: 60}
       events:
@@ -2349,18 +2543,85 @@ Probes:
           Type: 1391 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808220", Frameless: true}]
           Condition: null
+    - id: testTemplateWithNonexistantVariableName
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{nonexistentVariable}'
+      segments:
+        - json: {ref: nonexistentVariable}
+          dsl: nonexistentVariable
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1448 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1449 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedExpression
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: '{unsupportedExpression}'
+      segments:
+        - json: {foobar: unsupportedExpression}
+          dsl: unsupportedExpression
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1450 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Condition: null
+    - id: testTemplateWithUnsupportedVariable
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleNamedReturn}
+      template: Executed main.testMultipleNamedReturn, it took {@duration}ms
+      segments:
+        - 'Executed main.testMultipleNamedReturn, it took '
+        - json: {ref: '@duration'}
+          dsl: '@duration'
+        - ms
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - Kind: Entry
+          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Condition: null
     - id: testThreeStrings
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testThreeStrings}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}, {y}, {z}'
+      segments:
+        - json: {ref: x}
+          dsl: x
+        - ', '
+        - json: {ref: y}
+          dsl: y
+        - ', '
+        - json: {ref: z}
+          dsl: z
       captureSnapshot: true
       subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStrings]
+          Type: 1519 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80c340", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -2368,17 +2629,17 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStruct}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1520 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80c350", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1521 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c35c", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -2386,13 +2647,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testThreeStringsInStructPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1522 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c360", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -2400,8 +2661,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testTypeAlias}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 36}
       events:
@@ -2414,8 +2675,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint16Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
@@ -2428,8 +2689,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint32Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 13}
       events:
@@ -2442,8 +2703,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint64Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 14}
       events:
@@ -2456,8 +2717,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUint8Array}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
@@ -2470,8 +2731,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
@@ -2484,8 +2745,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintPointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
@@ -2498,13 +2759,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUintSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{u}'
+      segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testUintSlice]
+          Type: 1504 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80bf80", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -2512,13 +2773,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnitializedString}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testUnitializedString]
+          Type: 1526 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80c390", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -2526,8 +2787,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testUnsafePointer}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
@@ -2540,8 +2801,8 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeArray}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{a}'
+      segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       subprogram: {subprogram: 20}
       events:
@@ -2554,13 +2815,13 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1513 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
@@ -2568,30 +2829,35 @@ Probes:
       type: LOG_PROBE
       where: {methodName: main.testVeryLargeSlice}
       tags: ['foo:bar']
-      template: ""
-      segments: []
+      template: '{xs}'
+      segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1514 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
     - id: testZeroSizeArgAndReturn
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testZeroSizeArgAndReturn}
-      template: ""
-      segments: []
+      template: '{a}, {b}'
+      segments:
+        - json: {ref: a}
+          dsl: a
+        - ', '
+        - json: {ref: b}
+          dsl: b
       captureSnapshot: true
       subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1502 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1503 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80bb28", Frameless: false}]
           Condition: null
 Subprograms:
@@ -9386,10 +9652,10 @@ Types:
       GoKind: 22
       Pointee: 821 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1506
+      ID: 1516
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1507
+      ID: 1517
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9469,7 +9735,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1488
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9485,7 +9751,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1489
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9812,7 +10078,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1508
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9838,7 +10104,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1505
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9854,7 +10120,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1527
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9870,7 +10136,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1534
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9886,7 +10152,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1523
+      ID: 1533
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -10084,7 +10350,7 @@ Types:
       ID: 1376
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1528
+      ID: 1538
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1373
@@ -10116,16 +10382,16 @@ Types:
       ID: 1374
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1529
+      ID: 1539
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1530
+      ID: 1540
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1531
+      ID: 1541
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1542
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1377
@@ -10134,7 +10400,7 @@ Types:
       ID: 1378
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1535
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10150,7 +10416,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1527
+      ID: 1537
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10166,10 +10432,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1536
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1543
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10185,7 +10451,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1544
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10201,7 +10467,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1545
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -10313,7 +10579,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1486
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10329,7 +10595,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1487
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10416,7 +10682,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1492
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 74
       PresenceBitsetSize: 2
@@ -10512,7 +10778,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1493
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10848,7 +11114,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1524
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10864,7 +11130,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1525
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10880,7 +11146,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1484
+      ID: 1494
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -10976,7 +11242,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1485
+      ID: 1495
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -10992,7 +11258,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1488
+      ID: 1498
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -11018,7 +11284,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1499
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11044,7 +11310,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1490
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -11070,7 +11336,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1481
+      ID: 1491
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11086,7 +11352,7 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11102,7 +11368,175 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1446
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1448
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1445
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1449
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1451
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11200,7 +11634,39 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1441
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1443
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11242,7 +11708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1509
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11268,7 +11734,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1511
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -11304,7 +11770,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1502
+      ID: 1512
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11320,7 +11786,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1523
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11468,10 +11934,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1456
+      ID: 1466
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1467
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11487,10 +11953,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1468
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1469
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11506,10 +11972,10 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1454
+      ID: 1464
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1455
+      ID: 1465
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11525,10 +11991,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1472
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1473
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 82
       PresenceBitsetSize: 2
@@ -11624,10 +12090,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1484
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1485
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       PresenceBitsetSize: 1
@@ -11653,10 +12119,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1460
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1461
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11852,10 +12318,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1452
+      ID: 1462
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1453
+      ID: 1463
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11871,10 +12337,10 @@ Types:
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1448
+      ID: 1458
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1459
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -12050,10 +12516,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1470
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1471
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12069,10 +12535,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1466
+      ID: 1476
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1477
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12128,10 +12594,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1482
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1473
+      ID: 1483
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -12157,10 +12623,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1470
+      ID: 1480
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1481
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12176,10 +12642,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1456
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1457
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -12265,10 +12731,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1478
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1479
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12284,10 +12750,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1474
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1475
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -12479,7 +12945,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1508
+      ID: 1518
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12575,7 +13041,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1505
+      ID: 1515
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12591,7 +13057,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1506
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12623,7 +13089,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1454
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12639,7 +13105,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1455
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12675,7 +13141,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1486
+      ID: 1496
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -12691,7 +13157,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1487
+      ID: 1497
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12759,7 +13225,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1510
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12807,7 +13273,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1507
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12849,7 +13315,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1490
+      ID: 1500
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -12865,7 +13331,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1491
+      ID: 1501
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12891,7 +13357,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1529
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12907,10 +13373,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1520
+      ID: 1530
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1518
+      ID: 1528
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -12942,7 +13408,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1521
+      ID: 1531
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -12958,10 +13424,10 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1522
+      ID: 1532
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1512
+      ID: 1522
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -12977,7 +13443,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1520
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12993,10 +13459,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1511
+      ID: 1521
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1509
+      ID: 1519
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13144,7 +13610,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1504
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13160,7 +13626,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1516
+      ID: 1526
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13208,7 +13674,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1503
+      ID: 1513
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13224,7 +13690,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1514
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13240,7 +13706,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1502
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13266,7 +13732,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1503
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -21933,7 +22399,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1535
+MaxTypeID: 1545
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -153,6 +153,10 @@ func PrintJSON(p *ir.Program) ([]byte, error) {
 		encode(v.Subprogram)
 		writeToken(jsontext.String("events"))
 		encode(v.Events)
+		if v.Template.TemplateString != "" {
+			writeToken(jsontext.String("probeTemplate"))
+			encode(v.Template)
+		}
 		writeToken(endT)
 		return nil
 	}

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -1,0 +1,73 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testNamedReturn",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testNamedReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 91
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 393
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testNamedReturnWithTemplate",
+          "location": {
+            "method": "main.testNamedReturn"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "int",
+                "value": "40"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "result": {
+                "type": "int",
+                "value": "80"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
@@ -1,0 +1,77 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMultipleNamedReturn",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testMultipleNamedReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 99
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 394
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testSegmentsForParamsAndReturnsOutOfOrder",
+          "location": {
+            "method": "main.testMultipleNamedReturn"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "int",
+                "value": "41"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "result": {
+                "type": "int",
+                "value": "82"
+              },
+              "result2": {
+                "type": "int",
+                "value": "123"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -1,0 +1,77 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMultipleNamedReturn",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testMultipleNamedReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 99
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 394
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testTemplateWithNonexistantVariableName",
+          "location": {
+            "method": "main.testMultipleNamedReturn"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "int",
+                "value": "41"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "result": {
+                "type": "int",
+                "value": "82"
+              },
+              "result2": {
+                "type": "int",
+                "value": "123"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -1,0 +1,77 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMultipleNamedReturn",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testMultipleNamedReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 99
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 394
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testTemplateWithUnsupportedExpression",
+          "location": {
+            "method": "main.testMultipleNamedReturn"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "int",
+                "value": "41"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "result": {
+                "type": "int",
+                "value": "82"
+              },
+              "result2": {
+                "type": "int",
+                "value": "123"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -1,0 +1,77 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMultipleNamedReturn",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testMultipleNamedReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 99
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 394
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testTemplateWithUnsupportedVariable",
+          "location": {
+            "method": "main.testMultipleNamedReturn"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "int",
+                "value": "41"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "result": {
+                "type": "int",
+                "value": "82"
+              },
+              "result2": {
+                "type": "int",
+                "value": "123"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -6,6 +6,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleByte
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleRune
     type: LOG_PROBE
@@ -13,6 +18,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleRune
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleBool
     type: LOG_PROBE
@@ -20,6 +30,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleBool
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt
     type: LOG_PROBE
@@ -27,6 +42,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt8
     type: LOG_PROBE
@@ -34,6 +54,18 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt8
+    template: "parameter = {x}{x}{x}"
+    segments:
+      - str: "parameter = "
+      - json:
+          ref: "x"
+        dsl: "x"
+      - json:
+          ref: "x"
+        dsl: "x"
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt16
     type: LOG_PROBE
@@ -41,6 +73,12 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt16
+    template: "parameter = {x}"
+    segments:
+      - str: "parameter = "
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt32
     type: LOG_PROBE
@@ -48,6 +86,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt32
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleInt64
     type: LOG_PROBE
@@ -55,6 +98,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleInt64
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint
     type: LOG_PROBE
@@ -62,6 +110,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint8
     type: LOG_PROBE
@@ -69,6 +122,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint8
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint16
     type: LOG_PROBE
@@ -76,6 +134,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint16
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint32
     type: LOG_PROBE
@@ -83,6 +146,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint32
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleUint64
     type: LOG_PROBE
@@ -90,6 +158,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleUint64
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleFloat32
     type: LOG_PROBE
@@ -97,6 +170,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleFloat32
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleFloat64
     type: LOG_PROBE
@@ -104,6 +182,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSingleFloat64
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testTypeAlias
     type: LOG_PROBE
@@ -111,6 +194,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testTypeAlias
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testSingleString
     type: LOG_PROBE
@@ -119,12 +207,22 @@ probes:
     where:
       methodName: main.testSingleString
     captureSnapshot: true
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
   - id: testUnitializedString
     type: LOG_PROBE
     tags:
       - "foo:bar"
     where:
       methodName: main.testUnitializedString
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testMassiveString
     type: LOG_PROBE
@@ -132,6 +230,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMassiveString
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testMassiveStringWithSizeLimit
     type: LOG_PROBE
@@ -139,6 +242,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMassiveString
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     capture:
       maxLength: 11
@@ -148,6 +256,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEmptyString
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -157,6 +270,19 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testThreeStrings
+    template: "{x}, {y}, {z}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
+      - str: ", "
+      - json:
+          ref: "y"
+        dsl: "y"
+      - str: ", "
+      - json:
+          ref: "z"
+        dsl: "z"
     captureSnapshot: true
   - id: testThreeStringsInStruct
     type: LOG_PROBE
@@ -164,6 +290,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testThreeStringsInStruct
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testUnsafePointer
     type: LOG_PROBE
@@ -171,6 +302,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUnsafePointer
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testThreeStringsInStructPointer
     type: LOG_PROBE
@@ -178,6 +314,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testThreeStringsInStructPointer
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testOneStringInStructPointer
     type: LOG_PROBE
@@ -185,6 +326,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testOneStringInStructPointer
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testByteArray
     type: LOG_PROBE
@@ -192,6 +338,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testByteArray
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testRuneArray
     type: LOG_PROBE
@@ -199,6 +350,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testRuneArray
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testStringArray
     type: LOG_PROBE
@@ -206,6 +362,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStringArray
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testBoolArray
     type: LOG_PROBE
@@ -214,12 +375,22 @@ probes:
     where:
       methodName: main.testBoolArray
     captureSnapshot: true
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
   - id: testIntArray
     type: LOG_PROBE
     tags:
       - "foo:bar"
     where:
       methodName: main.testIntArray
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInt8Array
     type: LOG_PROBE
@@ -227,6 +398,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInt8Array
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInt16Array
     type: LOG_PROBE
@@ -234,6 +410,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInt16Array
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInt32Array
     type: LOG_PROBE
@@ -241,6 +422,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInt32Array
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInt64Array
     type: LOG_PROBE
@@ -248,6 +434,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInt64Array
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUintArray
     type: LOG_PROBE
@@ -255,6 +446,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUintArray
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUint8Array
     type: LOG_PROBE
@@ -262,6 +458,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUint8Array
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUint16Array
     type: LOG_PROBE
@@ -269,6 +470,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUint16Array
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUint32Array
     type: LOG_PROBE
@@ -276,6 +482,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUint32Array
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testUint64Array
     type: LOG_PROBE
@@ -283,6 +494,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testUint64Array
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testArrayOfArrays
     type: LOG_PROBE
@@ -290,6 +506,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayOfArrays
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testArrayOfStrings
     type: LOG_PROBE
@@ -297,6 +518,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayOfStrings
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testArrayOfArraysOfArrays
     type: LOG_PROBE
@@ -304,11 +530,21 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayOfArraysOfArrays
+    template: "{b}"
+    segments:
+      - json:
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true
   - id: testArrayOfStructs
     type: LOG_PROBE
     where:
       methodName: main.testArrayOfStructs
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testArrayEmptyStructs
     type: LOG_PROBE
@@ -316,6 +552,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayEmptyStructs
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testUintSlice
     type: LOG_PROBE
@@ -324,12 +565,22 @@ probes:
     where:
       methodName: main.testUintSlice
     captureSnapshot: true
+    template: "{u}"
+    segments:
+      - json:
+          ref: "u"
+        dsl: "u"
   - id: testVeryLargeSlice
     type: LOG_PROBE
     tags:
       - "foo:bar"
     where:
       methodName: main.testVeryLargeSlice
+    template: "{xs}"
+    segments:
+      - json:
+          ref: "xs"
+        dsl: "xs"
     captureSnapshot: true
   - id: testVeryLargeSliceWithSizeLimit
     type: LOG_PROBE
@@ -337,6 +588,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testVeryLargeSlice
+    template: "{xs}"
+    segments:
+      - json:
+          ref: "xs"
+        dsl: "xs"
     captureSnapshot: true
     capture:
       collectionSizeLimit: 12
@@ -346,6 +602,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testVeryLargeArray
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testEmptySlice
     type: LOG_PROBE
@@ -353,6 +614,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEmptySlice
+    template: "{u}"
+    segments:
+      - json:
+          ref: "u"
+        dsl: "u"
     captureSnapshot: true
   - id: testSliceOfSlices
     type: LOG_PROBE
@@ -360,6 +626,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSliceOfSlices
+    template: "{u}"
+    segments:
+      - json:
+          ref: "u"
+        dsl: "u"
     captureSnapshot: true
   - id: testStructSlice
     type: LOG_PROBE
@@ -367,6 +638,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStructSlice
+    template: "{xs}, {a}"
+    segments:
+      - json:
+          ref: "xs"
+        dsl: "xs"
+      - str: ", "
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testEmptySliceOfStructs
     type: LOG_PROBE
@@ -374,6 +654,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEmptySliceOfStructs
+    template: "{xs}, {a}"
+    segments:
+      - json:
+          ref: "xs"
+        dsl: "xs"
+      - str: ", "
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testNilSliceOfStructs
     type: LOG_PROBE
@@ -381,6 +670,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testNilSliceOfStructs
+    template: "{xs}, {a}"
+    segments:
+      - json:
+          ref: "xs"
+        dsl: "xs"
+      - str: ", "
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testStringSlice
     type: LOG_PROBE
@@ -388,6 +686,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStringSlice
+    template: "{s}"
+    segments:
+      - json:
+          ref: "s"
+        dsl: "s"
     captureSnapshot: true
   - id: testNilSliceWithOtherParams
     type: LOG_PROBE
@@ -395,6 +698,19 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testNilSliceWithOtherParams
+    template: "{a}, {s}, {x}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json:
+          ref: "s"
+        dsl: "s"
+      - str: ", "
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testNilSlice
     type: LOG_PROBE
@@ -402,6 +718,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testNilSlice
+    template: "{xs}"
+    segments:
+      - json:
+          ref: "xs"
+        dsl: "xs"
     captureSnapshot: true
   - id: testSliceEmptyStructs
     type: LOG_PROBE
@@ -409,6 +730,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSliceEmptyStructs
+    template: "{xs}"
+    segments:
+      - json:
+          ref: "xs"
+        dsl: "xs"
     captureSnapshot: true
   - id: testStruct
     type: LOG_PROBE
@@ -416,6 +742,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStruct
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testEmptyStruct
     type: LOG_PROBE
@@ -424,6 +755,11 @@ probes:
     where:
       methodName: main.testEmptyStruct
     captureSnapshot: true
+    template: "{e}"
+    segments:
+      - json:
+          ref: "e"
+        dsl: "e"
   - id: testUintPointer
     type: LOG_PROBE
     tags:
@@ -431,12 +767,22 @@ probes:
     where:
       methodName: main.testUintPointer
     captureSnapshot: true
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
   - id: testStringPointer
     type: LOG_PROBE
     tags:
       - "foo:bar"
     where:
       methodName: main.testStringPointer
+    template: "{z}"
+    segments:
+      - json:
+          ref: "z"
+        dsl: "z"
     captureSnapshot: true
   - id: testNilPointer
     type: LOG_PROBE
@@ -444,6 +790,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testNilPointer
+    template: "{z}, {a}"
+    segments:
+      - json:
+          ref: "z"
+        dsl: "z"
+      - str: ", "
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testCombinedByte
     type: LOG_PROBE
@@ -451,6 +806,19 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testCombinedByte
+    template: "{w}, {x}, {y}"
+    segments:
+      - json:
+          ref: "w"
+        dsl: "w"
+      - str: ", "
+      - json:
+          ref: "x"
+        dsl: "x"
+      - str: ", "
+      - json:
+          ref: "y"
+        dsl: "y"
     captureSnapshot: true
   - id: testMultipleSimpleParams
     type: LOG_PROBE
@@ -458,11 +826,37 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMultipleSimpleParams
+    template: "{a}, {b}, {c}, {d}, {e}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json:
+          ref: "b"
+        dsl: "b"
+      - str: ", "
+      - json:
+          ref: "c"
+        dsl: "c"
+      - str: ", "
+      - json:
+          ref: "d"
+        dsl: "d"
+      - str: ", "
+      - json:
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testInterface
     type: LOG_PROBE
     where:
       methodName: main.testInterface
+    template: "{b}"
+    segments:
+      - json:
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -470,6 +864,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testAny
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -479,6 +878,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testError
+    template: "{e}"
+    segments:
+      - json:
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testBigStruct
     type: LOG_PROBE
@@ -486,6 +890,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testBigStruct
+    template: "{b}"
+    segments:
+      - json:
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true
   - id: stackC
     type: LOG_PROBE
@@ -493,6 +902,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.stackC
+    template: "stackC"
+    segments:
+      - str: "stackC"
     captureSnapshot: true
   - id: testChannel
     type: LOG_PROBE
@@ -500,6 +912,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testChannel
+    template: "{c}"
+    segments:
+      - json:
+          ref: "c"
+        dsl: "c"
     captureSnapshot: true
   - id: testLinkedList
     type: LOG_PROBE
@@ -507,6 +924,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testLinkedList
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testPointerLoop
     type: LOG_PROBE
@@ -514,6 +936,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testPointerLoop
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testCycle
     type: LOG_PROBE
@@ -521,6 +948,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testCycle
+    template: "{t}"
+    segments:
+      - json:
+          ref: "t"
+        dsl: "t"
     captureSnapshot: true
   - id: testPointerToSimpleStruct
     type: LOG_PROBE
@@ -528,6 +960,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testPointerToSimpleStruct
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testEsotericStack
     type: LOG_PROBE
@@ -535,6 +972,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEsotericStack
+    template: "{e}"
+    segments:
+      - json:
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testEsotericHeap
     type: LOG_PROBE
@@ -542,6 +984,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testEsotericHeap
+    template: "{e}"
+    segments:
+      - json:
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testSmallMap
     type: LOG_PROBE
@@ -549,6 +996,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testSmallMap
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapIntToInt
     type: LOG_PROBE
@@ -556,6 +1008,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapIntToInt
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapStringToInt
     type: LOG_PROBE
@@ -563,6 +1020,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapStringToInt
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapStringToSlice
     type: LOG_PROBE
@@ -570,6 +1032,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapStringToSlice
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapArrayToArray
     type: LOG_PROBE
@@ -577,6 +1044,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapArrayToArray
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapStringToStruct
     type: LOG_PROBE
@@ -584,6 +1056,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapStringToStruct
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapMassive
     type: LOG_PROBE
@@ -591,6 +1068,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapMassive
+    template: "{redactMyEntries}"
+    segments:
+      - json:
+          ref: "redactMyEntries"
+        dsl: "redactMyEntries"
     captureSnapshot: true
   - id: testMapMassiveWithSizeLimit
     type: LOG_PROBE
@@ -598,6 +1080,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapMassive
+    template: "{redactMyEntries}"
+    segments:
+      - json:
+          ref: "redactMyEntries"
+        dsl: "redactMyEntries"
     captureSnapshot: true
     capture:
       collectionSizeLimit: 3
@@ -607,6 +1094,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapEmbeddedMaps
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapWithLinkedList
     type: LOG_PROBE
@@ -614,6 +1106,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithLinkedList
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapWithSmallValue
     type: LOG_PROBE
@@ -621,6 +1118,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithSmallValue
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapWithSmallValueMassive
     type: LOG_PROBE
@@ -628,6 +1130,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithSmallValueMassive
+    template: "{redactMyEntries}"
+    segments:
+      - json:
+          ref: "redactMyEntries"
+        dsl: "redactMyEntries"
     captureSnapshot: true
   - id: testMapWithSmallKeyAndValue
     type: LOG_PROBE
@@ -635,6 +1142,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithSmallKeyAndValue
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapWithSmallKeyAndValueMassive
     type: LOG_PROBE
@@ -642,6 +1154,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapWithSmallKeyAndValueMassive
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapSmallKeySmallValue
     type: LOG_PROBE
@@ -649,6 +1166,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapSmallKeySmallValue
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapSmallKeyLargeValue
     type: LOG_PROBE
@@ -656,6 +1178,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapSmallKeyLargeValue
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapLargeKeySmallValue
     type: LOG_PROBE
@@ -663,6 +1190,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapLargeKeySmallValue
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapLargeKeyLargeValue
     type: LOG_PROBE
@@ -670,6 +1202,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapLargeKeyLargeValue
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapEmptyKey
     type: LOG_PROBE
@@ -677,6 +1214,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapEmptyKey
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapEmptyValue
     type: LOG_PROBE
@@ -684,6 +1226,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapEmptyValue
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testMapEmptyKeyAndValue
     type: LOG_PROBE
@@ -691,6 +1238,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testMapEmptyKeyAndValue
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testStructWithMap
     type: LOG_PROBE
@@ -698,6 +1250,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testStructWithMap
+    template: "{s}"
+    segments:
+      - json:
+          ref: "s"
+        dsl: "s"
     captureSnapshot: true
   - id: testArrayOfMaps
     type: LOG_PROBE
@@ -705,6 +1262,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testArrayOfMaps
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testPointerToMap
     type: LOG_PROBE
@@ -712,6 +1274,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testPointerToMap
+    template: "{m}"
+    segments:
+      - json:
+          ref: "m"
+        dsl: "m"
     captureSnapshot: true
   - id: testInlinedPrint
     type: LOG_PROBE
@@ -719,6 +1286,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedPrint
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -728,6 +1300,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedSumArray
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -737,6 +1314,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedSq
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInlinedBA
     type: LOG_PROBE
@@ -744,6 +1326,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBA
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInlinedBB
     type: LOG_PROBE
@@ -751,6 +1338,15 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBB
+    template: "{x}, {y}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
+      - str: ", "
+      - json:
+          ref: "y"
+        dsl: "y"
     captureSnapshot: true
   - id: testInlinedBBA
     type: LOG_PROBE
@@ -758,6 +1354,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBBA
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testInlinedBBB
     type: LOG_PROBE
@@ -765,6 +1366,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBBB
+    template: "testInlinedBBB"
+    segments:
+      - str: "testInlinedBBB"
     captureSnapshot: true
   - id: testInlinedBC
     type: LOG_PROBE
@@ -772,6 +1376,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBC
+    template: "testInlinedBC"
+    segments:
+      - str: "testInlinedBC"
     captureSnapshot: true
   - id: testInlinedBCA
     type: LOG_PROBE
@@ -779,6 +1386,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBCA
+    template: "testInlinedBCA"
+    segments:
+      - str: "testInlinedBCA"
     captureSnapshot: true
   - id: testInlinedBCB
     type: LOG_PROBE
@@ -786,6 +1396,9 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testInlinedBCB
+    template: "testInlinedBCB"
+    segments:
+      - str: "testInlinedBCB"
     captureSnapshot: true
   - id: testFrameless
     type: LOG_PROBE
@@ -793,6 +1406,11 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testFrameless
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
   - id: testFramelessArray
     type: LOG_PROBE
@@ -800,11 +1418,21 @@ probes:
       - "foo:bar"
     where:
       methodName: main.testFramelessArray
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testDeepPtr1
     type: LOG_PROBE
     where:
       methodName: main.testDeepPtr1
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -812,6 +1440,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepPtr7
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 5
@@ -819,6 +1452,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepSlice1
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -826,6 +1464,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepSlice7
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 5
@@ -833,6 +1476,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepMap1
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -840,6 +1488,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testDeepMap7
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 5
@@ -847,6 +1500,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testStringType1
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -854,6 +1512,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testStringType2
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -861,11 +1524,21 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testEmptyStructPointer
+    template: "{e}"
+    segments:
+      - json:
+          ref: "e"
+        dsl: "e"
     captureSnapshot: true
   - id: testAnyPtr
     type: LOG_PROBE
     where:
       methodName: main.testAnyPtr
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -873,6 +1546,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testStructWithAny
+    template: "{s}"
+    segments:
+      - json:
+          ref: "s"
+        dsl: "s"
     captureSnapshot: true
     capture:
       maxReferenceDepth: 1
@@ -880,31 +1558,61 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testStructWithCyclicSlices
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testStructWithCyclicMaps
     type: LOG_PROBE
     where:
       methodName: main.testStructWithCyclicMaps
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
   - id: testReturnsInt
     type: LOG_PROBE
     where:
       methodName: main.testReturnsInt
+    template: "{i}"
+    segments:
+      - json:
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testReturnsIntPointer
     type: LOG_PROBE
     where:
       methodName: main.testReturnsIntPointer
+    template: "{i}"
+    segments:
+      - json:
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testReturnsIntAndFloat
     type: LOG_PROBE
     where:
       methodName: main.testReturnsIntAndFloat
+    template: "{i}"
+    segments:
+      - json:
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testReturnsError
     type: LOG_PROBE
     where:
       methodName: main.testReturnsError
+    template: "{failed}"
+    segments:
+      - json:
+          ref: "failed"
+        dsl: "failed"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -912,6 +1620,15 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testReturnsAnyAndError
+    template: "{v}, {failed}"
+    segments:
+      - json:
+          ref: "v"
+        dsl: "v"
+      - str: ", "
+      - json:
+          ref: "failed"
+        dsl: "failed"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -919,6 +1636,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testReturnsAny
+    template: "{v}"
+    segments:
+      - json:
+          ref: "v"
+        dsl: "v"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -926,6 +1648,11 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testReturnsInterface
+    template: "{v}"
+    segments:
+      - json:
+          ref: "v"
+        dsl: "v"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 10
@@ -933,16 +1660,46 @@ probes:
     type: LOG_PROBE
     where:
       methodName: main.testNamedReturn
+    template: "{i}"
+    segments:
+      - json:
+          ref: "i"
+        dsl: "i"
+    captureSnapshot: true
+  - id: testNamedReturnWithTemplate
+    type: LOG_PROBE
+    where:
+      methodName: main.testNamedReturn
+    template: "Parameter {i} * 2 = result {result}"
+    segments:
+      - str: "Parameter "
+      - dsl: "i"
+        json:
+          ref: "i"
+      - str: " * 2 = result "
+      - dsl: "result"
+        json:
+          ref: "result"
     captureSnapshot: true
   - id: testMultipleNamedReturn
     type: LOG_PROBE
     where:
       methodName: main.testMultipleNamedReturn
+    template: "{i}"
+    segments:
+      - json:
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testSomeNamedReturn
     type: LOG_PROBE
     where:
       methodName: main.testSomeNamedReturn
+    template: "{i}"
+    segments:
+      - json:
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testInlinedPrintLine
     type: LOG_PROBE
@@ -951,6 +1708,11 @@ probes:
       sourceFile: inlined.go
       lines:
         - "14"
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -961,6 +1723,9 @@ probes:
       sourceFile: inlined.go
       lines:
         - "63"
+    template: "testInlinedBCA"
+    segments:
+      - str: "testInlinedBCA"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -971,6 +1736,9 @@ probes:
       sourceFile: inlined.go
       lines:
         - "67"
+    template: "testInlinedBCB"
+    segments:
+      - str: "testInlinedBCB"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -981,6 +1749,11 @@ probes:
       sourceFile: inlined.go
       lines:
         - "75"
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -991,6 +1764,11 @@ probes:
       sourceFile: inlined.go
       lines:
         - "93"
+    template: "{a}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -1001,6 +1779,9 @@ probes:
       sourceFile: complex.go
       lines:
         - "208"
+    template: "testLongFunctionWithChangingState"
+    segments:
+      - str: "testLongFunctionWithChangingState"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -1011,6 +1792,9 @@ probes:
       sourceFile: complex.go
       lines:
         - "215"
+    template: "testLongFunctionWithChangingState"
+    segments:
+      - str: "testLongFunctionWithChangingState"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -1024,123 +1808,358 @@ probes:
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
+    template: "{a} and {b}"
+    segments:
+      - dsl: "a"
+        json:
+          ref: "a"
+      - str: " and "
+      - dsl: "b"
+        json:
+          ref: "b"
   - id: testReturnsPrimitives
     type: LOG_PROBE
     where:
       methodName: main.testReturnsPrimitives
+    template: "testReturnsPrimitives"
+    segments:
+      - str: "testReturnsPrimitives"
     captureSnapshot: true
   - id: testReturnsManyFloats
     type: LOG_PROBE
     where:
       methodName: main.testReturnsManyFloats
+    template: "testReturnsManyFloats"
+    segments:
+      - str: "testReturnsManyFloats"
     captureSnapshot: true
   - id: testReturnsComplex
     type: LOG_PROBE
     where:
       methodName: main.testReturnsComplex
+    template: "testReturnsComplex"
+    segments:
+      - str: "testReturnsComplex"
     captureSnapshot: true
   - id: testReturnsLargeStruct
     type: LOG_PROBE
     where:
       methodName: main.testReturnsLargeStruct
+    template: "testReturnsLargeStruct"
+    segments:
+      - str: "testReturnsLargeStruct"
     captureSnapshot: true
   - id: testReturnsArray
     type: LOG_PROBE
     where:
       methodName: main.testReturnsArray
+    template: "testReturnsArray"
+    segments:
+      - str: "testReturnsArray"
     captureSnapshot: true
   - id: testReturnsArrayOne
     type: LOG_PROBE
     where:
       methodName: main.testReturnsArrayOne
+    template: "testReturnsArrayOne"
+    segments:
+      - str: "testReturnsArrayOne"
     captureSnapshot: true
   - id: testReturnsArrayZero
     type: LOG_PROBE
     where:
       methodName: main.testReturnsArrayZero
+    template: "testReturnsArrayZero"
+    segments:
+      - str: "testReturnsArrayZero"
     captureSnapshot: true
   - id: testReturnsMixedStruct
     type: LOG_PROBE
     where:
       methodName: main.testReturnsMixedStruct
+    template: "testReturnsMixedStruct"
+    segments:
+      - str: "testReturnsMixedStruct"
     captureSnapshot: true
   - id: testReturnsBacktrackInt
     type: LOG_PROBE
     where:
       methodName: main.testReturnsBacktrackInt
+    template: "testReturnsBacktrackInt"
+    segments:
+      - str: "testReturnsBacktrackInt"
     captureSnapshot: true
   - id: testReturnsWideStruct
     type: LOG_PROBE
     where:
       methodName: main.testReturnsWideStruct
+    template: "testReturnsWideStruct"
+    segments:
+      - str: "testReturnsWideStruct"
     captureSnapshot: true
   - id: testReturnsMixed
     type: LOG_PROBE
     where:
       methodName: main.testReturnsMixed
+    template: "testReturnsMixed"
+    segments:
+      - str: "testReturnsMixed"
     captureSnapshot: true
   - id: testReturnsStructWithArray
     type: LOG_PROBE
     where:
       methodName: main.testReturnsStructWithArray
+    template: "testReturnsStructWithArray"
+    segments:
+      - str: "testReturnsStructWithArray"
     captureSnapshot: true
   - id: testReturnsOnlyFloat
     type: LOG_PROBE
     where:
       methodName: main.testReturnsOnlyFloat
+    template: "testReturnsOnlyFloat"
+    segments:
+      - str: "testReturnsOnlyFloat"
     captureSnapshot: true
   - id: testReturnsMultipleFloats
     type: LOG_PROBE
     where:
       methodName: main.testReturnsMultipleFloats
+    template: "testReturnsMultipleFloats"
+    segments:
+      - str: "testReturnsMultipleFloats"
     captureSnapshot: true
   - id: testReturnsBoolAndUintptr
     type: LOG_PROBE
     where:
       methodName: main.testReturnsBoolAndUintptr
+    template: "testReturnsBoolAndUintptr"
+    segments:
+      - str: "testReturnsBoolAndUintptr"
     captureSnapshot: true
   - id: testLargeArgAndReturn
     type: LOG_PROBE
     where:
       methodName: main.testLargeArgAndReturn
+    template: "{arg}"
+    segments:
+      - json:
+          ref: "arg"
+        dsl: "arg"
     captureSnapshot: true
   - id: testArrayArgAndReturn
     type: LOG_PROBE
     where:
       methodName: main.testArrayArgAndReturn
+    template: "{arg}"
+    segments:
+      - json:
+          ref: "arg"
+        dsl: "arg"
     captureSnapshot: true
   - id: testMultipleLargeArgs
     type: LOG_PROBE
     where:
       methodName: main.testMultipleLargeArgs
+    template: "{s1}, {s2}"
+    segments:
+      - json:
+          ref: "s1"
+        dsl: "s1"
+      - str: ", "
+      - json:
+          ref: "s2"
+        dsl: "s2"
     captureSnapshot: true
   - id: testManyArgsArrayReturn
     type: LOG_PROBE
     where:
       methodName: main.testManyArgsArrayReturn
+    template: "{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json:
+          ref: "b"
+        dsl: "b"
+      - str: ", "
+      - json:
+          ref: "c"
+        dsl: "c"
+      - str: ", "
+      - json:
+          ref: "d"
+        dsl: "d"
+      - str: ", "
+      - json:
+          ref: "e"
+        dsl: "e"
+      - str: ", "
+      - json:
+          ref: "f"
+        dsl: "f"
+      - str: ", "
+      - json:
+          ref: "g"
+        dsl: "g"
+      - str: ", "
+      - json:
+          ref: "h"
+        dsl: "h"
+      - str: ", "
+      - json:
+          ref: "i"
+        dsl: "i"
     captureSnapshot: true
   - id: testMixedArgsStackReturn
     type: LOG_PROBE
     where:
       methodName: main.testMixedArgsStackReturn
+    template: "{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json:
+          ref: "b"
+        dsl: "b"
+      - str: ", "
+      - json:
+          ref: "c"
+        dsl: "c"
+      - str: ", "
+      - json:
+          ref: "d"
+        dsl: "d"
+      - str: ", "
+      - json:
+          ref: "e"
+        dsl: "e"
+      - str: ", "
+      - json:
+          ref: "f"
+        dsl: "f"
+      - str: ", "
+      - json:
+          ref: "g"
+        dsl: "g"
+      - str: ", "
+      - json:
+          ref: "h"
+        dsl: "h"
+      - str: ", "
+      - json:
+          ref: "s"
+        dsl: "s"
     captureSnapshot: true
   - id: testStackArgRegReturns
     type: LOG_PROBE
     where:
       methodName: main.testStackArgRegReturns
+    template: "{arg}"
+    segments:
+      - json:
+          ref: "arg"
+        dsl: "arg"
     captureSnapshot: true
   - id: testMultipleArrayArgs
     type: LOG_PROBE
     where:
       methodName: main.testMultipleArrayArgs
+    template: "{a}, {b}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json:
+          ref: "b"
+        dsl: "b"
     captureSnapshot: true
   - id: testStructWithArrayArg
     type: LOG_PROBE
     where:
       methodName: main.testStructWithArrayArg
+    template: "{arg}"
+    segments:
+      - json:
+          ref: "arg"
+        dsl: "arg"
     captureSnapshot: true
   - id: testZeroSizeArgAndReturn
     type: LOG_PROBE
     where:
       methodName: main.testZeroSizeArgAndReturn
+    template: "{a}, {b}"
+    segments:
+      - json:
+          ref: "a"
+        dsl: "a"
+      - str: ", "
+      - json:
+          ref: "b"
+        dsl: "b"
+    captureSnapshot: true
+  - id: testSegmentsForParamsAndReturnsOutOfOrder
+    type: LOG_PROBE
+    where:
+      methodName: main.testMultipleNamedReturn
+    template: "{result2}{i}{result}{i}{i}{result2}{result}"
+    segments:
+      - json:
+          ref: "result2"
+        dsl: "result2"
+      - json:
+          ref: "i"
+        dsl: "i"
+      - json:
+          ref: "result"
+        dsl: "result"
+      - json:
+          ref: "i"
+        dsl: "i"
+      - json:
+          ref: "i"
+        dsl: "i"
+      - json:
+          ref: "result2"
+        dsl: "result2"
+      - json:
+          ref: "result"
+        dsl: "result"
+    captureSnapshot: true
+  - id: testTemplateWithNonexistantVariableName
+    type: LOG_PROBE
+    where:
+      methodName: main.testMultipleNamedReturn
+    template: "{nonexistentVariable}"
+    segments:
+      - json:
+          ref: "nonexistentVariable"
+        dsl: "nonexistentVariable"
+    captureSnapshot: true
+  - id: testTemplateWithUnsupportedExpression
+    type: LOG_PROBE
+    where:
+      methodName: main.testMultipleNamedReturn
+    template: "{unsupportedExpression}"
+    segments:
+      - json:
+          foobar: "unsupportedExpression"
+        dsl: "unsupportedExpression"
+    captureSnapshot: true
+  - id: testTemplateWithUnsupportedVariable
+    type: LOG_PROBE
+    where:
+      methodName: main.testMultipleNamedReturn
+    template: "Executed main.testMultipleNamedReturn, it took {@duration}ms"
+    segments:
+      - str: "Executed main.testMultipleNamedReturn, it took "
+      - json:
+          ref: "@duration"
+        dsl: "@duration"
+      - str: "ms"
     captureSnapshot: true


### PR DESCRIPTION
### What does this PR do?

1) Defines the structure of a template as relevant to an ir.Program
    
    The individual segment kinds (StringSegment and JSONSegment) hold not
    just the definitions of user defined data to evaluate but expression
    kind and index to tie this template segment into the program expressions.
    
    The newly defined RootExpressionKindTemplateSegment is not particularly
    useful as part of this set of commits but will be relevant when implementing
    future operations.

2) Generate ir needed for templates

    Adds generation of the template types in ir.Program from
    the template definition.

### Motivation
Track the notion of templates in ir, set up capturing of messages.


### Describe how you validated your changes

There's some testing. It could use more testing of erroneous cases.

### Additional Notes

Follow-up from #42212. 

Part of [DEBUG-4034](https://datadoghq.atlassian.net/browse/DEBUG-4034)


[DEBUG-4034]: https://datadoghq.atlassian.net/browse/DEBUG-4034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ