### PR TITLE
fix import loop from CertInfo

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -22,7 +22,6 @@ import (
 	networkpayload "github.com/DataDog/datadog-agent/pkg/network/payload"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/tls"
-	ssluprobes "github.com/DataDog/datadog-agent/pkg/network/tracer/connection/ssl-uprobes"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
@@ -259,7 +258,7 @@ type ConnectionStats struct {
 	ContainerID   struct {
 		Source, Dest *intern.Value
 	}
-	CertInfo unique.Handle[ssluprobes.CertInfo]
+	CertInfo unique.Handle[CertInfo]
 	DNSStats map[dns.Hostname]map[dns.QueryType]dns.Stats
 	// TCPFailures stores the number of failures for a POSIX error code
 	TCPFailures map[uint16]uint32
@@ -324,7 +323,7 @@ func (c ConnectionStats) IsEmpty() bool {
 
 // HasCertInfo returns whether the connection has a TLS cert associated
 func (c ConnectionStats) HasCertInfo() bool {
-	return c.CertInfo != unique.Handle[ssluprobes.CertInfo]{}
+	return c.CertInfo != unique.Handle[CertInfo]{}
 }
 
 // ByteKey returns a unique key for this connection represented as a byte slice

--- a/pkg/network/ssl.go
+++ b/pkg/network/ssl.go
@@ -3,8 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package ssluprobes contains the attachment logic for TLS cert collecting uprobes
-package ssluprobes
+package network
 
 import (
 	"time"

--- a/pkg/network/ssl_linux.go
+++ b/pkg/network/ssl_linux.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-package ssluprobes
+package network
 
 import (
 	"encoding/hex"

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -327,7 +327,7 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 	return tr, nil
 }
 
-type lookupCertCb = func(certID uint32, refreshTimestamp bool) unique.Handle[ssluprobes.CertInfo]
+type lookupCertCb = func(certID uint32, refreshTimestamp bool) unique.Handle[network.CertInfo]
 
 func initClosedConnEventHandler(config *config.Config, lookupCert lookupCertCb, closedCallback func(*network.ConnectionStats), pool ddsync.Pool[network.ConnectionStats], extractor *batchExtractor) (*perf.EventHandler, error) {
 	connHasher := newCookieHasher()
@@ -861,17 +861,17 @@ func (t *ebpfTracer) refreshCertTimestamp(certID uint32, certItem *netebpf.CertI
 	return nil
 }
 
-func (t *ebpfTracer) getSSLCertInfo(certID uint32, refreshTimestamp bool) unique.Handle[ssluprobes.CertInfo] {
+func (t *ebpfTracer) getSSLCertInfo(certID uint32, refreshTimestamp bool) unique.Handle[network.CertInfo] {
 	certItem, err := t.lookupSSLCertItem(certID)
 	if err != nil {
 		log.Warnf("getSSLCertInfoAndRefresh failed to lookupSSLCertItem: %s", err)
-		return unique.Handle[ssluprobes.CertInfo]{}
+		return unique.Handle[network.CertInfo]{}
 	}
 	if certItem == nil {
-		return unique.Handle[ssluprobes.CertInfo]{}
+		return unique.Handle[network.CertInfo]{}
 	}
 
-	var certInfo ssluprobes.CertInfo
+	var certInfo network.CertInfo
 	certInfo.FromCertItem(certItem)
 
 	if refreshTimestamp {

--- a/pkg/network/tracer/connection/ssl-uprobes/ebpf_ssl.go
+++ b/pkg/network/tracer/connection/ssl-uprobes/ebpf_ssl.go
@@ -5,6 +5,7 @@
 
 //go:build linux_bpf
 
+// Package ssluprobes contains the attachment logic for TLS cert collecting uprobes
 package ssluprobes
 
 import (

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3223,7 +3223,7 @@ func testTLSCertParsing(t *testing.T, client *http.Client, matcher func(c *netwo
 	require.NoError(t, err)
 	require.Equal(t, 200, code)
 
-	var cert ssluprobes.CertInfo
+	var cert network.CertInfo
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conns, cleanup := getConnections(collect, tr)
 		defer cleanup()


### PR DESCRIPTION
### What does this PR do?

Moves `CertInfo` type into `pkg/network`.

### Motivation

This prevents a possible import loop because importing `pkg/network/tracer/connection/ssl-uprobes` brings a bunch of other imports. Using the data type of `pkg/network.ConnectionStats` should carry limited dependencies.

### Describe how you validated your changes

Existing tests.

### Additional Notes
