### PR TITLE
Tags for TLS version offered and TLS version chosen for Windows

### DIFF
--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/tls"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
@@ -116,6 +117,13 @@ func FlowToConnStat(cs *ConnectionStats, flow *driver.PerFlowData, enableMonoton
 	cs.Direction = connDirection(flow.Flags)
 	cs.SPortIsEphemeral = IsPortInEphemeralRange(cs.Family, cs.Type, cs.SPort)
 	cs.Cookie = flow.FlowCookie
+
+	// cipher suite not yet supported on windows.
+	cs.TLSTags = tls.Tags{
+		ChosenVersion:   flow.Tls_version_chosen,
+		OfferedVersions: uint8(flow.Tls_versions_offered),
+	}
+
 	if connectionType == TCP {
 
 		tf := flow.TCPFlow()

--- a/pkg/network/event_windows_test.go
+++ b/pkg/network/event_windows_test.go
@@ -7,8 +7,12 @@ package network
 
 import (
 	"slices"
+	"syscall"
 	"testing"
+	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/network/driver"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 
@@ -68,4 +72,138 @@ func TestKeyTuplesFromConn(t *testing.T) {
 			(keyTuple.SrcPort == sourcePort) && (keyTuple.DstPort == destinationPort)
 	}), "Missing original connection")
 
+}
+
+func TestFlowToConnStatWithIPv6TcpMonotonic(t *testing.T) {
+	flow := &driver.PerFlowData{
+		FlowHandle:               1,
+		FlowCookie:               2,
+		ProcessId:                3,
+		AddressFamily:            syscall.AF_INET6,
+		Protocol:                 syscall.IPPROTO_TCP,
+		Flags:                    driver.FlowClosedMask | (driver.FlowDirectionInbound << driver.FlowDirectionBits),
+		PacketsOut:               10,
+		MonotonicSentBytes:       11,
+		TransportBytesOut:        12,
+		PacketsIn:                13,
+		MonotonicRecvBytes:       14,
+		TransportBytesIn:         15,
+		Timestamp:                16,
+		LocalPort:                17,
+		RemotePort:               18,
+		ClassificationStatus:     driver.ClassificationClassified,
+		ClassifyRequest:          driver.ClassificationRequestTLS,
+		ClassifyResponse:         21,
+		HttpUpgradeToH2Requested: 22,
+		HttpUpgradeToH2Accepted:  23,
+		Tls_versions_offered:     24,
+		Tls_version_chosen:       25,
+		Tls_alpn_requested:       26,
+		Tls_alpn_chosen:          27,
+	}
+
+	tcpData := &driver.TCPFlowData{
+		IRTT:             100,
+		SRTT:             101,
+		RttVariance:      102,
+		RetransmitCount:  103,
+		ConnectionStatus: uint32(driver.ConnectionStatusACKRST),
+	}
+
+	for i := 0; i < 16; i++ {
+		flow.LocalAddress[i] = byte(i + 1)
+		flow.RemoteAddress[i] = byte(i + 101)
+	}
+
+	flowData := (*driver.TCPFlowData)(unsafe.Pointer(&flow.Protocol_u[0]))
+	flowData.IRTT = tcpData.IRTT
+	flowData.SRTT = tcpData.SRTT
+	flowData.RttVariance = tcpData.RttVariance
+	flowData.RetransmitCount = tcpData.RetransmitCount
+	flowData.ConnectionStatus = tcpData.ConnectionStatus
+
+	cs := &ConnectionStats{}
+	FlowToConnStat(cs, flow, true)
+
+	assert.Equal(t, cs.Source, convertV6Addr(flow.LocalAddress))
+	assert.Equal(t, cs.Dest, convertV6Addr(flow.RemoteAddress))
+	assert.Equal(t, cs.Monotonic.SentBytes, flow.MonotonicSentBytes)
+	assert.Equal(t, cs.Monotonic.RecvBytes, flow.MonotonicRecvBytes)
+	assert.Equal(t, cs.Monotonic.SentPackets, flow.PacketsOut)
+	assert.Equal(t, cs.Monotonic.RecvPackets, flow.PacketsIn)
+	assert.Equal(t, cs.LastUpdateEpoch, driverTimeToUnixTime(flow.Timestamp))
+	assert.Equal(t, cs.Pid, uint32(flow.ProcessId))
+	assert.Equal(t, cs.SPort, flow.LocalPort)
+	assert.Equal(t, cs.DPort, flow.RemotePort)
+	assert.Equal(t, cs.Family, AFINET6)
+	assert.Equal(t, cs.Type, TCP)
+	assert.Equal(t, cs.Direction, INCOMING)
+	assert.Equal(t, cs.SPortIsEphemeral, IsPortInEphemeralRange(cs.Family, cs.Type, cs.SPort))
+	assert.Equal(t, cs.Cookie, flow.FlowCookie)
+	assert.Equal(t, cs.TLSTags.ChosenVersion, flow.Tls_version_chosen)
+	assert.Equal(t, cs.TLSTags.OfferedVersions, uint8(flow.Tls_versions_offered))
+
+	// TCP related stats.
+	assert.Equal(t, cs.Monotonic.Retransmits, uint32(tcpData.RetransmitCount))
+	assert.Equal(t, cs.RTT, uint32(tcpData.SRTT))
+	assert.Equal(t, cs.RTTVar, uint32(tcpData.RttVariance))
+	assert.Equal(t, cs.TCPFailures[111], uint32(1))
+	assert.Equal(t, cs.Monotonic.TCPEstablished, uint16(0))
+	assert.Equal(t, cs.Monotonic.TCPClosed, uint16(1))
+	assert.Equal(t, cs.ProtocolStack.Encryption, protocols.TLS)
+}
+
+func TestFlowToConnStatWithIPv4UdpNoMonotonicc(t *testing.T) {
+	flow := &driver.PerFlowData{
+		FlowHandle:               1,
+		FlowCookie:               2,
+		ProcessId:                3,
+		AddressFamily:            syscall.AF_INET,
+		Protocol:                 syscall.IPPROTO_UDP,
+		Flags:                    (driver.FlowDirectionOutbound << driver.FlowDirectionBits),
+		PacketsOut:               10,
+		MonotonicSentBytes:       11,
+		TransportBytesOut:        12,
+		PacketsIn:                13,
+		MonotonicRecvBytes:       14,
+		TransportBytesIn:         15,
+		Timestamp:                16,
+		LocalPort:                17,
+		RemotePort:               18,
+		ClassificationStatus:     driver.ClassificationClassified,
+		ClassifyRequest:          driver.ClassificationRequestUnclassified,
+		ClassifyResponse:         21,
+		HttpUpgradeToH2Requested: 22,
+		HttpUpgradeToH2Accepted:  23,
+		Tls_versions_offered:     24,
+		Tls_version_chosen:       25,
+		Tls_alpn_requested:       26,
+		Tls_alpn_chosen:          27,
+	}
+
+	for i := 0; i < 16; i++ {
+		flow.LocalAddress[i] = byte(i + 1)
+		flow.RemoteAddress[i] = byte(i + 101)
+	}
+
+	cs := &ConnectionStats{}
+	FlowToConnStat(cs, flow, false)
+
+	assert.Equal(t, cs.Source, convertV4Addr(flow.LocalAddress))
+	assert.Equal(t, cs.Dest, convertV4Addr(flow.RemoteAddress))
+	assert.Equal(t, cs.Monotonic.SentBytes, flow.TransportBytesOut)
+	assert.Equal(t, cs.Monotonic.RecvBytes, flow.TransportBytesIn)
+	assert.Equal(t, cs.Monotonic.SentPackets, flow.PacketsOut)
+	assert.Equal(t, cs.Monotonic.RecvPackets, flow.PacketsIn)
+	assert.Equal(t, cs.LastUpdateEpoch, driverTimeToUnixTime(flow.Timestamp))
+	assert.Equal(t, cs.Pid, uint32(flow.ProcessId))
+	assert.Equal(t, cs.SPort, flow.LocalPort)
+	assert.Equal(t, cs.DPort, flow.RemotePort)
+	assert.Equal(t, cs.Family, AFINET)
+	assert.Equal(t, cs.Type, UDP)
+	assert.Equal(t, cs.Direction, OUTGOING)
+	assert.Equal(t, cs.SPortIsEphemeral, IsPortInEphemeralRange(cs.Family, cs.Type, cs.SPort))
+	assert.Equal(t, cs.Cookie, flow.FlowCookie)
+	assert.Equal(t, cs.TLSTags.ChosenVersion, flow.Tls_version_chosen)
+	assert.Equal(t, cs.TLSTags.OfferedVersions, uint8(flow.Tls_versions_offered))
 }

--- a/releasenotes/notes/windows_tls_version_offered_chosen-2ca5666854ff4a0f.yaml
+++ b/releasenotes/notes/windows_tls_version_offered_chosen-2ca5666854ff4a0f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Included tags for TLS offered versions and TLS chosen version as part of TCP connections stats on Windows.


### PR DESCRIPTION
### What does this PR do?
This PR includes tags for TLS offered versions and TLS version chosen as part of connection stats.
This also add basic unit tests for Windows FlowToConnStat function.

### Motivation
https://datadoghq.atlassian.net/browse/NTWK-694

### Describe how you validated your changes
In a VM, make sure to enable Datadog network monitoring, launch system-probe.exe, run several web requests/browse web pages, then query system-probe with: `NamedPipeCmd.exe -method GET -path /network_tracer/connections`
In the output, look for the "tags" field and verify that TLS tags are present.

### Additional Notes
Tag for TLS cipher suite not yet supported, not yet on par with Linux.  ddnpm driver must be updated to report cipher suite.
