### PR TITLE
[e2e][npm] update sshd on SELinux host

### DIFF
--- a/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_selinux_test.go
@@ -60,7 +60,7 @@ func (v *ec2VMSELinuxSuite) SetupSuite() {
 	// SetupSuite needs to defer CleanupOnSetupFailure() if what comes after BaseSuite.SetupSuite() can fail.
 	defer v.CleanupOnSetupFailure()
 
-	v.Env().RemoteHost.MustExecute("sudo yum install -y bind-utils httpd-tools")
+	v.Env().RemoteHost.MustExecute("sudo yum install -y openssh-server bind-utils httpd-tools")
 	v.Env().RemoteHost.MustExecute("sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo")
 	v.Env().RemoteHost.MustExecute("sudo yum install -y docker-ce docker-ce-cli")
 	v.Env().RemoteHost.MustExecute("sudo systemctl start docker")


### PR DESCRIPTION
### What does this PR do?

Update the ssh server on the SELinux host used in NPM E2E tests

### Motivation

In incident-45562 SELinux NPM e2e test started suddenly failing with a broken ssh connection along the host life. Investigating we found it was caused by one of the setup steps that install docker. `sudo yum install bind-utils` was changing OpenSSL, messing with certificates and breaking ssh

```shell
> sshd 
OpenSSL version mismatch. Built against 30000070, you have 30500010
```

Updating ssh server at the same time fixes it.
 
### Describe how you validated your changes

Executed the setup manually, reconnecting at each step.

### Additional Notes
