### PR TITLE
discovery: e2e: Increase wait time for data

### DIFF
--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -298,8 +298,9 @@ func (s *linuxTestSuite) testProcessCheckWithServiceDiscovery(agentConfigStr str
 				// therefore we should wait for 2 minutes to ensure service discovery is run at least once
 				// start --> process collection, service discovery ignoring
 				// 1 min --> process collection + service discovery collection ignores processes/may capture some
-				// 2 min --> process collection + service discovery collection should capture everythinf
-			}, 2*time.Minute, 10*time.Second)
+				// 2 min --> process collection + service discovery collection should capture everything
+				// 3 min --> extra time for the collected data to actually be sent by the process check
+			}, 3*time.Minute, 10*time.Second)
 		})
 		if !ok {
 			s.dumpDebugInfo(t)


### PR DESCRIPTION
### What does this PR do?

In some cases, the two minute wait for the discovery data to be received at the
intake may not be sufficient, so add an extra minute.

For example, the following failure instance was [seen](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1217837344) in CI.  The notes
with question marks are theorized, the others are real events seen in
the log and data:

```
 18:26:56 // process 9613 created
 18:26:58 // test started
 ...
 18:27:55 // collector run, 9613 not running for one minute, so not recognized as service?
 ...
 18:28:50 // process check run, only process data for 9613 sent?
 18:28:55 // collector run, 9613 running for one minute, recognized as service?
 18:28:58 // test timeout
 18:29:00 // process check run, discovery+process data for 9613 sent?
```

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-207
