### PR TITLE
[config] Delete unused "kubelet_listener_polling_interval" option

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3710,13 +3710,6 @@ api_key:
 ## Set the duration to 0 to disable this filtering.
 #
 # kubernetes_pod_expiration_duration: 900
-
-## @param kubelet_listener_polling_interval - integer - optional - default: 5
-## @env DD_KUBELET_LISTENER_POLLING_INTERVAL - integer - optional - default: 5
-## Polling frequency in seconds at which autodiscovery will query the pod watcher to detect new pods/containers.
-## Note that kubelet_cache_pods_duration needs to be lower than this setting, or autodiscovery will only poll more frequently the same cached data (kubelet_cache_pods_duration controls the cache refresh frequency).
-#
-# kubelet_listener_polling_interval: 5
 {{ end -}}
 {{ if .KubeApiServer }}
 ####################################################

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1983,7 +1983,6 @@ func kubernetes(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("kubernetes_pod_expiration_duration", 15*60) // in seconds, default 15 minutes
 	config.BindEnvAndSetDefault("kubelet_cache_pods_duration", 5)            // Polling frequency in seconds of the agent to the kubelet "/pods" endpoint
-	config.BindEnvAndSetDefault("kubelet_listener_polling_interval", 5)      // Polling frequency in seconds of the pod watcher to detect new pods/containers (affected by kubelet_cache_pods_duration setting)
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_use_endpoint_slices", false)
 	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)


### PR DESCRIPTION
### What does this PR do?

This PR deletes the unused `kubelet_listener_polling_interval` config option. It seems that the last usage was deleted in https://github.com/DataDog/datadog-agent/pull/9014/

I realized this while I was working on something related (https://github.com/DataDog/datadog-agent/pull/41920).
