### PR TITLE
[SYNTH-22914] Use ignored context from Run.

### DIFF
--- a/pkg/networkpath/traceroute/sysprobe.go
+++ b/pkg/networkpath/traceroute/sysprobe.go
@@ -19,10 +19,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, tcpSynParisTracerouteMode bool, disableWindowsDriver bool, reverseDNS bool, maxTTL uint8, timeout time.Duration, tracerouteQueries int, e2eQueries int) ([]byte, error) {
+func getTraceroute(ctx context.Context, client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, tcpSynParisTracerouteMode bool, disableWindowsDriver bool, reverseDNS bool, maxTTL uint8, timeout time.Duration, tracerouteQueries int, e2eQueries int) ([]byte, error) {
 	httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second // allow extra time for the system probe communication overhead, calculate full timeout for TCP traceroute
 	log.Tracef("Network Path traceroute HTTP request timeout: %s", httpTimeout)
-	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
 	defer cancel()
 
 	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s&tcp_method=%s&tcp_syn_paris_traceroute_mode=%t&disable_windows_driver=%t&reverse_dns=%t&traceroute_queries=%d&e2e_queries=%d", host, clientID, port, maxTTL, timeout, protocol, tcpMethod, tcpSynParisTracerouteMode, disableWindowsDriver, reverseDNS, tracerouteQueries, e2eQueries))

--- a/pkg/networkpath/traceroute/sysprobe_test.go
+++ b/pkg/networkpath/traceroute/sysprobe_test.go
@@ -6,6 +6,7 @@
 package traceroute
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -89,6 +90,7 @@ func TestGetTracerouteURL(t *testing.T) {
 			}
 
 			_, err := getTraceroute(
+				context.TODO(),
 				mockClient,
 				tt.clientID,
 				tt.host,

--- a/pkg/networkpath/traceroute/traceroute_unix.go
+++ b/pkg/networkpath/traceroute/traceroute_unix.go
@@ -41,8 +41,8 @@ func New(cfg config.Config, _ telemetry.Component) (*UnixTraceroute, error) {
 }
 
 // Run executes a traceroute
-func (l *UnixTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.TCPSynParisTracerouteMode, l.cfg.DisableWindowsDriver, l.cfg.ReverseDNS, l.cfg.MaxTTL, l.cfg.Timeout, l.cfg.TracerouteQueries, l.cfg.E2eQueries)
+func (l *UnixTraceroute) Run(ctx context.Context) (payload.NetworkPath, error) {
+	resp, err := getTraceroute(ctx, l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.TCPSynParisTracerouteMode, l.cfg.DisableWindowsDriver, l.cfg.ReverseDNS, l.cfg.MaxTTL, l.cfg.Timeout, l.cfg.TracerouteQueries, l.cfg.E2eQueries)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}

--- a/pkg/networkpath/traceroute/traceroute_windows.go
+++ b/pkg/networkpath/traceroute/traceroute_windows.go
@@ -43,8 +43,8 @@ func New(cfg config.Config, _ telemetry.Component) (*WindowsTraceroute, error) {
 }
 
 // Run executes a traceroute
-func (w *WindowsTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.TCPSynParisTracerouteMode, w.cfg.DisableWindowsDriver, w.cfg.ReverseDNS, w.cfg.MaxTTL, w.cfg.Timeout, w.cfg.TracerouteQueries, w.cfg.E2eQueries)
+func (w *WindowsTraceroute) Run(ctx context.Context) (payload.NetworkPath, error) {
+	resp, err := getTraceroute(ctx, w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.TCPSynParisTracerouteMode, w.cfg.DisableWindowsDriver, w.cfg.ReverseDNS, w.cfg.MaxTTL, w.cfg.Timeout, w.cfg.TracerouteQueries, w.cfg.E2eQueries)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}


### PR DESCRIPTION
### What does this PR do?

The run traceroute get a context that is ignored. This doesn't help if we want to have the timeout outside of the Run (later) or when we cancel the transaction(shutdown).

This PR just use the context passed to the run method.

### Motivation

### Describe how you validated your changes

### Additional Notes
