### PR TITLE
Do not generate .a files for python lib

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -122,11 +122,6 @@ build do
     # We can also remove the DLLs that were put there by the python build since they won't be loaded anyway
     delete "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3.dll"
     delete "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3.dll"
-    # Generate libpython3XY.a for MinGW tools
-    # https://docs.python.org/3/whatsnew/3.8.html
-    major, minor, _ = version.split(".")
-    command "gendef #{windows_safe_path(python_3_embedded)}\\python#{major}#{minor}.dll"
-    command "dlltool --dllname python#{major}#{minor}.dll --def python#{major}#{minor}.def --output-lib #{windows_safe_path(python_3_embedded)}\\libs\\libpython#{major}#{minor}.a"
 
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"


### PR DESCRIPTION
### What does this PR do?

It removes a step that creates an .a library file for Python on Windows.

### Motivation

While working on migrating the Python build to bazel, I did some research into this and I found that our mingw64 toolchain may already support the .lib file that the Python build generates on its own. 

### Describe how you validated your changes

CI passing should be enough to confirm that we do indeed not need this file.

### Additional Notes
