### PR TITLE
[ AGNTLOG-400 ] Provide sane default values for byte_checksum fingerprint strategy

### DIFF
--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -232,7 +232,7 @@ func (a *logAgent) setupAgent() error {
 
 	fingerprintConfig, err := config.GlobalFingerprintConfig(a.config)
 	if err != nil {
-		message := fmt.Sprintf("Invalid fingerprinting config: %v", err)
+		message := fmt.Sprintf("Invalid fingerprint_config setting: %v", err)
 		status.AddGlobalError(invalidFingerprintConfig, message)
 		return errors.New(message)
 	}

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -157,6 +157,17 @@ func GlobalFingerprintConfig(coreConfig pkgconfigmodel.Reader) (*types.Fingerpri
 	if err != nil {
 		return nil, err
 	}
+
+	// Rectify the count value to the appropriate default value if not set.
+	if !coreConfig.IsConfigured("logs_config.fingerprint_config.count") {
+		switch config.FingerprintStrategy {
+		case types.FingerprintStrategyLineChecksum:
+			config.Count = types.DefaultLinesCount
+		case types.FingerprintStrategyByteChecksum:
+			config.Count = types.DefaultBytesCount
+		default:
+		}
+	}
 	log.Debugf("GlobalFingerprintConfig: after unmarshaling - FingerprintStrategy: %s, Count: %d, CountToSkip: %d, MaxBytes: %d",
 		config.FingerprintStrategy, config.Count, config.CountToSkip, config.MaxBytes)
 

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -172,6 +172,22 @@ func (suite *ConfigTestSuite) TestTaggerWarmupDuration() {
 	suite.Equal(5*time.Second, taggerWarmupDuration)
 }
 
+func (suite *ConfigTestSuite) TestGlobalFingerprintConfigCount() {
+	suite.config.SetWithoutSource("logs_config.fingerprint_config.fingerprint_strategy", "line_checksum")
+
+	config, err := GlobalFingerprintConfig(suite.config)
+	suite.Nil(err, "Expected no error")
+	suite.NotNil(config, "Expected config to be set")
+	suite.Equal(types.DefaultLinesCount, config.Count, "Expected count to be set to default lines count")
+
+	suite.config.SetWithoutSource("logs_config.fingerprint_config.fingerprint_strategy", "byte_checksum")
+
+	config, err = GlobalFingerprintConfig(suite.config)
+	suite.Nil(err, "Expected no error")
+	suite.NotNil(config, "Expected config to be set")
+	suite.Equal(types.DefaultBytesCount, config.Count, "Expected count to be set to default bytes count")
+}
+
 func (suite *ConfigTestSuite) TestGlobalFingerprintConfigShouldReturnConfigWithValidMap() {
 	suite.config.SetWithoutSource("logs_config.fingerprint_config.fingerprint_strategy", "line_checksum")
 	suite.config.SetWithoutSource("logs_config.fingerprint_config.count", 10)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -44,8 +44,10 @@ const (
 	// Whether we skip lines or bytes is dependent on whether we choose to compute the fingerprint by lines or by bytes.
 	DefaultLinesOrBytesToSkip = 0
 
-	// DefaultFingerprintingMaxLines is the default maximum number of lines to read before computing the fingerprint.
-	DefaultFingerprintingMaxLines = 1
+	// DefaultFingerprintingCount refers to the number of lines or bytes to use for fingerprinting.
+	// This option's default is an invalid value(0), and if not configured will be fixed to the appropriate default
+	// value based on the configured fingerprint_strategy.
+	DefaultFingerprintingCount = 0
 
 	// DefaultFingerprintStrategy is the default strategy for computing the checksum fingerprint.
 	// Options are:
@@ -1758,7 +1760,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// disable distributed senders
 	config.BindEnvAndSetDefault("logs_config.disable_distributed_senders", false)
 	// default fingerprint configuration
-	config.BindEnvAndSetDefault("logs_config.fingerprint_config.count", DefaultFingerprintingMaxLines)
+	config.BindEnvAndSetDefault("logs_config.fingerprint_config.count", DefaultFingerprintingCount)
 	config.BindEnvAndSetDefault("logs_config.fingerprint_config.max_bytes", DefaultFingerprintingMaxBytes)
 	config.BindEnvAndSetDefault("logs_config.fingerprint_config.count_to_skip", DefaultLinesOrBytesToSkip)
 	config.BindEnvAndSetDefault("logs_config.fingerprint_config.fingerprint_strategy", DefaultFingerprintStrategy)

--- a/pkg/logs/types/fingerprint.go
+++ b/pkg/logs/types/fingerprint.go
@@ -13,6 +13,10 @@ import (
 // InvalidFingerprintValue is the value that is returned when a fingerprint cannot be produced
 const (
 	InvalidFingerprintValue = 0
+	// DefaultLinesCount is the default number of lines to use for fingerprinting when fingerprint_strategy is line_checksum
+	DefaultLinesCount = 1
+	// DefaultBytesCount is the default number of bytes to use for fingerprinting when fingerprint_strategy is byte_checksum
+	DefaultBytesCount = 1024
 )
 
 // Fingerprint struct that stores both the value and config used to derive that value


### PR DESCRIPTION
### What does this PR do?
The current fingerprint configuration allows a user to specify a "bytes_checksum" fingerprint strategy with no associated count configuration. This defaults the count value to 1, which is an extremely unreasonable value for a bytes_checksum to have. As a fix, we will now generate an appropriate default count value for all valid fingerprint strategies.

Note that the per-source fingerprint configuration continues to expect all configuration options to be defined in order to be valid.

### Motivation

### Describe how you validated your changes

### Additional Notes
