### PR TITLE
chore: Simplify Global Tags Method

### DIFF
--- a/comp/core/tagger/def/component.go
+++ b/comp/core/tagger/def/component.go
@@ -27,6 +27,6 @@ type Component interface {
 	Subscribe(subscriptionID string, filter *types.Filter) (types.Subscription, error)
 	GetEntityHash(entityID types.EntityID, cardinality types.TagCardinality) string
 	AgentTags(cardinality types.TagCardinality) ([]string, error)
-	GlobalTags(cardinality types.TagCardinality) ([]string, error)
+	GlobalTags() ([]string, error)
 	EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo)
 }

--- a/comp/core/tagger/impl-noop/tagger.go
+++ b/comp/core/tagger/impl-noop/tagger.go
@@ -61,7 +61,7 @@ func (n *noopTagger) AgentTags(types.TagCardinality) ([]string, error) {
 	return nil, nil
 }
 
-func (n *noopTagger) GlobalTags(types.TagCardinality) ([]string, error) {
+func (n *noopTagger) GlobalTags() ([]string, error) {
 	return nil, nil
 }
 

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -423,8 +423,8 @@ func (t *remoteTagger) AgentTags(_ types.TagCardinality) ([]string, error) {
 	return nil, nil
 }
 
-func (t *remoteTagger) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
-	return t.Tag(types.GetGlobalEntityID(), cardinality)
+func (t *remoteTagger) GlobalTags() ([]string, error) {
+	return t.Tag(types.GetGlobalEntityID(), types.LowCardinality)
 }
 
 // EnrichTags enriches the tags with the global tags.

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -340,8 +340,8 @@ func (t *localTagger) AgentTags(cardinality types.TagCardinality) ([]string, err
 
 // GlobalTags queries global tags that should apply to all data coming from the
 // agent.
-func (t *localTagger) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
-	return t.Tag(types.GetGlobalEntityID(), cardinality)
+func (t *localTagger) GlobalTags() ([]string, error) {
+	return t.Tag(types.GetGlobalEntityID(), types.LowCardinality)
 }
 
 // globalTagBuilder queries global tags that should apply to all data coming

--- a/comp/core/tagger/impl/tagger_mock.go
+++ b/comp/core/tagger/impl/tagger_mock.go
@@ -150,8 +150,8 @@ func (f *fakeTagger) AgentTags(cardinality types.TagCardinality) ([]string, erro
 }
 
 // GlobalTags calls tagger.GlobalTags().
-func (f *fakeTagger) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
-	return f.tagger.GlobalTags(cardinality)
+func (f *fakeTagger) GlobalTags() ([]string, error) {
+	return f.tagger.GlobalTags()
 }
 
 // EnrichTags calls tagger.EnrichTags().

--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -476,9 +476,9 @@ func TestGlobalTags(t *testing.T) {
 	fakeTagger.SetTags(types.NewEntityID(types.ContainerID, "bar"), "fooSource", []string{"container-low"}, []string{"container-orch"}, []string{"container-high"}, nil)
 	fakeTagger.SetGlobalTags([]string{"global-low"}, []string{"global-orch"}, []string{"global-high"}, nil)
 
-	globalTags, err := fakeTagger.GlobalTags(types.OrchestratorCardinality)
+	globalTags, err := fakeTagger.GlobalTags()
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"global-low", "global-orch"}, globalTags)
+	assert.Equal(t, []string{"global-low"}, globalTags)
 
 	tb := tagset.NewHashingTagsAccumulator()
 	fakeTagger.EnrichTags(tb, taggertypes.OriginInfo{ContainerIDFromSocket: "container_id://bar", Cardinality: "orchestrator"})

--- a/comp/core/tagger/types/types.go
+++ b/comp/core/tagger/types/types.go
@@ -233,6 +233,6 @@ type TaggerClient interface {
 	// Tag is an interface function that queries taggerclient singleton
 	Tag(entity EntityID, cardinality TagCardinality) ([]string, error)
 	// GlobalTags is an interface function that queries taggerclient singleton
-	GlobalTags(cardinality TagCardinality) ([]string, error)
+	GlobalTags() ([]string, error)
 	GenerateContainerIDFromOriginInfo(originInfo origindetection.OriginInfo) (string, error)
 }

--- a/comp/forwarder/orchestrator/orchestratorimpl/forwarder_orchestrator.go
+++ b/comp/forwarder/orchestrator/orchestratorimpl/forwarder_orchestrator.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/orchestrator"
@@ -44,7 +43,7 @@ func newOrchestratorForwarder(log log.Component, config config.Component, tagger
 			forwarder := option.None[defaultforwarder.Forwarder]()
 			return &forwarder
 		}
-		globalTags, err := tagger.GlobalTags(types.LowCardinality)
+		globalTags, err := tagger.GlobalTags()
 		if err != nil {
 			log.Debugf("Error getting global tags for orchestrator config: %s", err)
 		}

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/common.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/common.go
@@ -81,7 +81,7 @@ func (p infraTagsProcessor) ProcessTags(
 			}
 		}
 	}
