### PR TITLE
use netip.Prefix for subnet instead of net.IPNet

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"sync"
 	"time"
@@ -170,16 +169,16 @@ func (s *npCollectorImpl) makePathtest(conn *model.Connection, domain string) co
 	}
 }
 
-func doSubnetsContainIP(subnets []*net.IPNet, ip netip.Addr) bool {
+func doSubnetsContainIP(subnets []netip.Prefix, ip netip.Addr) bool {
 	for _, subnet := range subnets {
-		if subnet.Contains(net.IP(ip.AsSlice())) {
+		if subnet.Contains(ip) {
 			return true
 		}
 	}
 	return false
 }
 
-func (s *npCollectorImpl) checkPassesConnCIDRFilters(conn *model.Connection, vpcSubnets []*net.IPNet) bool {
+func (s *npCollectorImpl) checkPassesConnCIDRFilters(conn *model.Connection, vpcSubnets []netip.Prefix) bool {
 	if len(vpcSubnets) == 0 && len(s.sourceExcludes) == 0 && len(s.destExcludes) == 0 {
 		// this should be most customers - parsing IPs is not necessary
 		return true
@@ -221,7 +220,7 @@ func (s *npCollectorImpl) checkPassesConnCIDRFilters(conn *model.Connection, vpc
 	return true
 
 }
-func (s *npCollectorImpl) shouldScheduleNetworkPathForConn(conn *model.Connection, vpcSubnets []*net.IPNet, domain string) bool {
+func (s *npCollectorImpl) shouldScheduleNetworkPathForConn(conn *model.Connection, vpcSubnets []netip.Prefix, domain string) bool {
 	if conn == nil {
 		return false
 	}
@@ -258,7 +257,7 @@ func (s *npCollectorImpl) shouldScheduleNetworkPathForConn(conn *model.Connectio
 	return true
 }
 
-func (s *npCollectorImpl) getVPCSubnets() ([]*net.IPNet, error) {
+func (s *npCollectorImpl) getVPCSubnets() ([]netip.Prefix, error) {
 	if !s.collectorConfigs.disableIntraVPCCollection {
 		return nil, nil
 	}

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_test.go
@@ -22,19 +22,19 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl/connfilter"
-	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go4.org/netipx"
 
+	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
 	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl/common"
+	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl/connfilter"
 	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
@@ -1482,7 +1482,7 @@ func Test_npCollectorImpl_shouldScheduleNetworkPathForConn(t *testing.T) {
 	tests := []struct {
 		name                   string
 		conn                   *model.Connection
-		vpcSubnets             []*net.IPNet
+		vpcSubnets             []netip.Prefix
 		domain                 string
 		shouldSchedule         bool
 		subnetSkipped          bool
@@ -1579,7 +1579,7 @@ func Test_npCollectorImpl_shouldScheduleNetworkPathForConn(t *testing.T) {
 				Raddr:     &model.Addr{Ip: "10.0.0.2", Port: int32(80)},
 				Direction: model.ConnectionDirection_outgoing,
 			},
-			vpcSubnets:     []*net.IPNet{mustParseCIDR(t, "192.168.0.0/16")},
+			vpcSubnets:     []netip.Prefix{mustParseCIDR(t, "192.168.0.0/16")},
 			shouldSchedule: true,
 			subnetSkipped:  false,
 		},
@@ -1591,7 +1591,7 @@ func Test_npCollectorImpl_shouldScheduleNetworkPathForConn(t *testing.T) {
 				Raddr:     &model.Addr{Ip: "192.168.1.1", Port: int32(80)},
 				Direction: model.ConnectionDirection_outgoing,
 			},
-			vpcSubnets:     []*net.IPNet{mustParseCIDR(t, "192.168.0.0/16")},
+			vpcSubnets:     []netip.Prefix{mustParseCIDR(t, "192.168.0.0/16")},
 			shouldSchedule: false,
 			subnetSkipped:  true,
 		},
@@ -1603,7 +1603,7 @@ func Test_npCollectorImpl_shouldScheduleNetworkPathForConn(t *testing.T) {
 				Raddr:     &model.Addr{Ip: "10.0.0.1", Port: int32(80)},
 				Direction: model.ConnectionDirection_outgoing,
 			},
-			vpcSubnets:     []*net.IPNet{mustParseCIDR(t, "192.168.0.0/16")},
+			vpcSubnets:     []netip.Prefix{mustParseCIDR(t, "192.168.0.0/16")},
 			shouldSchedule: true,
 			subnetSkipped:  false,
 		},
@@ -1619,7 +1619,7 @@ func Test_npCollectorImpl_shouldScheduleNetworkPathForConn(t *testing.T) {
 					ReplDstIP:   "10.1.2.3",
 				},
 			},
-			vpcSubnets:     []*net.IPNet{mustParseCIDR(t, "10.0.0.0/8")},
+			vpcSubnets:     []netip.Prefix{mustParseCIDR(t, "10.0.0.0/8")},
 			shouldSchedule: false,
 			subnetSkipped:  true,
 		},
@@ -1636,7 +1636,7 @@ func Test_npCollectorImpl_shouldScheduleNetworkPathForConn(t *testing.T) {
 					// ReplDstIP is the empty string
 				},
 			},
-			vpcSubnets:     []*net.IPNet{mustParseCIDR(t, "10.0.0.0/8")},
+			vpcSubnets:     []netip.Prefix{mustParseCIDR(t, "10.0.0.0/8")},
 			shouldSchedule: false,
 			subnetSkipped:  true,
 		},
@@ -1833,9 +1833,9 @@ network_path:
 	}
 }
 
-func mustParseCIDR(t *testing.T, cidr string) *net.IPNet {
-	_, ipNet, err := net.ParseCIDR(cidr)
-	assert.Nil(t, err)
+func mustParseCIDR(t *testing.T, cidr string) netip.Prefix {
+	ipNet, err := netip.ParsePrefix(cidr)
+	assert.NoError(t, err)
 	return ipNet
 }
 

--- a/pkg/util/cloudproviders/network/network.go
+++ b/pkg/util/cloudproviders/network/network.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"time"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -74,18 +74,18 @@ func getVPCSubnetsForHostImpl(ctx context.Context) ([]string, error) {
 var getVPCSubnetsForHost = getVPCSubnetsForHostImpl
 
 // GetVPCSubnetsForHost gets all the subnets in the VPCs this host has network interfaces for
-func GetVPCSubnetsForHost(ctx context.Context) ([]*net.IPNet, error) {
-	return cache.GetWithExpiration[[]*net.IPNet](
+func GetVPCSubnetsForHost(ctx context.Context) ([]netip.Prefix, error) {
+	return cache.GetWithExpiration[[]netip.Prefix](
 		vpcSubnetsForHostCacheKey,
-		func() ([]*net.IPNet, error) {
+		func() ([]netip.Prefix, error) {
 			subnets, err := getVPCSubnetsForHost(ctx)
 			if err != nil {
 				return nil, err
 			}
 
-			var parsedSubnets []*net.IPNet
+			var parsedSubnets []netip.Prefix
 			for _, subnet := range subnets {
-				_, ipnet, err := net.ParseCIDR(subnet)
+				ipnet, err := netip.ParsePrefix(subnet)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
### What does this PR do?

Uses `netip.Prefix` instead of `net.IPNet` for dealing with VPC subnets.

### Motivation

`net/netip` has more efficient types, and doesn't require an IP conversion from `netip.Addr` to check subnet membership.

### Describe how you validated your changes

Existing tests.

### Additional Notes
