### PR TITLE
[NDMII-3671] Display SNMP default scan progress in status command

### DIFF
--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"maps"
 	"math/rand"
 	"sync"
 	"time"
@@ -370,4 +371,11 @@ func (m *snmpScanManagerImpl) scheduleScanRetry(req snmpscanmanager.ScanRequest,
 		req:        req,
 		nextScanTs: lastScanTs.Add(scanRetryDelays[idx]),
 	})
+}
+
+func (m *snmpScanManagerImpl) cloneDeviceScans() deviceScansByIP {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	return maps.Clone(m.deviceScans)
 }

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/status"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
@@ -61,7 +62,8 @@ type Requires struct {
 
 // Provides defines the output of the snmpscanmanager component
 type Provides struct {
-	Comp snmpscanmanager.Component
+	Comp   snmpscanmanager.Component
+	Status status.InformationProvider
 }
 
 // NewComponent creates a new snmpscanmanager component
@@ -97,7 +99,8 @@ func NewComponent(reqs Requires) (Provides, error) {
 	})
 
 	return Provides{
-		Comp: scanManager,
+		Comp:   scanManager,
+		Status: status.NewInformationProvider(scanManager),
 	}, nil
 }
 

--- a/comp/snmpscanmanager/impl/snmpscanmanager_test.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"maps"
 	"testing"
 	"time"
 
@@ -641,7 +640,7 @@ func TestCacheIsLoaded(t *testing.T) {
 
 			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
 			assert.True(t, ok)
-			assert.Equal(t, tt.buildExpectedDeviceScans(), cloneDeviceScans(scanManager))
+			assert.Equal(t, tt.buildExpectedDeviceScans(), scanManager.cloneDeviceScans())
 
 			assertScanTasks(t, tt.expectedScanTasks, scanManager)
 		})
