### PR TITLE
extract connections forwarder as component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -356,6 +356,7 @@
 /comp/core/tagger @DataDog/container-platform
 /comp/core/workloadfilter @DataDog/container-platform
 /comp/core/workloadmeta @DataDog/container-platform
+/comp/forwarder/connectionsforwarder @DataDog/container-experiences
 /comp/forwarder/eventplatform @DataDog/agent-log-pipelines
 /comp/forwarder/eventplatformreceiver @DataDog/agent-log-pipelines
 /comp/forwarder/orchestrator @DataDog/container-app

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -314,6 +314,9 @@ issues:
     - path: comp/dogstatsd/serverDebug/serverdebugimpl/debug.go
       linters:
         - pkgconfigusage
+    - path: comp/forwarder/connectionsforwarder/impl/connectionsforwarder.go
+      linters:
+        - pkgconfigusage
     - path: comp/forwarder/defaultforwarder/blocked_endpoints.go
       linters:
         - pkgconfigusage

--- a/comp/README.md
+++ b/comp/README.md
@@ -272,6 +272,12 @@ Package status implements the core status component information provider interfa
 
 Package forwarder implements the "forwarder" bundle
 
+### [comp/forwarder/connectionsforwarder](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder)
+
+*Datadog Team*: container-experiences
+
+Package connectionsforwarder defines a component to send connections data to the backend
+
 ### [comp/forwarder/defaultforwarder](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder)
 
 Package defaultforwarder implements a component to send payloads to the backend

--- a/comp/forwarder/connectionsforwarder/def/component.go
+++ b/comp/forwarder/connectionsforwarder/def/component.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package connectionsforwarder defines a component to send connections data to the backend
+package connectionsforwarder
+
+import (
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
+)
+
+// team: container-experiences
+
+// Component describes the interface implemented by connections forwarder implementations
+type Component interface {
+	SubmitConnectionChecks(payload transaction.BytesPayloads, extra http.Header) (chan defaultforwarder.Response, error)
+}

--- a/comp/forwarder/connectionsforwarder/fx/fx.go
+++ b/comp/forwarder/connectionsforwarder/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the connectionsforwarder component
+package fx
+
+import (
+	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
+	connectionsforwarderimpl "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			connectionsforwarderimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[connectionsforwarder.Component](),
+	)
+}

--- a/comp/forwarder/connectionsforwarder/impl/connectionsforwarder.go
+++ b/comp/forwarder/connectionsforwarder/impl/connectionsforwarder.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package connectionsforwarderimpl implements the connectionsforwarder component interface
+package connectionsforwarderimpl
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/process/runner/endpoint"
+	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
+)
+
+// Requires defines the dependencies for the connectionsforwarder component
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+
+	Config config.Component
+	Logger log.Component
+}
+
+// Provides defines the output of the connectionsforwarder component
+type Provides struct {
+	Comp connectionsforwarder.Component
+}
+
+// NewComponent creates a new connectionsforwarder component
+func NewComponent(reqs Requires) (Provides, error) {
+	queueBytes := reqs.Config.GetInt("process_config.process_queue_bytes")
+	if queueBytes <= 0 {
+		reqs.Logger.Warnf("Invalid queue bytes size: %d. Using default value: %d", queueBytes, pkgconfigsetup.DefaultProcessQueueBytes)
+		queueBytes = pkgconfigsetup.DefaultProcessQueueBytes
+	}
+
+	processAPIEndpoints, err := endpoint.GetAPIEndpoints(reqs.Config)
+	if err != nil {
+		return Provides{}, err
+	}
+
+	processForwarderOpts, err := createParams(reqs.Config, reqs.Logger, queueBytes, processAPIEndpoints)
+	if err != nil {
+		return Provides{}, err
+	}
+
+	return Provides{
+		defaultforwarder.NewForwarder(reqs.Config, reqs.Logger, reqs.Lifecycle, false, processForwarderOpts).Comp,
+	}, nil
+}
+
+func createParams(config config.Component, log log.Component, queueBytes int, endpoints []apicfg.Endpoint) (*defaultforwarder.Options, error) {
+	r, err := resolver.NewSingleDomainResolvers(apicfg.KeysPerDomains(endpoints))
+	if err != nil {
+		return nil, err
+	}
+	forwarderOpts := defaultforwarder.NewOptionsWithResolvers(config, log, r)
+	forwarderOpts.DisableAPIKeyChecking = true
+	forwarderOpts.RetryQueuePayloadsTotalMaxSize = queueBytes // Allow more in-flight requests than the default
+	return forwarderOpts, nil
+}

