### PR TITLE
AGTMETRICS-340 Trigger container e2e on changes to metrics pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -684,7 +684,7 @@ workflow:
         - comp/core/autodiscovery/listeners/**/*
         - comp/core/autodiscovery/providers/**/*
         - comp/forwarder/defaultforwarder/**/*
-        - comp/serializer/defaultforwarder/**/*
+        - comp/serializer/**/*
         - pkg/aggregator/*/**
         - comp/languagedetection/**/*
         - pkg/clusteragent/admission/mutate/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -683,6 +683,9 @@ workflow:
         - comp/core/workloadmeta/**/*
         - comp/core/autodiscovery/listeners/**/*
         - comp/core/autodiscovery/providers/**/*
+        - comp/forwarder/defaultforwarder/**/*
+        - comp/serializer/defaultforwarder/**/*
+        - pkg/aggregator/*/**
         - comp/languagedetection/**/*
         - pkg/clusteragent/admission/mutate/**/*
         - pkg/collector/corechecks/cluster/**/*


### PR DESCRIPTION
### What does this PR do?

Add rules to trigger container e2e on changes to metrics pipeline

### Motivation

Container e2e tests check delivery of metrics for autoscaling failover, and should run when code that can affect that changes.

Follow up to [#incident-45632](https://dd.enterprise.slack.com/archives/C09SGPGCDDH)

### Describe how you validated your changes

### Additional Notes
