### PR TITLE
Make secret backend executables owner read and exec only

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -72,7 +72,7 @@ COPY --from=artifacts --chmod=0755 ./cws-instrumentation/ /opt/datadog-agent/bin
 RUN addgroup --system secret-manager \
     && chmod 755 entrypoint.sh \
     && chown root:secret-manager readsecret.sh readsecret_multiple_providers.sh \
-    && chmod 550 readsecret.sh readsecret_multiple_providers.sh \
+    && chmod 500 readsecret.sh readsecret_multiple_providers.sh \
     && chmod g+r,g+w,g+X -R /etc/datadog-agent/ \
     && chmod +x /opt/datadog-agent/bin/datadog-cluster-agent \
     && ln -s /opt/datadog-agent/bin/datadog-cluster-agent /opt/datadog-agent/bin/agent


### PR DESCRIPTION
### What does this PR do?

Changes the permissions of `readsecret.sh` and `readsecret_multiple_providers.sh` in the cluster-agent container image from 550 to 500.

### Motivation

I see these warning logs from my cluster-agent.

`2025-11-13 14:34:13 UTC | CLUSTER | WARN | (pkg/util/log/log.go:776 in func1) | Agent configuration relax permissions constraint on the secret backend cmd, Group can read and exec`

```
$ datadog-cluster-agent version
Cluster Agent 7.71.1 - Commit: bc04a7846d - Serialization version: v5.0.164 - Go version: go1.24.6
```

in image `gcr.io/datadoghq/cluster-agent:7.71.1@sha256:956d4049c881916d8ae14696cc9ca8166d9db883c08fa093d0b3075521eb46a5`

### Describe how you validated your changes