### PR TITLE
[NDMII-3696] Add SNMP default scan cache file to flare

### DIFF
--- a/comp/snmpscanmanager/impl/flare.go
+++ b/comp/snmpscanmanager/impl/flare.go
@@ -18,6 +18,10 @@ const (
 )
 
 func (m *snmpScanManagerImpl) fillFlare(fb flare.FlareBuilder) error {
+	if !persistentcache.Exists(cacheKey) {
+		return nil
+	}
+
 	filePath, err := persistentcache.GetFileForKey(cacheKey)
 	if err != nil {
 		return err

--- a/comp/snmpscanmanager/impl/flare.go
+++ b/comp/snmpscanmanager/impl/flare.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package snmpscanmanagerimpl
+
+import (
+	"path/filepath"
+
+	flare "github.com/DataDog/datadog-agent/comp/core/flare/types"
+	"github.com/DataDog/datadog-agent/pkg/persistentcache"
+)
+
+const (
+	flareDirName  = "snmp"
+	flareFileName = "snmp_scanned_devices"
+)
+
+func (m *snmpScanManagerImpl) fillFlare(fb flare.FlareBuilder) error {
+	filePath, err := persistentcache.GetFileForKey(cacheKey)
+	if err != nil {
+		return err
+	}
+
+	return fb.CopyFileTo(filePath, filepath.Join(flareDirName, flareFileName))
+}

--- a/comp/snmpscanmanager/impl/flare_test.go
+++ b/comp/snmpscanmanager/impl/flare_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package snmpscanmanagerimpl
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	snmpscanmock "github.com/DataDog/datadog-agent/comp/snmpscan/mock"
+	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFillFlare(t *testing.T) {
+	testDir := t.TempDir()
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("run_path", testDir)
+
+	mockLifecycle := compdef.NewTestLifecycle(t)
+	mockLogger := logmock.New(t)
+	mockIPC := ipcmock.New(t)
+	scanner := snmpscanmock.Mock(t)
+
+	mockScanner, ok := scanner.(*snmpscanmock.SnmpScanMock)
+	assert.True(t, ok)
+	mockScanner.On("ScanDeviceAndSendData",
+		mock.Anything, &snmpparse.SNMPConfig{
+			IPAddress:       "10.0.0.1",
+			Port:            161,
+			CommunityString: "public",
+		}, "namespace", mock.Anything, mock.Anything).
+		Return(nil).
+		Once()
+
+	reqs := Requires{
+		Lifecycle:  mockLifecycle,
+		Logger:     mockLogger,
+		Config:     mockConfig,
+		HTTPClient: mockIPC.GetClient(),
+		Scanner:    mockScanner,
+	}
+
+	provides, err := NewComponent(reqs)
+	assert.NoError(t, err)
+
+	scanManager, ok := provides.Comp.(*snmpScanManagerImpl)
+	assert.True(t, ok)
+
+	mockConfigProvider := newSnmpConfigProviderMock()
+	mockConfigProvider.On("GetDeviceConfig",
+		"10.0.0.1", mock.Anything, mock.Anything).
+		Return(&snmpparse.SNMPConfig{
+			IPAddress:       "10.0.0.1",
+			Port:            161,
+			CommunityString: "public",
+		}, "namespace", nil).
+		Once()
+	scanManager.snmpConfigProvider = mockConfigProvider
+
+	err = mockLifecycle.Start(context.Background())
+	assert.NoError(t, err)
+
+	provides.Comp.RequestScan(snmpscanmanager.ScanRequest{
+		DeviceIP: "10.0.0.1",
+	}, false)
+
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		assertDeviceScans(t, deviceScansByIP{
+			"10.0.0.1": {
+				DeviceIP:   "10.0.0.1",
+				ScanStatus: successScan,
+			},
+		}, scanManager)
+	}, 2*time.Second, 100*time.Millisecond)
+
+	err = mockLifecycle.Stop(context.Background())
+	assert.NoError(t, err)
+
+	mockScanner.AssertExpectations(t)
+	mockConfigProvider.AssertExpectations(t)
+
+	flareBuilderMock := helpers.NewFlareBuilderMock(t, false)
+
+	err = scanManager.fillFlare(flareBuilderMock)
+	assert.NoError(t, err)
+
+	filePath := filepath.Join(flareDirName, flareFileName)
+	flareBuilderMock.AssertFileExists(filePath)
+	flareBuilderMock.AssertFileContentMatch(
+		`{"device_ip":"10\.0\.0\.1","scan_status":"success","scan_end_ts":".+?","failures":0}`,
+		filePath)
+}

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	flare "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
@@ -64,8 +65,9 @@ type Requires struct {
 
 // Provides defines the output of the snmpscanmanager component
 type Provides struct {
-	Comp   snmpscanmanager.Component
-	Status status.InformationProvider
+	Comp          snmpscanmanager.Component
+	Status        status.InformationProvider
+	FlareProvider flare.Provider
 }
 
 // NewComponent creates a new snmpscanmanager component
@@ -101,8 +103,9 @@ func NewComponent(reqs Requires) (Provides, error) {
 	})
 
 	return Provides{
-		Comp:   scanManager,
-		Status: status.NewInformationProvider(scanManager),
+		Comp:          scanManager,
+		Status:        status.NewInformationProvider(scanManager),
+		FlareProvider: flare.NewProvider(scanManager.fillFlare),
 	}, nil
 }
 

