### PR TITLE
[Backport 7.73.x] dyninst: fix bugs related to stack tracking for events (#42984)

### DIFF
--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -278,8 +278,7 @@ int probe_run_with_cookie(struct pt_regs* regs) {
   if (!events_scratch_buf_submit(global_ctx.buf)) {
     // TODO: Report dropped events metric.
     LOG(1, "probe_run output dropped");
-  }
-  if (stack_hash != 0) {
+  } else if (stack_hash != 0) {
     upsert_stack_hash(stack_hash);
   }
   LOG(1, "probe_run done: %d steps", process_steps + chase_steps);

--- a/pkg/dyninst/module/dependencies.go
+++ b/pkg/dyninst/module/dependencies.go
@@ -87,6 +87,13 @@ type Decoder interface {
 		symbolicator symbol.Symbolicator,
 		out []byte,
 	) ([]byte, ir.ProbeDefinition, error)
+
+	// ReportStackPCs reports the program counters of the stack trace for a
+	// given stack hash.
+	ReportStackPCs(
+		stackHash uint64,
+		stackPCs []uint64,
+	)
 }
 
 // decoderFactory is the default decoder factory.

--- a/pkg/dyninst/module/module_test.go
+++ b/pkg/dyninst/module/module_test.go
@@ -70,6 +70,24 @@ func makeFakeEvent(header output.EventHeader, data []byte) dispatcher.Message {
 	))
 }
 
+func makeFakeEventWithStack(
+	header output.EventHeader, stackPCs []uint64,
+) dispatcher.Message {
+	eventHeaderSize := int(unsafe.Sizeof(output.EventHeader{}))
+	stackByteLen := len(stackPCs) * 8
+	header.Stack_byte_len = uint16(stackByteLen)
+	totalSize := eventHeaderSize + stackByteLen
+	header.Data_byte_len = uint32(totalSize)
+
+	buf := make([]byte, totalSize)
+	copy(buf, unsafe.Slice((*byte)(unsafe.Pointer(&header)), eventHeaderSize))
+	if len(stackPCs) > 0 {
+		stackBytes := unsafe.Slice((*byte)(unsafe.Pointer(&stackPCs[0])), stackByteLen)
+		copy(buf[eventHeaderSize:], stackBytes)
+	}
+	return dispatcher.MakeTestingMessage(buf)
+}
+
 // TestProgramLifecycleFlow tests the complete program lifecycle including
 // attachment, loading with metadata (git info, container info), and proper sink
 // creation with the correct uploader metadata.
@@ -410,6 +428,69 @@ func TestDecoderErrorHandling(t *testing.T) {
 	assert.Equal(t, json.RawMessage(decoder.output), logsUploader.messages[0])
 }
 
