### PR TITLE
Change MacOS jobs to use sonoma runners

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -33,10 +33,10 @@
   extends: .linux_arm64
 
 .bazel:runner:macos-amd64:
-  tags: [ "macos:ventura-amd64", "specific:true" ]
+  tags: [ "macos:sonoma-amd64", "specific:true" ]
 
 .bazel:runner:macos-arm64:
-  tags: [ "macos:ventura-arm64", "specific:true" ]
+  tags: [ "macos:sonoma-arm64", "specific:true" ]
 
 .bazel:runner:windows-amd64:
   extends: .windows_docker_default

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -17,8 +17,8 @@ include:
 
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:sonoma-amd64", "specific:true"]
 
 lint_macos_gitlab_arm64:
   extends: .lint_macos_gitlab
-  tags: ["macos:ventura-arm64", "specific:true"]
+  tags: ["macos:sonoma-arm64", "specific:true"]

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -71,8 +71,8 @@
 
 agent_dmg-x64-a7:
   extends: .agent_dmg
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:sonoma-amd64", "specific:true"]
 
 agent_dmg-arm64-a7:
   extends: .agent_dmg
-  tags: ["macos:ventura-arm64", "specific:true"]
+  tags: ["macos:sonoma-arm64", "specific:true"]

--- a/.gitlab/source_test/kmt_tasks.yml
+++ b/.gitlab/source_test/kmt_tasks.yml
@@ -7,6 +7,10 @@
   rules:
     - !reference [.on_invoke_tasks_changes]
     - !reference [.except_mergequeue]
+    - changes:
+        paths:
+          - .gitlab/source_test/kmt_tasks.yml
+        compare_to: $COMPARE_TO_BRANCH
   script:
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "git@github.com:"
     # Avoid rate limits when running kmt.init (pulumi queries the Github API to get the releases of plugins)

--- a/.gitlab/source_test/kmt_tasks.yml
+++ b/.gitlab/source_test/kmt_tasks.yml
@@ -32,7 +32,7 @@ test_kmt_local_setup_macos:
   extends: .test_kmt_local_setup
   before_script:
     - !reference [.macos_gitlab, before_script]
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:sonoma-amd64", "specific:true"]
   variables:
      # Some requirements cannot be tested in the CI yet:
     # - Docker,Compiler,UserInDockerGroup: no docker-in-docker support in these jobs yet

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -40,8 +40,8 @@ include:
 
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:sonoma-amd64", "specific:true"]
 
 tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
-  tags: ["macos:ventura-arm64", "specific:true"]
+  tags: ["macos:sonoma-arm64", "specific:true"]


### PR DESCRIPTION
### What does this PR do?

We've added a new group of macOS runners which use a newer version of macOS (see https://github.com/DataDog/ci-platform-machine-images/pull/503 and https://github.com/DataDog/cloud-inventory/pull/46351) with the intention of using that for datadog-agent CI moving forward. This makes it so that we start to use those runners in our CI.

### Motivation

[ABLD-293](https://datadoghq.atlassian.net/browse/ABLD-293)

### Describe how you validated your changes

CI passing.

### Additional Notes


[ABLD-293]: https://datadoghq.atlassian.net/browse/ABLD-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