### PR TITLE
[SMP] Update `quality_gate_metrics_logs` CPU threshold

### DIFF
--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."
     bounds:
       series: avg(total_cpu_usage_millicores)
-      upper_bound: 4000
+      upper_bound: 2000
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

The recent update to SMP v0.25.0 unblocks average quality gates. This PR starts decreasing the `quality_gate_metrics_logs` CPU usage threshold. This first change is very conservative: 2000 mcores. Current nightly runs are showing 250-350mcores. We'll crank this down further as we collect more data and evaluate how tightly we can constrain this.

### Motivation

Begin limiting CPU usage in `quality_gate_metrics_logs` experiment.

### Describe how you validated your changes

Uses data sourced from nightly Quality Gates runs.
