### PR TITLE
[ AGNTLOG-105 ] Remove extraneous systemd e2e testing

### DIFF
--- a/test/new-e2e/tests/agent-log-pipelines/linux-log/journald/journald_tailing_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/linux-log/journald/journald_tailing_test.go
@@ -7,12 +7,10 @@ package journaldlog
 
 import (
 	_ "embed"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -32,14 +30,8 @@ type LinuxJournaldFakeintakeSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
-//go:embed log-config/journald.yaml
-var logBasicConfig []byte
-
 //go:embed log-config/include.yaml
 var logIncludeConfig []byte
-
-//go:embed log-config/exclude.yaml
-var logExcludeConfig []byte
 
 //go:embed log-config/python-script.sh
 var pythonScript []byte
@@ -53,7 +45,7 @@ func TestVMJournaldTailingSuite(t *testing.T) {
 		e2e.WithProvisioner(awshost.Provisioner(
 			awshost.WithAgentOptions(
 				agentparams.WithLogs(),
-				agentparams.WithIntegration("custom_logs.d", string(logBasicConfig))))),
+				agentparams.WithIntegration("custom_logs.d", string(logIncludeConfig))))),
 	}
 
 	e2e.Run(t, &LinuxJournaldFakeintakeSuite{}, options...)
@@ -72,34 +64,7 @@ func (s *LinuxJournaldFakeintakeSuite) TearDownSuite() {
 }
 
 func (s *LinuxJournaldFakeintakeSuite) TestJournald() {
-	flake.Mark(s.T())
-	// Run test cases
-	s.Run("journaldLogCollection", s.journaldLogCollection)
-
 	s.Run("journaldIncludeServiceLogCollection()", s.journaldIncludeServiceLogCollection)
-
-	s.Run("journaldExcludeServiceCollection()", s.journaldExcludeServiceCollection)
-}
-
-func (s *LinuxJournaldFakeintakeSuite) journaldLogCollection() {
-	t := s.T()
-	// Add dd-agent user to systemd-journal group
-	_, err := s.Env().RemoteHost.Execute("sudo usermod -a -G systemd-journal dd-agent")
-	require.NoErrorf(t, err, "Unable to adjust permissions for dd-agent user: %s", err)
-
-	// Restart agent and make sure it's ready before adding logs
-	_, err = s.Env().RemoteHost.Execute("sudo systemctl restart datadog-agent")
-	assert.NoErrorf(t, err, "Failed to restart the agent: %s", err)
-	s.EventuallyWithT(func(t *assert.CollectT) {
-		agentReady := s.Env().Agent.Client.IsReady()
-		assert.True(t, agentReady)
-	}, utils.WaitFor, eventuallyWithTickDuration, "Agent was not ready")
-
-	// Generate log
-	appendJournaldLog(s, "hello-world", 1)
-
-	// Check that the generated log is collected
-	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-world", []string{})
 }
 
 func (s *LinuxJournaldFakeintakeSuite) journaldIncludeServiceLogCollection() {
@@ -110,10 +75,14 @@ func (s *LinuxJournaldFakeintakeSuite) journaldIncludeServiceLogCollection() {
 	vm := s.Env().RemoteHost
 	t := s.T()
 
+	// Add dd-agent user to systemd-journal group
+	_, err := s.Env().RemoteHost.Execute("sudo usermod -a -G systemd-journal dd-agent")
+	require.NoErrorf(t, err, "Unable to adjust permissions for dd-agent user: %s", err)
+
 	// Create journald log generation script
 	pythonScript := string(pythonScript)
 
-	_, err := vm.Execute(pythonScript)
+	_, err = vm.Execute(pythonScript)
 	if assert.NoErrorf(t, err, "Failed to create python script that generate journald log: %s", err) {
 		t.Log("Successfully created python script for journald log generation")
 	}
@@ -142,7 +111,8 @@ func (s *LinuxJournaldFakeintakeSuite) journaldIncludeServiceLogCollection() {
 	assert.NoErrorf(t, err, "Failed to restart the agent: %s", err)
 
 	s.EventuallyWithT(func(c *assert.CollectT) {
-		agentReady := s.Env().Agent.Client.IsReady()
+		agentStatus := s.Env().Agent.Client.Status()
+		agentReady := strings.Contains(agentStatus.Content, "random-logger")
 		assert.Truef(c, agentReady, "Agent is not ready after restart")
 	}, utils.WaitFor, eventuallyWithTickDuration)
 
@@ -152,45 +122,4 @@ func (s *LinuxJournaldFakeintakeSuite) journaldIncludeServiceLogCollection() {
 	// Disable journald log generation service
 	_, err = vm.Execute("sudo systemctl disable --now random-logger.service")
 	assert.NoErrorf(t, err, "Failed to disable the logging service: %s", err)
-}
-
-func (s *LinuxJournaldFakeintakeSuite) journaldExcludeServiceCollection() {
-	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(
-		agentparams.WithLogs(),
-		agentparams.WithIntegration("custom_logs.d", string(logExcludeConfig)))))
-
-	// Restart agent
-	s.Env().RemoteHost.Execute("sudo systemctl restart datadog-agent")
-
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		agentReady := s.Env().Agent.Client.IsReady()
-		assert.Truef(c, agentReady, "Agent is not ready after restart")
-	}, utils.WaitFor, eventuallyWithTickDuration)
-
-	// Check that the datadog-agent.service log is not collected, specifically logs from the check runners
-	utils.CheckLogsNotExpected(s.T(), s.Env().FakeIntake, "no-datadog", "running check")
-}
-
-// appendJournaldLog appends a log to journald.
-func appendJournaldLog(s *LinuxJournaldFakeintakeSuite, content string, recurrence int) {
-	t := s.T()
-	t.Helper()
-
-	logContent := strings.Repeat(content+"\n", recurrence)
-
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		cmd := fmt.Sprintf("sudo printf '%s' | systemd-cat", logContent)
-		_, err := s.Env().RemoteHost.Execute(cmd)
-		if assert.NoErrorf(c, err, "Error writing log: %v", err) {
-			t.Log("Writing logs to journald")
-		}
-
-		checkCmd := fmt.Sprintf("sudo journalctl --since '1 minute ago' | grep '%s'", content)
-		output, err := s.Env().RemoteHost.Execute(checkCmd)
-		assert.NoErrorf(c, err, "Error found checking for journald logs: %s", err)
-
-		if assert.Contains(c, output, content, "Journald log not properly generated.") {
-			t.Log("Finished generating journald log.")
-		}
-	}, utils.WaitFor, eventuallyWithTickDuration)
 }

