### PR TITLE
Use an older version of the docker disk 

### DIFF
--- a/test/new-e2e/system-probe/config/vmconfig-system-probe.json
+++ b/test/new-e2e/system-probe/config/vmconfig-system-probe.json
@@ -11,7 +11,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-x86_64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/yoanngh/add-cws-container-images/docker-x86_64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-x86_64.qcow2",
                     "type": "default"
                 }
@@ -29,7 +29,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-arm64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/yoanngh/add-cws-container-images/docker-arm64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-arm64.qcow2",
                     "type": "default"
                 }


### PR DESCRIPTION
### What does this PR do?
This PR uses an older version of the docker disk from a dev branch to stabilize the agent CI until the root cause of incident-45638 can be found

### Motivation

### Describe how you validated your changes

### Additional Notes
