### PR TITLE
Add cleanup & retry logic to `apt-get update` from `ubuntu:latest`

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -541,7 +541,8 @@ RUN find /usr/src/datadog-agent -type d -empty -print0 | xargs -0 rmdir
 FROM ubuntu:latest AS bin
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
+RUN apt-get clean && \
+    apt-get -o Acquire::Retries=4 update && \
     apt-get install -y patchelf
 
 COPY bin/agent/agent                            /opt/datadog-agent/bin/agent/agent
@@ -559,7 +560,8 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM {base_image} AS bash_completion
 
-RUN apt-get update && \
+RUN apt-get clean && \
+    apt-get -o Acquire::Retries=4 update && \
     apt-get install -y gawk
 
 RUN awk -i inplace '!/^#/ {{uncomment=0}} uncomment {{gsub(/^#/, "")}} /# enable bash completion/ {{uncomment=1}} {{print}}' /etc/bash.bashrc
@@ -567,7 +569,8 @@ RUN awk -i inplace '!/^#/ {{uncomment=0}} uncomment {{gsub(/^#/, "")}} /# enable
 FROM {base_image}
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
+RUN apt-get clean && \
+    apt-get -o Acquire::Retries=4 update && \
     apt-get install -y bash-completion less vim tshark && \
     apt-get clean
 

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -196,7 +196,8 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 FROM {base_image}
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
+RUN apt-get clean && \
+    apt-get -o Acquire::Retries=4 update && \
     apt-get install -y bash-completion less vim tshark && \
     apt-get clean
 

--- a/test/integration/serverless/recorder-extension/Dockerfile.build
+++ b/test/integration/serverless/recorder-extension/Dockerfile.build
@@ -27,8 +27,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # zip the extension
 FROM ubuntu:latest as compresser
-RUN apt-get update
-RUN apt-get install -y zip binutils
+RUN apt-get clean && \
+    apt-get -o Acquire::Retries=4 update && \
+    apt-get install -y zip binutils
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/recorder-extension/recorder-extension /extensions/recorder-extension


### PR DESCRIPTION
### Motivation
The `docker` builds have been experiencing intermittent failures due to transient `apt` mirror sync issues, especially when using `ubuntu:latest` as base image.
The `apt-get update` command would fail with errors like "File has unexpected size" when Ubuntu mirrors were mid-sync, causing build failures ([example](https://github.com/DataDog/datadog-agent/actions/runs/19281918088/job/55134663529?pr=42960#step:12:403)).

### What does this PR do?
For `ubuntu:latest`-based images, add `apt-get clean` before update to clear stale cache, and enable up to 4 retries to `apt-get update` commands to transient mirror sync issues, matching the retry configuration used elsewhere in the pipeline (aligns with AWS retry configuration of 5 max attempts).

### Additional Notes
This combination follows the recommended approach from the Ubuntu community for dealing with mirror synchronization problems:
- https://askubuntu.com/a/1107071
- https://askubuntu.com/a/1533430
- https://forums.percona.com/t/apt-repo-issue-failed-to-fetch-file-has-unexpected-size/27474/4
- https://superuser.com/a/1485610