--- a/test/new-e2e/tests/agent-log-pipelines/linux-log/journald/log-config/exclude.yaml
+++ b/test/new-e2e/tests/agent-log-pipelines/linux-log/journald/log-config/exclude.yaml
@@ -1,8 +1,0 @@
-logs:
-  - type: journald
-    source: custom_log
-    service: no-datadog
-    exclude_units:
-      - datadog-agent.service
-      - datadog-agent-trace.service
-      - datadog-agent-process.service

--- a/test/new-e2e/tests/agent-log-pipelines/linux-log/journald/log-config/journald.yaml
+++ b/test/new-e2e/tests/agent-log-pipelines/linux-log/journald/log-config/journald.yaml
@@ -1,4 +1,0 @@
-logs:
-  - type: journald
-    service: hello
-    source: custom_log


### PR DESCRIPTION
### What does this PR do?
Several of the journald system tests were well covered in the tailer_test.go equivalent, and could be safely removed from the e2e suite. Included in these removable tests are the ones responsible for the test suite's flakiness, which happened when journal logs were written before the first journal tailer had been initiated. The one remaining test should not be vulnerable to this error, but a slight change was made to the agent status check to confirm the tailer is present anyway. The hope is that this change will encourage any test expansions in this area to do the same.

### Motivation

### Describe how you validated your changes

### Additional Notes
