### PR TITLE
 [corechecks/helm] Set "helm_status" tag to "uninstalled" on delete events

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -447,6 +447,17 @@ func (hc *HelmCheck) deleteRelease(encodedRelease string, storageDriver helmStor
 	// one when there are no more revisions left.
 	if hc.instance.CollectEvents && !moreRevisionsLeft {
 		tags := hc.allTags(decodedRelease, storageDriver, false)
+
+		// The "helm_status" tag contains the last known status before
+		// uninstalling. Since the release is now deleted, we can set the status
+		// to "uninstalled".
+		for i, tag := range tags {
+			if strings.HasPrefix(tag, "helm_status:") {
+				tags[i] = "helm_status:uninstalled"
+				break
+			}
+		}
+
 		hc.eventsManager.addEventForDeletedRelease(decodedRelease, tags)
 	}
 }

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -390,6 +391,12 @@ func TestRun_withCollectEvents(t *testing.T) {
 	err = check.Run()
 	require.NoError(t, err)
 	expectedTags = check.allTags(&rel, k8sSecrets, false)
+	for i, tag := range expectedTags {
+		if strings.HasPrefix(tag, "helm_status:") {
+			expectedTags[i] = "helm_status:uninstalled"
+			break
+		}
+	}
 	mockedSender.AssertEventWithCompareFunc(
 		t,
 		eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace has been deleted.", expectedTags),

--- a/releasenotes-dca/notes/helm-status-tag-on-delete-events-1744745693c2c051.yaml
+++ b/releasenotes-dca/notes/helm-status-tag-on-delete-events-1744745693c2c051.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    In the Helm check, the "helm_status" tag is now always set to "uninstalled"
+    in delete events.


### PR DESCRIPTION
### What does this PR do?

This PR updates the Helm check to always set the "helm_status" tag to "uninstalled" on delete events.

The tag wasn’t useful because it showed the last known status of the Helm release, which is already outdated when the release is being deleted.

~Opened as draft because https://github.com/DataDog/datadog-agent/pull/42929 needs to be merged first. The first commit of this PR contains that PR.~

### Describe how you validated your changes

CI + manual test to verify that the "helm_status" tag is set to "uninstalled" on delete events.

