### PR TITLE
[Backport 7.72.x] Remove loader process from heroku package #43037

### DIFF
--- a/cmd/loader/main_noop.sh
+++ b/cmd/loader/main_noop.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# noop loader for heroku
+# shouldn't be needed in practice, but it is used by the systemd service,
+# which is used when installing the deb manually
+
+shift # remove the path to the configuration file
+exec "$@"

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -146,9 +146,16 @@ build do
       move "#{install_dir}/bin/installer/installer", "#{install_dir}/embedded/bin"
   end
 
-  unless windows_target?
-    command "dda inv -- -e loader.build --install-path=#{install_dir} --major-version #{major_version_arg}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
-    copy "bin/trace-loader/trace-loader", "#{install_dir}/embedded/bin"
+  if linux_target?
+    if heroku_target?
+      # shouldn't be needed in practice, but it is used by the systemd service,
+      # which is used when installing the deb manually
+      copy "cmd/loader/main_noop.sh", "#{install_dir}/embedded/bin/trace-loader"
+      command "chmod 0755 #{install_dir}/embedded/bin/trace-loader"
+    else
+      command "dda inv -- -e loader.build --install-path=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
+      copy "bin/trace-loader/trace-loader", "#{install_dir}/embedded/bin"
+    end
   end
 
   if windows_target?


### PR DESCRIPTION
### What does this PR do?
Remove the trace-loader process from the Linux heroku and MacOS packages.

### Motivation
Reduce package size.
The loader is currently unused on Heroku and MacOS, and we want to reduce package size.

### Describe how you validated your changes
CI.

### Additional Notes
