### PR TITLE
adds permission for update kubernetes job

### DIFF
--- a/.github/chainguard/self.update-kubernetes-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-kubernetes-versions.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:environment:main
+
+claim_pattern:
+  event_name: (workflow_dispatch|schedule)
+  ref: (refs/heads/main|refs/heads/test_release/.*)
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/create_rc_pr\.yml@refs/heads/(main|test_release/.*)
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/chainguard/self.update-kubernetes-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-kubernetes-versions.create-pr.sts.yaml
@@ -5,8 +5,9 @@ subject: repo:DataDog/datadog-agent:environment:main
 
 claim_pattern:
   event_name: (workflow_dispatch|schedule)
-  ref: (refs/heads/main|refs/heads/test_release/.*)
-  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/create_rc_pr\.yml@refs/heads/(main|test_release/.*)
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/update-kubernetes-versions\.yml@refs/heads/main
 
 permissions:
   contents: write


### PR DESCRIPTION
### What does this PR do?
adds octo-sts permission for update-kubernetes-versions github action

### Motivation
failing job - https://github.com/DataDog/datadog-agent/actions/runs/19322127255/job/55265444783

### Describe how you validated your changes

### Additional Notes