--- a/comp/forwarder/connectionsforwarder/impl/connectionsforwarder.go
+++ b/comp/forwarder/connectionsforwarder/impl/connectionsforwarder.go
@@ -7,6 +7,8 @@
 package connectionsforwarderimpl
 
 import (
+	"context"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
@@ -49,8 +51,14 @@ func NewComponent(reqs Requires) (Provides, error) {
 		return Provides{}, err
 	}
 
+	forwarder := defaultforwarder.NewDefaultForwarder(reqs.Config, reqs.Logger, processForwarderOpts)
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: func(context.Context) error { return forwarder.Start() },
+		OnStop:  func(context.Context) error { forwarder.Stop(); return nil },
+	})
+
 	return Provides{
-		defaultforwarder.NewForwarder(reqs.Config, reqs.Logger, reqs.Lifecycle, false, processForwarderOpts).Comp,
+		Comp: forwarder,
 	}, nil
 }
 

--- a/comp/forwarder/connectionsforwarder/mock/mock.go
+++ b/comp/forwarder/connectionsforwarder/mock/mock.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+// Package mock provides a mock for the connectionsforwarder component
+package mock
+
+import (
+	"testing"
+
+	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
+)
+
+// Mock returns a mock for connectionsforwarder component.
+func Mock(_ *testing.T) connectionsforwarder.Component {
+	return &defaultforwarder.MockedForwarder{}
+}

--- a/comp/forwarder/defaultforwarder/forwarder.go
+++ b/comp/forwarder/defaultforwarder/forwarder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
@@ -24,7 +25,7 @@ type dependencies struct {
 	fx.In
 	Config config.Component
 	Log    log.Component
-	Lc     fx.Lifecycle
+	Lc     compdef.Lifecycle
 	Params Params
 }
 
