### PR TITLE
[CXP-2850] fix manual rtprocesscheck panic

### DIFF
--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -46,19 +46,23 @@ func makeProcess(pid int32, cmdline string) *procutil.Process {
 	return &procutil.Process{
 		Pid:     pid,
 		Cmdline: strings.Split(cmdline, " "),
-		Stats: &procutil.Stats{
-			CPUPercent: &procutil.CPUPercentStat{
-				UserPct:   float64(rand.Uint64()),
-				SystemPct: float64(rand.Uint64()),
-			},
-			MemInfo: &procutil.MemoryInfoStat{
-				RSS: rand.Uint64(),
-				VMS: rand.Uint64(),
-			},
-			MemInfoEx:   &procutil.MemoryInfoExStat{},
-			IOStat:      &procutil.IOCountersStat{},
-			CtxSwitches: &procutil.NumCtxSwitchesStat{},
+		Stats:   makeProcessStats(pid),
+	}
+}
+
+func makeProcessStats(pid int32) *procutil.Stats {
+	return &procutil.Stats{
+		CPUPercent: &procutil.CPUPercentStat{
+			UserPct:   float64(rand.Uint64()),
+			SystemPct: float64(rand.Uint64()),
 		},
+		MemInfo: &procutil.MemoryInfoStat{
+			RSS: rand.Uint64(),
+			VMS: rand.Uint64(),
+		},
+		MemInfoEx:   &procutil.MemoryInfoExStat{},
+		IOStat:      &procutil.IOCountersStat{},
+		CtxSwitches: &procutil.NumCtxSwitchesStat{},
 	}
 }
 

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -46,11 +46,11 @@ func makeProcess(pid int32, cmdline string) *procutil.Process {
 	return &procutil.Process{
 		Pid:     pid,
 		Cmdline: strings.Split(cmdline, " "),
-		Stats:   makeProcessStats(pid),
+		Stats:   makeProcessStats(),
 	}
 }
 
-func makeProcessStats(pid int32) *procutil.Stats {
+func makeProcessStats() *procutil.Stats {
 	return &procutil.Stats{
 		CPUPercent: &procutil.CPUPercentStat{
 			UserPct:   float64(rand.Uint64()),

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -99,7 +99,7 @@ func fmtProcessStats(
 	now time.Time,
 ) [][]*model.ProcessStat {
 	chunked := make([][]*model.ProcessStat, 0)
-	// set max chunk capacity to len(procs) since it can be set to MaxInt for manual checks
+	// set max chunk capacity to len(procs) since maxBatchSize can be set to MaxInt for manual checks
 	numChunks := len(procs)
 	if maxBatchSize > 0 && maxBatchSize < numChunks {
 		numChunks = maxBatchSize

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -99,12 +99,11 @@ func fmtProcessStats(
 	now time.Time,
 ) [][]*model.ProcessStat {
 	chunked := make([][]*model.ProcessStat, 0)
-	// set max chunk capacity to len(procs) since maxBatchSize can be set to MaxInt for manual checks
-	numChunks := len(procs)
-	if maxBatchSize > 0 && maxBatchSize < numChunks {
-		numChunks = maxBatchSize
+	chunkSize := len(procs)
+	if maxBatchSize > 0 && maxBatchSize < chunkSize {
+		chunkSize = maxBatchSize
 	}
-	chunk := make([]*model.ProcessStat, 0, numChunks)
+	chunk := make([]*model.ProcessStat, 0, chunkSize)
 
 	for pid, fp := range procs {
 		// Skipping any processes that didn't exist in the previous run.

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -99,7 +99,12 @@ func fmtProcessStats(
 	now time.Time,
 ) [][]*model.ProcessStat {
 	chunked := make([][]*model.ProcessStat, 0)
-	chunk := make([]*model.ProcessStat, 0, maxBatchSize)
+	// set max chunk capacity to len(procs) since it can be set to MaxInt for manual checks
+	numChunks := len(procs)
+	if maxBatchSize > 0 && maxBatchSize < numChunks {
+		numChunks = maxBatchSize
+	}
+	chunk := make([]*model.ProcessStat, 0, numChunks)
 
 	for pid, fp := range procs {
 		// Skipping any processes that didn't exist in the previous run.

--- a/pkg/process/checks/process_rt_test.go
+++ b/pkg/process/checks/process_rt_test.go
@@ -146,9 +146,9 @@ func TestFmtProcessStats(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			chunked := fmtProcessStats(tc.maxBatchSize, procs, lastProcs, map[int]string{}, cpu.TimesStat{}, cpu.TimesStat{}, time.Now().Add(-time.Second), time.Now())
-			require.Len(t, chunked, tc.expectedNumChunks)
+			assert.Len(t, chunked, tc.expectedNumChunks)
 			for i, size := range tc.expectedChunkSizes {
-				require.Len(t, chunked[i], size)
+				assert.Len(t, chunked[i], size)
 			}
 		})
 	}

--- a/pkg/process/checks/process_rt_test.go
+++ b/pkg/process/checks/process_rt_test.go
@@ -6,9 +6,12 @@
 package checks
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -86,4 +89,67 @@ func TestProcessCheckRealtimeSecondRun(t *testing.T) {
 	assert.ElementsMatch(t, expected, rt.Stats)
 	assert.Equal(t, int32(1), rt.GroupSize)
 	assert.Equal(t, int32(len(processCheck.hostInfo.SystemInfo.Cpus)), rt.NumCpus)
+}
+
+// TestFmtProcessStats test the chunking logic of fmtProcessStats
+func TestFmtProcessStats(t *testing.T) {
+	procs := map[int32]*procutil.Stats{
+		1: makeProcessStats(1),
+		2: makeProcessStats(2),
+		3: makeProcessStats(3),
+	}
+	lastProcs := map[int32]*procutil.Stats{
+		1: makeProcessStats(1),
+		2: makeProcessStats(2),
+		3: makeProcessStats(3),
+	}
+
+	type testCase struct {
+		description        string
+		maxBatchSize       int
+		expectedNumChunks  int
+		expectedChunkSizes []int
+	}
+	tests := []testCase{
+		{
+			description:        "Chunking - max batch size 1",
+			maxBatchSize:       1,
+			expectedNumChunks:  3,
+			expectedChunkSizes: []int{1, 1, 1},
+		},
+		{
+			description:        "Chunking - max batch size 2",
+			maxBatchSize:       2,
+			expectedNumChunks:  2,
+			expectedChunkSizes: []int{2, 1},
+		},
+		{
+			description:        "No chunking - max batch size",
+			maxBatchSize:       math.MaxInt,
+			expectedNumChunks:  1,
+			expectedChunkSizes: []int{3},
+		},
+		{
+			description:        "No chunking - max batch size 0",
+			maxBatchSize:       0,
+			expectedNumChunks:  1,
+			expectedChunkSizes: []int{3},
+		},
+		{
+			description:        "No chunking - max batch size 10",
+			maxBatchSize:       10,
+			expectedNumChunks:  1,
+			expectedChunkSizes: []int{3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			chunked := fmtProcessStats(tc.maxBatchSize, procs, lastProcs, map[int]string{}, cpu.TimesStat{}, cpu.TimesStat{}, time.Now().Add(-time.Second), time.Now())
+			require.Len(t, chunked, tc.expectedNumChunks)
+			for i, size := range tc.expectedChunkSizes {
+				require.Len(t, chunked[i], size)
+			}
+		})
+	}
 }

--- a/pkg/process/checks/process_rt_test.go
+++ b/pkg/process/checks/process_rt_test.go
@@ -94,14 +94,14 @@ func TestProcessCheckRealtimeSecondRun(t *testing.T) {
 // TestFmtProcessStats test the chunking logic of fmtProcessStats
 func TestFmtProcessStats(t *testing.T) {
 	procs := map[int32]*procutil.Stats{
-		1: makeProcessStats(1),
-		2: makeProcessStats(2),
-		3: makeProcessStats(3),
+		1: makeProcessStats(),
+		2: makeProcessStats(),
+		3: makeProcessStats(),
 	}
 	lastProcs := map[int32]*procutil.Stats{
-		1: makeProcessStats(1),
-		2: makeProcessStats(2),
-		3: makeProcessStats(3),
+		1: makeProcessStats(),
+		2: makeProcessStats(),
+		3: makeProcessStats(),
 	}
 
 	type testCase struct {

--- a/releasenotes/notes/rtprocess-check-panic-fix-05e0ddc9d05da3bd.yaml
+++ b/releasenotes/notes/rtprocess-check-panic-fix-05e0ddc9d05da3bd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a panic that occurs when running a manual cli rtprocess check via `datadog-agent processchecks rtprocess`

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -340,7 +340,7 @@ func (s *linuxTestSuite) TestManualRTProcessCheckCoreAgent() {
 
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
 		check := s.Env().RemoteHost.MustExecute("sudo datadog-agent processchecks rtprocess --json")
-		assertManualProcessCheck(c, check, false, "stress")
+		assertManualRTProcessCheck(c, check)
 	}, 2*time.Minute, 10*time.Second)
 }
 

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -335,6 +335,15 @@ func (s *linuxTestSuite) TestManualProcessCheckCoreAgent() {
 	}, 2*time.Minute, 10*time.Second)
 }
 
+func (s *linuxTestSuite) TestManualRTProcessCheckCoreAgent() {
+	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr))))
+
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		check := s.Env().RemoteHost.MustExecute("sudo datadog-agent processchecks rtprocess --json")
+		assertManualProcessCheck(c, check, false, "stress")
+	}, 2*time.Minute, 10*time.Second)
+}
+
 func (s *linuxTestSuite) TestManualProcessDiscoveryCheck() {
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
 		check := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent check process_discovery --json")

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -367,7 +367,7 @@ func assertManualRTProcessCheck(t require.TestingT, check string) {
 	var rt agentmodel.CollectorRealTime
 	err := json.NewDecoder(strings.NewReader(check)).Decode(&rt)
 	require.NoError(t, err)
-	assert.NotEmpty(t, rt.Stats, "no process stats in realtime output %s", check)
+	assert.NotEmptyf(t, rt.Stats, "no process stats in realtime output %s", check)
 }
 
 // assertManualContainerCheck asserts that the given container is collected from a manual container check

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -367,7 +367,7 @@ func assertManualRTProcessCheck(t require.TestingT, check string) {
 	var rt agentmodel.CollectorRealTime
 	err := json.NewDecoder(strings.NewReader(check)).Decode(&rt)
 	require.NoError(t, err)
-	assert.NotEmpty(t, rt.Stats, "no process stats in realtime output")
+	assert.NotEmpty(t, rt.Stats, "no process stats in realtime output %s", check)
 }
 
 // assertManualContainerCheck asserts that the given container is collected from a manual container check

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -362,6 +362,14 @@ func assertManualProcessCheck(t require.TestingT, check string, withIOStats bool
 	assertManualContainerCheck(t, check, expectedContainers...)
 }
 
+// assertManualRTProcessCheck asserts that the realtime manual check output contains at least one process stat
+func assertManualRTProcessCheck(t require.TestingT, check string) {
+	var rt agentmodel.CollectorRealTime
+	err := json.NewDecoder(strings.NewReader(check)).Decode(&rt)
+	require.NoError(t, err)
+	assert.NotEmpty(t, rt.Stats, "no process stats in realtime output")
+}
+
 // assertManualContainerCheck asserts that the given container is collected from a manual container check
 func assertManualContainerCheck(t require.TestingT, check string, expectedContainers ...string) {
 	var checkOutput struct {


### PR DESCRIPTION
### What does this PR do?
- Fixes panic bug for manual rtprocess check via `datadog-agent processchecks rtprocess` for issue https://github.com/DataDog/datadog-agent/issues/42837
    - we cannot create a slice of size `math.MaxInt`  https://stackoverflow.com/questions/27647737/maximum-length-of-a-slice-in-go

### Motivation
- https://github.com/DataDog/datadog-agent/issues/42837

### Describe how you validated your changes
- added unit tests for failing `fmtProcessStats` function
- added integration test for rtprocess check

### Additional Notes
