### PR TITLE
[AGENTCFG-466] Fetch vmSize from azure instance metadata

### DIFF
--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -95,6 +95,23 @@ func GetNTPHosts(ctx context.Context) []string {
 	return nil
 }
 
+var instanceTypeFetcher = cachedfetch.Fetcher{
+	Name: "Azure Instance Type",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		instanceType, err := getResponse(ctx,
+			metadataURL+"/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text")
+		if err != nil {
+			return "", fmt.Errorf("failed to get Azure instance type: %s", err)
+		}
+		return instanceType, nil
+	},
+}
+
+// GetInstanceType returns the instance type as reported by Azure instance metadata.
+func GetInstanceType(ctx context.Context) (string, error) {
+	return instanceTypeFetcher.FetchString(ctx)
+}
+
 func getResponseWithMaxLength(ctx context.Context, endpoint string, maxLength int) (string, error) {
 	result, err := getResponse(ctx, endpoint)
 	if err != nil {

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -220,3 +220,23 @@ func TestGetCCRID(t *testing.T) {
 	assert.Equal(t, "/metadata/instance/compute/resourceId", lastRequest.URL.Path)
 	assert.Equal(t, "api-version=2021-02-01&format=text", lastRequest.URL.RawQuery)
 }
+
+func TestInstanceType(t *testing.T) {
+	ctx := context.Background()
+	expected := "Standard_E2s_v3"
+
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, expected)
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	instanceType, err := GetInstanceType(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, instanceType)
+	assert.Equal(t, "/metadata/instance/compute/vmSize", lastRequest.URL.Path)
+	assert.Equal(t, "api-version=2021-02-01&format=text", lastRequest.URL.RawQuery)
+}

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -229,6 +229,7 @@ var hostInstanceTypeDetectors = map[string]cloudProviderInstanceTypeDetector{
 	ec2.CloudProviderName:    ec2.GetInstanceType,
 	gce.CloudProviderName:    gce.GetInstanceType,
 	oracle.CloudProviderName: oracle.GetInstanceType,
+	azure.CloudProviderName:  azure.GetInstanceType,
 }
 
 // GetInstanceType returns the instance type from the first cloud provider that works.


### PR DESCRIPTION
### What does this PR do?

On Azure, fetch the vmSize (instance type, in other clouds) from the instance metadata endpoint. It will be sent as part of the inventory payload.

### Motivation

https://docs.google.com/document/d/1lQiJII2b4R8TzvPElg9Q8ynMqdMg3GHapQ_rVQFmFAQ/edit?tab=t.0

### Describe how you validated your changes

1. Created a VM on Azure
2. Downloaded the deb package from `agent_deb-x64-a7` and installed it on my VM
3. Created a flare, unzipped the flare to see that `metadata/inventory/host.json` contained the instance-type field that matched my VM size.

### Additional Notes
