### PR TITLE
[SYNTH-22915] Timeout when worker pool exhausted, add logs

### DIFF
--- a/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
+++ b/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -745,4 +746,71 @@ func TestFlushEnqueuesDueTests(t *testing.T) {
 	assert.Equal(t, expectedNextRun, rt.nextRun)
 }
 
+func TestFlushEnqueueExhaustion(t *testing.T) {
+	now := time.Now()
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	l, err := utillog.LoggerFromWriterWithMinLevelAndLvlFuncMsgFormat(w, utillog.DebugLvl)
+	assert.Nil(t, err)
+	tl := &testLogger{
+		LoggerInterface: l,
+	}
+	utillog.SetupLogger(tl, "debug")
+
+	scheduler := &syntheticsTestScheduler{
+		timeNowFn:                    func() time.Time { return now },
+		syntheticsTestProcessingChan: make(chan SyntheticsTestCtx, 1),
+		running:                      true,
+		state: runningState{
+			tests: map[string]*runningTestState{
+				"test1": {
+					cfg: common.SyntheticsTestConfig{
+						PublicID: "test1",
+						Interval: 10, // seconds
+					},
+					nextRun: now.Add(-10 * time.Second),
+				},
+				"test2": {
+					cfg: common.SyntheticsTestConfig{
+						PublicID: "test1",
+						Interval: 10, // seconds
+					},
+					nextRun: now.Add(-10 * time.Second),
+				},
+			},
+		},
+		flushInterval: 100 * time.Millisecond,
+		log:           tl,
+	}
+
+	// Flush at 'now'
+	scheduler.flush(context.Background(), now)
+
+	select {
+	case ctx := <-scheduler.syntheticsTestProcessingChan:
+		time.Sleep(200 * time.Millisecond)
+		if ctx.cfg.PublicID != "test1" {
+			t.Errorf("expected test1, got %s", ctx.cfg.PublicID)
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Errorf("expected test2 not to be enqueued")
+	}
+
+	assert.Equal(t, []string{"test queue high usage (≥70%), increase the number of workers", "enqueuing test test1 timed out, increase the number of workers"}, tl.errorCalls)
+	rt := scheduler.state.tests["test1"]
+
+	// The nextRun should be updated based on the old nextRun, not flushTime
+	expectedNextRun := now // old nextRun (-10s) + interval (10s) = now
+	assert.Equal(t, expectedNextRun, rt.nextRun)
+}
+
+type testLogger struct {
+	utillog.LoggerInterface
+	errorCalls []string
+}
+
+func (l *testLogger) Warnf(format string, params ...interface{}) error {
+	l.errorCalls = append(l.errorCalls, fmt.Sprintf(format, params...))
+	return nil
+}
 func ptr[T any](v T) *T { return &v }

--- a/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
+++ b/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
@@ -725,7 +725,7 @@ func TestFlushEnqueuesDueTests(t *testing.T) {
 	}
 
 	// Flush at 'now'
-	scheduler.flush(now)
+	scheduler.flush(context.Background(), now)
 
 	select {
 	case ctx := <-scheduler.syntheticsTestProcessingChan:

--- a/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
+++ b/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
@@ -721,7 +721,8 @@ func TestFlushEnqueuesDueTests(t *testing.T) {
 				},
 			},
 		},
-		log: l,
+		flushInterval: 10 * time.Second,
+		log:           l,
 	}
 
 	// Flush at 'now'
