### PR TITLE
Add retry logic to `curl` commands in macOS CI

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -46,16 +46,17 @@
   - |
     # Perform installation only if the directory does not exist
     if [ ! -d "$DDA_DIR" ]; then
+      robust_curl="curl -fsSL --retry 4"  # recommended flags + resist transient errors like `Connection reset by peer`
       # Get the commit from the build image variable in the format `vPIPELINE_ID-COMMIT`
       export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
-      export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
+      export DDA_VERSION="$($robust_curl https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
       # Detect architecture and download appropriate binary
       if [ "$(uname -m)" = "arm64" ]; then
         dda_target_triple="aarch64-apple-darwin"
       else
         dda_target_triple="x86_64-apple-darwin"
       fi
-      curl -Lo dda.tar.gz https://github.com/DataDog/datadog-agent-dev/releases/download/${DDA_VERSION}/dda-${dda_target_triple}.tar.gz
+      $robust_curl -o dda.tar.gz https://github.com/DataDog/datadog-agent-dev/releases/download/${DDA_VERSION}/dda-${dda_target_triple}.tar.gz
       tar -xzf dda.tar.gz
       mkdir -p "$DDA_DIR"
       sudo mv dda $DDA_DIR


### PR DESCRIPTION
### What does this PR do?
Fixes intermittent failures in Agent CI, triggered by page [#68980](https://app.datadoghq.com/on-call/pages/68980).

### Motivation
Some macOS jobs were experiencing intermittent failures due to transient network errors when downloading DDA. The `curl` commands were failing with "Connection reset by peer" errors ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1226810600#L74)) without retry attempts, causing job failures and triggering pages.

### Additional Notes
Added `robust_curl` variable with recommended flags (`-fsSL`) and retry logic (`--retry 4`) to automatically retry on transient failures. This aligns with the AWS retry configuration (5 max attempts) used elsewhere in the pipeline.