--- a/pkg/persistentcache/persistentcache.go
+++ b/pkg/persistentcache/persistentcache.go
@@ -18,10 +18,10 @@ import (
 // Invalid characters to clean up
 var invalidChars = regexp.MustCompile("[^a-zA-Z0-9_-]")
 
-// Return a file where to store the data. We split the key by ":", using the
-// first prefix as directory, if present. This is useful for integrations, which
-// use the check_id formed with $check_name:$hash
-func getFileForKey(key string) (string, error) {
+// GetFileForKey returns a file where to store the data.
+// We split the key by ":", using the first prefix as directory, if present.
+// This is useful for integrations, which use the check_id formed with $check_name:$hash.
+func GetFileForKey(key string) (string, error) {
 	parent := pkgconfigsetup.Datadog().GetString("run_path")
 	paths := strings.SplitN(key, ":", 2)
 	cleanedPath := invalidChars.ReplaceAllString(paths[0], "")
@@ -40,7 +40,7 @@ func getFileForKey(key string) (string, error) {
 
 // Write stores data on disk in the run directory.
 func Write(key, value string) error {
-	path, err := getFileForKey(key)
+	path, err := GetFileForKey(key)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func Write(key, value string) error {
 
 // Read returns a value previously stored, or the empty string.
 func Read(key string) (string, error) {
-	path, err := getFileForKey(key)
+	path, err := GetFileForKey(key)
 	if err != nil {
 		return "", err
 	}
@@ -66,7 +66,7 @@ func Read(key string) (string, error) {
 
 // Exists returns whether the cache exists.
 func Exists(key string) bool {
-	path, err := getFileForKey(key)
+	path, err := GetFileForKey(key)
 	if err != nil {
 		return false
 	}
@@ -76,11 +76,11 @@ func Exists(key string) bool {
 
 // Rename renames a cache file.
 func Rename(oldKey, newKey string) error {
-	oldPath, err := getFileForKey(oldKey)
+	oldPath, err := GetFileForKey(oldKey)
 	if err != nil {
 		return err
 	}
-	newPath, err := getFileForKey(newKey)
+	newPath, err := GetFileForKey(newKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

This PR adds the default scan cache file to the Agent's flare, which could be useful for support cases.

### Motivation

### Describe how you validated your changes

Tested the flare command, and the file is present.

### Additional Notes
