### PR TITLE
[AGENTRUN-859] Remove loader process from heroku package

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -149,7 +149,7 @@ build do
     move 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"
   end
 
-  if linux_target?
+  if linux_target? and !heroku_target?
     command "dda inv -- -e loader.build --install-path=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
     copy "bin/trace-loader/trace-loader", "#{install_dir}/embedded/bin"
   end


### PR DESCRIPTION
### What does this PR do?
Remove the trace-loader binary from the Heroku package.

### Motivation
Reduce package size.
The loader is currently unused on Heroku, and we'd rather reduce package size for this build.

### Describe how you validated your changes
CI.

### Additional Notes
