### PR TITLE
Mark runnerimpl.TestRunnerRealtime as flaky

### DIFF
--- a/comp/process/runner/runnerimpl/runner_test.go
+++ b/comp/process/runner/runnerimpl/runner_test.go
@@ -11,10 +11,9 @@ import (
 	"testing"
 	"time"
 
+	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
-
-	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -31,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/submitter/submitterimpl"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 func TestRunnerLifecycle(t *testing.T) {
@@ -38,6 +38,9 @@ func TestRunnerLifecycle(t *testing.T) {
 }
 
 func TestRunnerRealtime(t *testing.T) {
+	// https://datadoghq.atlassian.net/browse/CXP-2284
+	flake.Mark(t)
+
 	enableProcessAgent(t)
 
 	t.Run("rt allowed", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Title.

### Motivation

Failing every few days recently ([CI](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fcomp%2Fprocess%2Frunner%2Frunnerimpl.TestRunnerRealtime%2Frt_allowed%22&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&index=citest&start=1760471252468&end=1763153252468&paused=false))
<img width="616" height="185" alt="image" src="https://github.com/user-attachments/assets/ac876b7d-0cf4-4c10-9015-17fbaf1ee7d3" />

### Describe how you validated your changes

N/A

### Additional Notes

https://datadoghq.atlassian.net/browse/CXP-2284