### PR TITLE
[ABLD-291] Install zlib license from deps instead of omnibus script.

### DIFF
--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -35,7 +35,8 @@
 
 """Agent specific BUILD file for zlib."""
 
-load("@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
@@ -53,10 +54,6 @@ license(
     license_text = "LICENSE",
     visibility = ["//visibility:public"],
 )
-
-exports_files([
-    "LICENSE",
-])
 
 _ZLIB_PUBLIC_HEADERS = [
     "zconf.h",
@@ -168,9 +165,28 @@ pkg_install(
     ],
 )
 
+copy_file(
+    name = "renamed_license",
+    src = ":LICENSE",
+    out = "zlib-zlib.license",
+)
+
+pkg_files(
+    name = "license_files",
+    srcs = [
+        ":renamed_license",
+    ],
+)
+
+pkg_install(
+    name = "install_license",
+    srcs = [
+        ":license_files",
+    ],
+)
+
 # buildifier: disable=no-effect
 """
-TODO: Syntheizes license file up to licenses.csv
 TODO: patch source: "zlib-windows-relocate.patch", env: env
 
 build do

--- a/omnibus/config/software/zlib.rb
+++ b/omnibus/config/software/zlib.rb
@@ -15,11 +15,8 @@
 #
 
 name "zlib"
-default_version "1.3.1"
 
 build do
-  license "Zlib"
-  license_file "https://gist.githubusercontent.com/remh/77877aa00b45c1ebc152/raw/372a65de9f4c4ed376771b8d2d0943da83064726/zlib.license"
-
   command_on_repo_root "bazelisk run -- @zlib//:install --destdir='#{install_dir}/embedded'"
+  command_on_repo_root "bazelisk run -- @zlib//:install_license --destdir='#{install_dir}/LICENSES'"
 end


### PR DESCRIPTION
- Use pkg_install to rename LICENSE to 'zlib-zlib.license', which is the current name found in /opt/datadog/LICENSES
  - This is for consistency with what exists. We could automate things better if we rename it to zlib.LICENSE. But I want to defer that decision until I can write an RFC about a lot of license things.
  - Obviously, we can do better once we use license gathering to find and install these things.
- Remove enough from the ruby script so we do not do downloads any more.

The intent of the change is to prove that removing the version numbers from the ruby scripts does not break releases.
If that works, I'll come back and design a more elegant solution.  But I don't want to do that until I write an RFC about how to handle license collection better. 

# Tested
- Look at the current value of the license. For most of us, that is `/opt/datadog-agent/LICENSES/zlib-zlib.license`. 
```
ls -l /opt/datadog-agent/LICENSES/zlib-zlib.license
-rw-r--r--  1 root  wheel  1106 Aug 26 11:18 /opt/datadog-agent/LICENSES/zlib-zlib.license
```
- Grab the currently built artifact. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1233429851/artifacts/file/omnibus/pkg/datadog-agent_7.74.0~devel.git.254.831da84.pipeline.82300936-1_amd64.deb
```
ar x datadog-agent_7.74.0~devel.git.254.831da84.pipeline.82300936-1_amd64.deb data.tar.xz
tar xf data.tar.xz ./opt/datadog-agent/LICENSES/zlib-zlib.license
ls -l ./opt/datadog-agent/LICENSES/zlib-zlib.license
-rw-r--r--  1 tony.aiuto  staff  1002 Nov 13 12:58 ./opt/datadog-agent/LICENSES/zlib-zlib.license
```

The size difference is expected, and correct. Because now we are including [the actual license file in the release](https://github.com/madler/zlib/blob/develop/LICENSE), rather than the one pulled from https://gist.githubusercontent.com/remh/77877aa00b45c1ebc152/raw/372a65de9f4c4ed376771b8d2d0943da83064726/zlib.license