### PR TITLE
Update Regression Detector lading to 0.29.0

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.28.0
+  version: 0.29.0
 
 target:
 


### PR DESCRIPTION
### What does this PR do?

This commit updates the lading release used in Regression Detector to the latest version. Release notes [here](https://github.com/DataDog/lading/releases/tag/v0.29.0).