### PR TITLE
(fleet) use yaml.v2 instead of yaml.v3

### DIFF
--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	patch "gopkg.in/evanphx/json-patch.v4"
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 )
 
 // FileOperationType is the type of operation to perform on the config.

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -387,17 +387,14 @@ func buildOperationsFromLegacyConfigFile(fullFilePath, fullRootPath, managedDirS
 		return FileOperation{}, err
 	}
 
-	// Since the config is YAML, we need to convert it to JSON
-	// 1. Parse the YAML in interface{}
-	// 2. Serialize the interface{} to JSON
-	var stableDatadogJSON interface{}
+	var stableDatadogJSON map[string]any
 	err = yaml.Unmarshal(stableDatadogYAML, &stableDatadogJSON)
 	if err != nil {
-		return FileOperation{}, err
+		return FileOperation{}, fmt.Errorf("failed to unmarshal stable datadog.yaml: %w", err)
 	}
 	stableDatadogJSONBytes, err := json.Marshal(stableDatadogJSON)
 	if err != nil {
-		return FileOperation{}, err
+		return FileOperation{}, fmt.Errorf("failed to marshal stable datadog.yaml: %w", err)
 	}
 
 	managedFilePath, err := filepath.Rel(fullRootPath, fullFilePath)

--- a/pkg/fleet/installer/packages/apminject/apm_inject.go
+++ b/pkg/fleet/installer/packages/apminject/apm_inject.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"go.uber.org/multierr"
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_windows.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 
 	windowssvc "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/windows"
 	windowsuser "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user/windows"

--- a/pkg/fleet/installer/packages/otel_config_common.go
+++ b/pkg/fleet/installer/packages/otel_config_common.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 )
 
 // enableOtelCollectorConfigCommon adds otelcollector.enabled and agent_ipc defaults to the given datadog.yaml path

--- a/releasenotes/notes/fix-multiple-keys-in-config-fleet-2064212d3d25ed04.yaml
+++ b/releasenotes/notes/fix-multiple-keys-in-config-fleet-2064212d3d25ed04.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug preventing Fleet Automation from updating configurations files with the same YAML key set multiple times.


### PR DESCRIPTION
This PR moves all (except one in setup scripts) uses of yaml.v3 to yaml.v2.

The motivation is some clients that have the same keys defined multiple times (we saw `api_key` * 2). Since viper uses v2, we have to use it as well.

