### PR TITLE
[ABLD-184] Add processing for --metadata files to gather licensing.

### DIFF
--- a/compliance/gather_licenses.py
+++ b/compliance/gather_licenses.py
@@ -1,11 +1,13 @@
 """Helper tool for gathering third party license information.
 
+NOTE: This is just a shell of the tool to deal with licenses. The behaviors
+      and conditions will be documented later as we learn the requirements.
+
 The goal is to turn license data into the format for LICENSES.csv.
 Sample:
    Component,Origin,License,Copyright
    core,cel.dev/expr,Apache-2.0,TristonianJones <tswadell@google.com>
    core,cloud.google.com/go/auth,Apache-2.0,Copyright 2019 Google LLC
-
 
 This change refactors the original helper for correctness.
 It now emits something close.
@@ -14,14 +16,24 @@ It now emits something close.
   core,@@+_repo_rules+xz//:license,@rules_license+//licenses/spdx:0BSD,Permission to use, copy, modify, and/or distribute
   core,@@+_repo_rules+zlib//:license,@rules_license+//licenses/spdx:Zlib,Copyright notice:
 
-Next steps:
+Next steps for licenses.csv:
 - replace @@+_repo_rules+libffi with the purl of the rule
 - remove @rules_license+//licenses in a generic way.
 - use the license parser to extact the copyright.
+
+TODO:
+- We can recognize ship_source_offer, but don't do anything with it yet.
+- figure out how we will merge into the workflow in tasks/license.py
+- See if we can have this produce a unified output that could be untarred
+  in /opt/datadog/LICENSES so that we don't need pkg_install from each
+  library.
 """
 
 import argparse
+import csv
 import json
+
+_DEBUG = 0
 
 
 class AttrUsage:
@@ -38,32 +50,54 @@ class AttrUsage:
             raise ValueError(f"Got file path that has no kind: '{file}'")
         with open(file) as attr_inp:
             if kind == "build.bazel.rules_license.license":
-                self.process_license(file, json.load(attr_inp), users)
+                self.process_license(json.load(attr_inp))
             else:
                 # TODO: When we start wrtigin other types than JSON, we have to be more careful about this
                 self.process_attribute_json(file, json.load(attr_inp), users)
 
-    def process_license(self, file, attr, users):
-        # Sample: {
+    def process_attribute_json(self, file, attr):
+        """Process a standalone attributes file."""
+        if _DEBUG > 0:
+            print(f"=== {file}")
+        kind = attr.get('kind') or None
+        if not kind:
+            raise ValueError(f"Badly formated attribute file: {file}\n{attr}")
+
+        if kind == "bazel-contrib.supply-chain.attribute.license":
+            self.process_license(attr)
+            return
+        raise ValueError(f"Unknown attribute type: {kind}")
+
+    def process_package_metadata(self, package_metadata_file):
+        """Process a package_metadata bundle file."""
+        with open(package_metadata_file) as inp:
+            mx = json.load(inp)
+            purl = mx.get("purl") or "unset"
+            if _DEBUG > 0:
+                print(json.dumps(mx, indent="  "))
+                print(f"  metadata target: {mx['label']}")
+                print(f"  PURL: {purl}")
+            if mx.get("attributes"):
+                for attr_type, file in mx["attributes"].items():
+                    if attr_type == "build.bazel.rules_license.license":
+                        with open(file) as attr_inp:
+                            self.process_license(json.load(attr_inp), origin=purl)
+                    else:
+                        print("    ", attr_type, file)
+
+    def process_license(self, attr, origin=None):
+        # Sample attr dict:
         #  'kind': 'bazel-contrib.supply-chain.attribute.license',
         #  'label': '@@+_repo_rules+zlib//:license',
         #  'license_kinds': [{'identifier': '@rules_license//licenses/spdx:Zlib', 'name': 'zlib License'}],
         #  'text': 'external/+_repo_rules+zlib/LICENSE'}
+        origin = origin or attr["label"]
         with open(attr["text"]) as license_text:
             text = license_text.read()
             # TODO: We should use the identifier for more precision, but we can't do that until we
             # rebuild the downstream processing of LICENSES.CSV
