### PR TITLE
Validate that OIDs are increasing during snmp scan

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -291,9 +291,10 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 		ScanType: metadata.ManualScan,
 	})
 	if err != nil {
-		fmt.Printf("Unable to perform device scan for device %s : %e", deviceID, err)
+		fmt.Printf("Unable to perform device scan for device %s : %v\n", deviceID, err)
+	} else {
+		fmt.Printf("Completed scan successfully for device: %s\n", deviceID)
 	}
-	fmt.Printf("Completed scan successfully for device: %s\n", deviceID)
 	return err
 }
 

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -36,7 +36,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 		Namespace:        namespace,
 	}
 	if err = s.sendPayload(inProgressStatusPayload); err != nil {
-		return fmt.Errorf("unable to send in progress status: %v", err)
+		return fmt.Errorf("unable to send in progress status: %w", err)
 	}
 	if err = snmp.Connect(); err != nil {
 		// Send an error status if we can't connect to the agent
@@ -50,7 +50,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 			Namespace:        namespace,
 		}
 		if sendErr := s.sendPayload(errorStatusPayload); sendErr != nil {
-			return fmt.Errorf("unable to send error status: %v", sendErr)
+			return fmt.Errorf("unable to send error status: %w", sendErr)
 		}
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}
@@ -67,9 +67,9 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 			Namespace:        namespace,
 		}
 		if sendErr := s.sendPayload(errorStatusPayload); sendErr != nil {
-			return fmt.Errorf("unable to send error status: %v", sendErr)
+			return fmt.Errorf("unable to send error status: %w", sendErr)
 		}
-		return fmt.Errorf("unable to perform device scan: %v", err)
+		return fmt.Errorf("unable to perform device scan: %w", err)
 	}
 	// Send a completed status if the scan was successful
 	completedStatusPayload := metadata.NetworkDevicesMetadata{
@@ -82,7 +82,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 		Namespace:        namespace,
 	}
 	if err = s.sendPayload(completedStatusPayload); err != nil {
-		return fmt.Errorf("unable to send completed status: %v", err)
+		return fmt.Errorf("unable to send completed status: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This inserts a check that will make `gosnmplib.ConditionalWalk` return an error if OIDs appear out of order.

### Motivation

Typically this is a sign that the device is behaving improperly - calls to GetNext shouldn't ever return earlier OIDs than the one that was just used. Our current behavior is to get stuck in an infinite loop; it would be better to error out with a sensible error message.

Note that the `gosnmp` package that we use for normal walks doesn't check for this, and just goes into an infinite loop. 

### Describe how you validated your changes
I [tweaked an snmp simulator to respond to GetNext in the wrong order](https://github.com/delimitry/snmp-server/commit/44dcb82dd9c0b5bc4a539bfbd7cbced8b2cfad87) and confirmed that the scan looped forever without this tweak and stopped with an appropriate error with it.
