### PR TITLE
Revert "[AGENTRUN-859] Remove loader process from heroku package"

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -149,7 +149,7 @@ build do
     move 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"
   end
 
-  if linux_target? and !heroku_target?
+  if linux_target?
     command "dda inv -- -e loader.build --install-path=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
     copy "bin/trace-loader/trace-loader", "#{install_dir}/embedded/bin"
   end


### PR DESCRIPTION
[#incident-45629](https://dd.enterprise.slack.com/archives/C09T1TR7R7B).
Following jobs fail consistently after the PR got merged to `main`:
- `new-e2e-agent-platform-install-script-debian-heroku-agent-a7-x86_64`
- `new-e2e-agent-platform-install-script-ubuntu-heroku-agent-a7-x86_64`

Reverts DataDog/datadog-agent#42965