### PR TITLE
Retry `e2e` test commands on SSH connection resets

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -164,32 +164,17 @@ func (h *sshExecutor) Execute(command string, options ...ExecuteOption) (string,
 	return h.executeAndReconnectOnError(command)
 }
 
-// Execute `fn` and try again after reconnecting when encountering a transient error.
-// See: https://app.datadoghq.com/incidents/45562
-func (h *sshExecutor) callAndReconnectOnError(command string, fn func() error) error {
+func (h *sshExecutor) executeAndReconnectOnError(command string) (string, error) {
 	scrubbedCommand := h.scrubber.ScrubLine(command) // scrub the command in case it contains secrets
 	h.context.T().Logf("%s - %s - Executing command `%s`", time.Now().Format("02-01-2006 15:04:05"), h.context.T().Name(), scrubbedCommand)
-	err := fn()
-	if err == nil {
-		return nil
+	stdout, err := execute(h.client, command)
+	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
+		err = h.Reconnect()
+		if err != nil {
+			return "", err
+		}
+		stdout, err = execute(h.client, command)
 	}
-	errStr := err.Error()
-	if !strings.Contains(errStr, "failed to create session:") && !strings.Contains(errStr, "handshake failed:") {
-		return err
-	}
-	if err = h.Reconnect(); err != nil {
-		return err
-	}
-	return fn()
-}
-
-func (h *sshExecutor) executeAndReconnectOnError(command string) (string, error) {
-	var stdout string
-	err := h.callAndReconnectOnError(command, func() error {
-		var execErr error
-		stdout, execErr = execute(h.client, command)
-		return execErr
-	})
 	if err != nil {
 		return "", fmt.Errorf("%v: %w", stdout, err)
 	}
@@ -207,14 +192,16 @@ func (h *sshExecutor) Start(command string, options ...ExecuteOption) (*ssh.Sess
 }
 
 func (h *sshExecutor) startAndReconnectOnError(command string) (*ssh.Session, io.WriteCloser, io.Reader, error) {
-	var session *ssh.Session
-	var stdin io.WriteCloser
-	var stdout io.Reader
-	err := h.callAndReconnectOnError(command, func() error {
-		var startErr error
-		session, stdin, stdout, startErr = start(h.client, command)
-		return startErr
-	})
+	scrubbedCommand := h.scrubber.ScrubLine(command) // scrub the command in case it contains secrets
+	h.context.T().Logf("%s - %s - Executing command `%s`", time.Now().Format("02-01-2006 15:04:05"), h.context.T().Name(), scrubbedCommand)
+	session, stdin, stdout, err := start(h.client, command)
+	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
+		err = h.Reconnect()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		session, stdin, stdout, err = start(h.client, command)
+	}
 	return session, stdin, stdout, err
 }
 

--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -64,6 +64,12 @@ func getKnownErrors() []knownError {
 			maxRetry:     stackUpMaxRetry,
 		},
 		{
+			// https://app.datadoghq.com/incidents/45562
+			errorMessage: `ssh: handshake failed: read tcp .+: read: connection reset by peer`,
+			retryType:    ReCreate,
+			maxRetry:     stackUpMaxRetry,
+		},
+		{
 			// https://datadoghq.atlassian.net/browse/ADXT-798
 			// https://datadoghq.atlassian.net/browse/ADXT-813
 			errorMessage: `error: awsx:ecs:FargateTaskDefinition resource '.+fakeintake.+' has a problem: grpc: the client connection is closing`,


### PR DESCRIPTION
### Motivation
[#incident-45562](https://app.datadoghq.com/incidents/45562): some `e2e` tests started failing with "connection reset by peer" errors during SSH command execution ([likely due to `openssl` changes](https://dd.slack.com/archives/C09S7PUF92P/p1762959042106449)). These are transient network errors that should trigger a reconnection and retry rather than failing the test.

### What does this PR do?
Extract `callAndReconnectOnError` helper to `host.go` that retries SSH operations once after reconnecting when encountering retriable errors ("failed to create session:" as before, and now "connection reset by peer"). This handles transient SSH failures during test execution runtime.