### PR TITLE
[CWS] make sure we handle the execution context tag name without case sensitivity

### DIFF
--- a/pkg/security/secl/rules/bucket.go
+++ b/pkg/security/secl/rules/bucket.go
@@ -8,6 +8,7 @@ package rules
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
@@ -36,7 +37,7 @@ func (rb *RuleBucket) AddRule(rule *Rule) error {
 		rb.fields[index] = field
 	}
 
-	if rule.Def != nil && rule.Def.Tags != nil && rule.Def.Tags[ExecutionContextTagName] == "true" {
+	if rule.Def != nil && rule.Def.Tags != nil && strings.EqualFold(rule.Def.Tags[ExecutionContextTagName], "true") {
 		rb.rules = append(rb.rules, nil)
 		copy(rb.rules[rb.execContextRuleCount+1:], rb.rules[rb.execContextRuleCount:])
 		rb.rules[rb.execContextRuleCount] = rule

--- a/pkg/security/secl/rules/bucket_test.go
+++ b/pkg/security/secl/rules/bucket_test.go
@@ -9,9 +9,10 @@
 package rules
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"reflect"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -54,7 +55,7 @@ func TestRuleBucket_AddRule_Order(t *testing.T) {
 
 	// Create rules with unique fields
 	e1 := newTestRuleWithExecContextTag(t, "E1", "true")
-	e2 := newTestRuleWithExecContextTag(t, "E2", "true")
+	e2 := newTestRuleWithExecContextTag(t, "E2", "True") // handle all cases
 	e3 := newTestRuleWithExecContextTag(t, "E3", "true")
 	n1 := newTestRuleWithExecContextTag(t, "N1", "false")
 	n2 := newTestRuleWithExecContextTag(t, "N2", "false")


### PR DESCRIPTION
### What does this PR do?

Python serializes `true` to `True`, so let's handle the execution context tag case insensitively to handle this potential footgun.

### Motivation

### Describe how you validated your changes

### Additional Notes
