### PR TITLE
[SMP] Adjust quality_gate_logs memory limit

### DIFF
--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_pss_bytes
-      upper_bound: "205 MiB"
+      upper_bound: "220 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?

Bumps the `quality_gate_logs` upper bound on memory usage in response to lading update 0.29.0 and https://github.com/DataDog/datadog-agent/pull/42862. These two changes modify the contents of the logs generated in this experiment.

This limit is generous but will be cranked back down after a few days of seeing the new behavior.
