### PR TITLE
APM: Bump evp proxy payload limit to 10 mb for llmobs

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -647,7 +647,7 @@ func New() *AgentConfig {
 		},
 		EVPProxy: EVPProxy{
 			Enabled:        true,
-			MaxPayloadSize: 5 * 1024 * 1024,
+			MaxPayloadSize: 10 * 1024 * 1024,
 		},
 		OpenLineageProxy: OpenLineageProxy{
 			Enabled:    true,

--- a/releasenotes/notes/trace-agent-evp-proxy-max-payload-size-06ab0136144e5f08.yaml
+++ b/releasenotes/notes/trace-agent-evp-proxy-max-payload-size-06ab0136144e5f08.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Increase the default EVP proxy maximum payload size from 5 MB to 10 MB in the Trace Agent.
+


### PR DESCRIPTION
### What does this PR do?
Increase the default limit for this proxy endpoint to 10MB,

### Motivation
this is to support larger LLMOBS payloads

### Describe how you validated your changes
Unit tests are sufficient here, and ML Obs team validated intake is okay

### Additional Notes
