### PR TITLE
[CONTP-1040] Add e2e tests for container filtering and autodiscovery

### DIFF
--- a/test/new-e2e/tests/containers/filtering_test.go
+++ b/test/new-e2e/tests/containers/filtering_test.go
@@ -6,26 +6,19 @@
 package containers
 
 import (
-	"context"
-	"regexp"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
-	"github.com/DataDog/datadog-agent/test/fakeintake/client"
+	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
-	localkubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/local/kubernetes"
+	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
 	"github.com/DataDog/test-infra-definitions/common/config"
-	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
 	kubeComp "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
-	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
-	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
-	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/stretchr/testify/assert"
 )
 
 // k8sFilteringSuite tests container filtering behavior in Kubernetes environments
@@ -34,22 +27,24 @@ type k8sFilteringSuite struct {
 }
 
 const (
-	filteredAppName      = "filtered-nginx"
-	filteredAppNamespace = "workload-filtering"
+	filteredAppName      = "nginx"
+	filteredAppNamespace = "filtered-ns"
 )
 
 // TestK8SFilteringSuite runs the Kubernetes filtering test suite
 func TestK8SFilteringSuite(t *testing.T) {
 	e2e.Run(t, &k8sFilteringSuite{}, e2e.WithProvisioner(
-		localkubernetes.Provisioner(
-			localkubernetes.WithAgentOptions(
-				// Configure agent to exclude containers matching the filter
+		awskubernetes.KindProvisioner(
+			awskubernetes.WithAgentOptions(
 				kubernetesagentparams.WithHelmValues(`
 datadog:
-  containerExclude: "name:filtered-.*"
+  containerExclude: "kube_namespace:filtered-ns name:redis*"
 `),
 			),
-			localkubernetes.WithWorkloadApp(deployFilteredNginxWorkload),
+			awskubernetes.WithDeployTestWorkload(),
+			awskubernetes.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
+				return nginx.K8sAppDefinition(e, kubeProvider, filteredAppNamespace, "", false, nil)
+			}),
 		),
 	))
 }
