### PR TITLE
Add dependency to the job pre-building binaries for flake finder and fips pipelines

### DIFF
--- a/tasks/fips.py
+++ b/tasks/fips.py
@@ -53,7 +53,12 @@ def generate_fips_e2e_pipeline(ctx, generate_config=False):
         if "needs" in job:
             job["needs"] = update_needs_parent(
                 job["needs"],
-                deps_to_keep=["go_e2e_deps", "tests_windows_sysprobe_x64", "tests_windows_secagent_x64"],
+                deps_to_keep=[
+                    "go_e2e_deps",
+                    "tests_windows_sysprobe_x64",
+                    "tests_windows_secagent_x64",
+                    "go_e2e_test_binaries",
+                ],
                 package_deps=[
                     "agent_deb-x64-a7-fips",
                     "agent_deb-x64-a7",

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -252,7 +252,12 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
         if "needs" in job:
             job["needs"] = update_needs_parent(
                 job["needs"],
-                deps_to_keep=["go_e2e_deps", "tests_windows_sysprobe_x64", "tests_windows_secagent_x64"],
+                deps_to_keep=[
+                    "go_e2e_deps",
+                    "tests_windows_sysprobe_x64",
+                    "tests_windows_secagent_x64",
+                    "go_e2e_test_binaries",
+                ],
                 package_deps=[
                     "agent_deb-x64-a7-fips",
                     "agent_deb-x64-a7",


### PR DESCRIPTION
### What does this PR do?

Update the flake finder and fips pipeline generation so that the jobs rely on the jobs pre-building the test artifacts.
Should help with OOMKills observed in these pipelines.

https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1221473997
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1229045225

### Motivation

### Describe how you validated your changes

### Additional Notes
