### PR TITLE
Revert "[WP] Add user session ID as part of the process_context_t in kernel events (#41124)"

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -91,15 +91,7 @@ static struct proc_cache_t *__attribute__((always_inline)) fill_process_context_
         data->is_kworker = 1;
     }
 
-    struct pid_cache_t *pid_entry = get_pid_cache(tgid);
-    if (!pid_entry) {
-        return NULL;
-    }
-
-    // copy user session id
-    data->user_session_id = pid_entry->user_session_id;
-
-    struct proc_cache_t *pc = get_proc_from_cookie(pid_entry->cookie);
+    struct proc_cache_t *pc = get_proc_cache(tgid);
     if (pc) {
         data->inode = pc->entry.executable.path_key.ino;
     }

--- a/pkg/security/ebpf/c/include/structs/events_context.h
+++ b/pkg/security/ebpf/c/include/structs/events_context.h
@@ -30,7 +30,6 @@ struct process_context_t {
     u32 netns;
     u32 is_kworker;
     u64 inode;
-    u64 user_session_id;
 };
 
 struct ktimeval {

--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -33,8 +33,8 @@ const (
 	// raw packet data, see kernel definition
 	// pahole /opt/datadog-agent/embedded/share/system-probe/ebpf/runtime-security-syscall-wrapper.o -y raw_packet_event_t -E --structs -V
 	structRawPacketEventPidOffset      = 16
-	structRawPacketEventCgroupIdOffset = 72
-	structRawPacketEventDataOffset     = 100
+	structRawPacketEventCgroupIdOffset = 64
+	structRawPacketEventDataOffset     = 92
 
 	// payload size
 	structRawPacketEventDataSize = 256

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -635,13 +635,9 @@ func (fh *EBPFFieldHandlers) ResolveProcessCreatedAt(_ *model.Event, e *model.Pr
 }
 
 // ResolveUserSessionContext resolves and updates the provided user session context
-func (fh *EBPFFieldHandlers) ResolveUserSessionContext(event *model.Event, evtCtx *model.UserSessionContext) {
+func (fh *EBPFFieldHandlers) ResolveUserSessionContext(evtCtx *model.UserSessionContext) {
 	if !evtCtx.Resolved {
-		id := evtCtx.ID
-		if id == 0 {
-			id = event.ProcessContext.UserSessionID
-		}
-		ctx := fh.resolvers.UserSessionsResolver.ResolveUserSession(id)
+		ctx := fh.resolvers.UserSessionsResolver.ResolveUserSession(evtCtx.ID)
 		if ctx != nil {
 			*evtCtx = *ctx
 		}
@@ -742,20 +738,20 @@ func (fh *EBPFFieldHandlers) ResolveFileMetadataIsGarbleObfuscated(event *model.
 }
 
 // ResolveK8SUsername resolves the k8s username of the event
-func (fh *EBPFFieldHandlers) ResolveK8SUsername(event *model.Event, evtCtx *model.UserSessionContext) string {
-	fh.ResolveUserSessionContext(event, evtCtx)
+func (fh *EBPFFieldHandlers) ResolveK8SUsername(_ *model.Event, evtCtx *model.UserSessionContext) string {
+	fh.ResolveUserSessionContext(evtCtx)
 	return evtCtx.K8SUsername
 }
 
 // ResolveK8SUID resolves the k8s UID of the event
-func (fh *EBPFFieldHandlers) ResolveK8SUID(event *model.Event, evtCtx *model.UserSessionContext) string {
-	fh.ResolveUserSessionContext(event, evtCtx)
+func (fh *EBPFFieldHandlers) ResolveK8SUID(_ *model.Event, evtCtx *model.UserSessionContext) string {
+	fh.ResolveUserSessionContext(evtCtx)
 	return evtCtx.K8SUID
 }
 
 // ResolveK8SGroups resolves the k8s groups of the event
-func (fh *EBPFFieldHandlers) ResolveK8SGroups(event *model.Event, evtCtx *model.UserSessionContext) []string {
-	fh.ResolveUserSessionContext(event, evtCtx)
+func (fh *EBPFFieldHandlers) ResolveK8SGroups(_ *model.Event, evtCtx *model.UserSessionContext) []string {
+	fh.ResolveUserSessionContext(evtCtx)
 	return evtCtx.K8SGroups
 }
 

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -438,8 +438,7 @@ func (fh *EBPFLessFieldHandlers) ResolveHashesFromEvent(ev *model.Event, f *mode
 }
 
 // ResolveUserSessionContext resolves and updates the provided user session context
-func (fh *EBPFLessFieldHandlers) ResolveUserSessionContext(_ *model.Event, _ *model.UserSessionContext) {
-}
+func (fh *EBPFLessFieldHandlers) ResolveUserSessionContext(_ *model.UserSessionContext) {}
 
 // ResolveProcessCmdArgv resolves the command line
 func (fh *EBPFLessFieldHandlers) ResolveProcessCmdArgv(ev *model.Event, process *model.Process) []string {

--- a/pkg/security/secl/model/model_helpers_unix.go
+++ b/pkg/security/secl/model/model_helpers_unix.go
@@ -379,7 +379,7 @@ func (dfh *FakeFieldHandlers) ResolveHashes(_ EventType, _ *Process, _ *FileEven
 }
 
 // ResolveUserSessionContext resolves and updates the provided user session context
-func (dfh *FakeFieldHandlers) ResolveUserSessionContext(_ *Event, _ *UserSessionContext) {}
+func (dfh *FakeFieldHandlers) ResolveUserSessionContext(_ *UserSessionContext) {}
 
 // ResolveAWSSecurityCredentials resolves and updates the AWS security credentials of the input process entry
 func (dfh *FakeFieldHandlers) ResolveAWSSecurityCredentials(_ *Event) []AWSSecurityCredentials {
@@ -405,7 +405,7 @@ const (
 type ExtraFieldHandlers interface {
 	BaseExtraFieldHandlers
 	ResolveHashes(eventType EventType, process *Process, file *FileEvent) []string
-	ResolveUserSessionContext(event *Event, evtCtx *UserSessionContext)
+	ResolveUserSessionContext(evtCtx *UserSessionContext)
 	ResolveAWSSecurityCredentials(event *Event) []AWSSecurityCredentials
 	ResolveSyscallCtxArgs(ev *Event, e *SyscallContext)
 }

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -589,12 +589,11 @@ type SELinuxEvent struct {
 
 // PIDContext holds the process context of a kernel event
 type PIDContext struct {
-	Pid           uint32 `field:"pid"` // SECLDoc[pid] Definition:`Process ID of the process (also called thread group ID)`
-	Tid           uint32 `field:"tid"` // SECLDoc[tid] Definition:`Thread ID of the thread`
-	NetNS         uint32 `field:"-"`
-	IsKworker     bool   `field:"is_kworker"` // SECLDoc[is_kworker] Definition:`Indicates whether the process is a kworker`
-	ExecInode     uint64 `field:"-"`          // used to track exec and event loss
-	UserSessionID uint64 `field:"-"`          // used to track user sessions from kernel space
+	Pid       uint32 `field:"pid"` // SECLDoc[pid] Definition:`Process ID of the process (also called thread group ID)`
+	Tid       uint32 `field:"tid"` // SECLDoc[tid] Definition:`Thread ID of the thread`
+	NetNS     uint32 `field:"-"`
+	IsKworker bool   `field:"is_kworker"` // SECLDoc[is_kworker] Definition:`Indicates whether the process is a kworker`
+	ExecInode uint64 `field:"-"`          // used to track exec and event loss
 	// used for ebpfless
 	NSID uint64 `field:"-"`
 }

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -580,7 +580,7 @@ func (e *SELinuxEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself, process_context_t kernel side
 func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 32 {
+	if len(data) < 24 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -589,9 +589,8 @@ func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
 	p.NetNS = binary.NativeEndian.Uint32(data[8:12])
 	p.IsKworker = binary.NativeEndian.Uint32(data[12:16]) > 0
 	p.ExecInode = binary.NativeEndian.Uint64(data[16:24])
-	p.UserSessionID = binary.NativeEndian.Uint64(data[24:32])
 
-	return 32, nil
+	return 24, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -978,7 +978,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 }
 
 func newUserSessionContextSerializer(ctx *model.UserSessionContext, e *model.Event) *UserSessionContextSerializer {
-	e.FieldHandlers.ResolveUserSessionContext(e, ctx)
+	e.FieldHandlers.ResolveUserSessionContext(ctx)
 
 	return &UserSessionContextSerializer{
 		ID:          fmt.Sprintf("%x", ctx.ID),


### PR DESCRIPTION
### Motivation
[#incident-45625](https://slack.com/app_redirect?channel=C09TH6GSAL8&team=T024FSN2Y).
It seems the original PR leads to extra kilobytes: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1230824248
After reverting it: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1232109442

### What does this PR do?
This reverts commit 70e09c4bcb3fa7a5ac24e68655900aa43fdac2e0.