### PR TITLE
[NCM] Fallback to agent collection timestamp if config timestamp is missing

### DIFF
--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
@@ -270,7 +270,7 @@ func TestCheck_Run_Success(t *testing.T) {
 				DeviceIP:     "10.0.0.1",
 				ConfigType:   "startup",
 				ConfigSource: "cli",
-				Timestamp:    0,
+				Timestamp:    1754043600, // timestamp taken from agent collection (could not be extracted from config)
 				Tags:         expectedTags,
 				Content:      startupOutput,
 			},

--- a/pkg/networkconfigmanagement/report/payload.go
+++ b/pkg/networkconfigmanagement/report/payload.go
@@ -50,6 +50,12 @@ type NetworkDeviceConfig struct {
 
 // ToNCMPayload converts the given parameters into a NCMPayload (sent to event platform / backend).
 func ToNCMPayload(namespace string, configs []NetworkDeviceConfig, timestamp int64) NCMPayload {
+	for i := range configs {
+		// if timestamp could not be extracted from the configurations / commands, use the agent timestamp
+		if configs[i].Timestamp == 0 {
+			configs[i].Timestamp = timestamp
+		}
+	}
 	return NCMPayload{
 		Namespace:        namespace,
 		Configs:          configs,

--- a/pkg/networkconfigmanagement/report/payload_test.go
+++ b/pkg/networkconfigmanagement/report/payload_test.go
@@ -118,3 +118,31 @@ func TestNetworkDevicesConfigPayload_EmptyConfigs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(jsonData), "\"configs\":[]")
 }
+
+func TestNetworkDevicesConfigPayload_EmptyTimestamps(t *testing.T) {
+	agentTs := time.Now().Unix()
+	ndc := NetworkDeviceConfig{
+		DeviceID:     "default:10.0.0.1",
+		DeviceIP:     "10.0.0.1",
+		ConfigType:   string(RUNNING),
+		ConfigSource: string(CLI),
+		Timestamp:    0,
+	}
+	payload := ToNCMPayload("test", []NetworkDeviceConfig{ndc}, agentTs)
+
+	expected := NetworkDeviceConfig{
+		DeviceID:     "default:10.0.0.1",
+		DeviceIP:     "10.0.0.1",
+		ConfigType:   string(RUNNING),
+		ConfigSource: string(CLI),
+		Timestamp:    agentTs,
+	}
+
+	// check NCM payload
+	assert.Equal(t, "test", payload.Namespace)
+	assert.Len(t, payload.Configs, 1)
+	assert.Equal(t, agentTs, payload.CollectTimestamp)
+
+	// check the config's empty timestamp replaced with agent collection timestamp
+	assert.Equal(t, payload.Configs[0], expected)
+}


### PR DESCRIPTION
### What does this PR do?

Small PR to address issue if a timestamp cannot be extracted from the configuration to fallback to the timestamp that the agent collected as closest accurate time of last update.

Reasons why timestamp may not be able to be extracted from a configuration:
* The device was rebooted and the running config may not have a "last updated" because it copied from startup
  * Booting up a completely fresh device (thus the config was also never "updated")
* Profile processing rules error (for extracting metadata)

**The approach is as follows:**
* Create the config metadata utilizing the extracted timestamp is available, or otherwise defaults to `0`
* When creating the "batched" payload holding all configs from a device
  *  Check if there are any configs that have a timestamp of `0` (thus empty/default)
  * If timestamp 0: use the agent collection timestamp to have closer to accurate picture of when it was last updated (compared to 0)

### Motivation

### Describe how you validated your changes

Pull in the ndm-tools/cml-qa repo and follow instructions for setting up the CLI ([link](https://github.com/DataDog/ndm-tools/tree/main/cml-qa))
```
python cml_template_generator.py \
  --deb-url <INSERT THE DEB FROM CI/CD BUILD> \
  --api-key <INSERT YOUR KEY> \
  --site "datad0g.com" \
  --integrations snmp ncm \
  --namespace <some-name>-cml-test \
  --title "<YOUR NAME/TITLE> NCM Agent QA"
```
* Go the NDM hosted CML ([docs](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5061640281/Getting+Started+with+Cisco+Modeling+Labs+CML))
* Press Import
* Pull in the YAML that gets created, start the lab, connect to the ubuntu machine's console

```
cisco@qa-agent:~$ sudo -u dd-agent -- datadog-agent check network_config_management
{"namespace":"cml-test","configs":[{"device_id":"cml-test:10.10.1.1","device_ip":"10.10.1.1","config_type":"running","config_source":"cli","timestamp":1763563211,"tags":["device_namespace:cml-test","device_ip:10.10.1.1","device_id:cml-test:10.10.1.1","config_source:cli","profile:cisco-ios"],"content":"\n\n\nBuilding configuration...\n\n\nCurrent configuration : 3082 bytes\n!\nversion 15.9\nservice timestamps debug datetime msec\nservice timestamps log datetime msec\nno service password-encryption\n!\nhostname qa-device\n!\nboot-start-marker\nboot-end-marker\n!\n!\n!\nno aaa new-model\n!\n!\n!\nmmi polling-interval 60\nno mmi auto-configure\nno mmi pvc\nmmi snmp-timeout 180\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\nip domain name lab.local\nip cef\nno ipv6 cef\n!\nmultilink bundle-name authenticated\n!\n!\n!\n!\nusername cisco privilege 15 secret 9 \u003csecret hidden\u003e\n!\nredundancy\n!\n!\n! \n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\ninterface GigabitEthernet0/0\n ip address 10.10.1.1 255.255.255.0\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/1\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/2\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/3\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\nip forward-protocol nd\n!\n!\nno ip http server\nno ip http secure-server\nip ssh version 2\n!\nipv6 ioam timestamp\n!\nsnmp-server community \u003cconfiguration removed\u003e\nsnmp-server chassis-id \n!\n!\ncontrol-plane\n!\n!\nline con 0\nline aux 0\nline vty 0 4\n login local\n transport input ssh\n!\nno scheduler allocate\n!\nend\n"}],"collect_timestamp":1763563211}
=== Series ===
[
  {
    "metric": "datadog.ncm.check_duration",
    "points": [
      [
        1763563211,
        2.204061247
      ]
    ],
    "tags": [
      "agent_host:qa-agent",
      "agent_version:7.74.0-devel+git.280.cc0dd10",
      "config_source:cli",
      "device_id:cml-test:10.10.1.1",
      "device_ip:10.10.1.1",
      "device_namespace:cml-test",
      "profile:cisco-ios"
    ],
    "host": "qa-agent",
    "type": "gauge",
    "interval": 0,
    "source_type_name": "System"
  }
]
=== ndmconfig ===
[
  {
    "EventType": "ndmconfig",
    "UnmarshalledEvent": {
      "collect_timestamp": 1763563211,
      "configs": [
        {
          "config_source": "cli",
          "config_type": "running",
          "content": "\n\n\nBuilding configuration...\n\n\nCurrent configuration : 3082 bytes\n!\nversion 15.9\nservice timestamps debug datetime msec\nservice timestamps log datetime msec\nno service password-encryption\n!\nhostname qa-device\n!\nboot-start-marker\nboot-end-marker\n!\n!\n!\nno aaa new-model\n!\n!\n!\nmmi polling-interval 60\nno mmi auto-configure\nno mmi pvc\nmmi snmp-timeout 180\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\nip domain name lab.local\nip cef\nno ipv6 cef\n!\nmultilink bundle-name authenticated\n!\n!\n!\n!\nusername cisco privilege 15 secret 9 \u003csecret hidden\u003e\n!\nredundancy\n!\n!\n! \n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\ninterface GigabitEthernet0/0\n ip address 10.10.1.1 255.255.255.0\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/1\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/2\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/3\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\nip forward-protocol nd\n!\n!\nno ip http server\nno ip http secure-server\nip ssh version 2\n!\nipv6 ioam timestamp\n!\nsnmp-server community \u003cconfiguration removed\u003e\nsnmp-server chassis-id \n!\n!\ncontrol-plane\n!\n!\nline con 0\nline aux 0\nline vty 0 4\n login local\n transport input ssh\n!\nno scheduler allocate\n!\nend\n",
          "device_id": "cml-test:10.10.1.1",
          "device_ip": "10.10.1.1",
          "tags": [
            "device_namespace:cml-test",
            "device_ip:10.10.1.1",
            "device_id:cml-test:10.10.1.1",
            "config_source:cli",
            "profile:cisco-ios"
          ],
          "timestamp": 1763563211
        }
      ],
      "namespace": "cml-test"
    }
  }
]


  Running Checks
  ==============
    
    network_config_management
    -------------------------
      Instance ID: network_config_management:bd436a37500d07da [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/network_config_management.d/conf.yaml[0]
      Total Runs: 1
      Metric Samples: Last Run: 1, Total: 1
      Events: Last Run: 0, Total: 0
      ndmconfig: Last Run: 1, Total: 1
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 2.269s
      Last Execution Date : 2025-11-19 14:40:11.643 UTC (1763563211643)
      Last Successful Execution Date : 2025-11-19 14:40:11 UTC (1763563211000)
      
  Check Worker Utilization
  ========================
    No worker utilization data available

  Metadata
  ========
    config.hash: network_config_management:bd436a37500d07da
    config.provider: file
    config.source: /etc/datadog-agent/conf.d/network_config_management.d/conf.yaml[0]

```



### Additional Notes
