### PR TITLE
[ AGNTLOG-390 ] Extend core e2e test logs with a timestamp and the name of the test emitting the log

### DIFF
--- a/test/e2e-framework/common/utils/log.go
+++ b/test/e2e-framework/common/utils/log.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+// logf logs a message prepended with the current timestamp + test name, along with the given format and args
+func Logf(t *testing.T, format string, args ...any) {
+	t.Helper()
+	args = append([]any{time.Now().Format("02-01-2006 15:04:05"), t.Name()}, args...)
+	t.Logf("%s - %s - "+format, args...)
+}
+
+// errorf logs an error message prepended with the current timestamp + test name, along with the given format and args
+func Errorf(t *testing.T, format string, args ...any) {
+	t.Helper()
+	args = append([]any{time.Now().Format("02-01-2006 15:04:05"), t.Name()}, args...)
+	t.Errorf("%s - %s - "+format, args...)
+}

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -156,9 +156,10 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 
+	"gopkg.in/zorkian/go-datadog-api.v2"
+
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components"
-	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
@@ -229,7 +230,7 @@ func (bs *BaseSuite[Env]) EventuallyWithT(condition func(*assert.CollectT), time
 	return bs.Suite.EventuallyWithT(func(c *assert.CollectT) {
 		defer func() {
 			if r := recover(); r != nil {
-				bs.T().Errorf("EventuallyWithT, panic: %v", r)
+				utils.Errorf(bs.T(), "EventuallyWithT, panic: %v", r)
 			}
 		}()
 		condition(c)
@@ -257,7 +258,7 @@ func (bs *BaseSuite[Env]) EventuallyWithTf(condition func(*assert.CollectT), wai
 	return bs.Suite.EventuallyWithTf(func(c *assert.CollectT) {
 		defer func() {
 			if r := recover(); r != nil {
-				bs.T().Errorf("EventuallyWithTf, panic: %v", r)
+				utils.Errorf(bs.T(), "EventuallyWithTf, panic: %v", r)
 			}
 		}()
 		condition(c)
@@ -271,7 +272,7 @@ func (bs *BaseSuite[Env]) CleanupOnSetupFailure() {
 	if err := recover(); err != nil || bs.T().Failed() {
 		bs.firstFailTest = "Initial provisioning SetupSuite" // This is required to handle skipDeleteOnFailure
 		defer func() {
-			bs.T().Logf("Calling TearDownSuite after SetupSuite failed with the following error: %v", err)
+			utils.Logf(bs.T(), "Calling TearDownSuite after SetupSuite failed with the following error: %v", err)
 			bs.TearDownSuite()
 			bs.T().Fatal("TearDownSuite called after SetupSuite failed")
 		}()
@@ -282,9 +283,9 @@ func (bs *BaseSuite[Env]) CleanupOnSetupFailure() {
 				// at least one test failed, diagnose the environment
 				diagnose, diagnoseErr := diagnosableEnv.Diagnose(bs.SessionOutputDir())
 				if diagnoseErr != nil {
-					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+					utils.Logf(bs.T(), "unable to diagnose environment: %v", diagnoseErr)
 				} else {
-					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+					utils.Logf(bs.T(), "Diagnose result:\n\n%s", diagnose)
 				}
 			}
 		}
@@ -381,11 +382,11 @@ func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
 
 func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.ProvisionerMap) error {
 	if reflect.DeepEqual(bs.currentProvisioners, targetProvisioners) {
-		bs.T().Logf("No change in provisioners, skipping environment update")
+		utils.Logf(bs.T(), "No change in provisioners, skipping environment update")
 		return nil
 	}
 
-	bs.T().Logf("Updating environment with new provisioners")
+	utils.Logf(bs.T(), "Updating environment with new provisioners")
 
 	logger := newTestLogger(bs.T())
 	ctx, cancel := bs.providerContext(createTimeout)
@@ -399,7 +400,7 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.Provision
 	// Check for removed provisioners, we need to call delete on them first
 	for id, provisioner := range bs.currentProvisioners {
 		if _, found := targetProvisioners[id]; !found {
-			bs.T().Logf("Destroying stack %s with provisioner %s", bs.params.stackName, id)
+			utils.Logf(bs.T(), "Destroying stack %s with provisioner %s", bs.params.stackName, id)
 			if err := provisioner.Destroy(ctx, bs.params.stackName, logger); err != nil {
 				return fmt.Errorf("unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
 			}
@@ -412,7 +413,7 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.Provision
 		var provisionerResources provisioners.RawResources
 		var err error
 
-		bs.T().Logf("Provisioning environment stack %s with provisioner %s", bs.params.stackName, id)
+		utils.Logf(bs.T(), "Provisioning environment stack %s with provisioner %s", bs.params.stackName, id)
 		switch pType := provisioner.(type) {
 		case provisioners.TypedProvisioner[Env]:
 			provisionerResources, err = pType.ProvisionEnv(ctx, bs.params.stackName, logger, newEnv)
@@ -426,13 +427,13 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.Provision
 			if diagnosableProvisioner, ok := provisioner.(provisioners.Diagnosable); ok {
 				stackName, err := infra.GetStackManager().GetPulumiStackName(bs.params.stackName)
 				if err != nil {
-					bs.T().Logf("unable to get stack name for diagnose, err: %v", err)
+					utils.Logf(bs.T(), "unable to get stack name for diagnose, err: %v", err)
 				} else {
 					diagnoseResult, diagnoseErr := diagnosableProvisioner.Diagnose(ctx, stackName)
 					if diagnoseErr != nil {
-						bs.T().Logf("WARNING: Diagnose failed: %v", diagnoseErr)
+						utils.Logf(bs.T(), "WARNING: Diagnose failed: %v", diagnoseErr)
 					} else if diagnoseResult != "" {
-						bs.T().Logf("Diagnose result: %s", diagnoseResult)
+						utils.Logf(bs.T(), "Diagnose result: %s", diagnoseResult)
 					}
 				}
 
@@ -600,10 +601,10 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 	// Create the root output directory for the test suite session
 	sessionDirectory, err := runner.GetProfile().CreateOutputSubDir(bs.getSuiteSessionSubdirectory())
 	if err != nil {
-		bs.T().Errorf("unable to create session output directory: %v", err)
+		utils.Errorf(bs.T(), "unable to create session output directory: %v", err)
 	}
 	bs.outputDir = sessionDirectory
-	bs.T().Logf("Suite session output directory: %s", bs.outputDir)
+	utils.Logf(bs.T(), "Suite session output directory: %s", bs.outputDir)
 	// In `SetupSuite` we cannot fail as `TearDownSuite` will not be called otherwise.
 	// Meaning that stack clean up may not be called.
 	// We do implement an explicit recover to handle this manuallay.
@@ -672,7 +673,7 @@ func (bs *BaseSuite[Env]) AfterTest(suiteName, testName string) {
 		testOutputDir := filepath.Join(bs.SessionOutputDir(), testPart)
 		err := os.MkdirAll(testOutputDir, 0755)
 		if err != nil {
-			bs.T().Logf("unable to create test output directory: %v", err)
+			utils.Logf(bs.T(), "unable to create test output directory: %v", err)
 		} else {
 			// run environment diagnose if the test failed
 			if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok && diagnosableEnv != nil {
@@ -680,9 +681,9 @@ func (bs *BaseSuite[Env]) AfterTest(suiteName, testName string) {
 				bs.T().Logf("========= Some tests failed, diagnosing environment ==========")
 				diagnose, diagnoseErr := diagnosableEnv.Diagnose(testOutputDir)
 				if diagnoseErr != nil {
-					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+					utils.Logf(bs.T(), "unable to diagnose environment: %v", diagnoseErr)
 				} else {
-					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+					utils.Logf(bs.T(), "Diagnose result:\n\n%s", diagnose)
 				}
 				bs.T().Logf("========= Environment diagnosed ==========")
 			}
@@ -709,14 +710,14 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 	}
 
 	if bs.initOnly {
-		bs.T().Logf("INIT_ONLY is set, skipping deletion")
+		utils.Logf(bs.T(), "INIT_ONLY is set, skipping deletion")
 		return
 	}
 
 	if bs.coverage && !bs.params.disableCoverage {
 		err := bs.SaveCoverage(bs.coverageOutDir)
 		if err != nil {
-			bs.T().Errorf("fatal errors were encounterned while computing coverage: %v", err)
+			utils.Errorf(bs.T(), "fatal errors were encounterned while computing coverage: %v", err)
 		}
 
 		bs.attachMetadataToCoverage(bs.coverageOutDir)
@@ -735,44 +736,44 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 		// Run provisioner Diagnose before tearing down the stack
 		stackName, err := infra.GetStackManager().GetPulumiStackName(bs.params.stackName)
 		if err != nil {
-			bs.T().Logf("unable to get stack name for diagnose, err: %v", err)
+			utils.Logf(bs.T(), "unable to get stack name for diagnose, err: %v", err)
 			continue
 		}
 		if diagnosableProvisioner, ok := provisioner.(provisioners.Diagnosable); ok && !bs.teardownOnly {
-			bs.T().Logf("Running Diagnose for provisioner %s", id)
+			utils.Logf(bs.T(), "Running Diagnose for provisioner %s", id)
 			diagnoseResult, diagnoseErr := diagnosableProvisioner.Diagnose(ctx, stackName)
 			if diagnoseErr != nil {
-				bs.T().Logf("WARNING: Diagnose failed: %v", diagnoseErr)
+				utils.Logf(bs.T(), "WARNING: Diagnose failed: %v", diagnoseErr)
 			} else if diagnoseResult != "" {
-				bs.T().Logf("Diagnose result: %s", diagnoseResult)
+				utils.Logf(bs.T(), "Diagnose result: %s", diagnoseResult)
 			}
 		}
 
 		if bs.IsWithinCI() && os.Getenv("REMOTE_STACK_CLEANING") == "true" {
 			fullStackName := "organization/e2eci/" + stackName
-			bs.T().Logf("Remote stack cleaning enabled for stack %s", fullStackName)
+			utils.Logf(bs.T(), "Remote stack cleaning enabled for stack %s", fullStackName)
 
 			// If we are within CI, we let the stack be destroyed by the stackcleaner-worker service
 			// After 10s, the API will time out without an error, this can happen on high workload but the stack will still be created from the agent-ci-api
 			cmd := exec.Command("dda", "inv", "agent-ci-api", "stackcleaner/stack", "--env", "prod", "--ty", "stackcleaner_workflow_request", "--attrs", fmt.Sprintf("stack_name=%s,job_name=%s,job_id=%s,pipeline_id=%s,ref=%s,ignore_lock=bool:true,ignore_not_found=bool:false,cancel_first=bool:true", fullStackName, os.Getenv("CI_JOB_NAME"), os.Getenv("CI_JOB_ID"), os.Getenv("CI_PIPELINE_ID"), os.Getenv("CI_COMMIT_REF_NAME")), "--timeout", "10", "--ignore-timeout-error")
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				bs.T().Logf("WARNING: Unable to destroy stack %s: %s", stackName, out)
+				utils.Logf(bs.T(), "WARNING: Unable to destroy stack %s: %s", stackName, out)
 				_, err := bs.datadogClient.PostEvent(&datadog.Event{
 					Title: pointer.Ptr("Unable to destroy stack " + stackName),
 					Text:  pointer.Ptr(fmt.Sprintf("Unable to destroy stack %s: %s", stackName, out)),
 					Tags:  []string{"test:e2e", "stack:destroy", "stack_name:" + stackName, "service:stackcleaner-worker", "ci.job.name:" + os.Getenv("CI_JOB_NAME"), "ci.job.id:" + os.Getenv("CI_JOB_ID"), "ci.pipeline.id:" + os.Getenv("CI_PIPELINE_ID")},
 				})
 				if err != nil {
-					bs.T().Logf("Unable to post event: %v", err)
+					utils.Logf(bs.T(), "Unable to post event: %v", err)
 				}
 			} else {
-				bs.T().Logf("Stack %s will be cleaned up by the stackcleaner-worker service", fullStackName)
+				utils.Logf(bs.T(), "Stack %s will be cleaned up by the stackcleaner-worker service", fullStackName)
 			}
 		} else {
-			bs.T().Logf("Destroying stack %s with provisioner %s", bs.params.stackName, id)
+			utils.Logf(bs.T(), "Destroying stack %s with provisioner %s", bs.params.stackName, id)
 			if err := provisioner.Destroy(ctx, bs.params.stackName, newTestLogger(bs.T())); err != nil {
-				bs.T().Errorf("unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
+				utils.Errorf(bs.T(), "unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
 			}
 		}
 	}
@@ -790,16 +791,16 @@ func (bs *BaseSuite[Env]) SaveCoverage(coverageDir string) error {
 		if _, err := os.Stat(coverageFolder); os.IsNotExist(err) {
 			err := os.MkdirAll(coverageFolder, 0755)
 			if err != nil {
-				bs.T().Logf("WARNING: Unable to create coverage folder: %v", err)
+				utils.Logf(bs.T(), "WARNING: Unable to create coverage folder: %v", err)
 			}
 		}
 		result, err := coverageEnv.Coverage(coverageFolder)
-		bs.T().Logf("Coverage result: %s", result)
+		utils.Logf(bs.T(), "Coverage result: %s", result)
 		if err != nil {
 			return err
 		}
 	} else {
-		bs.T().Logf("WARNING: Coverage is enabled but the environment does not implement the Coverageable interface")
+		utils.Logf(bs.T(), "WARNING: Coverage is enabled but the environment does not implement the Coverageable interface")
 		return nil
 	}
 	return nil
@@ -809,7 +810,7 @@ func (bs *BaseSuite[Env]) attachMetadataToCoverage(coverageDir string) {
 
 	rootTestName := strings.Split(bs.T().Name(), "/")[0]
 	if _, err := os.Stat(filepath.Join(coverageDir, strings.ToLower(rootTestName))); os.IsNotExist(err) {
-		bs.T().Logf("WARNING: Coverage folder %s does not exist", filepath.Join(coverageDir, strings.ToLower(rootTestName)))
+		utils.Logf(bs.T(), "WARNING: Coverage folder %s does not exist", filepath.Join(coverageDir, strings.ToLower(rootTestName)))
 		return
 	}
 
@@ -821,13 +822,13 @@ func (bs *BaseSuite[Env]) attachMetadataToCoverage(coverageDir string) {
 	metadataFilePath := filepath.Join(coverageDir, strings.ToLower(rootTestName), "metadata.json")
 	metadataFile, err := os.Create(metadataFilePath)
 	if err != nil {
-		bs.T().Logf("WARNING: Unable to create metadata file: %v", err)
+		utils.Logf(bs.T(), "WARNING: Unable to create metadata file: %v", err)
 		return
 	}
 	defer metadataFile.Close()
 	err = json.NewEncoder(metadataFile).Encode(metadata)
 	if err != nil {
-		bs.T().Logf("WARNING: Unable to encode metadata: %v", err)
+		utils.Logf(bs.T(), "WARNING: Unable to encode metadata: %v", err)
 	}
 }
 
@@ -843,7 +844,7 @@ func (bs *BaseSuite[Env]) SessionOutputDir() string {
 func Run[Env any, T Suite[Env]](t *testing.T, s T, options ...SuiteOption) {
 	devMode, err := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.DevMode, false)
 	if err != nil {
-		t.Logf("Unable to get DevMode value, DevMode will be disabled, error: %v", err)
+		utils.Logf(t, "Unable to get DevMode value, DevMode will be disabled, error: %v", err)
 	} else if devMode {
 		options = append(options, WithDevMode())
 	}

--- a/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/optional"
 
@@ -195,7 +196,7 @@ func (agent *agentCommandRunner) WorkloadList() (*agentclient.Status, error) {
 func (agent *agentCommandRunner) waitForReadyTimeout(timeout time.Duration) error {
 	interval := 100 * time.Millisecond
 	maxRetries := timeout.Milliseconds() / interval.Milliseconds()
-	agent.t.Log("Waiting for the agent to be ready")
+	utils.Logf(agent.t, "Waiting for the agent to be ready")
 	err := backoff.Retry(func() error {
 		_, err := agent.executor.execute([]string{"status"})
 		if err != nil {

--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -20,12 +20,14 @@ import (
 	"strings"
 	"time"
 
-	oscomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
 	"github.com/cenkalti/backoff"
 	"github.com/pkg/sftp"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	oscomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
 
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
@@ -130,7 +132,7 @@ func NewHost(context common.Context, hostOutput remote.HostOutput) (*Host, error
 
 // Reconnect closes the current ssh client and creates a new one, with retries.
 func (h *sshExecutor) Reconnect() error {
-	h.context.T().Log("Reconnecting to host")
+	utils.Logf(h.context.T(), "Reconnecting to host")
 	if h.client != nil {
 		_ = h.client.Close()
 	}
@@ -146,7 +148,7 @@ func (h *sshExecutor) Reconnect() error {
 
 		privileged, err := getSSHClient(h.privilegedUsername, h.host, h.privateKey, h.privateKeyPassphrase)
 		if err != nil {
-			h.context.T().Logf("Unable to create privileged SSH connection: %v", err)
+			utils.Logf(h.context.T(), "Unable to create privileged SSH connection: %v", err)
 			// Ignore this error for now, since SSH connection as root are not enable on some providers
 		}
 		h.privileged = privileged
@@ -166,7 +168,7 @@ func (h *sshExecutor) Execute(command string, options ...ExecuteOption) (string,
 
 func (h *sshExecutor) executeAndReconnectOnError(command string) (string, error) {
 	scrubbedCommand := h.scrubber.ScrubLine(command) // scrub the command in case it contains secrets
-	h.context.T().Logf("%s - %s - Executing command `%s`", time.Now().Format("02-01-2006 15:04:05"), h.context.T().Name(), scrubbedCommand)
+	utils.Logf(h.context.T(), "Executing command `%s`", scrubbedCommand)
 	stdout, err := execute(h.client, command)
 	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
 		err = h.Reconnect()
@@ -193,7 +195,7 @@ func (h *sshExecutor) Start(command string, options ...ExecuteOption) (*ssh.Sess
 
 func (h *sshExecutor) startAndReconnectOnError(command string) (*ssh.Session, io.WriteCloser, io.Reader, error) {
 	scrubbedCommand := h.scrubber.ScrubLine(command) // scrub the command in case it contains secrets
-	h.context.T().Logf("%s - %s - Executing command `%s`", time.Now().Format("02-01-2006 15:04:05"), h.context.T().Name(), scrubbedCommand)
+	utils.Logf(h.context.T(), "Executing command `%s`", scrubbedCommand)
 	session, stdin, stdout, err := start(h.client, command)
 	if err != nil && strings.Contains(err.Error(), "failed to create session:") {
 		err = h.Reconnect()
@@ -214,7 +216,7 @@ func (h *sshExecutor) MustExecute(command string, options ...ExecuteOption) stri
 
 // CopyFileFromFS creates a sftp session and copy a single embedded file to the remote host through SSH
 func (h *Host) CopyFileFromFS(fs fs.FS, src, dst string) {
-	h.context.T().Logf("Copying file from local %s to remote %s", src, dst)
+	utils.Logf(h.context.T(), "Copying file from local %s to remote %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -227,7 +229,7 @@ func (h *Host) CopyFileFromFS(fs fs.FS, src, dst string) {
 
 // CopyFile creates a sftp session and copy a single file to the remote host through SSH
 func (h *Host) CopyFile(src string, dst string) {
-	h.context.T().Logf("Copying file from local %s to remote %s", src, dst)
+	utils.Logf(h.context.T(), "Copying file from local %s to remote %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -237,7 +239,7 @@ func (h *Host) CopyFile(src string, dst string) {
 
 // CopyFolder create a sftp session and copy a folder to remote host through SSH
 func (h *Host) CopyFolder(srcFolder string, dstFolder string) error {
-	h.context.T().Logf("Copying folder from local %s to remote %s", srcFolder, dstFolder)
+	utils.Logf(h.context.T(), "Copying folder from local %s to remote %s", srcFolder, dstFolder)
 	dstFolder = h.convertPathSeparator(dstFolder)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -246,7 +248,7 @@ func (h *Host) CopyFolder(srcFolder string, dstFolder string) error {
 
 // FileExists create a sftp session to and returns true if the file exists and is a regular file
 func (h *Host) FileExists(path string) (bool, error) {
-	h.context.T().Logf("Checking if file exists: %s", path)
+	utils.Logf(h.context.T(), "Checking if file exists: %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -276,7 +278,7 @@ func (h *Host) EnsureFileIsReadable(path string) error {
 
 // GetFile create a sftp session and copy a single file from the remote host through SSH
 func (h *Host) GetFile(src string, dst string) error {
-	h.context.T().Logf("Copying file from remote %s to local %s", src, dst)
+	utils.Logf(h.context.T(), "Copying file from remote %s to local %s", src, dst)
 	dst = h.convertPathSeparator(dst)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -285,7 +287,7 @@ func (h *Host) GetFile(src string, dst string) error {
 
 // GetFolder create a sftp session and copy a folder from the remote host through SSH
 func (h *Host) GetFolder(srcFolder string, dstFolder string) error {
-	h.context.T().Logf("Copying folder from remote %s to local %s", srcFolder, dstFolder)
+	utils.Logf(h.context.T(), "Copying folder from remote %s to local %s", srcFolder, dstFolder)
 	srcFolder = h.convertPathSeparator(srcFolder)
 	dstFolder = h.convertPathSeparator(dstFolder)
 	sftpClient := h.getSFTPClient()
@@ -294,7 +296,7 @@ func (h *Host) GetFolder(srcFolder string, dstFolder string) error {
 }
 
 func (h *Host) readFileWithClient(sftpClient *sftp.Client, path string) ([]byte, error) {
-	h.context.T().Logf("Reading file with client at %s", path)
+	utils.Logf(h.context.T(), "Reading file with client at %s", path)
 	path = h.convertPathSeparator(path)
 	defer sftpClient.Close()
 
@@ -314,19 +316,19 @@ func (h *Host) readFileWithClient(sftpClient *sftp.Client, path string) ([]byte,
 
 // ReadFile reads the content of the file, return bytes read and error if any
 func (h *Host) ReadFile(path string) ([]byte, error) {
-	h.context.T().Logf("Reading file at %s", path)
+	utils.Logf(h.context.T(), "Reading file at %s", path)
 	return h.readFileWithClient(h.getSFTPClient(), path)
 }
 
 // ReadFilePrivileged reads the content of the file with a privileged user, return bytes read and error if any
 func (h *Host) ReadFilePrivileged(path string) ([]byte, error) {
-	h.context.T().Logf("Reading file with privileges at %s", path)
+	utils.Logf(h.context.T(), "Reading file with privileges at %s", path)
 	return h.readFileWithClient(h.getSFTPPrivilegedClient(), path)
 }
 
 // WriteFile write content to the file and returns the number of bytes written and error if any
 func (h *Host) WriteFile(path string, content []byte) (int64, error) {
-	h.context.T().Logf("Writing to file at %s", path)
+	utils.Logf(h.context.T(), "Writing to file at %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -343,7 +345,7 @@ func (h *Host) WriteFile(path string, content []byte) (int64, error) {
 
 // AppendFile append content to the file and returns the number of bytes appened and error if any
 func (h *Host) AppendFile(os, path string, content []byte) (int64, error) {
-	h.context.T().Logf("Appending to file at %s", path)
+	utils.Logf(h.context.T(), "Appending to file at %s", path)
 	path = h.convertPathSeparator(path)
 	if os == "linux" {
 		return h.appendWithSudo(path, content)
@@ -353,7 +355,7 @@ func (h *Host) AppendFile(os, path string, content []byte) (int64, error) {
 
 // ReadDir returns list of directory entries in path
 func (h *Host) ReadDir(path string) ([]fs.DirEntry, error) {
-	h.context.T().Logf("Reading filesystem at %s", path)
+	utils.Logf(h.context.T(), "Reading filesystem at %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 
@@ -397,7 +399,7 @@ func (h *Host) FindFiles(name string) ([]string, error) {
 // Lstat returns a FileInfo structure describing path.
 // if path is a symbolic link, the FileInfo structure describes the symbolic link.
 func (h *Host) Lstat(path string) (fs.FileInfo, error) {
-	h.context.T().Logf("Reading file info of %s", path)
+	utils.Logf(h.context.T(), "Reading file info of %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -409,7 +411,7 @@ func (h *Host) Lstat(path string) (fs.FileInfo, error) {
 // If the path is already a directory, does nothing and returns nil.
 // Otherwise returns an error if any.
 func (h *Host) MkdirAll(path string) error {
-	h.context.T().Logf("Creating directory %s", path)
+	utils.Logf(h.context.T(), "Creating directory %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -420,7 +422,7 @@ func (h *Host) MkdirAll(path string) error {
 // Remove removes the specified file or directory.
 // Returns an error if file or directory does not exist, or if the directory is not empty.
 func (h *Host) Remove(path string) error {
-	h.context.T().Logf("Removing %s", path)
+	utils.Logf(h.context.T(), "Removing %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -431,7 +433,7 @@ func (h *Host) Remove(path string) error {
 // RemoveAll recursively removes all files/folders in the specified directory.
 // Returns an error if the directory does not exist.
 func (h *Host) RemoveAll(path string) error {
-	h.context.T().Logf("Removing all under %s", path)
+	utils.Logf(h.context.T(), "Removing all under %s", path)
 	path = h.convertPathSeparator(path)
 	sftpClient := h.getSFTPClient()
 	defer sftpClient.Close()
@@ -441,7 +443,7 @@ func (h *Host) RemoveAll(path string) error {
 
 // DialPort creates a connection from the remote host to its `port`.
 func (h *Host) DialPort(port uint16) (net.Conn, error) {
-	h.context.T().Logf("Creating connection to host port %d", port)
+	utils.Logf(h.context.T(), "Creating connection to host port %d", port)
 	address := fmt.Sprintf("127.0.0.1:%d", port)
 	protocol := "tcp"
 	// TODO add context to host
@@ -560,8 +562,8 @@ func (h *Host) getSFTPClient() *sftp.Client {
 func (h *Host) getSFTPPrivilegedClient() *sftp.Client {
 	if h.privileged == nil {
 		// Some cloud provider don't provide SSH connection as root (GCP) required for these file operations
-		h.context.T().Logf("Can't SFTP files without a privileged SSH connection")
-		h.context.T().Fail()
+		utils.Logf(h.context.T(), "Can't SFTP files without a privileged SSH connection")
+		require.Fail(h.context.T(), "Can't SFTP files without a privileged SSH connection")
 		return nil
 	}
 	sftpClient, err := sftp.NewClient(h.privileged, sftp.UseConcurrentWrites(true))

--- a/test/e2e-framework/testing/utils/e2e/client/host.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host.go
@@ -563,7 +563,7 @@ func (h *Host) getSFTPPrivilegedClient() *sftp.Client {
 	if h.privileged == nil {
 		// Some cloud provider don't provide SSH connection as root (GCP) required for these file operations
 		utils.Logf(h.context.T(), "Can't SFTP files without a privileged SSH connection")
-		require.Fail(h.context.T(), "Can't SFTP files without a privileged SSH connection")
+		h.context.T().Fail()
 		return nil
 	}
 	sftpClient, err := sftp.NewClient(h.privileged, sftp.UseConcurrentWrites(true))


### PR DESCRIPTION
### What does this PR do?
Currently, e2e tests will run a number of operations on remote machines via the test framework itself, rather than via the actual test code. This that the calling file and line number, both of whom are automatically prepended to logs emitted via the testing library's logging functionality, are not enough to identify which test actually emitted the log. This causes a traceability problem when multiple tests are being run in parallel.

There is already a framework in place for disambiguating logs, utilized in a high-value log emitting from host.go. This MR extends that slightly, targeting the most common files emitting logs in the test runs to shift over to a common logger.

Log lines under the new format:
```
    host.go:135: 03-12-2025 15:54:29 - TestLinuxVMFileTailingSuite - Reconnecting to host
    agent_commands.go:199: 03-12-2025 15:54:30 - TestLinuxVMFileTailingSuite - Waiting for the agent to be ready
    host.go:171: 03-12-2025 15:54:30 - TestLinuxVMFileTailingSuite - Executing command `sudo datadog-agent "status"`
=== RUN   TestLinuxVMFileTailingSuite/TestLinuxLogTailing
    suite.go:385: 03-12-2025 15:54:30 - TestLinuxVMFileTailingSuite/TestLinuxLogTailing - No change in provisioners, skipping environment update
```

### Motivation

### Describe how you validated your changes

### Additional Notes
