### PR TITLE
Fix `new-e2e-language` failing to kill wrong process

### DIFF
--- a/test/new-e2e/tests/language-detection/node_test.go
+++ b/test/new-e2e/tests/language-detection/node_test.go
@@ -38,7 +38,7 @@ func (s *languageDetectionSuite) TestNodeDetection() {
 	s.installNode()
 
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf(`echo "%s" > prog.js`, nodeProg))
-	s.Env().RemoteHost.MustExecute("nohup node prog.js >myscript.log 2>&1 </dev/null &")
+	pid := s.Env().RemoteHost.MustExecute("nohup node prog.js >myscript.log 2>&1 </dev/null & echo $!")
 
-	s.checkDetectedLanguage("node", "node", "process_collector")
+	s.checkDetectedLanguage(pid, "node", "process_collector")
 }

--- a/test/new-e2e/tests/language-detection/node_test.go
+++ b/test/new-e2e/tests/language-detection/node_test.go
@@ -38,7 +38,7 @@ func (s *languageDetectionSuite) TestNodeDetection() {
 	s.installNode()
 
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf(`echo "%s" > prog.js`, nodeProg))
-	pid := s.Env().RemoteHost.MustExecute("nohup node prog.js >myscript.log 2>&1 </dev/null & echo $!")
+	pid := s.Env().RemoteHost.MustExecute("nohup node prog.js >myscript.log 2>&1 </dev/null & echo -n $!")
 
 	s.checkDetectedLanguage(pid, "node", "process_collector")
 }

--- a/test/new-e2e/tests/language-detection/php_test.go
+++ b/test/new-e2e/tests/language-detection/php_test.go
@@ -28,5 +28,5 @@ func (s *languageDetectionSuite) TestPHPDetectionCoreAgent() {
 
 func (s *languageDetectionSuite) startPHP() string {
 	s.Env().RemoteHost.MustExecute("echo -e '<?php sleep(60);' > prog.php")
-	return s.Env().RemoteHost.MustExecute("nohup php prog.php >myscript.log 2>&1 </dev/null & echo $!")
+	return s.Env().RemoteHost.MustExecute("nohup php prog.php >myscript.log 2>&1 </dev/null & echo -n $!")
 }

--- a/test/new-e2e/tests/language-detection/php_test.go
+++ b/test/new-e2e/tests/language-detection/php_test.go
@@ -22,11 +22,11 @@ func (s *languageDetectionSuite) installPHP() {
 
 func (s *languageDetectionSuite) TestPHPDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
-	s.runPHP()
-	s.checkDetectedLanguage("php", "php", "process_collector")
+	pid := s.startPHP()
+	s.checkDetectedLanguage(pid, "php", "process_collector")
 }
 
-func (s *languageDetectionSuite) runPHP() {
+func (s *languageDetectionSuite) startPHP() string {
 	s.Env().RemoteHost.MustExecute("echo -e '<?php sleep(60);' > prog.php")
-	s.Env().RemoteHost.MustExecute("nohup php prog.php >myscript.log 2>&1 </dev/null &")
+	return s.Env().RemoteHost.MustExecute("nohup php prog.php >myscript.log 2>&1 </dev/null & echo $!")
 }

--- a/test/new-e2e/tests/language-detection/python_test.go
+++ b/test/new-e2e/tests/language-detection/python_test.go
@@ -22,29 +22,29 @@ func (s *languageDetectionSuite) installPython() {
 
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
-	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_collector")
+	pid := s.startPython()
+	s.checkDetectedLanguage(pid, "python", "process_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgentNoCheck() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigNoCheckStr))))
-	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_collector")
+	pid := s.startPython()
+	s.checkDetectedLanguage(pid, "python", "process_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionProcessAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(processConfigStr))))
-	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_collector")
+	pid := s.startPython()
+	s.checkDetectedLanguage(pid, "python", "process_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionProcessAgentNoCheck() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(processConfigNoCheckStr))))
-	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_collector")
+	pid := s.startPython()
+	s.checkDetectedLanguage(pid, "python", "process_collector")
 }
 
-func (s *languageDetectionSuite) runPython() {
+func (s *languageDetectionSuite) startPython() string {
 	s.Env().RemoteHost.MustExecute("echo -e 'import time\ntime.sleep(60)' > prog.py")
-	s.Env().RemoteHost.MustExecute("nohup python3 prog.py >myscript.log 2>&1 </dev/null &")
+	return s.Env().RemoteHost.MustExecute("nohup python3 prog.py >myscript.log 2>&1 </dev/null & echo $!")
 }

--- a/test/new-e2e/tests/language-detection/python_test.go
+++ b/test/new-e2e/tests/language-detection/python_test.go
@@ -46,5 +46,5 @@ func (s *languageDetectionSuite) TestPythonDetectionProcessAgentNoCheck() {
 
 func (s *languageDetectionSuite) startPython() string {
 	s.Env().RemoteHost.MustExecute("echo -e 'import time\ntime.sleep(60)' > prog.py")
-	return s.Env().RemoteHost.MustExecute("nohup python3 prog.py >myscript.log 2>&1 </dev/null & echo $!")
+	return s.Env().RemoteHost.MustExecute("nohup python3 prog.py >myscript.log 2>&1 </dev/null & echo -n $!")
 }


### PR DESCRIPTION
### Motivation
Triggered by Agent CI page [#69543](https://app.datadoghq.com/on-call/pages/69543). Fixes Agent CI case [AC-810](https://app.datadoghq.com/cases/AC-810).

The `new-e2e-language` job was experiencing intermittent "Operation not permitted" errors when attempting to kill processes ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1227543437#L390)).

Some tests were using `ps -C <command>` to find PIDs by command name, which returned all matching processes system-wide and took the first one. This at times targeted unrelated system processes instead of the test's own processes.

### What does this PR do?
Changed to capture the PID at process launch time using the `$!` POSIX shell variable, ensuring we always kill the exact process the test started.

Also renamed helper methods from `run*` to `start*` to better reflect that they start processes asynchronously, implying they return the PID of the process to `stop`.

[AC-810]: https://datadoghq.atlassian.net/browse/AC-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