@@ -729,12 +730,12 @@ func TestFlushEnqueuesDueTests(t *testing.T) {
 
 	select {
 	case ctx := <-scheduler.syntheticsTestProcessingChan:
-		time.Sleep(1000 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 		if ctx.cfg.PublicID != "test1" {
 			t.Errorf("expected test1, got %s", ctx.cfg.PublicID)
 		}
 	case <-time.After(1 * time.Second):
-		t.Errorf("expected test1 to be enqueuedffff")
+		t.Errorf("expected test1 to be enqueued")
 	}
 
 	rt := scheduler.state.tests["test1"]

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -166,7 +166,7 @@ func (s *syntheticsTestScheduler) runWorker(ctx context.Context, workerID int) {
 
 			status, err := s.sendResult(wResult)
 			if err != nil {
-				s.log.Infof("[worker%d] error sending result: %s, publicID %s", workerID, err, syntheticsTestCtx.cfg.PublicID)
+				s.log.Debugf("[worker%d] error sending result: %s, publicID %s", workerID, err, syntheticsTestCtx.cfg.PublicID)
 				s.statsdClient.Incr(syntheticsMetricPrefix+"evp.send_result_failure", []string{"reason:error_sending_result", fmt.Sprintf("org_id:%d", syntheticsTestCtx.cfg.OrgID), fmt.Sprintf("subtype:%s", syntheticsTestCtx.cfg.Config.Request.GetSubType())}, 1) //nolint:errcheck
 			}
 			s.statsdClient.Incr(syntheticsMetricPrefix+"checks_processed", []string{fmt.Sprintf("status:%s", status), fmt.Sprintf("org_id:%d", syntheticsTestCtx.cfg.OrgID), fmt.Sprintf("subtype:%s", syntheticsTestCtx.cfg.Config.Request.GetSubType())}, 1) //nolint:errcheck

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -57,13 +57,13 @@ func (s *syntheticsTestScheduler) flushLoop(ctx context.Context) {
 			s.log.Info("stopped flush loop")
 			return
 		case flushTime := <-s.tickerC:
-			s.flush(flushTime)
+			s.flush(ctx, flushTime)
 		}
 	}
 }
 
 // flush enqueues tests whose nextRun is due.
-func (s *syntheticsTestScheduler) flush(flushTime time.Time) {
+func (s *syntheticsTestScheduler) flush(ctx context.Context, flushTime time.Time) {
 	if !s.running {
 		return
 	}
@@ -77,15 +77,31 @@ func (s *syntheticsTestScheduler) flush(flushTime time.Time) {
 			testsToRun = append(testsToRun, rt)
 		}
 	}
+	if len(testsToRun) == 0 {
+		return
+	}
 
+	threshold := int(float64(cap(s.syntheticsTestProcessingChan)) * 0.7)
+	if len(s.syntheticsTestProcessingChan) >= threshold {
+		s.log.Warnf("test queue high usage (≥70%%), increase the number of workers")
+	}
+
+	maxWait := time.Duration(float64(s.flushInterval) / float64(len(testsToRun)) * 0.9)
 	for _, rt := range testsToRun {
 		if !s.running {
 			return
 		}
 		s.log.Debugf("enqueuing test %s", rt.cfg.PublicID)
-		s.syntheticsTestProcessingChan <- SyntheticsTestCtx{
+		select {
+		case s.syntheticsTestProcessingChan <- SyntheticsTestCtx{
 			nextRun: flushTime,
 			cfg:     rt.cfg,
+		}:
+		case <-time.After(maxWait):
+			s.log.Warnf("enqueuing test %s timed out, increase the number of workers", rt.cfg.PublicID)
+		case <-ctx.Done():
+			s.log.Debugf("enqueuing test %s failed because we are stopping the process", rt.cfg.PublicID)
+			return
 		}
 		rt.nextRun = rt.nextRun.Add(time.Duration(rt.cfg.Interval) * time.Second)
 	}
@@ -103,6 +119,8 @@ func (s *syntheticsTestScheduler) runWorker(ctx context.Context, workerID int) {
 				s.log.Debugf("worker %d stopping: processing channel closed", workerID)
 				return
 			}
+			s.log.Debugf("[worker%d] received, publicID %s", workerID, syntheticsTestCtx.cfg.PublicID)
+
 			tracerouteCfg, err := toNetpathConfig(syntheticsTestCtx.cfg)
 			if err != nil {
 				s.log.Debugf("[worker%d] error interpreting test config: %s", workerID, err)
@@ -126,12 +144,12 @@ func (s *syntheticsTestScheduler) runWorker(ctx context.Context, workerID int) {
 			wResult.finishedAt = s.timeNowFn()
 			wResult.duration = wResult.finishedAt.Sub(wResult.startedAt)
 			if tracerouteErr != nil {
-				s.log.Debugf("[worker%d] error running traceroute: %s", workerID, tracerouteErr)
+				s.log.Debugf("[worker%d] error running traceroute: %s, publicID %s", workerID, tracerouteErr, syntheticsTestCtx.cfg.PublicID)
 				wResult.tracerouteError = tracerouteErr
 				s.statsdClient.Incr(syntheticsMetricPrefix+"traceroute.error", []string{"reason:error_running_datadog_traceroute", fmt.Sprintf("org_id:%d", syntheticsTestCtx.cfg.OrgID), fmt.Sprintf("subtype:%s", syntheticsTestCtx.cfg.Config.Request.GetSubType())}, 1) //nolint:errcheck
 				_, err := s.sendResult(wResult)
 				if err != nil {
-					s.log.Debugf("[worker%d] error sending result: %s", workerID, err)
+					s.log.Debugf("[worker%d] error sending result: %s, publicID %s", workerID, err, syntheticsTestCtx.cfg.PublicID)
 					s.statsdClient.Incr(syntheticsMetricPrefix+"evp.send_result_failure", []string{"reason:error_sending_result", fmt.Sprintf("org_id:%d", syntheticsTestCtx.cfg.OrgID), fmt.Sprintf("subtype:%s", syntheticsTestCtx.cfg.Config.Request.GetSubType())}, 1) //nolint:errcheck
 				}
 				continue
@@ -148,7 +166,7 @@ func (s *syntheticsTestScheduler) runWorker(ctx context.Context, workerID int) {
 
 			status, err := s.sendResult(wResult)
 			if err != nil {
-				s.log.Debugf("[worker%d] error sending result: %s", workerID, err)
+				s.log.Infof("[worker%d] error sending result: %s, publicID %s", workerID, err, syntheticsTestCtx.cfg.PublicID)
 				s.statsdClient.Incr(syntheticsMetricPrefix+"evp.send_result_failure", []string{"reason:error_sending_result", fmt.Sprintf("org_id:%d", syntheticsTestCtx.cfg.OrgID), fmt.Sprintf("subtype:%s", syntheticsTestCtx.cfg.Config.Request.GetSubType())}, 1) //nolint:errcheck
 			}
 			s.statsdClient.Incr(syntheticsMetricPrefix+"checks_processed", []string{fmt.Sprintf("status:%s", status), fmt.Sprintf("org_id:%d", syntheticsTestCtx.cfg.OrgID), fmt.Sprintf("subtype:%s", syntheticsTestCtx.cfg.Config.Request.GetSubType())}, 1) //nolint:errcheck


### PR DESCRIPTION
### What does this PR do?

It adds a timeout when enqueing a new test, look for exhaustion of the workers and logs warning to be able to correct the situation

### Motivation

### Describe how you validated your changes

### Additional Notes
