### PR TITLE
Run appsec injector cleanup on disabled proxy and add more labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -458,7 +458,7 @@
 /pkg/clusteragent/admission/mutate/autoscaling          @DataDog/container-integrations
 /pkg/clusteragent/admission/mutate/autoinstrumentation/ @DataDog/container-platform @DataDog/injection-platform
 /pkg/clusteragent/admission/mutate/cwsinstrumentation    @Datadog/agent-security
-/pkg/clusteragent/appsec/               @DataDog/asm-go
+/pkg/clusteragent/appsec/               @DataDog/asm-go @DataDog/container-platform
 /pkg/clusteragent/orchestrator/         @DataDog/container-app
 /pkg/clusteragent/telemetry/            @DataDog/apm-trace-storage
 /pkg/collector/                         @DataDog/agent-runtimes

--- a/pkg/clusteragent/appsec/cleanup.go
+++ b/pkg/clusteragent/appsec/cleanup.go
@@ -44,7 +44,7 @@ func Cleanup(ctx context.Context, logger log.Component, datadogConfig config.Com
 			<-leaderNotifChange
 		}
 
-		patterns := injector.CompilePatterns()
+		patterns := injector.InstantiatePatterns()
 		for _, pattern := range patterns {
 			cleanupPattern(ctx, logger, apiClient.DynamicCl, pattern)
 		}

--- a/pkg/clusteragent/appsec/config/config.go
+++ b/pkg/clusteragent/appsec/config/config.go
@@ -39,6 +39,7 @@ const (
 	ProxyTypeIstio ProxyType = "istio"
 )
 
