### PR TITLE
smp: update cli from v0.24.1 to v0.25.0

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -97,7 +97,7 @@ single-machine-performance-regression_detector:
       - outputs/decision_record.md # for posterity, this is appended to final PR comment
     when: always
   variables:
-    SMP_VERSION: 0.24.1
+    SMP_VERSION: 0.25.0
   # See 'decision_record.md' for the determination of whether this job passes or fails.
   allow_failure: false
   retry: !reference [.retry_only_infra_failure, retry]


### PR DESCRIPTION
### What does this PR do?

To keep the SMP CLI version used up-to-date with the current backend release series, this pull request updates the SMP CLI version used in Agent CI from v0.24.1 to v0.25.0.

### Motivation

See above.

### Describe how you validated your changes

This pull request.

### Additional Notes

n/a