### PR TITLE
[NDMII-3669] Add a max number of allowed SNMP calls during a default scan

### DIFF
--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -26,6 +26,13 @@ type Component interface {
 
 // ScanParams contains options for a device scan
 type ScanParams struct {
-	ScanType     metadata.ScanType
-	CallInterval time.Duration // Duration to sleep between SNMP calls
+	ScanType metadata.ScanType
+
+	// CallInterval specifies how long to wait between consecutive SNMP calls.
+	// A value of 0 means calls are made without any delay.
+	CallInterval time.Duration
+
+	// MaxCallCount limits the total number of SNMP calls in a scan.
+	// A value of 0 means there is no limit.
+	MaxCallCount int
 }

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -29,10 +29,11 @@ import (
 
 const (
 	scanWorkers   = 2 // Max concurrent scans allowed
-	scanQueueSize = 10000
+	scanQueueSize = 10_000
 
 	snmpCallsPerSecond = 8
 	snmpCallInterval   = time.Second / snmpCallsPerSecond
+	maxSnmpCallCount   = 100_000
 
 	scanSchedulerCheckInterval = 10 * time.Minute
 	scanRefreshInterval        = 182 * 24 * time.Hour   // 6 months
@@ -201,6 +202,7 @@ func (m *snmpScanManagerImpl) processScanRequest(req snmpscanmanager.ScanRequest
 		snmpscan.ScanParams{
 			ScanType:     metadata.DefaultScan,
 			CallInterval: snmpCallInterval,
+			MaxCallCount: maxSnmpCallCount,
 		})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {


### PR DESCRIPTION
### What does this PR do?

This PR adds a parameter to specify the max number of SNMP calls in a device scan.
It uses this parameter for default scans to limit the calls to a max of 100 000.
The value 100 000 can be discussed but it seems reasonable to me because the device with the most OID on prod currently has 18 000 OIDs. Plus since we'll sleep about ~0.2 seconds per SNMP call in a default scan, querying 100 000 OIDs would take about ~6 hours.

### Motivation

### Describe how you validated your changes

### Additional Notes
