### PR TITLE
Flaky `tests_nodetreemodel`: fix OTLP `max_recv_msg_size_mib` type conversion

### DIFF
--- a/comp/otelcol/otlp/configcheck/configcheck_common.go
+++ b/comp/otelcol/otlp/configcheck/configcheck_common.go
@@ -54,7 +54,7 @@ func readConfigSection(cfg configmodel.Reader, section string) map[string]interf
 			// deep copy since `cfg.Get` returns a reference
 			var val interface{}
 			if _, ok := intConfigs[key]; ok {
-				val = deepcopy.Copy(cfg.GetInt(key)) // ensure to get an int even if it is set as a string in env vars
+				val = cfg.GetInt(key) // ensure to get an int even if it is set as a string in env vars
 			} else {
 				val = deepcopy.Copy(cfg.Get(key))
 			}


### PR DESCRIPTION
### What does this PR do?
This removes a `deepcopy.Copy`[^1] wrapper around the result of `cfg.GetInt`. The [`GetInt` method](https://pkg.go.dev/github.com/spf13/viper#Viper.GetInt) already returns a native `int` value, and wrapping it in [`deepcopy.Copy`](https://pkg.go.dev/github.com/mohae/deepcopy#Copy) might lead to an ambiguous type:
> [The returned value will need to be asserted to the correct type](https://pkg.go.dev/github.com/mohae/deepcopy#section-readme:~:text=The%20returned%20value%20will%20need%20to%20be%20asserted%20to%20the%20correct%20type).

### Motivation
This is likely the reason of recurring failed `tests_nodetreemodel` jobs in `main` where `max_recv_msg_size_mib` was interpreted as a `string` instead of an `int`:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1227774470
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1229387498
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1230355722
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1233048180
```diff
--- Expected
+++ Actual
@@ -5,3 +5,3 @@
     (string) (len=8) "endpoint": (string) (len=12) "0.0.0.0:9999",
-    (string) (len=21) "max_recv_msg_size_mib": (int) 10
+    (string) (len=21) "max_recv_msg_size_mib": (string) (len=2) "10"
    }
```

### Additional Notes
This should fix #33977 where the `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_MAX_RECV_MSG_SIZE_MIB` environment variable was incorrectly parsed as `string` instead of `int`, (partially?) fixed by #36122.

[^1]: The `deepcopy.Copy` is still necessary for `cfg.Get` calls that return reference types (`map`s, slices), but primitive types like `int` don't need it since they are already passed by value in Go.