### PR TITLE
[EBPF-903] gpu: Add infinite reapplication option for cgroup device configuration

### DIFF
--- a/cmd/system-probe/modules/gpu.go
+++ b/cmd/system-probe/modules/gpu.go
@@ -62,7 +62,7 @@ var GPUMonitoring = &module.Factory{
 		c := gpuconfig.New()
 
 		if c.ConfigureCgroupPerms {
-			configureCgroupPermissions(c.CgroupReapplyDelay)
+			configureCgroupPermissions(c.CgroupReapplyInterval, c.CgroupReapplyInfinitely)
 		}
 
 		probeDeps := gpu.ProbeDependencies{
@@ -213,12 +213,12 @@ func getAgentPID(procRoot string) (uint32, error) {
 // configureCgroupPermissions configures the cgroup permissions to access NVIDIA
 // devices for the system-probe and agent processes, as the NVIDIA device plugin
 // sets them in a way that can be overwritten by SystemD cgroups.
-func configureCgroupPermissions(reapplyDelay time.Duration) {
+func configureCgroupPermissions(reapplyInterval time.Duration, reapplyInfinitely bool) {
 	root := hostRoot()
 
 	sysprobePID := uint32(os.Getpid())
 	log.Infof("Configuring cgroup permissions for system-probe process with PID %d", sysprobePID)
-	if err := gpu.ConfigureDeviceCgroups(sysprobePID, root, reapplyDelay); err != nil {
+	if err := gpu.ConfigureDeviceCgroups(sysprobePID, root, reapplyInterval, reapplyInfinitely); err != nil {
 		log.Warnf("Failed to configure cgroup permissions for system-probe process: %v. gpu-monitoring module might not work properly", err)
 	}
 
@@ -230,7 +230,7 @@ func configureCgroupPermissions(reapplyDelay time.Duration) {
 	}
 
 	log.Infof("Configuring cgroup permissions for agent process with PID %d", agentPID)
-	if err := gpu.ConfigureDeviceCgroups(agentPID, root, reapplyDelay); err != nil {
+	if err := gpu.ConfigureDeviceCgroups(agentPID, root, reapplyInterval, reapplyInfinitely); err != nil {
 		log.Warnf("Failed to configure cgroup permissions for agent process: %v. gpu-monitoring module might not work properly", err)
 	}
 }

--- a/cmd/system-probe/modules/gpu.go
+++ b/cmd/system-probe/modules/gpu.go
@@ -8,6 +8,7 @@
 package modules
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -61,8 +62,10 @@ var GPUMonitoring = &module.Factory{
 
 		c := gpuconfig.New()
 
+		ctx, cancel := context.WithCancel(context.Background())
+
 		if c.ConfigureCgroupPerms {
-			configureCgroupPermissions(c.CgroupReapplyInterval, c.CgroupReapplyInfinitely)
+			configureCgroupPermissions(ctx, c.CgroupReapplyInterval, c.CgroupReapplyInfinitely)
 		}
 
 		probeDeps := gpu.ProbeDependencies{
@@ -72,11 +75,14 @@ var GPUMonitoring = &module.Factory{
 		}
 		p, err := gpu.NewProbe(c, probeDeps)
 		if err != nil {
+			cancel()
 			return nil, fmt.Errorf("unable to start %s: %w", config.GPUMonitoringModule, err)
 		}
 
 		return &GPUMonitoringModule{
-			Probe: p,
+			Probe:         p,
+			contextCancel: cancel,
+			context:       ctx,
 		}, nil
 	},
 	NeedsEBPF: func() bool {
@@ -87,6 +93,8 @@ var GPUMonitoring = &module.Factory{
 // GPUMonitoringModule is a module for GPU monitoring
 type GPUMonitoringModule struct {
 	*gpu.Probe
+	context       context.Context    // Context associated with the module
+	contextCancel context.CancelFunc // Cancel function associated with the context
 }
 
 // Register registers the GPU monitoring module
@@ -159,6 +167,7 @@ func (t *GPUMonitoringModule) collectEventsHandler(w http.ResponseWriter, r *htt
 
 // Close closes the GPU monitoring module
 func (t *GPUMonitoringModule) Close() {
+	t.contextCancel()
 	t.Probe.Close()
 }
 
@@ -213,12 +222,12 @@ func getAgentPID(procRoot string) (uint32, error) {
 // configureCgroupPermissions configures the cgroup permissions to access NVIDIA
 // devices for the system-probe and agent processes, as the NVIDIA device plugin
 // sets them in a way that can be overwritten by SystemD cgroups.
-func configureCgroupPermissions(reapplyInterval time.Duration, reapplyInfinitely bool) {
+func configureCgroupPermissions(ctx context.Context, reapplyInterval time.Duration, reapplyInfinitely bool) {
 	root := hostRoot()
 
 	sysprobePID := uint32(os.Getpid())
 	log.Infof("Configuring cgroup permissions for system-probe process with PID %d", sysprobePID)
-	if err := gpu.ConfigureDeviceCgroups(sysprobePID, root, reapplyInterval, reapplyInfinitely); err != nil {
+	if err := gpu.ConfigureDeviceCgroups(ctx, sysprobePID, root, reapplyInterval, reapplyInfinitely); err != nil {
 		log.Warnf("Failed to configure cgroup permissions for system-probe process: %v. gpu-monitoring module might not work properly", err)
 	}
 
@@ -230,7 +239,7 @@ func configureCgroupPermissions(reapplyInterval time.Duration, reapplyInfinitely
 	}
 
 	log.Infof("Configuring cgroup permissions for agent process with PID %d", agentPID)
-	if err := gpu.ConfigureDeviceCgroups(agentPID, root, reapplyInterval, reapplyInfinitely); err != nil {
+	if err := gpu.ConfigureDeviceCgroups(ctx, agentPID, root, reapplyInterval, reapplyInfinitely); err != nil {
 		log.Warnf("Failed to configure cgroup permissions for agent process: %v. gpu-monitoring module might not work properly", err)
 	}
 }

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -394,7 +394,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(gpuNS, "attacher_detailed_logs"), false)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "ringbuffer_flush_interval"), 1*time.Second)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "device_cache_refresh_interval"), 5*time.Second)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "cgroup_reapply_delay"), 30*time.Second)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "cgroup_reapply_interval"), 30*time.Second)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "cgroup_reapply_infinitely"), false)
 
 	// gpu - stream config
 	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "max_kernel_launches"), 1000)

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -64,7 +64,7 @@ func ConfigureDeviceCgroups(ctx context.Context, pid uint32, hostRoot string, re
 					if err != nil {
 						log.Warnf("Failed to re-apply cgroup device configuration for pid %d: %v", pid, err)
 					} else {
-						log.Infof("Successfully re-applied cgroup device configuration for pid %d", pid)
+						log.Debugf("Successfully re-applied cgroup device configuration for pid %d", pid)
 					}
 
 					if !reapplyInfinitely {

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -46,9 +46,12 @@ type Config struct {
 	AttacherDetailedLogs bool
 	// DeviceCacheRefreshInterval is the interval at which the probe scans for the latest devices
 	DeviceCacheRefreshInterval time.Duration
-	// CgroupReapplyDelay is the delay before re-applying cgroup device configuration. 0 means no re-application.
+	// CgroupReapplyInterval is the interval at which to re-apply cgroup device configuration. 0 means no re-application.
 	// Defaults to 30 seconds. It is used to fix race conditions between systemd and the system-probe permission patching.
-	CgroupReapplyDelay time.Duration
+	CgroupReapplyInterval time.Duration
+	// CgroupReapplyInfinitely controls whether the cgroup device configuration should be reapplied infinitely (true) or only once (false).
+	// Defaults to false. When true, the configuration will be reapplied every CgroupReapplyInterval interval.
+	CgroupReapplyInfinitely bool
 }
 
 // StreamConfig is the configuration for the streams.
@@ -91,6 +94,7 @@ func New() *Config {
 		},
 		AttacherDetailedLogs:       spCfg.GetBool(sysconfig.FullKeyPath(consts.GPUNS, "attacher_detailed_logs")),
 		DeviceCacheRefreshInterval: spCfg.GetDuration(sysconfig.FullKeyPath(consts.GPUNS, "device_cache_refresh_interval")),
-		CgroupReapplyDelay:         spCfg.GetDuration(sysconfig.FullKeyPath(consts.GPUNS, "cgroup_reapply_delay")),
+		CgroupReapplyInterval:      spCfg.GetDuration(sysconfig.FullKeyPath(consts.GPUNS, "cgroup_reapply_interval")),
+		CgroupReapplyInfinitely:    spCfg.GetBool(sysconfig.FullKeyPath(consts.GPUNS, "cgroup_reapply_infinitely")),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds a configuration option to control whether cgroup device configuration is reapplied infinitely or only once. Also renames `cgroup_reapply_delay` to `cgroup_reapply_interval` for better clarity.

### Motivation

The current implementation only reapplies the cgroup device configuration once after a delay, to deal with possible timing issues between the patching and systemd reloading (see https://github.com/DataDog/datadog-agent/pull/42431 for details). However, if the agent restarts, we might lose the permissions and need to reapply again. This implementation ensures that the agent will regain permissions with a simple implementation, while we work on obtaining permissions through alternative methods.

### Describe how you validated your changes

Tested locally, will monitor staging.

### Additional Notes