@@ -86,10 +87,10 @@ func createOptions(params Params, config config.Component, log log.Component) (*
 // NewForwarder returns a new forwarder component.
 //
 //nolint:revive
-func NewForwarder(config config.Component, log log.Component, lc fx.Lifecycle, ignoreLifeCycleError bool, options *Options) provides {
+func NewForwarder(config config.Component, log log.Component, lc compdef.Lifecycle, ignoreLifeCycleError bool, options *Options) provides {
 	forwarder := NewDefaultForwarder(config, log, options)
 
-	lc.Append(fx.Hook{
+	lc.Append(compdef.Hook{
 		OnStart: func(context.Context) error {
 			err := forwarder.Start()
 			if ignoreLifeCycleError {

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.64.0-devel
 	github.com/DataDog/datadog-agent/comp/core/status v0.72.0-rc.1
+	github.com/DataDog/datadog-agent/comp/def v0.61.0
 	github.com/DataDog/datadog-agent/pkg/api v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.1
@@ -38,7 +39,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.0.0-20251003153905-4e3e64f07b69 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/create v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -12,6 +12,7 @@
 package process
 
 import (
+	connectionsforwarderfx "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/fx"
 	"github.com/DataDog/datadog-agent/comp/process/agent/agentimpl"
 	"github.com/DataDog/datadog-agent/comp/process/apiserver"
 	"github.com/DataDog/datadog-agent/comp/process/connectionscheck/connectionscheckimpl"
@@ -56,6 +57,7 @@ func Bundle() fxutil.BundleOptions {
 		expvarsimpl.Module(),
 
 		apiserver.Module(),
+		connectionsforwarderfx.Module(),
 		forwardersimpl.Module(),
 		logscompression.Module(),
 

--- a/comp/process/forwarders/component.go
+++ b/comp/process/forwarders/component.go
@@ -7,6 +7,7 @@
 package forwarders
 
 import (
+	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 )
 
@@ -17,5 +18,5 @@ type Component interface {
 	GetEventForwarder() defaultforwarder.Component
 	GetProcessForwarder() defaultforwarder.Component
 	GetRTProcessForwarder() defaultforwarder.Component
-	GetConnectionsForwarder() defaultforwarder.Component
+	GetConnectionsForwarder() connectionsforwarder.Component
 }

--- a/comp/process/forwarders/forwardersimpl/forwarders.go
+++ b/comp/process/forwarders/forwardersimpl/forwarders.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders"
@@ -30,16 +32,17 @@ func Module() fxutil.Module {
 type dependencies struct {
 	fx.In
 
-	Config config.Component
-	Logger log.Component
-	Lc     fx.Lifecycle
+	Config                config.Component
+	Logger                log.Component
+	ConnectionsForwarders connectionsforwarder.Component
+	Lc                    compdef.Lifecycle
 }
 
 type forwardersComp struct {
 	eventForwarder       defaultforwarder.Component
 	processForwarder     defaultforwarder.Component
 	rtProcessForwarder   defaultforwarder.Component
-	connectionsForwarder defaultforwarder.Component
+	connectionsForwarder connectionsforwarder.Component
 }
 
 func newForwarders(deps dependencies) (forwarders.Component, error) {
@@ -74,7 +77,7 @@ func newForwarders(deps dependencies) (forwarders.Component, error) {
 		eventForwarder:       createForwarder(deps, eventForwarderOpts),
 		processForwarder:     createForwarder(deps, processForwarderOpts),
 		rtProcessForwarder:   createForwarder(deps, processForwarderOpts),
-		connectionsForwarder: createForwarder(deps, processForwarderOpts),
+		connectionsForwarder: deps.ConnectionsForwarders,
 	}, nil
 }
 
@@ -105,6 +108,6 @@ func (f *forwardersComp) GetRTProcessForwarder() defaultforwarder.Component {
 	return f.rtProcessForwarder
 }
 
-func (f *forwardersComp) GetConnectionsForwarder() defaultforwarder.Component {
+func (f *forwardersComp) GetConnectionsForwarder() connectionsforwarder.Component {
 	return f.connectionsForwarder
 }

--- a/comp/process/submitter/submitterimpl/submitter_test.go
+++ b/comp/process/submitter/submitterimpl/submitter_test.go
@@ -12,6 +12,8 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
+	connectionsforwardermock "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/mock"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders/forwardersimpl"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo/hostinfoimpl"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
@@ -22,6 +24,7 @@ func TestSubmitterLifecycle(t *testing.T) {
 	_ = fxutil.Test[submitter.Component](t, fx.Options(
 		hostinfoimpl.MockModule(),
 		core.MockBundle(),
+		fx.Provide(func() connectionsforwarder.Component { return connectionsforwardermock.Mock(t) }),
 		forwardersimpl.MockModule(),
 		fx.Provide(func() statsd.ClientInterface {
 			return &statsd.NoOpClient{}

--- a/pkg/process/runner/endpoint/endpoints.go
+++ b/pkg/process/runner/endpoint/endpoints.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 )
@@ -28,7 +27,7 @@ func GetEventsAPIEndpoints(config pkgconfigmodel.Reader) (eps []apicfg.Endpoint,
 
 func getAPIEndpointsWithKeys(config pkgconfigmodel.Reader, prefix, defaultEpKey, additionalEpsKey string) (eps []apicfg.Endpoint, err error) {
 	// Setup main endpoint
-	mainEndpointURL, err := url.Parse(utils.GetMainEndpoint(pkgconfigsetup.Datadog(), prefix, defaultEpKey))
+	mainEndpointURL, err := url.Parse(utils.GetMainEndpoint(config, prefix, defaultEpKey))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing %s: %s", defaultEpKey, err)
 	}

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -24,8 +24,7 @@ import (
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
-	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
-	connectionsforwardermock "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/mock"
+	connectionsforwarderfx "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/fx"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders/forwardersimpl"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -485,8 +484,8 @@ func getSubmitterDeps(t *testing.T, configOverrides map[string]interface{}, sysp
 		fx.Provide(func() config.Component { return config.NewMockWithOverrides(t, configOverrides) }),
 		sysprobeconfigimpl.MockModule(),
 		fx.Replace(sysprobeconfigimpl.MockParams{Overrides: sysprobeconfigOverrides}),
-		fx.Provide(func() connectionsforwarder.Component { return connectionsforwardermock.Mock(t) }),
-		forwardersimpl.MockModule(),
+		connectionsforwarderfx.Module(),
+		forwardersimpl.Module(),
 		fx.Provide(func() log.Component {
 			return logmock.New(t)
 		}),
@@ -502,8 +501,8 @@ func getSubmitterDepsWithConfig(t *testing.T, configObj config.Component) submit
 			return configObj
 		}),
 		sysprobeconfigimpl.MockModule(),
-		fx.Provide(func() connectionsforwarder.Component { return connectionsforwardermock.Mock(t) }),
-		forwardersimpl.MockModule(),
+		connectionsforwarderfx.Module(),
+		forwardersimpl.Module(),
 		fx.Provide(func() log.Component {
 			return logmock.New(t)
 		}),

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -24,6 +24,8 @@ import (
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
+	connectionsforwardermock "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/mock"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders/forwardersimpl"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -483,6 +485,7 @@ func getSubmitterDeps(t *testing.T, configOverrides map[string]interface{}, sysp
 		fx.Provide(func() config.Component { return config.NewMockWithOverrides(t, configOverrides) }),
 		sysprobeconfigimpl.MockModule(),
 		fx.Replace(sysprobeconfigimpl.MockParams{Overrides: sysprobeconfigOverrides}),
+		fx.Provide(func() connectionsforwarder.Component { return connectionsforwardermock.Mock(t) }),
 		forwardersimpl.MockModule(),
 		fx.Provide(func() log.Component {
 			return logmock.New(t)
@@ -499,6 +502,7 @@ func getSubmitterDepsWithConfig(t *testing.T, configObj config.Component) submit
 			return configObj
 		}),
 		sysprobeconfigimpl.MockModule(),
+		fx.Provide(func() connectionsforwarder.Component { return connectionsforwardermock.Mock(t) }),
 		forwardersimpl.MockModule(),
 		fx.Provide(func() log.Component {
 			return logmock.New(t)

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders/forwardersimpl"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -77,7 +78,7 @@ func TestNewCollectorQueueSize(t *testing.T) {
 			deps := getSubmitterDeps(t, tc.configOverrides, nil)
 			c, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedQueueSize, c.processResults.MaxSize())
+			assert.Equal(t, tc.expectedQueueSize, c.resultsQueue[checks.ProcessCheckName].MaxSize())
 		})
 	}
 }
@@ -126,7 +127,7 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 			deps := getSubmitterDeps(t, tc.configOverrides, nil)
 			c, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedQueueSize, c.rtProcessResults.MaxSize())
+			assert.Equal(t, tc.expectedQueueSize, c.resultsQueue[checks.RTProcessCheckName].MaxSize())
 		})
 	}
 }
@@ -175,8 +176,8 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 			deps := getSubmitterDeps(t, tc.configOverrides, nil)
 			s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 			assert.NoError(t, err)
-			assert.Equal(t, int64(tc.expectedQueueSize), s.processResults.MaxWeight())
-			assert.Equal(t, int64(tc.expectedQueueSize), s.rtProcessResults.MaxWeight())
+			assert.Equal(t, int64(tc.expectedQueueSize), s.resultsQueue[checks.ProcessCheckName].MaxWeight())
+			assert.Equal(t, int64(tc.expectedQueueSize), s.resultsQueue[checks.RTProcessCheckName].MaxWeight())
 			assert.Equal(t, tc.expectedQueueSize, s.forwarderRetryMaxQueueBytes)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Extracts the connections forwarder as a separate component.

### Motivation

The connections forwarder will be used independently in the system-probe for sending data directly to the backend.

### Describe how you validated your changes

Existing tests.

### Additional Notes