@@ -882,7 +881,7 @@ func TestQueueDueScans(t *testing.T) {
 }
 
 func assertDeviceScans(t assert.TestingT, expectedDeviceScans deviceScansByIP, scanManager *snmpScanManagerImpl) {
-	actualDeviceScans := cloneDeviceScans(scanManager)
+	actualDeviceScans := scanManager.cloneDeviceScans()
 
 	assert.Equal(t, len(expectedDeviceScans), len(actualDeviceScans))
 	for _, actualScan := range actualDeviceScans {
@@ -925,11 +924,4 @@ func assertScanTasks(t assert.TestingT, expectedScanTasks []*scanTask, scanManag
 
 		assert.Contains(t, expectedScanTasks, actualTask)
 	}
-}
-
-func cloneDeviceScans(m *snmpScanManagerImpl) deviceScansByIP {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	return maps.Clone(m.deviceScans)
 }

--- a/comp/snmpscanmanager/impl/status.go
+++ b/comp/snmpscanmanager/impl/status.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package snmpscanmanagerimpl
+
+import (
+	"embed"
+	"io"
+	"slices"
+
+	"github.com/DataDog/datadog-agent/comp/core/status"
+)
+
+//go:embed status_templates
+var templatesFS embed.FS
+
+// Name renders the name
+func (m *snmpScanManagerImpl) Name() string {
+	return "SNMP"
+}
+
+// Section renders the section
+func (m *snmpScanManagerImpl) Section() string {
+	return "SNMP"
+}
+
+// JSON populates the status map
+func (m *snmpScanManagerImpl) JSON(_ bool, stats map[string]interface{}) error {
+	m.populateStatus(stats)
+
+	return nil
+}
+
+// Text renders the text output
+func (m *snmpScanManagerImpl) Text(_ bool, buffer io.Writer) error {
+	return status.RenderText(templatesFS, "snmpscanmanager.tmpl", buffer, m.getStatusInfo())
+}
+
+// HTML renders the html output
+func (m *snmpScanManagerImpl) HTML(_ bool, buffer io.Writer) error {
+	return status.RenderHTML(templatesFS, "snmpscanmanagerHTML.tmpl", buffer, m.getStatusInfo())
+}
+
+func (m *snmpScanManagerImpl) populateStatus(stats map[string]interface{}) {
+	deviceScans := m.cloneDeviceScans()
+
+	pendingScansCount := len(m.scanQueue)
+
+	successScansCount := 0
+	failedScansIPs := make([]string, 0)
+	for _, scan := range deviceScans {
+		if scan.isSuccess() {
+			successScansCount++
+		}
+		if scan.isFailed() {
+			failedScansIPs = append(failedScansIPs, scan.DeviceIP)
+		}
+	}
+	slices.Sort(failedScansIPs)
+
+	stats["pendingScanCount"] = pendingScansCount
+	stats["successScanCount"] = successScansCount
+	stats["failedScanIPs"] = failedScansIPs
+}
+
+func (m *snmpScanManagerImpl) getStatusInfo() map[string]interface{} {
+	stats := make(map[string]interface{})
+
+	m.populateStatus(stats)
+
+	return stats
+}

--- a/comp/snmpscanmanager/impl/status.go
+++ b/comp/snmpscanmanager/impl/status.go
@@ -16,12 +16,12 @@ import (
 //go:embed status_templates
 var templatesFS embed.FS
 
-// Name renders the name
+// Name returns the name
 func (m *snmpScanManagerImpl) Name() string {
 	return "SNMP"
 }
 
-// Section renders the section
+// Section returns the section
 func (m *snmpScanManagerImpl) Section() string {
 	return "SNMP"
 }

--- a/comp/snmpscanmanager/impl/status_templates/snmpscanmanager.tmpl
+++ b/comp/snmpscanmanager/impl/status_templates/snmpscanmanager.tmpl
@@ -1,0 +1,13 @@
+  Device Scans
+  ============
+  Pending scans count: {{ .pendingScanCount }}
+  Successful scans count: {{ .successScanCount }}
+
+{{- if .failedScanIPs }}
+  Failed scans IPs:
+{{- range $ip := .failedScanIPs }}
+    - {{ $ip }}
+{{- end }}
+{{- else }}
+  No failed scans.
+{{- end }}

--- a/comp/snmpscanmanager/impl/status_templates/snmpscanmanager.tmpl
+++ b/comp/snmpscanmanager/impl/status_templates/snmpscanmanager.tmpl
@@ -1,3 +1,4 @@
+{{- if or (gt .pendingScanCount 0) (gt .successScanCount 0) .failedScanIPs }}
   Device Scans
   ============
   Pending scans count: {{ .pendingScanCount }}
@@ -11,3 +12,4 @@
 {{- else }}
   No failed scans.
 {{- end }}
+{{- end -}}

--- a/comp/snmpscanmanager/impl/status_templates/snmpscanmanagerHTML.tmpl
+++ b/comp/snmpscanmanager/impl/status_templates/snmpscanmanagerHTML.tmpl
@@ -1,5 +1,5 @@
 <div class="stat">
-  <span class="stat_title">Device Scans</span>
+  <span class="stat_title">SNMP Device Scans</span>
   <span class="stat_data">
     Pending scans count: {{ .pendingScanCount }}</br>
     Successful scans count: {{ .successScanCount }}</br>

--- a/comp/snmpscanmanager/impl/status_templates/snmpscanmanagerHTML.tmpl
+++ b/comp/snmpscanmanager/impl/status_templates/snmpscanmanagerHTML.tmpl
@@ -1,0 +1,16 @@
+<div class="stat">
+  <span class="stat_title">Device Scans</span>
+  <span class="stat_data">
+    Pending scans count: {{ .pendingScanCount }}</br>
+    Successful scans count: {{ .successScanCount }}</br>
+
+    {{- if .failedScanIPs }}
+    Failed scans IPs:</br>
+    {{- range $ip := .failedScanIPs }}
+      - {{ $ip }}</br>
+    {{- end }}
+    {{- else }}
+    No failed scans.</br>
+    {{- end }}
+  </span>
+</div>

--- a/comp/snmpscanmanager/impl/status_templates/snmpscanmanagerHTML.tmpl
+++ b/comp/snmpscanmanager/impl/status_templates/snmpscanmanagerHTML.tmpl
@@ -1,3 +1,4 @@
+{{- if or (gt .pendingScanCount 0) (gt .successScanCount 0) .failedScanIPs }}
 <div class="stat">
   <span class="stat_title">SNMP Device Scans</span>
   <span class="stat_data">
@@ -14,3 +15,4 @@
     {{- end }}
   </span>
 </div>
+{{- end -}}

--- a/comp/snmpscanmanager/impl/status_test.go
+++ b/comp/snmpscanmanager/impl/status_test.go
@@ -1,0 +1,193 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package snmpscanmanagerimpl
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	snmpscanmock "github.com/DataDog/datadog-agent/comp/snmpscan/mock"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatus(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name         string
+		scanReqs     []snmpscanmanager.ScanRequest
+		deviceScans  deviceScansByIP
+		expectedJSON map[string]interface{}
+		expectedText string
+		expectedHTML string
+	}{
+		{
+			name:        "no devices",
+			scanReqs:    []snmpscanmanager.ScanRequest{},
+			deviceScans: deviceScansByIP{},
+			expectedJSON: map[string]interface{}{
+				"pendingScanCount": 0,
+				"successScanCount": 0,
+				"failedScanIPs":    []string{},
+			},
+			expectedText: `  Device Scans
+  ============
+  Pending scans count: 0
+  Successful scans count: 0
+  No failed scans.
+`,
+			expectedHTML: `<div class="stat">
+  <span class="stat_title">Device Scans</span>
+  <span class="stat_data">
+    Pending scans count: 0</br>
+    Successful scans count: 0</br>
+    No failed scans.</br>
+  </span>
+</div>
+`,
+		},
+		{
+			name: "multiple devices",
+			scanReqs: []snmpscanmanager.ScanRequest{
+				{
+					DeviceIP: "192.168.0.1",
+				},
+				{
+					DeviceIP: "192.168.0.2",
+				},
+				{
+					DeviceIP: "192.168.0.3",
+				},
+				{
+					DeviceIP: "192.168.0.4",
+				},
+			},
+			deviceScans: deviceScansByIP{
+				"10.0.0.1": deviceScan{
+					DeviceIP:   "10.0.0.1",
+					ScanStatus: successScan,
+					ScanEndTs:  now,
+				},
+				"10.0.0.2": deviceScan{
+					DeviceIP:   "10.0.0.2",
+					ScanStatus: successScan,
+					ScanEndTs:  now,
+				},
+				"10.0.0.3": deviceScan{
+					DeviceIP:   "10.0.0.3",
+					ScanStatus: failedScan,
+					ScanEndTs:  now,
+					Failures:   1,
+				},
+				"10.0.0.4": deviceScan{
+					DeviceIP:   "10.0.0.4",
+					ScanStatus: failedScan,
+					ScanEndTs:  now,
+					Failures:   2,
+				},
+				"10.0.0.5": deviceScan{
+					DeviceIP:   "10.0.0.5",
+					ScanStatus: failedScan,
+					ScanEndTs:  now,
+					Failures:   3,
+				},
+				"10.0.0.6": deviceScan{
+					DeviceIP:   "10.0.0.6",
+					ScanStatus: failedScan,
+					ScanEndTs:  now,
+					Failures:   4,
+				},
+			},
+			expectedJSON: map[string]interface{}{
+				"pendingScanCount": 4,
+				"successScanCount": 2,
+				"failedScanIPs": []string{
+					"10.0.0.3",
+					"10.0.0.4",
+					"10.0.0.5",
+					"10.0.0.6",
+				},
+			},
+			expectedText: `  Device Scans
+  ============
+  Pending scans count: 4
+  Successful scans count: 2
+  Failed scans IPs:
+    - 10.0.0.3
+    - 10.0.0.4
+    - 10.0.0.5
+    - 10.0.0.6
+`,
+			expectedHTML: `<div class="stat">
+  <span class="stat_title">Device Scans</span>
+  <span class="stat_data">
+    Pending scans count: 4</br>
+    Successful scans count: 2</br>
+    Failed scans IPs:</br>
+      - 10.0.0.3</br>
+      - 10.0.0.4</br>
+      - 10.0.0.5</br>
+      - 10.0.0.6</br>
+  </span>
+</div>
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("run_path", testDir)
+
+			mockLifecycle := compdef.NewTestLifecycle(t)
+			mockLogger := logmock.New(t)
+			mockIPC := ipcmock.New(t)
+			mockScanner := snmpscanmock.Mock(t)
+
+			reqs := Requires{
+				Lifecycle:  mockLifecycle,
+				Logger:     mockLogger,
+				Config:     mockConfig,
+				HTTPClient: mockIPC.GetClient(),
+				Scanner:    mockScanner,
+			}
+
+			provides, err := NewComponent(reqs)
+			assert.NoError(t, err)
+
+			scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
+			assert.True(t, ok)
+
+			for _, req := range tt.scanReqs {
+				scanManager.scanQueue <- req
+			}
+			scanManager.deviceScans = tt.deviceScans
+
+			stats := map[string]interface{}{}
+			err = scanManager.JSON(false, stats)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedJSON, stats)
+
+			bf := new(bytes.Buffer)
+			err = scanManager.Text(false, bf)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedText, bf.String())
+
+			bf = new(bytes.Buffer)
+			err = scanManager.HTML(false, bf)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHTML, bf.String())
+		})
+	}
+}

--- a/comp/snmpscanmanager/impl/status_test.go
+++ b/comp/snmpscanmanager/impl/status_test.go
@@ -40,24 +40,54 @@ func TestStatus(t *testing.T) {
 				"successScanCount": 0,
 				"failedScanIPs":    []string{},
 			},
-			expectedText: `  Device Scans
-  ============
-  Pending scans count: 0
-  Successful scans count: 0
-  No failed scans.
-`,
-			expectedHTML: `<div class="stat">
-  <span class="stat_title">Device Scans</span>
-  <span class="stat_data">
-    Pending scans count: 0</br>
-    Successful scans count: 0</br>
-    No failed scans.</br>
-  </span>
-</div>
-`,
+			expectedText: ``,
+			expectedHTML: ``,
 		},
 		{
-			name: "multiple devices",
+			name: "multiple devices without failures",
+			scanReqs: []snmpscanmanager.ScanRequest{
+				{
+					DeviceIP: "192.168.0.1",
+				},
+				{
+					DeviceIP: "192.168.0.2",
+				},
+			},
+			deviceScans: deviceScansByIP{
+				"10.0.0.1": deviceScan{
+					DeviceIP:   "10.0.0.1",
+					ScanStatus: successScan,
+					ScanEndTs:  now,
+				},
+				"10.0.0.2": deviceScan{
+					DeviceIP:   "10.0.0.2",
+					ScanStatus: successScan,
+					ScanEndTs:  now,
+				},
+			},
+			expectedJSON: map[string]interface{}{
+				"pendingScanCount": 2,
+				"successScanCount": 2,
+				"failedScanIPs":    []string{},
+			},
+			expectedText: `
+  Device Scans
+  ============
+  Pending scans count: 2
+  Successful scans count: 2
+  No failed scans.`,
+			expectedHTML: `
+<div class="stat">
+  <span class="stat_title">SNMP Device Scans</span>
+  <span class="stat_data">
+    Pending scans count: 2</br>
+    Successful scans count: 2</br>
+    No failed scans.</br>
+  </span>
+</div>`,
+		},
+		{
+			name: "multiple devices with failures",
 			scanReqs: []snmpscanmanager.ScanRequest{
 				{
 					DeviceIP: "192.168.0.1",
@@ -118,7 +148,8 @@ func TestStatus(t *testing.T) {
 					"10.0.0.6",
 				},
 			},
-			expectedText: `  Device Scans
+			expectedText: `
+  Device Scans
   ============
   Pending scans count: 4
   Successful scans count: 2
@@ -126,10 +157,10 @@ func TestStatus(t *testing.T) {
     - 10.0.0.3
     - 10.0.0.4
     - 10.0.0.5
-    - 10.0.0.6
-`,
-			expectedHTML: `<div class="stat">
-  <span class="stat_title">Device Scans</span>
+    - 10.0.0.6`,
+			expectedHTML: `
+<div class="stat">
+  <span class="stat_title">SNMP Device Scans</span>
   <span class="stat_data">
     Pending scans count: 4</br>
     Successful scans count: 2</br>
@@ -139,8 +170,7 @@ func TestStatus(t *testing.T) {
       - 10.0.0.5</br>
       - 10.0.0.6</br>
   </span>
-</div>
-`,
+</div>`,
 		},
 	}
 

--- a/comp/snmpscanmanager/impl/status_test.go
+++ b/comp/snmpscanmanager/impl/status_test.go
@@ -7,6 +7,7 @@ package snmpscanmanagerimpl
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -209,15 +210,19 @@ func TestStatus(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedJSON, stats)
 
-			bf := new(bytes.Buffer)
-			err = scanManager.Text(false, bf)
+			bText := new(bytes.Buffer)
+			err = scanManager.Text(false, bText)
+			expectedText := strings.ReplaceAll(tt.expectedText, "\r\n", "\n")
+			outText := strings.ReplaceAll(bText.String(), "\r\n", "\n")
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedText, bf.String())
+			assert.Equal(t, expectedText, outText)
 
-			bf = new(bytes.Buffer)
-			err = scanManager.HTML(false, bf)
+			bHTML := new(bytes.Buffer)
+			err = scanManager.HTML(false, bHTML)
+			expectedHTML := strings.ReplaceAll(tt.expectedHTML, "\r\n", "\n")
+			outHTML := strings.ReplaceAll(bHTML.String(), "\r\n", "\n")
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedHTML, bf.String())
+			assert.Equal(t, expectedHTML, outHTML)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds displaying the progress of the SNMP default scans in the status command of the Agent.

CLI:
<img width="1111" height="401" alt="image" src="https://github.com/user-attachments/assets/72fc3d69-e91d-45fd-b76c-ffc876d3e420" />

GUI:
<img width="308" height="228" alt="image" src="https://github.com/user-attachments/assets/b9e02585-f1ce-47f0-b3e1-07a2fabb7ecd" />

### Motivation

### Describe how you validated your changes

### Additional Notes