@@ -63,201 +58,85 @@ func (suite *k8sFilteringSuite) SetupSuite() {
 // TestFilteredContainerNoMetrics verifies that the container core check does not collect
 // telemetry for containers that match the exclusion filter
 func (suite *k8sFilteringSuite) TestFilteredContainerNoMetrics() {
-	ctx := context.Background()
-
-	// Wait for the workload to be deployed and running
-	suite.EventuallyWithT(func(c *assert.CollectT) {
-		deployment, err := suite.Env().KubernetesCluster.Client().AppsV1().Deployments(filteredAppNamespace).Get(
-			ctx,
-			filteredAppName,
-			metav1.GetOptions{},
-		)
-		assert.NoError(c, err, "Failed to get filtered nginx deployment")
-		if deployment != nil {
-			assert.Greater(c, deployment.Status.ReadyReplicas, int32(0), "No ready replicas for filtered nginx")
+	suite.Never(func() bool {
+		containerMetrics := []string{
+			"container.cpu.usage",
+			"container.memory.usage",
+			"container.memory.working_set",
+			"container.io.read_bytes",
+			"container.io.write_bytes",
 		}
-	}, 2*time.Minute, 10*time.Second)
 
-	// Wait a reasonable time for metrics to potentially arrive (if filtering is broken)
-	time.Sleep(30 * time.Second)
-
-	// Query for container metrics that should NOT exist for the filtered container
-	containerMetrics := []string{
-		"container.cpu.usage",
-		"container.memory.usage",
-		"container.memory.working_set",
-		"container.io.read_bytes",
-		"container.io.write_bytes",
-	}
-
-	for _, metricName := range containerMetrics {
-		suite.Run(metricName, func() {
+		foundMetric := false
+		for _, metricName := range containerMetrics {
 			metrics, err := suite.Fakeintake.FilterMetrics(
 				metricName,
-				client.WithTags[*aggregator.MetricSeries]([]string{
-					`container_name:` + filteredAppName,
+				fakeintake.WithTags[*aggregator.MetricSeries]([]string{
+					`kube_namespace` + filteredAppNamespace,
 				}),
 			)
 			suite.NoError(err, "Error querying metrics")
-			suite.Empty(metrics, "Expected no %s metrics for filtered container %s, but found %d metrics",
-				metricName, filteredAppName, len(metrics))
-		})
-	}
+			if len(metrics) > 0 {
+				foundMetric = true
+			}
+		}
+		return foundMetric
+	}, 2*time.Minute, 15*time.Second, "Metrics were found for a container in a filtered namespace")
 
-	// Also verify Kubernetes-specific metrics are not collected
-	k8sMetrics := []string{
-		"kubernetes.cpu.usage.total",
-		"kubernetes.memory.usage",
-		"kubernetes.memory.working_set",
-	}
+	suite.Never(func() bool {
+		containerMetrics := []string{
+			"container.cpu.usage",
+			"container.memory.usage",
+			"container.memory.working_set",
+			"container.io.read_bytes",
+			"container.io.write_bytes",
+		}
 
-	for _, metricName := range k8sMetrics {
-		suite.Run(metricName, func() {
+		foundMetric := false
+		for _, metricName := range containerMetrics {
 			metrics, err := suite.Fakeintake.FilterMetrics(
 				metricName,
-				client.WithTags[*aggregator.MetricSeries]([]string{
-					`kube_container_name:` + filteredAppName,
+				fakeintake.WithTags[*aggregator.MetricSeries]([]string{
+					`container_name:` + "redis",
 				}),
 			)
 			suite.NoError(err, "Error querying metrics")
-			suite.Empty(metrics, "Expected no %s metrics for filtered container %s, but found %d metrics",
-				metricName, filteredAppName, len(metrics))
-		})
-	}
+			if len(metrics) > 0 {
+				foundMetric = true
+			}
+		}
+		return foundMetric
+	}, 2*time.Minute, 15*time.Second, "Metrics were found for a container filtered by name")
 }
 
 // TestFilteredContainerNoAutodiscovery verifies that integrations are NOT auto-discovered
 // on containers that match the exclusion filter, even if they have AD annotations
 func (suite *k8sFilteringSuite) TestFilteredContainerNoAutodiscovery() {
-	ctx := context.Background()
-
-	// Wait for the workload to be deployed and running
-	suite.EventuallyWithT(func(c *assert.CollectT) {
-		deployment, err := suite.Env().KubernetesCluster.Client().AppsV1().Deployments(filteredAppNamespace).Get(
-			ctx,
-			filteredAppName,
-			metav1.GetOptions{},
-		)
-		assert.NoError(c, err, "Failed to get filtered nginx deployment")
-		if deployment != nil {
-			assert.Greater(c, deployment.Status.ReadyReplicas, int32(0), "No ready replicas for filtered nginx")
+	// Query for nginx integration metrics should NOT exist
+	suite.Never(func() bool {
+		nginxMetrics := []string{
+			"nginx.net.request_per_s",
+			"nginx.net.conn_active",
+			"nginx.net.conn_reading",
+			"nginx.net.conn_writing",
+			"nginx.net.conn_waiting",
 		}
-	}, 2*time.Minute, 10*time.Second)
 
-	// Wait a reasonable time for autodiscovery to potentially occur (if filtering is broken)
-	time.Sleep(30 * time.Second)
-
-	// Query for nginx integration metrics that should NOT exist
-	nginxMetrics := []string{
-		"nginx.net.request_per_s",
-		"nginx.net.conn_active",
-		"nginx.net.conn_reading",
-		"nginx.net.conn_writing",
-		"nginx.net.conn_waiting",
-	}
-
-	for _, metricName := range nginxMetrics {
-		suite.Run(metricName, func() {
-			metrics, err := suite.Fakeintake.FilterMetrics(
-				metricName,
-				client.WithTags[*aggregator.MetricSeries]([]string{
-					`kube_container_name:` + filteredAppName,
-				}),
-			)
-			suite.NoError(err, "Error querying metrics")
-			suite.Empty(metrics, "Expected no nginx integration metric %s for filtered container, but found %d metrics",
-				metricName, len(metrics))
-		})
-	}
-
-	// Verify that no nginx check runs exist for the filtered container
-	suite.Run("check_runs", func() {
-		checkRuns, err := suite.Fakeintake.FilterCheckRuns("nginx")
-		suite.NoError(err, "Error querying check runs")
-
-		// Filter check runs to find any that match our filtered container
-		filteredCheckRuns := make([]*aggregator.CheckRun, 0)
-		for _, checkRun := range checkRuns {
-			for _, tag := range checkRun.Tags {
-				if matched, _ := regexp.MatchString(`kube_container_name:`+filteredAppName, tag); matched {
-					filteredCheckRuns = append(filteredCheckRuns, checkRun)
-					break
+		foundMetric := false
+		for _, metricName := range nginxMetrics {
+			suite.Run(metricName, func() {
+				metrics, err := suite.Fakeintake.FilterMetrics(
+					metricName,
+					fakeintake.WithTags[*aggregator.MetricSeries]([]string{
+						`container_name:` + filteredAppName,
+					}),
+				)
+				suite.NoError(err, "Error querying metrics")
+				if len(metrics) > 0 {
+					foundMetric = true
 				}
-			}
+			})
 		}
-
-		suite.Empty(filteredCheckRuns, "Expected no nginx check runs for filtered container, but found %d check runs",
-			len(filteredCheckRuns))
-	})
-}
-
-// deployFilteredNginxWorkload deploys an nginx application with autodiscovery annotations
-// but with a name that matches the container exclusion filter
-func deployFilteredNginxWorkload(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
-	namespace, err := corev1.NewNamespace(e.Ctx(), e.Namer().ResourceName(filteredAppNamespace), &corev1.NamespaceArgs{
-		Metadata: &metav1.ObjectMetaArgs{
-			Name: pulumi.String(filteredAppNamespace),
-		},
-	}, pulumi.Provider(kubeProvider))
-	if err != nil {
-		return nil, err
-	}
-
-	// Deploy nginx with autodiscovery annotations
-	// The container name matches the filter pattern "name:filtered-.*"
-	// so it should be excluded despite having AD annotations
-	deployment, err := appsv1.NewDeployment(e.Ctx(), e.Namer().ResourceName(filteredAppName), &appsv1.DeploymentArgs{
-		Metadata: &metav1.ObjectMetaArgs{
-			Name:      pulumi.String(filteredAppName),
-			Namespace: namespace.Metadata.Name(),
-			Annotations: pulumi.StringMap{
-				// Autodiscovery annotations for nginx integration
-				"ad.datadoghq.com/filtered-nginx.check_names":  pulumi.String(`["nginx"]`),
-				"ad.datadoghq.com/filtered-nginx.init_configs": pulumi.String(`[{}]`),
-				"ad.datadoghq.com/filtered-nginx.instances":    pulumi.String(`[{"nginx_status_url": "http://%%host%%:8080/nginx_status"}]`),
-			},
-		},
-		Spec: &appsv1.DeploymentSpecArgs{
-			Replicas: pulumi.Int(1),
-			Selector: &metav1.LabelSelectorArgs{
-				MatchLabels: pulumi.StringMap{
-					"app": pulumi.String(filteredAppName),
-				},
-			},
-			Template: &corev1.PodTemplateSpecArgs{
-				Metadata: &metav1.ObjectMetaArgs{
-					Labels: pulumi.StringMap{
-						"app": pulumi.String(filteredAppName),
-					},
-					Annotations: pulumi.StringMap{
-						// Pod-level annotations for autodiscovery
-						"ad.datadoghq.com/filtered-nginx.check_names":  pulumi.String(`["nginx"]`),
-						"ad.datadoghq.com/filtered-nginx.init_configs": pulumi.String(`[{}]`),
-						"ad.datadoghq.com/filtered-nginx.instances":    pulumi.String(`[{"nginx_status_url": "http://%%host%%:8080/nginx_status"}]`),
-					},
-				},
-				Spec: &corev1.PodSpecArgs{
-					Containers: corev1.ContainerArray{
-						&corev1.ContainerArgs{
-							Name:  pulumi.String(filteredAppName),
-							Image: pulumi.String("ghcr.io/datadog/apps-nginx:" + apps.Version),
-							Ports: corev1.ContainerPortArray{
-								&corev1.ContainerPortArgs{
-									ContainerPort: pulumi.Int(8080),
-									Name:          pulumi.String("http"),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}, pulumi.Provider(kubeProvider), pulumi.DependsOn([]pulumi.Resource{namespace}))
-	if err != nil {
-		return nil, err
-	}
-
-	return &kubeComp.Workload{
-		Deployment: deployment,
-	}, nil
+		return foundMetric
+	}, 2*time.Minute, 15*time.Second, "Metrics were found for a container filtered by namespace")
 }

--- a/test/new-e2e/tests/containers/filtering_test.go
+++ b/test/new-e2e/tests/containers/filtering_test.go
@@ -6,6 +6,7 @@
 package containers
 
 import (
+	_ "embed"
 	"regexp"
 	"testing"
 	"time"
@@ -23,43 +24,30 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 )
 
-// k8sFilteringSuite tests container filtering behavior in Kubernetes environments
-type k8sFilteringSuite struct {
-	baseSuite[environments.Kubernetes]
-}
+//go:embed fixtures/datadog-agent-legacy-exclude.yml
+var legacyContainerExcludeConfig string
+
+//go:embed fixtures/datadog-agent-cel-exclude.yml
+var celContainerExcludeConfig string
 
 const (
 	filteredAppName   = "redis"
 	filteredNamespace = "filtered-ns"
 )
 
-// TestK8SFilteringSuite runs the Kubernetes filtering test suite
-func TestK8SFilteringSuite(t *testing.T) {
-	e2e.Run(t, &k8sFilteringSuite{}, e2e.WithProvisioner(
-		awskubernetes.KindProvisioner(
-			awskubernetes.WithAgentOptions(
-				kubernetesagentparams.WithHelmValues(`
-datadog:
-  containerExclude: "kube_namespace:filtered-ns name:redis*"
-`),
-			),
-			awskubernetes.WithDeployTestWorkload(),
-			awskubernetes.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
-				return nginx.K8sAppDefinition(e, kubeProvider, filteredNamespace, "", false, nil)
-			}),
-		),
-	))
+// k8sFilteringSuiteBase provides common test methods for filtering test suites
+type k8sFilteringSuiteBase struct {
+	baseSuite[environments.Kubernetes]
 }
 
-func (suite *k8sFilteringSuite) SetupSuite() {
+func (suite *k8sFilteringSuiteBase) SetupSuite() {
 	suite.baseSuite.SetupSuite()
 	suite.Fakeintake = suite.Env().FakeIntake.Client()
-	suite.clusterName = suite.Env().KubernetesCluster.ClusterName
 }
 
-// TestContainerExcludeNoMetrics verifies that the container core check does not collect
-// telemetry for containers that match the exclusion filter
-func (suite *k8sFilteringSuite) TestContainerExcludeNoMetrics() {
+// TestWorkloadExcludeNoMetrics verifies that the container core check does not collect
+// telemetry for workloads that match the exclusion filter
+func (suite *k8sFilteringSuiteBase) TestWorkloadExcludeNoMetrics() {
 	// nginx workload in filtered namespace should never have metrics
 	suite.Never(func() bool {
 		containerMetrics := []string{
@@ -75,7 +63,7 @@ func (suite *k8sFilteringSuite) TestContainerExcludeNoMetrics() {
 			metrics, err := suite.Fakeintake.FilterMetrics(
 				metricName,
 				fakeintake.WithTags[*aggregator.MetricSeries]([]string{
-					`kube_namespace` + filteredNamespace,
+					`kube_namespace:` + filteredNamespace,
 				}),
 			)
 			suite.NoError(err, "Error querying metrics")
@@ -84,13 +72,13 @@ func (suite *k8sFilteringSuite) TestContainerExcludeNoMetrics() {
 			}
 		}
 		return foundMetric
-	}, 1*time.Minute, 5*time.Second, "Metrics were found for a container in a filtered namespace")
+	}, 1*time.Minute, 5*time.Second, "Metrics were found for a workload in a filtered namespace")
 }
 
-// TestContainerExcludeForAutodiscovery verifies that integrations are NOT auto-discovered
-// on containers that match the exclusion filter, even for auto config enabled integrations
-func (suite *k8sFilteringSuite) TestContainerExcludeForAutodiscovery() {
-	// redis workload is excluded by its container name and should not have auto-config metrics
+// TestWorkloadExcludeForAutodiscovery verifies that integrations are NOT auto-discovered
+// on workloads that match the exclusion filter, even for auto config enabled integrations
+func (suite *k8sFilteringSuiteBase) TestWorkloadExcludeForAutodiscovery() {
+	// redis workload is excluded and should not have auto-config metrics
 	suite.Never(func() bool {
 		metrics, err := suite.Fakeintake.FilterMetrics(
 			"redis.net.instantaneous_ops_per_sec",
@@ -103,9 +91,9 @@ func (suite *k8sFilteringSuite) TestContainerExcludeForAutodiscovery() {
 	}, 1*time.Minute, 5*time.Second, "Metrics were found for filtered redis workload")
 }
 
-// TestUnfilteredWorkloadsHaveTelemetry confirms that workloads not included in the container exclude filter
+// TestUnfilteredWorkloadsHaveTelemetry confirms that workloads not matched by the exclude filter
 // continue to run and collect telemetry.
-func (suite *k8sFilteringSuite) TestUnfilteredWorkloadsHaveTelemetry() {
+func (suite *k8sFilteringSuiteBase) TestUnfilteredWorkloadsHaveTelemetry() {
 	// nginx workload in default namespace should have metrics
 	suite.testMetric(&testMetricArgs{
 		Filter: testMetricFilterArgs{
@@ -167,4 +155,47 @@ func (suite *k8sFilteringSuite) TestUnfilteredWorkloadsHaveTelemetry() {
 			Message: `GET / HTTP/1\.1`,
 		},
 	})
+}
+
+// k8sLegacyFilteringSuite tests legacy container filtering behavior in Kubernetes environments
+type k8sLegacyFilteringSuite struct {
+	k8sFilteringSuiteBase
+}
+
+// TestK8SLegacyFilteringSuite runs the Kubernetes legacy filtering test suite
+func TestK8SLegacyFilteringSuite(t *testing.T) {
+	e2e.Run(t, &k8sLegacyFilteringSuite{}, e2e.WithProvisioner(
+		awskubernetes.KindProvisioner(
+			awskubernetes.WithAgentOptions(
+				kubernetesagentparams.WithHelmValues(legacyContainerExcludeConfig),
+			),
+			awskubernetes.WithDeployTestWorkload(),
+			// Deploy additional nginx workload except in an excluded namespace
+			awskubernetes.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
+				return nginx.K8sAppDefinition(e, kubeProvider, filteredNamespace, "", false, nil)
+			}),
+		),
+	))
+}
+
+// k8sCELFilteringSuite tests CEL-based workload filtering in Kubernetes environments
+type k8sCELFilteringSuite struct {
+	k8sFilteringSuiteBase
+}
+
+// TestK8SCELFilteringSuite runs the Kubernetes CEL filtering test suite
+func TestK8SCELFilteringSuite(t *testing.T) {
+	e2e.Run(t, &k8sCELFilteringSuite{}, e2e.WithProvisioner(
+		awskubernetes.KindProvisioner(
+			awskubernetes.WithAgentOptions(
+				kubernetesagentparams.WithAgentFullImagePath("public.ecr.aws/datadog/agent:7.73.0-rc.6"),
+				kubernetesagentparams.WithHelmValues(celContainerExcludeConfig),
+			),
+			awskubernetes.WithDeployTestWorkload(),
+			// Deploy additional nginx workload except in an excluded namespace
+			awskubernetes.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
+				return nginx.K8sAppDefinition(e, kubeProvider, filteredNamespace, "", false, nil)
+			}),
+		),
+	))
 }

--- a/test/new-e2e/tests/containers/filtering_test.go
+++ b/test/new-e2e/tests/containers/filtering_test.go
@@ -10,16 +10,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/nginx"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/redis"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
-	"github.com/DataDog/test-infra-definitions/common/config"
-	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
-	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
-	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
-	kubeComp "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 )
 
@@ -131,7 +131,6 @@ func TestK8SCELFilteringSuite(t *testing.T) {
 	e2e.Run(t, &k8sCELFilteringSuite{}, e2e.WithProvisioner(
 		awskubernetes.KindProvisioner(
 			awskubernetes.WithAgentOptions(
-				kubernetesagentparams.WithAgentFullImagePath("public.ecr.aws/datadog/agent:7.73.0-rc.6"),
 				kubernetesagentparams.WithHelmValues(celContainerExcludeConfig),
 			),
 			awskubernetes.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {

--- a/test/new-e2e/tests/containers/filtering_test.go
+++ b/test/new-e2e/tests/containers/filtering_test.go
@@ -1,0 +1,263 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package containers
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/datadog-agent/test/fakeintake/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	localkubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/local/kubernetes"
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
+	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/test-infra-definitions/components/kubernetes"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+)
+
+// k8sFilteringSuite tests container filtering behavior in Kubernetes environments
+type k8sFilteringSuite struct {
+	baseSuite[environments.Kubernetes]
+}
+
+const (
+	filteredAppName      = "filtered-nginx"
+	filteredAppNamespace = "workload-filtering"
+)
+
+// TestK8SFilteringSuite runs the Kubernetes filtering test suite
+func TestK8SFilteringSuite(t *testing.T) {
+	e2e.Run(t, &k8sFilteringSuite{}, e2e.WithProvisioner(
+		localkubernetes.Provisioner(
+			localkubernetes.WithAgentOptions(
+				// Configure agent to exclude containers matching the filter
+				kubernetesagentparams.WithHelmValues(`
+datadog:
+  containerExclude: "name:filtered-.*"
+`),
+			),
+			localkubernetes.WithWorkloadApp(deployFilteredNginxWorkload),
+		),
+	))
+}
+
+func (suite *k8sFilteringSuite) SetupSuite() {
+	suite.baseSuite.SetupSuite()
+	suite.Fakeintake = suite.Env().FakeIntake.Client()
+	suite.clusterName = suite.Env().KubernetesCluster.ClusterName
+}
+
+// TestFilteredContainerNoMetrics verifies that the container core check does not collect
+// telemetry for containers that match the exclusion filter
+func (suite *k8sFilteringSuite) TestFilteredContainerNoMetrics() {
+	ctx := context.Background()
+
+	// Wait for the workload to be deployed and running
+	suite.EventuallyWithT(func(c *assert.CollectT) {
+		deployment, err := suite.Env().KubernetesCluster.Client().AppsV1().Deployments(filteredAppNamespace).Get(
+			ctx,
+			filteredAppName,
+			metav1.GetOptions{},
+		)
+		assert.NoError(c, err, "Failed to get filtered nginx deployment")
+		if deployment != nil {
+			assert.Greater(c, deployment.Status.ReadyReplicas, int32(0), "No ready replicas for filtered nginx")
+		}
+	}, 2*time.Minute, 10*time.Second)
+
+	// Wait a reasonable time for metrics to potentially arrive (if filtering is broken)
+	time.Sleep(30 * time.Second)
+
+	// Query for container metrics that should NOT exist for the filtered container
+	containerMetrics := []string{
+		"container.cpu.usage",
+		"container.memory.usage",
+		"container.memory.working_set",
+		"container.io.read_bytes",
+		"container.io.write_bytes",
+	}
+
+	for _, metricName := range containerMetrics {
+		suite.Run(metricName, func() {
+			metrics, err := suite.Fakeintake.FilterMetrics(
+				metricName,
+				client.WithTags[*aggregator.MetricSeries]([]string{
+					`container_name:` + filteredAppName,
+				}),
+			)
+			suite.NoError(err, "Error querying metrics")
+			suite.Empty(metrics, "Expected no %s metrics for filtered container %s, but found %d metrics",
+				metricName, filteredAppName, len(metrics))
+		})
+	}
+
+	// Also verify Kubernetes-specific metrics are not collected
+	k8sMetrics := []string{
+		"kubernetes.cpu.usage.total",
+		"kubernetes.memory.usage",
+		"kubernetes.memory.working_set",
+	}
+
+	for _, metricName := range k8sMetrics {
+		suite.Run(metricName, func() {
+			metrics, err := suite.Fakeintake.FilterMetrics(
+				metricName,
+				client.WithTags[*aggregator.MetricSeries]([]string{
+					`kube_container_name:` + filteredAppName,
+				}),
+			)
+			suite.NoError(err, "Error querying metrics")
+			suite.Empty(metrics, "Expected no %s metrics for filtered container %s, but found %d metrics",
+				metricName, filteredAppName, len(metrics))
+		})
+	}
+}
+
+// TestFilteredContainerNoAutodiscovery verifies that integrations are NOT auto-discovered
+// on containers that match the exclusion filter, even if they have AD annotations
+func (suite *k8sFilteringSuite) TestFilteredContainerNoAutodiscovery() {
+	ctx := context.Background()
+
+	// Wait for the workload to be deployed and running
+	suite.EventuallyWithT(func(c *assert.CollectT) {
+		deployment, err := suite.Env().KubernetesCluster.Client().AppsV1().Deployments(filteredAppNamespace).Get(
+			ctx,
+			filteredAppName,
+			metav1.GetOptions{},
+		)
+		assert.NoError(c, err, "Failed to get filtered nginx deployment")
+		if deployment != nil {
+			assert.Greater(c, deployment.Status.ReadyReplicas, int32(0), "No ready replicas for filtered nginx")
+		}
+	}, 2*time.Minute, 10*time.Second)
+
+	// Wait a reasonable time for autodiscovery to potentially occur (if filtering is broken)
+	time.Sleep(30 * time.Second)
+
+	// Query for nginx integration metrics that should NOT exist
+	nginxMetrics := []string{
+		"nginx.net.request_per_s",
+		"nginx.net.conn_active",
+		"nginx.net.conn_reading",
+		"nginx.net.conn_writing",
+		"nginx.net.conn_waiting",
+	}
+
+	for _, metricName := range nginxMetrics {
+		suite.Run(metricName, func() {
+			metrics, err := suite.Fakeintake.FilterMetrics(
+				metricName,
+				client.WithTags[*aggregator.MetricSeries]([]string{
+					`kube_container_name:` + filteredAppName,
+				}),
+			)
+			suite.NoError(err, "Error querying metrics")
+			suite.Empty(metrics, "Expected no nginx integration metric %s for filtered container, but found %d metrics",
+				metricName, len(metrics))
+		})
+	}
+
+	// Verify that no nginx check runs exist for the filtered container
+	suite.Run("check_runs", func() {
+		checkRuns, err := suite.Fakeintake.FilterCheckRuns("nginx")
+		suite.NoError(err, "Error querying check runs")
+
+		// Filter check runs to find any that match our filtered container
+		filteredCheckRuns := make([]*aggregator.CheckRun, 0)
+		for _, checkRun := range checkRuns {
+			for _, tag := range checkRun.Tags {
+				if matched, _ := regexp.MatchString(`kube_container_name:`+filteredAppName, tag); matched {
+					filteredCheckRuns = append(filteredCheckRuns, checkRun)
+					break
+				}
+			}
+		}
+
+		suite.Empty(filteredCheckRuns, "Expected no nginx check runs for filtered container, but found %d check runs",
+			len(filteredCheckRuns))
+	})
+}
+
+// deployFilteredNginxWorkload deploys an nginx application with autodiscovery annotations
+// but with a name that matches the container exclusion filter
+func deployFilteredNginxWorkload(e config.Env, kubeProvider *kubernetes.Provider) (*kubeComp.Workload, error) {
+	namespace, err := corev1.NewNamespace(e.Ctx(), e.Namer().ResourceName(filteredAppNamespace), &corev1.NamespaceArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name: pulumi.String(filteredAppNamespace),
+		},
+	}, pulumi.Provider(kubeProvider))
+	if err != nil {
+		return nil, err
+	}
+
+	// Deploy nginx with autodiscovery annotations
+	// The container name matches the filter pattern "name:filtered-.*"
+	// so it should be excluded despite having AD annotations
+	deployment, err := appsv1.NewDeployment(e.Ctx(), e.Namer().ResourceName(filteredAppName), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String(filteredAppName),
+			Namespace: namespace.Metadata.Name(),
+			Annotations: pulumi.StringMap{
+				// Autodiscovery annotations for nginx integration
+				"ad.datadoghq.com/filtered-nginx.check_names":  pulumi.String(`["nginx"]`),
+				"ad.datadoghq.com/filtered-nginx.init_configs": pulumi.String(`[{}]`),
+				"ad.datadoghq.com/filtered-nginx.instances":    pulumi.String(`[{"nginx_status_url": "http://%%host%%:8080/nginx_status"}]`),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String(filteredAppName),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String(filteredAppName),
+					},
+					Annotations: pulumi.StringMap{
+						// Pod-level annotations for autodiscovery
+						"ad.datadoghq.com/filtered-nginx.check_names":  pulumi.String(`["nginx"]`),
+						"ad.datadoghq.com/filtered-nginx.init_configs": pulumi.String(`[{}]`),
+						"ad.datadoghq.com/filtered-nginx.instances":    pulumi.String(`[{"nginx_status_url": "http://%%host%%:8080/nginx_status"}]`),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String(filteredAppName),
+							Image: pulumi.String("ghcr.io/datadog/apps-nginx:" + apps.Version),
+							Ports: corev1.ContainerPortArray{
+								&corev1.ContainerPortArgs{
+									ContainerPort: pulumi.Int(8080),
+									Name:          pulumi.String("http"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, pulumi.Provider(kubeProvider), pulumi.DependsOn([]pulumi.Resource{namespace}))
+	if err != nil {
+		return nil, err
+	}
+
+	return &kubeComp.Workload{
+		Deployment: deployment,
+	}, nil
+}

--- a/test/new-e2e/tests/containers/fixtures/datadog-agent-cel-exclude.yml
+++ b/test/new-e2e/tests/containers/fixtures/datadog-agent-cel-exclude.yml
@@ -1,9 +1,8 @@
 datadog:
-  env:
-    - name: DD_CEL_WORKLOAD_EXCLUDE
-      value: |-
-        - products: ["global"]
-          rules:
-            containers:
-            - container.name == "redis"
-            - container.pod.namespace == "filtered-ns"
+  envDict:
+    DD_CEL_WORKLOAD_EXCLUDE: |-
+      - products: ["global"]
+        rules:
+          containers:
+          - container.name == "redis"
+          - container.pod.namespace == "filtered-ns"

--- a/test/new-e2e/tests/containers/fixtures/datadog-agent-cel-exclude.yml
+++ b/test/new-e2e/tests/containers/fixtures/datadog-agent-cel-exclude.yml
@@ -1,0 +1,9 @@
+datadog:
+  env:
+    - name: DD_CEL_WORKLOAD_EXCLUDE
+      value: |-
+        - products: ["global"]
+          rules:
+            containers:
+            - container.name == "redis"
+            - container.pod.namespace == "filtered-ns"

--- a/test/new-e2e/tests/containers/fixtures/datadog-agent-legacy-exclude.yml
+++ b/test/new-e2e/tests/containers/fixtures/datadog-agent-legacy-exclude.yml
@@ -1,0 +1,2 @@
+datadog:
+  containerExclude: "kube_namespace:filtered-ns name:redis*"


### PR DESCRIPTION
### What does this PR do?

Adds e2e test suite for container filtering including autodiscovery filtering. Both legacy and cel container exclude options are tested against the same test suite to confirm feature parity and consistency in behaviour.

### Motivation

Faulty container filtering can mean large numbers of unwanted metrics/logs being unknowingly sent to DD, resulting in changes in billing or noisy metrics/logs. Adding e2e tests ensures reliability for this component and any future changes.

### Describe how you validated your changes

- e2e test CI is green ✅ 

### Additional Notes

Test suites are usually grouped by environment instead of feature under `new-e2e/tests/containers`, however for this type of test, we need them to be separate otherwise filtering will have side effects on other workloads. Managing these side effects, updating and revering the env just for these tests is much more complicated when added as part of another suite.
