### PR TITLE
Otel-agent without core: Disable remote tagger and remote config when CMD_PORT is negative

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -199,6 +199,9 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	if addr := ddc.Traces.Endpoint; addr != "" {
 		pkgconfig.Set("apm_config.apm_dd_url", addr, pkgconfigmodel.SourceFile)
 	}
+	if pkgconfig.GetInt("cmd_port") <= 0 {
+		pkgconfig.Set("remote_configuration.enabled", false, pkgconfigmodel.SourceFile)
+	}
 
 	if pkgconfig.Get("apm_config.features") == nil {
 		apmConfigFeatures := []string{}

--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -93,7 +93,7 @@ func runTraceAgentProcess(ctx context.Context, cliParams *Params, defaultConfPat
 				// that we do not need the container tagging provided by the
 				// remote tagger in this environment, so we can use the noop
 				// tagger instead.
-				Disable: serverlessenv.IsAzureAppServicesExtension,
+				Disable: func(_ coreconfig.Component) bool { return serverlessenv.IsAzureAppServicesExtension() },
 			},
 			tagger.NewRemoteParams()),
 		fx.Invoke(func(_ config.Component) {}),

--- a/comp/core/tagger/def/params.go
+++ b/comp/core/tagger/def/params.go
@@ -85,5 +85,5 @@ type DualParams struct {
 // OptionalRemoteParams provides the optional remote tagger parameters
 type OptionalRemoteParams struct {
 	// Disable opts out of the remote tagger in favor of the noop tagger
-	Disable func() bool
+	Disable func(config.Component) bool
 }

--- a/comp/core/tagger/impl-optional-remote/optional-remote.go
+++ b/comp/core/tagger/impl-optional-remote/optional-remote.go
@@ -40,7 +40,7 @@ type Provides struct {
 
 // NewComponent returns either a remote tagger or a noop tagger based on the configuration
 func NewComponent(req Requires) (Provides, error) {
-	if req.OptionalRemoteParams.Disable() {
+	if req.OptionalRemoteParams.Disable(req.Config) {
 		return Provides{
 			remote.Provides{
 				Comp: noop.NewComponent(),

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
@@ -24,7 +24,7 @@ import (
 
 	logfx "github.com/DataDog/datadog-agent/comp/core/log/fx"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
+	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-optional-remote"
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -61,7 +61,7 @@ func (f *factory) getOrCreateData() (*data, error) {
 		logfx.Module(),
 		telemetryModule(),
 		fxutil.FxAgentBase(),
-		remoteTaggerfx.Module(tagger.NewRemoteParams()),
+		remoteTaggerfx.Module(tagger.OptionalRemoteParams{Disable: func(cfg config.Component) bool { return cfg.GetInt("cmd_port") <= 0 }}, tagger.NewRemoteParams()),
 		fx.Provide(func(t tagger.Component) taggerTypes.TaggerClient {
 			return t
 		}),

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/factory.go
@@ -24,7 +24,7 @@ import (
 
 	logfx "github.com/DataDog/datadog-agent/comp/core/log/fx"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-optional-remote"
+	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -61,7 +61,7 @@ func (f *factory) getOrCreateData() (*data, error) {
 		logfx.Module(),
 		telemetryModule(),
 		fxutil.FxAgentBase(),
-		remoteTaggerfx.Module(tagger.OptionalRemoteParams{Disable: func(cfg config.Component) bool { return cfg.GetInt("cmd_port") <= 0 }}, tagger.NewRemoteParams()),
+		remoteTaggerfx.Module(tagger.NewRemoteParams()),
 		fx.Provide(func(t tagger.Component) taggerTypes.TaggerClient {
 			return t
 		}),

--- a/releasenotes/notes/otel-agent-without-core-agent-262f6d669ba8c826.yaml
+++ b/releasenotes/notes/otel-agent-without-core-agent-262f6d669ba8c826.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The otel-agent can now be told not to contact the core-agent by setting ``DD_CMD_PORT`` to 0


### PR DESCRIPTION
### What does this PR do?

Prevent the otel agent to continuously try to contact the core agent when it is deployed without one.

The way it will know there is no core agent is by relying on the `CMD_PORT` being configured to 0 or some negative value.

### Motivation

[OTAGENT-565](https://datadoghq.atlassian.net/browse/OTAGENT-565?atlOrigin=eyJpIjoiNjJmZjZkY2IyZTUyNDkxYjkzMzRjNWM4NDgzY2Q4YWQiLCJwIjoiaiJ9)

Open-telemetry gateway deployment is a use case where we want an otel-agent running without a core agent, while currently it was designed with the assumption that there would always be a core agent next to it.

### Describe how you validated your changes

```shell
dda inv otel-agent.build

export DD_SITE=datadoghq.com
export DD_API_KEY="[...]"
export DD_OTELCOLLECTOR_CONVERTER_FEATURES="health_check,zpages,pprof"
export DD_OTELCOLLECTOR_ENABLED=1
DD_CMD_PORT=5001 ./bin/otel-agent/otel-agent run --config bin/otel-agent/dist/otel-config.yaml
# Get spam about connection refused
DD_CMD_PORT=-1 ./bin/otel-agent/otel-agent run --config bin/otel-agent/dist/otel-config.yaml
# No spam
```

### Additional Notes

TODO in this PR:
- [x] Disable the remote tagger
- [x] Disable the remote config of the embedded trace agent

To be done in other PRs:
- Do not try to contact the core agent at startup to determine the hostname
  - Do we want to ship the core agent binary to be able to exec it to get the hostname ?
  - Or instead rely on the OS hostname ?
  - Or embed the logic in the otel-agent ?

[OTAGENT-565]: https://datadoghq.atlassian.net/browse/OTAGENT-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