### PR TITLE
[omnibus] Rewrite sysctl-probe-offline-skip patch to OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/sysctl-probe-offline-skip.patch
+++ b/omnibus/config/patches/openscap/sysctl-probe-offline-skip.patch
@@ -1,16 +1,11 @@
---- a/src/OVAL/results/oval_resultTest.c
-+++ b/src/OVAL/results/oval_resultTest.c
-@@ -1144,6 +1144,13 @@ oval_result_t oval_result_test_eval(struct oval_result_test *rtest)
- 	const char *comment = oval_test_get_comment(test);
- 	dI("Evaluating %s test '%s': %s.", type, test_id, comment);
+--- a/src/OVAL/probes/unix/sysctl_probe.c
++++ b/src/OVAL/probes/unix/sysctl_probe.c
+@@ -62,7 +62,7 @@
  
-+	/* Skip systctl probe in offline mode */
-+	if (getenv("OSCAP_PROBE_ROOT") != NULL && oval_test_get_subtype(test) == OVAL_UNIX_SYSCTL) {
-+		dI("Skip %s probe in offline mode.", type);
-+		rtest->result = OVAL_RESULT_TRUE;
-+		return rtest->result;
-+	}
-+
- 	if (rtest->result == OVAL_RESULT_NOT_EVALUATED) {
- 		if (oval_test_get_subtype(oval_result_test_get_test(rtest)) != OVAL_INDEPENDENT_UNKNOWN) {
- 			struct oval_string_map *tmp_map = oval_string_map_new();
+ int sysctl_probe_offline_mode_supported(void)
+ {
+-        return PROBE_OFFLINE_OWN;
++        return PROBE_OFFLINE_NONE;
+ }
+ 
+ int sysctl_probe_main(probe_ctx *ctx, void *probe_arg)


### PR DESCRIPTION
### What does this PR do?

This change rewrites the sysctl-probe-offline-skip patch to OpenSCAP, so it returns SYSCHAR_FLAG_NOT_APPLICABLE instead of OVAL_RESULT_TRUE when OpenSCAP is running in offline mode.

Sysctl rules usually check for both the value present in sysctl configuration files and sysctl value at runtime. When running in offline mode, we chose to consider only the value of the sysctl configuration files.

### Motivation

### Describe how you validated your changes

### Additional Notes