-	globalTags, err := p.tagger.GlobalTags(cardinality)
+	globalTags, err := p.tagger.GlobalTags()
 	if err != nil {
 		logger.Error("Cannot get global tags", zap.Error(err))
 	}

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/logs_test.go
@@ -189,7 +189,7 @@ func TestInfraAttributesLogProcessor(t *testing.T) {
 			tc := testutil.NewTestTaggerClient()
 			tc.TagMap["container_id://test"] = []string{"container:id"}
 			tc.TagMap["deployment://namespace/deployment"] = []string{"deployment:name"}
-			tc.TagMap[types.NewEntityID("internal", "global-entity-id").String()] = []string{"global:tag"}
+			tc.TagMap[types.GetGlobalEntityID().String()] = []string{"global:tag"}
 			tc.ContainerIDMap["pid:12345"] = "test"
 			tc.ContainerIDMap["inode:12345"] = "test"
 			tc.ContainerIDMap["pod:01234567-89ab-cdef-0123-456789abcdef,name:mycontainer,init:true"] = "test"

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics_test.go
@@ -193,7 +193,7 @@ func TestInfraAttributesMetricProcessor(t *testing.T) {
 			tc := testutil.NewTestTaggerClient()
 			tc.TagMap["container_id://test"] = []string{"container:id"}
 			tc.TagMap["deployment://namespace/deployment"] = []string{"deployment:name"}
-			tc.TagMap[types.NewEntityID("internal", "global-entity-id").String()] = []string{"global:tag"}
+			tc.TagMap[types.GetGlobalEntityID().String()] = []string{"global:tag"}
 			tc.ContainerIDMap["pid:12345"] = "test"
 			tc.ContainerIDMap["inode:12345"] = "test"
 			tc.ContainerIDMap["pod:01234567-89ab-cdef-0123-456789abcdef,name:mycontainer,init:true"] = "test"

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/traces_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/traces_test.go
@@ -189,7 +189,7 @@ func TestInfraAttributesTraceProcessor(t *testing.T) {
 			tc := testutil.NewTestTaggerClient()
 			tc.TagMap["container_id://test"] = []string{"container:id"}
 			tc.TagMap["deployment://namespace/deployment"] = []string{"deployment:name"}
-			tc.TagMap[types.NewEntityID("internal", "global-entity-id").String()] = []string{"global:tag"}
+			tc.TagMap[types.GetGlobalEntityID().String()] = []string{"global:tag"}
 			tc.ContainerIDMap["pid:12345"] = "test"
 			tc.ContainerIDMap["inode:12345"] = "test"
 			tc.ContainerIDMap["pod:01234567-89ab-cdef-0123-456789abcdef,name:mycontainer,init:true"] = "test"

--- a/comp/otelcol/otlp/testutil/testutil.go
+++ b/comp/otelcol/otlp/testutil/testutil.go
@@ -637,8 +637,8 @@ func (t *TestTaggerClient) Tag(entityID types.EntityID, _ types.TagCardinality) 
 }
 
 // GlobalTags mocks taggerimpl.GlobalTags functionality for purpose of testing, removing dependency on Taggerimpl
-func (t *TestTaggerClient) GlobalTags(_ types.TagCardinality) ([]string, error) {
-	return t.TagMap[types.NewEntityID("internal", "global-entity-id").String()], nil
+func (t *TestTaggerClient) GlobalTags() ([]string, error) {
+	return t.TagMap[types.GetGlobalEntityID().String()], nil
 }
 
 // GenerateContainerIDFromOriginInfo mocks taggerimpl.GenerateContainerIDFromOriginInfo functionality

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -266,7 +266,7 @@ type BufferedAggregator struct {
 
 	tlmContainerTagsEnabled     bool                                         // Whether we should call the tagger to tag agent telemetry metrics
 	agentTags                   func(types.TagCardinality) ([]string, error) // This function gets the agent tags from the tagger (defined as a struct field to ease testing)
-	globalTags                  func(types.TagCardinality) ([]string, error) // This function gets global tags from the tagger when host tags are not available
+	globalTags                  func() ([]string, error)                     // This function gets global tags from the tagger when host tags are not available
 	tagger                      tagger.Component
 	flushAndSerializeInParallel FlushAndSerializeInParallel
 }
@@ -853,7 +853,7 @@ func (agg *BufferedAggregator) tags(withVersion bool) []string {
 	var tags []string
 
 	var err error
-	tags, err = agg.globalTags(types.ChecksConfigCardinality)
+	tags, err = agg.globalTags()
 	if err != nil {
 		log.Debugf("Couldn't get Global tags: %v", err)
 	}

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -565,7 +565,7 @@ func TestTags(t *testing.T) {
 		hostname                string
 		tlmContainerTagsEnabled bool
 		agentTags               func(types.TagCardinality) ([]string, error)
-		globalTags              func(types.TagCardinality) ([]string, error)
+		globalTags              func() ([]string, error)
 		withVersion             bool
 		haAgentEnabled          bool
 		configID                string
@@ -576,7 +576,7 @@ func TestTags(t *testing.T) {
 			hostname:                "hostname",
 			tlmContainerTagsEnabled: false,
 			agentTags:               func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
+			globalTags:              func() ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             true,
 			want:                    versionTags(),
 		},
@@ -585,7 +585,7 @@ func TestTags(t *testing.T) {
 			hostname:                "hostname",
 			tlmContainerTagsEnabled: false,
 			agentTags:               func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
+			globalTags:              func() ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             false,
 			want:                    []string{},
 		},
@@ -594,7 +594,7 @@ func TestTags(t *testing.T) {
 			hostname:                "hostname",
 			tlmContainerTagsEnabled: true,
 			agentTags:               func(types.TagCardinality) ([]string, error) { return []string{"container_name:agent"}, nil },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
+			globalTags:              func() ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             true,
 			want:                    append(versionTags(), "container_name:agent"),
 		},
@@ -603,7 +603,7 @@ func TestTags(t *testing.T) {
 			hostname:                "hostname",
 			tlmContainerTagsEnabled: true,
 			agentTags:               func(types.TagCardinality) ([]string, error) { return []string{"container_name:agent"}, nil },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
+			globalTags:              func() ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             false,
 			want:                    []string{"container_name:agent"},
 		},
@@ -612,7 +612,7 @@ func TestTags(t *testing.T) {
 			hostname:                "hostname",
 			tlmContainerTagsEnabled: true,
 			agentTags:               func(types.TagCardinality) ([]string, error) { return nil, errors.New("no tags") },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
+			globalTags:              func() ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             true,
 			want:                    versionTags(),
 		},
@@ -621,7 +621,7 @@ func TestTags(t *testing.T) {
 			hostname:                "",
 			tlmContainerTagsEnabled: true,
 			agentTags:               func(types.TagCardinality) ([]string, error) { return []string{"container_name:agent"}, nil },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
+			globalTags:              func() ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
 			withVersion:             true,
 			want:                    append(versionTags(), "container_name:agent", "kube_cluster_name:foo"),
 		},
@@ -630,7 +630,7 @@ func TestTags(t *testing.T) {
 			hostname:                "hostname",
 			tlmContainerTagsEnabled: true,
 			agentTags:               func(types.TagCardinality) ([]string, error) { return []string{"container_name:agent"}, nil },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
+			globalTags:              func() ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
 			withVersion:             true,
 			want:                    append(versionTags(), "container_name:agent", "kube_cluster_name:foo"),
 		},

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	cctypes "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -56,7 +55,7 @@ func newDispatcher(tagger tagger.Component) *dispatcher {
 	// Attach the cluster agent's global tags to all dispatched checks
 	// as defined in the tagger's workloadmeta collector
 	var err error
-	d.extraTags, err = tagger.GlobalTags(types.LowCardinality)
+	d.extraTags, err = tagger.GlobalTags()
 	if err != nil {
 		log.Warnf("Cannot get global tags from the tagger: %v", err)
 	} else {

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/unbundled_events.go
@@ -13,7 +13,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -163,7 +162,7 @@ func (c *unbundledTransformer) getTagsFromTagger(tagsAcc tagset.TagsAccumulator)
 		return
 	}
 
-	globalTags, err := c.taggerInstance.GlobalTags(types.HighCardinality)
+	globalTags, err := c.taggerInstance.GlobalTags()
 	if err != nil {
 		log.Debugf("error getting global tags: %s", err)
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	configcomp "github.com/DataDog/datadog-agent/comp/core/config"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -154,7 +153,7 @@ func (o *OrchestratorCheck) Configure(senderManager sender.SenderManager, integr
 	}
 
 	// Retrieves tags from the tagger (applicable when scheduled on DCA)
-	taggerExtraTags, err := o.tagger.GlobalTags(types.LowCardinality)
+	taggerExtraTags, err := o.tagger.GlobalTags()
 	if err != nil {
 		return fmt.Errorf("could not get global tags from tagger: %w", err)
 	}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
@@ -734,7 +733,7 @@ func (a *APIServer) getGlobalTags() []string {
 		return nil
 	}
 
-	globalTags, err := tagger.GlobalTags(types.OrchestratorCardinality)
+	globalTags, err := tagger.GlobalTags()
 	if err != nil {
 		seclog.Errorf("failed to get global tags: %v", err)
 		return nil

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -29,7 +29,7 @@ const (
 // Tagger defines a Tagger for the Tags Resolver
 type Tagger interface {
 	Tag(entity types.EntityID, cardinality types.TagCardinality) ([]string, error)
-	GlobalTags(cardinality types.TagCardinality) ([]string, error)
+	GlobalTags() ([]string, error)
 }
 
 // Resolver represents a cache resolver

--- a/pkg/security/tests/fake_tags_resolver.go
+++ b/pkg/security/tests/fake_tags_resolver.go
@@ -43,7 +43,7 @@ func (fr *FakeTagger) Tag(entity types.EntityID, _ types.TagCardinality) ([]stri
 }
 
 // GlobalTags returns the global tags
-func (fr *FakeTagger) GlobalTags(_ types.TagCardinality) ([]string, error) {
+func (fr *FakeTagger) GlobalTags() ([]string, error) {
 	return nil, nil
 }
 
@@ -63,7 +63,7 @@ func (fmr *FakeMonoTagger) Tag(entity types.EntityID, _ types.TagCardinality) ([
 }
 
 // GlobalTags returns the global tags
-func (fmr *FakeMonoTagger) GlobalTags(_ types.TagCardinality) ([]string, error) {
+func (fmr *FakeMonoTagger) GlobalTags() ([]string, error) {
 	return nil, nil
 }
 
@@ -130,7 +130,7 @@ func (fmr *FakeManualTagger) Tag(entity types.EntityID, _ types.TagCardinality) 
 }
 
 // GlobalTags returns the global tags
-func (fmr *FakeManualTagger) GlobalTags(_ types.TagCardinality) ([]string, error) {
+func (fmr *FakeManualTagger) GlobalTags() ([]string, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

As highlighted in this [PR comment](https://github.com/DataDog/datadog-agent/pull/42920#discussion_r2514752095) from @vickenty, the tagger's `GlobalTags` method exposed a parameter for the requested global tag cardinality which unnecessarily increased the complexity for client usage.

Global tags should be static and thus by definition should always be `LowCardinality`. The way that the tagger works, any higher cardinality requests such as `OrchestratorCardinality` and `HighCardinality` will also return the associated lower cardinality values.

Below are the only references to the `internal://global-entity-id` via `types. GetGlobalEntityID()` in the Agent codebase:

<details>
<summary><strong>Workloadmeta Initialization</strong></summary>

This is the general initialization of global tags from the config. We can see that all the values are stored as `Low`

https://github.com/DataDog/datadog-agent/blob/89092212b237785026f26c7973e5b6bc56d350a6/comp/core/tagger/collectors/workloadmeta_main.go#L118-L130

</details>

<details>
<summary><strong>Workloadmeta Initialization on ECS</strong></summary>

Edge case on ECS Fargate we also include the `TaskARN` as a `OrchestratorCardinality` global tag. This may have implications in the bufferedAggregator when a user configured the ChecksConfigCardinality to be Orch or High and thus the TaskARN tags would be missing from relevant data.

https://github.com/DataDog/datadog-agent/blob/0d6b48e5ed45dadbe6f711706c4e63ee713ec623/comp/core/tagger/collectors/workloadmeta_extract.go#L505-L520

https://github.com/DataDog/datadog-agent/blob/0d6b48e5ed45dadbe6f711706c4e63ee713ec623/comp/core/tagger/collectors/workloadmeta_extract.go#L576-L587

</details>

### Motivation

Simplify tagger interface for GlobalTags

### Describe how you validated your changes

CI

### Additional Notes

The only edge case would be if clients are using the `NoneCardinality` but that does not appear to be the case.

Additionally on the workloadmeta ECS case there are 