+// TestStackPCsRecordedForEntryEvents verifies that stack PCs are recorded in
+// the decoder when entry events are stored in the buffer tree for later
+// pairing. This works around a bug where return events may need the PCs but
+// don't have them.
+func TestStackPCsRecordedForEntryEvents(t *testing.T) {
+	deps := newFakeTestingDependencies(t)
+	decoder := &fakeDecoder{output: `{"test":"data"}`}
+	processUpdate := createTestProcessConfig()
+	deps.decoderFactory.decoder = decoder
+	deps.irGenerator.program = createTestProgram()
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
+
+	deps.sendUpdates(processUpdate)
+
+	loaded, err := deps.actuator.tenant.rt.Load(
+		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes,
+	)
+	require.NoError(t, err)
+	sink := deps.dispatcher.sinks[ir.ProgramID(42)]
+	require.NotNil(t, sink)
+
+	_, err = loaded.Attach(processUpdate.ProcessID, processUpdate.Executable)
+	require.NoError(t, err)
+
+	// Create an entry event with stack PCs that expects return pairing.
+	stackHash := uint64(0x1234567890abcdef)
+	stackPCs := []uint64{0x1000, 0x2000, 0x3000}
+	entryHeader := output.EventHeader{
+		Goid:                      1,
+		Stack_byte_depth:          2,
+		Probe_id:                  0,
+		Stack_hash:                stackHash,
+		Event_pairing_expectation: uint8(output.EventPairingExpectationReturnPairingExpected),
+	}
+	entryEvent := makeFakeEventWithStack(entryHeader, stackPCs)
+
+	// Handle the entry event. It should be stored in the buffer tree and
+	// the stack PCs should be recorded.
+	require.NoError(t, sink.HandleEvent(entryEvent))
+
+	// Verify that ReportStackPCs was called with the correct values.
+	require.NotNil(t, decoder.reportedStackPCs)
+	require.Equal(t, stackPCs, decoder.reportedStackPCs[stackHash])
+
+	// Now create a return event that pairs with the entry event.
+	returnHeader := output.EventHeader{
+		Goid:                      1,
+		Stack_byte_depth:          2,
+		Probe_id:                  0,
+		Stack_hash:                stackHash,
+		Event_pairing_expectation: uint8(output.EventPairingExpectationEntryPairingExpected),
+	}
+	// Return event may not have stack PCs, but decoder should have them cached.
+	returnEvent := makeFakeEvent(returnHeader, nil)
+
+	decoder.probe = processUpdate.Probes[0]
+	require.NoError(t, sink.HandleEvent(returnEvent))
+
+	// Verify that Decode was called, which means the events were paired.
+	require.Len(t, decoder.decodeCalls, 1)
+}
+
 // TestProcessRemoval verifies that process removals are properly handled by
 // updating the internal state and notifying the actuator.
 func TestProcessRemoval(t *testing.T) {
@@ -715,12 +796,17 @@ func (d *failOnceDecoder) Decode(
 	return bytes, probe, nil
 }
 
+func (d *failOnceDecoder) ReportStackPCs(stackHash uint64, stackPCs []uint64) {
+	d.inner.ReportStackPCs(stackHash, stackPCs)
+}
+
 type fakeDecoder struct {
 	probe  ir.ProbeDefinition
 	err    error
 	output string
 
-	decodeCalls []decodeCall
+	decodeCalls      []decodeCall
+	reportedStackPCs map[uint64][]uint64
 }
 
 type decodeCall struct {
@@ -734,6 +820,13 @@ func (f *fakeDecoder) Decode(
 ) ([]byte, ir.ProbeDefinition, error) {
 	f.decodeCalls = append(f.decodeCalls, decodeCall{event, symbolicator, out})
 	return []byte(f.output), f.probe, f.err
+}
+
+func (f *fakeDecoder) ReportStackPCs(stackHash uint64, stackPCs []uint64) {
+	if f.reportedStackPCs == nil {
+		f.reportedStackPCs = make(map[uint64][]uint64)
+	}
+	f.reportedStackPCs[stackHash] = stackPCs
 }
 
 type fakeDiagnosticsUploader struct {

--- a/pkg/dyninst/module/sink.go
+++ b/pkg/dyninst/module/sink.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -31,6 +32,10 @@ type sink struct {
 	service      string
 	logUploader  LogsUploader
 	tree         *bufferTree
+
+	// Probes is an ordered list of probes. The event header's probe_id is an
+	// index into this list.
+	probes []*ir.Probe
 }
 
 var _ dispatcher.Sink = &sink{}
@@ -39,7 +44,10 @@ var _ dispatcher.Sink = &sink{}
 // about them and we don't want to bail out completely.
 var decodingErrorLogLimiter = rate.NewLimiter(rate.Every(1*time.Minute), 10)
 
-var noMatchingEventLogLimiter = rate.NewLimiter(rate.Every(1*time.Minute), 10)
+var noMatchingEventLogLimiter = rate.NewLimiter(rate.Every(10*time.Minute), 10)
+var eventPairingBufferFullLogLimiter = rate.NewLimiter(rate.Every(10*time.Minute), 10)
+var eventPairingCallMapFullLogLimiter = rate.NewLimiter(rate.Every(10*time.Minute), 10)
+var eventPairingCallCountExceededLogLimiter = rate.NewLimiter(rate.Every(10*time.Minute), 10)
 
 func (s *sink) HandleEvent(msg dispatcher.Message) error {
 	defer func() {
@@ -56,6 +64,24 @@ func (s *sink) HandleEvent(msg dispatcher.Message) error {
 	evHeader, err := msgEvent.Header()
 	if err != nil {
 		return fmt.Errorf("error getting event header: %w", err)
+	}
+
+	recordEventPairingIssue := func(
+		stats *atomic.Uint64, limiter *rate.Limiter, issueMsg string,
+	) {
+		stats.Add(1)
+		var probeID string
+		if int(evHeader.Probe_id) < len(s.probes) {
+			probeID = s.probes[evHeader.Probe_id].GetID()
+		} else {
+			probeID = fmt.Sprintf("unknown probeID %d", evHeader.Probe_id)
+		}
+		const format = "event pairing issue for probe %s: %s"
+		if limiter.Allow() {
+			log.Infof(format, probeID, issueMsg)
+		} else {
+			log.Tracef(format, probeID, issueMsg)
+		}
 	}
 	var entryEvent, returnEvent output.Event
 	switch output.EventPairingExpectation(evHeader.Event_pairing_expectation) {
@@ -90,6 +116,12 @@ func (s *sink) HandleEvent(msg dispatcher.Message) error {
 			stackByteDepth: evHeader.Stack_byte_depth,
 			probeID:        evHeader.Probe_id,
 		}, msg) {
+			// Record stack PCs for later use when the return event arrives.
+			// This works around a bug where the return event may need the PCs
+			// but doesn't have them.
+			if stackPCs, err := msgEvent.StackPCs(); err == nil {
+				s.decoder.ReportStackPCs(evHeader.Stack_hash, stackPCs)
+			}
 			msg = dispatcher.Message{} // prevent release
 			return nil
 		}
@@ -98,10 +130,27 @@ func (s *sink) HandleEvent(msg dispatcher.Message) error {
 		// it directly.
 		evHeader.Event_pairing_expectation =
 			uint8(output.EventPairingExpectationBufferFull)
-		fallthrough
-	case output.EventPairingExpectationNone,
-		output.EventPairingExpectationCallMapFull,
-		output.EventPairingExpectationCallCountExceeded:
+		recordEventPairingIssue(
+			&s.runtime.stats.eventPairingBufferFull,
+			eventPairingBufferFullLogLimiter,
+			"userspace buffer capacity exceeded",
+		)
+		entryEvent = msgEvent
+	case output.EventPairingExpectationCallMapFull:
+		recordEventPairingIssue(
+			&s.runtime.stats.eventPairingCallMapFull,
+			eventPairingCallMapFullLogLimiter,
+			"call map capacity exceeded",
+		)
+		entryEvent = msgEvent
+	case output.EventPairingExpectationCallCountExceeded:
+		recordEventPairingIssue(
+			&s.runtime.stats.eventPairingCallCountExceeded,
+			eventPairingCallCountExceededLogLimiter,
+			"maximum call count exceeded",
+		)
+		entryEvent = msgEvent
+	case output.EventPairingExpectationNone:
 		entryEvent = msgEvent
 	default:
 		return fmt.Errorf("unknown event pairing expectation: %d", evHeader.Event_pairing_expectation)


### PR DESCRIPTION
### What does this PR do?

This PR fixes issues we've seen where stack traces are not being properly recorded. It also adds better observability into complex buffering scenarios, and fixes a bug when the ring buffer is full.

### Motivation

We've seen in the wild that stack traces are missing in some events where returns are also missing. This can be explained by situations where the entry event was buffered while a subsequent event corresponding to that entry stack was emitted. 

### Describe how you validated your changes

There's some testing.

### Additional Notes

Relates to https://datadoghq.atlassian.net/browse/DEBUG-4031
Fixes https://datadoghq.atlassian.net/browse/DEBUG-4744