### PR TITLE
Potential fix for flaky `TestHTTP/runtime_compiled/TestSanity/with_dnat/with_keep_alive`

### DIFF
--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -29,16 +29,14 @@
 
 SEC("kprobe/__nf_conntrack_hash_insert")
 int BPF_BYPASSABLE_KPROBE(kprobe___nf_conntrack_hash_insert, struct nf_conn *ct) {
-    u32 status = 0;
-    BPF_CORE_READ_INTO(&status, ct, status);
-    if (!(status&IPS_NAT_MASK)) {
-        return 0;
-    }
-
-    log_debug("kprobe/__nf_conntrack_hash_insert: netns: %u, status: %x", get_netns(ct), status);
+    log_debug("kprobe/__nf_conntrack_hash_insert: netns: %u", get_netns(ct));
 
     conntrack_tuple_t orig = {}, reply = {};
     if (nf_conn_to_conntrack_tuples(ct, &orig, &reply) != 0) {
+        return 0;
+    }
+
+    if (!is_conn_nat(&orig, &reply)) {
         return 0;
     }
 

--- a/pkg/network/ebpf/c/runtime/conntrack.h
+++ b/pkg/network/ebpf/c/runtime/conntrack.h
@@ -17,6 +17,12 @@
 #include "conntrack/maps.h"
 #include "conntrack/helpers.h"
 
+static __always_inline bool is_conn_nat(const conntrack_tuple_t* orig, const conntrack_tuple_t* reply) {
+    return orig->daddr_l != reply->saddr_l || orig->dport != reply->sport ||
+        orig->saddr_l != reply->daddr_l || orig->sport != reply->dport ||
+        orig->daddr_h != reply->saddr_h;
+}
+
 static __always_inline u32 get_netns(const struct nf_conn *ct) {
     u32 net_ns_inum = 0;
 


### PR DESCRIPTION
### What does this PR do?
This is a tentative fix for a flaky test failure in `TestHTTP/runtime_compiled/TestSanity/with_dnat/with_keep_alive` where HTTP requests over a keep-alive connection with DNAT translation would not be tracked by the runtime eBPF conntrack code.

#### Problem
In an [occurrence](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1234336605#L2364), the test sends 100 HTTP requests over a single keep-alive connection through DNAT (client -> 2.2.2.2:8080 which iptables translates to 1.1.1.1:8080). The runtime eBPF is intermittently failing to track these connections, causing "connection not found" errors.

Test failure pattern:
- first run: request 100 missing (1 out of 100)
- re-run 2: requests 49, 64-100 missing (31 out of 100)
- only fails with: runtime_compiled + with_dnat + with_keep_alive
- CO-RE variant: PASSES
- without keep-alive: PASSES (each request creates new connection)
- without DNAT: PASSES

#### Potential culprit
The runtime eBPF code in `__nf_conntrack_hash_insert` checks the `IPS_NAT_MASK` status bit before extracting connection tuples:
```c
u32 status = 0;
BPF_CORE_READ_INTO(&status, ct, status);
if (!(status&IPS_NAT_MASK)) {
    return 0;
}
```

While _NAT status bits should normally be set before hash insertion_ according to the kernel source code, the status field read may be unreliable in eBPF context due to potential verifier or memory access issues. Similar reliability issues led to removing the `IPS_CONFIRMED` check in commit fad16049baabf88451b2b7ba453a4c7786eb2bf3 (#41848).

The CO-RE/prebuilt variant (pkg/network/ebpf/c/prebuilt/conntrack.c) is more robust because it uses `RETURN_IF_NOT_NAT` which checks the actual tuple differences (`orig` vs `reply`), therefore disregarding status bit reads.

#### Proposed solution
Replace the status bit check with tuple-based NAT detection in `kprobe___nf_conntrack_hash_insert`, matching the prebuilt/CO-RE implementation.

The tuple comparison is reliable because NAT is present if `orig` and `reply` tuples don't properly invert.

Performance note: this change moves tuple extraction before the NAT check, which means non-NAT connections will incur the **overhead** of extracting tuples before being rejected. The original code checked the status bit first, likely as an optimization. However, reliability is prioritized here.

Note: the sibling `kprobe_ctnetlink_fill_info` is left unchanged as it only fires during conntrack dump operations (not during the test failure path), but it could potentially benefit from the same tuple-based check for consistency.

### Motivation
CI reliability.