### PR TITLE
discovery: Report tracer tags separately

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -3122,6 +3122,12 @@ func TestHandleProcess(t *testing.T) {
 							ServiceEnv: "test",
 						},
 						{
+							// These will be skipped because they match the UST tags
+							ServiceName:    serviceNameFromDD,
+							ServiceEnv:     envFromDD,
+							ServiceVersion: versionFromDD,
+						},
+						{
 							ServiceName:    "second-tracer-service",
 							ServiceEnv:     envFromDD,
 							ServiceVersion: "2.0.0",
@@ -3137,6 +3143,12 @@ func TestHandleProcess(t *testing.T) {
 					fmt.Sprintf("env:%s", envFromDD),
 					"framework:express",
 					"runtime:nodejs",
+					"tracer_service_env:dev",
+					"tracer_service_env:test",
+					"tracer_service_name:first-tracer-service",
+					"tracer_service_name:second-tracer-service",
+					"tracer_service_version:1.0.0",
+					"tracer_service_version:2.0.0",
 					fmt.Sprintf("service:%s", serviceNameFromDD),
 					fmt.Sprintf("version:%s", versionFromDD),
 				},
@@ -3279,78 +3291,6 @@ func TestHandleProcess(t *testing.T) {
 				require.Len(t, result, 1)
 				assertTagInfoEqual(t, tt.expectedTagInfo, result[0])
 			}
-		})
-	}
-}
-
-func TestParseProcessTags(t *testing.T) {
-	tests := []struct {
-		name         string
-		processTags  string
-		expectedTags []string
-	}{
-		{
-			name:        "valid comma-separated tags",
-			processTags: "entrypoint.name:com.example.App,service.type:tomcat,service.framework:spring",
-			expectedTags: []string{
-				"entrypoint.name:com.example.App",
-				"service.framework:spring",
-				"service.type:tomcat",
-			},
-		},
-		{
-			name:        "single tag",
-			processTags: "entrypoint.workdir:app",
-			expectedTags: []string{
-				"entrypoint.workdir:app",
-			},
-		},
-		{
-			name:         "empty string",
-			processTags:  "",
-			expectedTags: []string{},
-		},
-		{
-			name:        "tags with spaces",
-			processTags: " service.runtime : java-17 , entrypoint.name : com.app.Main ",
-			expectedTags: []string{
-				"entrypoint.name:com.app.Main",
-				"service.runtime:java-17",
-			},
-		},
-		{
-			name:        "tag with colon in value",
-			processTags: "url:http://example.com:8080",
-			expectedTags: []string{
-				"url:http://example.com:8080",
-			},
-		},
-		{
-			name:         "malformed tag without colon",
-			processTags:  "invalid_tag,service.type:nginx",
-			expectedTags: []string{"service.type:nginx"},
-		},
-		{
-			name:         "tags with empty keys or values",
-			processTags:  ":value,key:,service.runtime:python3.9",
-			expectedTags: []string{"service.runtime:python3.9"},
-		},
-		{
-			name:         "empty tag entries",
-			processTags:  "service.framework:django,,entrypoint.name:manage.py,",
-			expectedTags: []string{"entrypoint.name:manage.py", "service.framework:django"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tagList := taglist.NewTagList()
-			parseProcessTags(tagList, tt.processTags)
-
-			low, _, _, _ := tagList.Compute()
-			sort.Strings(low)
-			sort.Strings(tt.expectedTags)
-			assert.Equal(t, tt.expectedTags, low)
 		})
 	}
 }

--- a/pkg/discovery/tracermetadata/tracer_memfd.go
+++ b/pkg/discovery/tracermetadata/tracer_memfd.go
@@ -56,24 +56,3 @@ func GetTracerMetadata(pid int, procRoot string) (TracerMetadata, error) {
 	}
 	return parseData(data)
 }
-
-// GetTags returns a list of tags from the tracer metadata
-func (t TracerMetadata) GetTags() []string {
-	var tags []string
-	if t.ServiceName != "" {
-		tags = append(tags, "service:"+t.ServiceName)
-	}
-	if t.ServiceEnv != "" {
-		tags = append(tags, "env:"+t.ServiceEnv)
-	}
-	if t.ServiceVersion != "" {
-		tags = append(tags, "version:"+t.ServiceVersion)
-	}
-	for tag := range strings.SplitSeq(t.ProcessTags, ",") {
-		if tag == "" {
-			continue
-		}
-		tags = append(tags, tag)
-	}
-	return tags
-}

