### PR TITLE
dyninst: let symdb processing take a long time

### DIFF
--- a/pkg/dyninst/module/symdb_test.go
+++ b/pkg/dyninst/module/symdb_test.go
@@ -367,7 +367,7 @@ func TestSymdbManagerRespectsPersistentCache(t *testing.T) {
 				select {
 				case <-uploadCh:
 					// Success - upload was queued.
-				case <-time.After(time.Second):
+				case <-time.After(30 * time.Second):
 					t.Fatal("expected upload to be retried")
 				}
 			} else if tt.expectRejected {


### PR DESCRIPTION
### What does this PR do?

Deflakes a test.
### Motivation

When the system was super overloaded, this test would fail due to a timeout.

### Describe how you validated your changes

Testing only.