+// AllProxyTypes is the list of all supported proxy types for appsec injection mode
 var AllProxyTypes = []ProxyType{
 	ProxyTypeEnvoyGateway,
 	ProxyTypeIstio,
@@ -125,9 +126,9 @@ func FromComponent(cfg config.Component, logger log.Component) Config {
 	}
 
 	staticLabels := map[string]string{
-		kubernetes.KubeAppComponentLabelKey:  "datadog-appsec-injector",
-		kubernetes.KubeAppPartOfLabelKey:     "datadog",
-		kubernetes.KubeAppManagedByLabelKey:  "datadog-cluster-agent",
+		kubernetes.KubeAppComponentLabelKey:      "datadog-appsec-injector",
+		kubernetes.KubeAppPartOfLabelKey:         "datadog",
+		kubernetes.KubeAppManagedByLabelKey:      "datadog-cluster-agent",
 		"appsec.datadoghq.com/injection-version": "v1",
 	}
 

--- a/pkg/clusteragent/appsec/config/config.go
+++ b/pkg/clusteragent/appsec/config/config.go
@@ -39,7 +39,7 @@ const (
 	ProxyTypeIstio ProxyType = "istio"
 )
 
-var proxyList = []ProxyType{
+var AllProxyTypes = []ProxyType{
 	ProxyTypeEnvoyGateway,
 	ProxyTypeIstio,
 }
@@ -103,7 +103,7 @@ func FromComponent(cfg config.Component, logger log.Component) Config {
 	proxiesMap := make(map[ProxyType]struct{}, len(proxiesEnabled))
 	for _, p := range proxiesEnabled {
 		proxyType := ProxyType(p)
-		if !slices.Contains(proxyList, proxyType) {
+		if !slices.Contains(AllProxyTypes, proxyType) {
 			logger.Warnf("Proxy type %s is not supported for appsec injection, ignoring...", proxyType)
 			continue
 		}
@@ -125,8 +125,10 @@ func FromComponent(cfg config.Component, logger log.Component) Config {
 	}
 
 	staticLabels := map[string]string{
-		kubernetes.KubeAppComponentLabelKey: "datadog-appsec-injector",
-		kubernetes.KubeAppPartOfLabelKey:    "datadog",
+		kubernetes.KubeAppComponentLabelKey:  "datadog-appsec-injector",
+		kubernetes.KubeAppPartOfLabelKey:     "datadog",
+		kubernetes.KubeAppManagedByLabelKey:  "datadog-cluster-agent",
+		"appsec.datadoghq.com/injection-version": "v1",
 	}
 
 	staticAnnotations := map[string]string{

--- a/pkg/clusteragent/appsec/envoygateway/envoy.go
+++ b/pkg/clusteragent/appsec/envoygateway/envoy.go
@@ -186,7 +186,7 @@ func (e *envoyGatewayInjectionPattern) Deleted(ctx context.Context, obj *unstruc
 }
 
 func (e *envoyGatewayInjectionPattern) createEnvoyExtensionPolicy(ctx context.Context, namespace string, gatewayName string) error {
-	policy := e.newPolicy(namespace)
+	policy := e.newPolicy(gatewayName, namespace)
 
 	unstructuredGrant, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&policy)
 	if err != nil {
@@ -212,7 +212,7 @@ func (e *envoyGatewayInjectionPattern) createEnvoyExtensionPolicy(ctx context.Co
 	return nil
 }
 
-func (e *envoyGatewayInjectionPattern) newPolicy(namespace string) egv1a1.EnvoyExtensionPolicy {
+func (e *envoyGatewayInjectionPattern) newPolicy(gwName, namespace string) egv1a1.EnvoyExtensionPolicy {
 	return egv1a1.EnvoyExtensionPolicy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "gateway.envoyproxy.io/v1alpha1",

--- a/pkg/clusteragent/appsec/envoygateway/envoy.go
+++ b/pkg/clusteragent/appsec/envoygateway/envoy.go
@@ -186,7 +186,7 @@ func (e *envoyGatewayInjectionPattern) Deleted(ctx context.Context, obj *unstruc
 }
 
 func (e *envoyGatewayInjectionPattern) createEnvoyExtensionPolicy(ctx context.Context, namespace string, gatewayName string) error {
-	policy := e.newPolicy(gatewayName, namespace)
+	policy := e.newPolicy(namespace)
 
 	unstructuredGrant, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&policy)
 	if err != nil {
@@ -212,7 +212,7 @@ func (e *envoyGatewayInjectionPattern) createEnvoyExtensionPolicy(ctx context.Co
 	return nil
 }
 
-func (e *envoyGatewayInjectionPattern) newPolicy(gwName, namespace string) egv1a1.EnvoyExtensionPolicy {
+func (e *envoyGatewayInjectionPattern) newPolicy(namespace string) egv1a1.EnvoyExtensionPolicy {
 	return egv1a1.EnvoyExtensionPolicy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "gateway.envoyproxy.io/v1alpha1",

--- a/pkg/clusteragent/appsec/injector.go
+++ b/pkg/clusteragent/appsec/injector.go
@@ -61,9 +61,13 @@ func Start(ctx context.Context, logger log.Component, datadogConfig config.Compo
 		}
 
 		logger.Infof("Starting appsec proxy injector with config: %#v", injector.config)
-		patterns := injector.CompilePatterns()
+		patterns := injector.InstantiatePatterns()
 		for typ, pattern := range patterns {
-			go injector.run(ctx, typ, pattern)
+			if _, enabled := config.Proxies[typ]; enabled {
+				go injector.run(ctx, typ, pattern)
+			} else {
+				go cleanupPattern(ctx, logger, injector.k8sClient, pattern)
+			}
 		}
 	})
 
@@ -320,9 +324,9 @@ func (si *securityInjector) processWorkItem(ctx context.Context, proxyType appse
 	return false
 }
 
-func (si *securityInjector) CompilePatterns() map[appsecconfig.ProxyType]appsecconfig.InjectionPattern {
+func (si *securityInjector) InstantiatePatterns() map[appsecconfig.ProxyType]appsecconfig.InjectionPattern {
 	patterns := make(map[appsecconfig.ProxyType]appsecconfig.InjectionPattern, len(si.config.Proxies))
-	for proxy := range si.config.Proxies {
+	for _, proxy := range appsecconfig.AllProxyTypes {
 		constructor, ok := proxyConstructorMap[proxy]
 		if !ok {
 			si.logger.Warnf("unknown proxy type for appsec injector: %s", proxy)
@@ -334,7 +338,8 @@ func (si *securityInjector) CompilePatterns() map[appsecconfig.ProxyType]appsecc
 		config.Injection.CommonAnnotations = maps.Clone(config.Injection.CommonAnnotations)
 		config.Injection.CommonAnnotations[appsecconfig.AppsecProcessorProxyTypeAnnotation] = string(proxy)
 
-		patterns[proxy] = constructor(si.k8sClient, si.logger, config, si.recorder)
+		pattern := constructor(si.k8sClient, si.logger, config, si.recorder)
+		patterns[proxy] = pattern
 	}
 
 	return patterns

--- a/pkg/clusteragent/appsec/injector_integration_test.go
+++ b/pkg/clusteragent/appsec/injector_integration_test.go
@@ -126,7 +126,7 @@ func TestIntegration_NewSecurityInjector_UnsupportedProxy(t *testing.T) {
 	assert.NotContains(t, config.Proxies, appsecconfig.ProxyType("unsupported-proxy"), "Unsupported proxy should not be in proxies")
 }
 
-func TestIntegration_CompilePatterns_WithValidConfig(t *testing.T) {
+func TestIntegration_InstanciatePatterns_WithValidConfig(t *testing.T) {
 	f := newIntegrationFixture(t, map[string]interface{}{
 		"appsec.proxy.enabled":                                      true,
 		"cluster_agent.appsec.injector.enabled":                     true,
@@ -176,7 +176,7 @@ func TestIntegration_CompilePatterns_WithValidConfig(t *testing.T) {
 
 	patterns := si.InstantiatePatterns()
 
-	require.Len(t, patterns, 1, "Should have one pattern")
+	require.Len(t, patterns, len(appsecconfig.AllProxyTypes), "Should have one pattern")
 	assert.Contains(t, patterns, appsecconfig.ProxyTypeEnvoyGateway, "Should have envoy-gateway pattern")
 
 	pattern := patterns[appsecconfig.ProxyTypeEnvoyGateway]

--- a/pkg/clusteragent/appsec/injector_integration_test.go
+++ b/pkg/clusteragent/appsec/injector_integration_test.go
@@ -174,7 +174,7 @@ func TestIntegration_CompilePatterns_WithValidConfig(t *testing.T) {
 		leaderSub: leaderFakeSub,
 	}
 
-	patterns := si.CompilePatterns()
+	patterns := si.InstantiatePatterns()
 
 	require.Len(t, patterns, 1, "Should have one pattern")
 	assert.Contains(t, patterns, appsecconfig.ProxyTypeEnvoyGateway, "Should have envoy-gateway pattern")

--- a/pkg/clusteragent/appsec/injector_test.go
+++ b/pkg/clusteragent/appsec/injector_test.go
@@ -325,7 +325,7 @@ func TestCompilePatterns(t *testing.T) {
 	ctx := context.Background()
 	injector := newMockSecurityInjector(ctx, mockClient, mockLogger, mockConfig)
 
-	patterns := injector.CompilePatterns()
+	patterns := injector.InstantiatePatterns()
 
 	require.Len(t, patterns, 1, "Should have one pattern for envoy-gateway")
 	assert.Contains(t, patterns, appsecconfig.ProxyTypeEnvoyGateway, "Should have envoy-gateway pattern")

--- a/pkg/clusteragent/appsec/injector_test.go
+++ b/pkg/clusteragent/appsec/injector_test.go
@@ -327,7 +327,7 @@ func TestCompilePatterns(t *testing.T) {
 
 	patterns := injector.InstantiatePatterns()
 
-	require.Len(t, patterns, 1, "Should have one pattern for envoy-gateway")
+	require.Len(t, patterns, len(appsecconfig.AllProxyTypes), "Should have one pattern for envoy-gateway")
 	assert.Contains(t, patterns, appsecconfig.ProxyTypeEnvoyGateway, "Should have envoy-gateway pattern")
 
 	// Verify the pattern is configured correctly

--- a/pkg/clusteragent/appsec/testdata/cluster-agent-rbac.yml
+++ b/pkg/clusteragent/appsec/testdata/cluster-agent-rbac.yml
@@ -279,4 +279,27 @@ rules:
   - get
   - create
   - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    app: datadog
+  name: datadog-cluster-agent
+  namespace: datadog
+
 

--- a/pkg/clusteragent/appsec/testdata/extproc-deploy.yml
+++ b/pkg/clusteragent/appsec/testdata/extproc-deploy.yml
@@ -26,10 +26,7 @@ spec:
           env:
             - name: DD_APPSEC_BODY_PARSING_SIZE_LIMIT
               value: "10000000" # 10MB limit for body parsing
-
-            # Requires v2.4.0+ of the extension
-            # If you _must_ use TLS you need to create a BackendTLSPolicy
-            # and use DD_SERVICE_EXTENSION_TLS_KEY_FILE and DD_SERVICE_EXTENSION_TLS_CERT_FILE
+            # at least v2.3.1-docker.1 required to disable TLS
             - name: DD_SERVICE_EXTENSION_TLS
               value: "false"
           readinessProbe:


### PR DESCRIPTION
### What does this PR do?

- [x] Run cleanup on proxies that just goes disabled even if the whole feature is enabled 
- [x] Add more ownership annotations 

### Motivation

Better life cycle management

### Describe how you validated your changes

### Additional Notes