--- a/pkg/discovery/tracermetadata/tracer_memfd_test.go
+++ b/pkg/discovery/tracermetadata/tracer_memfd_test.go
@@ -49,9 +49,9 @@ func TestGetTracerMetadata(t *testing.T) {
 
 		tags := trm.GetTags()
 		assert.Equal(t, []string{
-			"service:my-service",
-			"env:my-env",
-			"version:my-version",
+			"tracer_service_name:my-service",
+			"tracer_service_env:my-env",
+			"tracer_service_version:my-version",
 		}, tags)
 	})
 
@@ -74,9 +74,9 @@ func TestGetTracerMetadata(t *testing.T) {
 
 		tags := trm.GetTags()
 		assert.Equal(t, []string{
-			"service:test-go",
-			"env:prod",
-			"version:abc123",
+			"tracer_service_name:test-go",
+			"tracer_service_env:prod",
+			"tracer_service_version:abc123",
 			"entrypoint.basedir:exe",
 			"entrypoint.name:gotrace",
 			"entrypoint.type:executable",

--- a/pkg/discovery/tracermetadata/tracer_metadata.go
+++ b/pkg/discovery/tracermetadata/tracer_metadata.go
@@ -9,6 +9,11 @@
 // Package tracermetadata parses the tracer-generated metadata
 package tracermetadata
 
+import (
+	"iter"
+	"strings"
+)
+
 // TracerMetadata as defined in
 // https://github.com/DataDog/libdatadog/blob/0b59f64c4fc08105e5b73c5a0752ced3cf8f653e/datadog-library-config/src/tracer_metadata.rs#L7-L34
 type TracerMetadata struct {
@@ -22,4 +27,79 @@ type TracerMetadata struct {
 	ServiceVersion string `json:"service_version,omitempty"`
 	ProcessTags    string `json:"process_tags,omitempty"`
 	ContainerID    string `json:"container_id,omitempty"`
+}
+
+// ShouldSkipServiceTagKV checks if a tracer service tag key-value pair should be
+// skipped if it matches the UST tags.
+func ShouldSkipServiceTagKV(tagKey, tagValue, ustService, ustEnv, ustVersion string) bool {
+	if tagKey == "tracer_service_name" && tagValue == ustService {
+		return true
+	}
+	if tagKey == "tracer_service_env" && tagValue == ustEnv {
+		return true
+	}
+	if tagKey == "tracer_service_version" && tagValue == ustVersion {
+		return true
+	}
+	return false
+}
+
+// ShouldSkipServiceTag checks if a tracer service tag should be skipped if it
+// matches the UST tags.
+func ShouldSkipServiceTag(tag string, ustService, ustEnv, ustVersion string) bool {
+	if tagKey, tagValue, ok := strings.Cut(tag, ":"); ok {
+		return ShouldSkipServiceTagKV(tagKey, tagValue, ustService, ustEnv, ustVersion)
+	}
+	return false
+}
+
+// Tags returns a sequence of tags from the tracer metadata
+func (t TracerMetadata) Tags() iter.Seq2[string, string] {
+	return func(yield func(string, string) bool) {
+		if t.ServiceName != "" {
+			if !yield("tracer_service_name", t.ServiceName) {
+				return
+			}
+		}
+		if t.ServiceEnv != "" {
+			if !yield("tracer_service_env", t.ServiceEnv) {
+				return
+			}
+		}
+		if t.ServiceVersion != "" {
+			if !yield("tracer_service_version", t.ServiceVersion) {
+				return
+			}
+		}
+		for tag := range strings.SplitSeq(t.ProcessTags, ",") {
+			tag = strings.TrimSpace(tag)
+			if tag == "" {
+				continue
+			}
+
+			key, value, ok := strings.Cut(tag, ":")
+			if !ok {
+				continue
+			}
+
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			if key == "" || value == "" {
+				continue
+			}
+
+			if !yield(key, value) {
+				return
+			}
+		}
+	}
+}
+
+// GetTags returns a list of tags from the tracer metadata
+func (t TracerMetadata) GetTags() []string {
+	var tags []string
+	for key, value := range t.Tags() {
+		tags = append(tags, key+":"+value)
+	}
+	return tags
 }

--- a/pkg/discovery/tracermetadata/tracer_metadata_test.go
+++ b/pkg/discovery/tracermetadata/tracer_metadata_test.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package tracermetadata
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldSkipServiceTag(t *testing.T) {
+	ustService := "my-service"
+	ustEnv := "my-env"
+	ustVersion := "my-version"
+
+	tests := []struct {
+		tagKey       string
+		tagValue     string
+		expectedSkip bool
+	}{
+		{
+			tagKey:       "tracer_service_name",
+			tagValue:     "my-service",
+			expectedSkip: true,
+		},
+		{
+			tagKey:       "tracer_service_name",
+			tagValue:     "not-my-service",
+			expectedSkip: false,
+		},
+		{
+			tagKey:       "tracer_service_env",
+			tagValue:     "my-env",
+			expectedSkip: true,
+		},
+		{
+			tagKey:       "tracer_service_version",
+			tagValue:     "my-version",
+			expectedSkip: true,
+		},
+		{
+			tagKey:       "tracer_service_version",
+			tagValue:     "not-my-version",
+			expectedSkip: false,
+		},
+	}
+	for _, tt := range tests {
+		skip := ShouldSkipServiceTagKV(tt.tagKey, tt.tagValue, ustService, ustEnv, ustVersion)
+		assert.Equal(t, tt.expectedSkip, skip)
+
+		skip = ShouldSkipServiceTag(tt.tagKey+":"+tt.tagValue, ustService, ustEnv, ustVersion)
+		assert.Equal(t, tt.expectedSkip, skip)
+	}
+}
+
+func TestTags(t *testing.T) {
+	trm := TracerMetadata{}
+	tags := trm.GetTags()
+	assert.Empty(t, tags)
+
+	trm = TracerMetadata{
+		ProcessTags: "entrypoint.name:com.example.App,service.type:tomcat,service.framework:spring",
+	}
+	tags = trm.GetTags()
+	assert.Equal(t, []string{
+		"entrypoint.name:com.example.App",
+		"service.type:tomcat",
+		"service.framework:spring",
+	}, tags)
+
+	trm = TracerMetadata{
+		ServiceName:    "my-service",
+		ServiceEnv:     "my-env",
+		ServiceVersion: "my-version",
+		ProcessTags:    "entrypoint.name:com.example.App,service.type:tomcat,service.framework:spring",
+	}
+	tags = trm.GetTags()
+	assert.Equal(t, []string{
+		"tracer_service_name:my-service",
+		"tracer_service_env:my-env",
+		"tracer_service_version:my-version",
+		"entrypoint.name:com.example.App",
+		"service.type:tomcat",
+		"service.framework:spring",
+	}, tags)
+	i := 0
+	for key, value := range trm.Tags() {
+		assert.Equal(t, tags[i], key+":"+value)
+		i++
+	}
+}
+
+func TestParseProcessTags(t *testing.T) {
+	t.Helper()
+	tests := []struct {
+		name         string
+		processTags  string
+		expectedTags []string
+	}{
+		{
+			name:        "valid comma-separated tags",
+			processTags: "entrypoint.name:com.example.App,service.type:tomcat,service.framework:spring",
+			expectedTags: []string{
+				"entrypoint.name:com.example.App",
+				"service.framework:spring",
+				"service.type:tomcat",
+			},
+		},
+		{
+			name:        "single tag",
+			processTags: "entrypoint.workdir:app",
+			expectedTags: []string{
+				"entrypoint.workdir:app",
+			},
+		},
+		{
+			name:         "empty string",
+			processTags:  "",
+			expectedTags: nil,
+		},
+		{
+			name:        "tags with spaces",
+			processTags: " service.runtime : java-17 , entrypoint.name : com.app.Main ",
+			expectedTags: []string{
+				"entrypoint.name:com.app.Main",
+				"service.runtime:java-17",
+			},
+		},
+		{
+			name:        "tag with colon in value",
+			processTags: "url:http://example.com:8080",
+			expectedTags: []string{
+				"url:http://example.com:8080",
+			},
+		},
+		{
+			name:         "malformed tag without colon",
+			processTags:  "invalid_tag,service.type:nginx",
+			expectedTags: []string{"service.type:nginx"},
+		},
+		{
+			name:         "tags with empty keys or values",
+			processTags:  ":value,key:,service.runtime:python3.9",
+			expectedTags: []string{"service.runtime:python3.9"},
+		},
+		{
+			name:         "empty tag entries",
+			processTags:  "service.framework:django,,entrypoint.name:manage.py,",
+			expectedTags: []string{"entrypoint.name:manage.py", "service.framework:django"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trm := TracerMetadata{
+				ProcessTags: tt.processTags,
+			}
+
+			tags := trm.GetTags()
+			sort.Strings(tags)
+			sort.Strings(tt.expectedTags)
+			assert.Equal(t, tt.expectedTags, tags)
+		})
+	}
+}

--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/atomic"
 	"go4.org/intern"
 
+	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -132,7 +133,7 @@ func (h *eventConsumerWrapper) Copy(ev *model.Event) any {
 	// keep the map of tagsFound, so that entries found at lower levels
 	// don't supercede those at higher.  However, we must actually parse
 	// all of the inputs to ensure that we don't miss any tags that are
-	tagsFound := make(map[string]struct{})
+	tagsFound := make(map[string]string)
 
 	envs := model.FilterEnvs(ev.GetProcessEnvp(), envFilter)
 	if len(envs) > 0 {
@@ -142,7 +143,7 @@ func (h *eventConsumerWrapper) Copy(ev *model.Event) any {
 			if len(v) > 0 {
 				if t := envTagNames[k]; t != "" {
 					p.Tags = append(p.Tags, intern.GetByString(t+":"+v))
-					tagsFound[k] = struct{}{}
+					tagsFound[k] = v
 				}
 			}
 		}
@@ -157,9 +158,13 @@ func (h *eventConsumerWrapper) Copy(ev *model.Event) any {
 
 	tracerTags := ev.GetProcessTracerTags()
 	for _, tag := range tracerTags {
-		if !isStandardTag(tag) {
-			p.Tags = append(p.Tags, intern.GetByString(tag))
+		if tracermetadata.ShouldSkipServiceTag(tag,
+			tagsFound["DD_SERVICE"],
+			tagsFound["DD_ENV"],
+			tagsFound["DD_VERSION"]) {
+			continue
 		}
+		p.Tags = append(p.Tags, intern.GetByString(tag))
 	}
 
 	if cid := ev.GetContainerID(); cid != "" {
@@ -167,14 +172,6 @@ func (h *eventConsumerWrapper) Copy(ev *model.Event) any {
 	}
 
 	return p
-}
-
-// isStandardTag returns true if the tag is a standard service/env/version tag
-// that should not be included from tracer metadata to avoid conflicts with UST
-func isStandardTag(tag string) bool {
-	return strings.HasPrefix(tag, "service:") ||
-		strings.HasPrefix(tag, "env:") ||
-		strings.HasPrefix(tag, "version:")
 }
 
 // EventTypes returns the event types handled by this consumer

--- a/pkg/network/events/monitor_linux.go
+++ b/pkg/network/events/monitor_linux.go
@@ -32,6 +32,6 @@ func getProcessStartTime(ev *model.Event) time.Time {
 	return time.Time{}
 }
 
-func getAPMTags(_ map[string]struct{}, _ string) []*intern.Value {
+func getAPMTags(_ map[string]string, _ string) []*intern.Value {
 	return nil
 }

--- a/pkg/network/events/monitor_test.go
+++ b/pkg/network/events/monitor_test.go
@@ -255,13 +255,19 @@ func TestEventHandleTracerTags(t *testing.T) {
 						},
 						ExecTime: now,
 						Envp: []string{
+							"DD_SERVICE=service-from-envp",
 							"DD_ENV=env-from-envp",
+							"DD_VERSION=version-from-envp",
 						},
 						TracerTags: []string{
-							"service:my-service",
-							"env:my-env",
-							"version:my-version",
+							"tracer_service_name:my-service",
+							"tracer_service_env:my-env",
+							"tracer_service_version:my-version",
 							"entrypoint.name:my-entrypoint",
+							// Should be skipped because it matches the UST tags
+							"tracer_service_name:service-from-envp",
+							"tracer_service_env:env-from-envp",
+							"tracer_service_version:version-from-envp",
 						},
 					},
 				},
@@ -275,10 +281,14 @@ func TestEventHandleTracerTags(t *testing.T) {
 		require.Len(t, handler.events, 1, "should have received 1 process event")
 		receivedProc := handler.events[0]
 		assert.Equal(t, uint32(1234), receivedProc.Pid)
+		assert.Contains(t, receivedProc.Tags, intern.GetByString("service:service-from-envp"))
 		assert.Contains(t, receivedProc.Tags, intern.GetByString("env:env-from-envp"))
-		assert.NotContains(t, receivedProc.Tags, intern.GetByString("service:my-service"))
-		assert.NotContains(t, receivedProc.Tags, intern.GetByString("env:my-env"))
-		assert.NotContains(t, receivedProc.Tags, intern.GetByString("version:my-version"))
+		assert.Contains(t, receivedProc.Tags, intern.GetByString("tracer_service_name:my-service"))
+		assert.Contains(t, receivedProc.Tags, intern.GetByString("tracer_service_env:my-env"))
+		assert.Contains(t, receivedProc.Tags, intern.GetByString("tracer_service_version:my-version"))
+		assert.NotContains(t, receivedProc.Tags, intern.GetByString("tracer_service_name:service-from-envp"))
+		assert.NotContains(t, receivedProc.Tags, intern.GetByString("tracer_service_env:env-from-envp"))
+		assert.NotContains(t, receivedProc.Tags, intern.GetByString("tracer_service_version:version-from-envp"))
 		assert.Contains(t, receivedProc.Tags, intern.GetByString("entrypoint.name:my-entrypoint"))
 	})
 

--- a/pkg/network/events/monitor_windows.go
+++ b/pkg/network/events/monitor_windows.go
@@ -27,24 +27,24 @@ func getProcessStartTime(ev *model.Event) time.Time {
 	return time.Time{}
 }
 
-func makeTagsSlice(already map[string]struct{}, apmtags iisconfig.APMTags) []*intern.Value {
+func makeTagsSlice(already map[string]string, apmtags iisconfig.APMTags) []*intern.Value {
 	tags := make([]*intern.Value, 0, 3)
 	if _, found := already["DD_SERVICE"]; !found {
 		if len(apmtags.DDService) > 0 {
 			tags = append(tags, intern.GetByString("service"+":"+apmtags.DDService))
-			already["DD_SERVICE"] = struct{}{}
+			already["DD_SERVICE"] = apmtags.DDService
 		}
 	}
 	if _, found := already["DD_ENV"]; !found {
 		if len(apmtags.DDEnv) > 0 {
 			tags = append(tags, intern.GetByString("env"+":"+apmtags.DDEnv))
-			already["DD_ENV"] = struct{}{}
+			already["DD_ENV"] = apmtags.DDEnv
 		}
 	}
 	if _, found := already["DD_VERSION"]; !found {
 		if len(apmtags.DDVersion) > 0 {
 			tags = append(tags, intern.GetByString("version"+":"+apmtags.DDVersion))
-			already["DD_VERSION"] = struct{}{}
+			already["DD_VERSION"] = apmtags.DDVersion
 		}
 	}
 	if len(tags) == 0 {
@@ -53,7 +53,7 @@ func makeTagsSlice(already map[string]struct{}, apmtags iisconfig.APMTags) []*in
 	return tags
 }
 
-func getAPMTags(already map[string]struct{}, filename string) []*intern.Value {
+func getAPMTags(already map[string]string, filename string) []*intern.Value {
 
 	dir := filepath.Dir(filename)
 	if dir == "" {

--- a/pkg/security/tests/tracer_memfd_test.go
+++ b/pkg/security/tests/tracer_memfd_test.go
@@ -149,9 +149,9 @@ func TestTracerMemfd(t *testing.T) {
 
 		// Verify expected tags from the msgp-encoded metadata
 		expectedTags := []string{
-			"service:test-service",
-			"env:test-env",
-			"version:1.0.0",
+			"tracer_service_name:test-service",
+			"tracer_service_env:test-env",
+			"tracer_service_version:1.0.0",
 			"custom.tag:value",
 		}
 


### PR DESCRIPTION
### What does this PR do?

The standard service/name/env tags can also be set via tracer APIs in
which case they, for APM, override any tags set by UST.

The discovery code allows propagating tracer metadata to other products
via the tagger and event stream. However, reporting the
service/name/env values from the tracer as standard tags may cause
regressions with products other than APM where, until this point, UST is
respected over any settings done via the tracer APIs.

To make the new information available without risking causing
regressions, report the tracer tags with different names (below) to
other products so that the backend can decided how and when to allow
them to override UST:

```
 service -> tracer_service_name
 version -> tracer_service_version
 env -> tracer_service_env
```

The naming with `tracer_service_*` was chosen since `tracer_version`
would be ambiguous, since the tracer itself has a version.

### Motivation

https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/5637341349

### Describe how you validated your changes

Tests modified