-            kinds = "+".join([k["name"] for k in attr.get("license_kinds", [])])
-            self.licenses[attr["label"]] = (kinds, text)
-
-    def process_attribute_json(self, file, attr, users):
-        print("=== ", file)
-        kind = attr.get('kind') or None
-        if not kind:
-            raise ValueError(f"Badly formated attribute file: {file}\n{attr}")
-        if kind == "bazel-contrib.supply-chain.attribute.license":
-            self.process_license(file, attr, users)
-        print(f"Unknown attribute type: {kind}")
+            kinds = "+".join([k["identifier"] for k in attr.get("license_kinds", [])])
+            self.licenses[origin] = (kinds, text[:50])
 
 
 def main():
@@ -86,17 +120,25 @@ def main():
     for attr_file, users in usage.items():
         attrs.process_file(attr_file, users)
 
-    csv = []
+    processed_files = set()  # the wrapper may duplicate things, so dedup here
+    for metadata in options.metadata or []:
+        if metadata not in processed_files:
+            processed_files.add(metadata)
+            attrs.process_package_metadata(metadata)
+
+    licenses = []
     for license_target, data in attrs.licenses.items():
         # Sample: '@@+_repo_rules+libffi//:license': ('@rules_license+//licenses/spdx:GPL-2.0', "libffi - Copyright (c) 1996-2024  ...)
         origin = license_target
         license_type = data[0]
         license_text = data[1]
         short = license_text[:50]  # just print a little to show we have it working
-        csv.append(f"core,{origin},{license_type},{short}")
+        licenses.append(["core", origin, license_type, short])
 
-    with open(options.output, "w") as out:
-        out.write("\n".join(csv))
+    with open(options.output, "w", newline="") as out:
+        csv_writer = csv.writer(out, quotechar="\"", quoting=csv.QUOTE_MINIMAL)
+        for license in licenses:
+            csv_writer.writerow(license)
 
 
 if __name__ == '__main__':

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -44,9 +44,4 @@ license_csv(
     out = "licenses.csv",
     tags = ["manual"],
     target = ":all_deps",
-    target_compatible_with = select({
-        "@platforms//os:linux": ["@platforms//cpu:x86_64"],
-        "@platforms//os:macos": [],
-        "@platforms//os:windows": [],
-    }),
 )

--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -1,12 +1,28 @@
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
+package(default_package_metadata = [":package_metadata"])
+
 _VERSION = "2.5.1"
+
+# This is going to change in the future. Debate the syntax in https://github.com/bazel-contrib/supply-chain/issues/124
+PURL = "pkg:https/download.savannah.nongnu.org/attr@{version}?url=https://download.savannah.nongnu.org/releases/attr/attr-%{version}.tar.xz".format(
+    version = _VERSION,
+)
+
+package_metadata(
+    name = "package_metadata",
+    attributes = [
+        ":license",
+    ],
+    purl = PURL,
+)
 
 license(
     name = "license",


### PR DESCRIPTION
We were receiving them, but ignoring them.
- Add processing
- Convert 1 library (attr) to package_metadata rules to show the impact.
- Drive-by cleanup: Use csv writer

## smoke test
```
$ bazel build //deps:licenses
$ cat bazel-bin/deps/licenses.csv
core,@@+_repo_rules+bzip2//:license,@rules_license+//licenses/spdx:bzip2-1.0.6,"
-------------------------------------------------"
core,@@+_repo_rules+libffi//:license,@rules_license+//licenses/spdx:GPL-2.0,"libffi - Copyright (c) 1996-2024  Anthony Green, R"
core,@@+_repo_rules+nghttp2//:license,@rules_license+//licenses/spdx:MIT,"The MIT License

Copyright (c) 2012, 2014, 2015, 2"
core,@@+_repo_rules+xz//:license,@rules_license+//licenses/spdx:0BSD,"Permission to use, copy, modify, and/or distribute"
core,@@+_repo_rules+zlib//:license,@rules_license+//licenses/spdx:Zlib,"Copyright notice:

 (C) 1995-2022 Jean-loup Gailly"
core,pkg:https/download.savannah.nongnu.org/attr@2.5.1?url=https://download.savannah.nongnu.org/releases/attr/attr-%2.5.1.tar.xz,@rules_license+//licenses/spdx:LGPL-2.1,"Most components of the ""attr"" package are licensed"
```

Note the addition of attr in the list. The `origin` field is the PURL from `package_metadata`.