### PR TITLE
[ABLD-295] Add ability to detect ship_source_offer

### DIFF
--- a/compliance/gather_licenses.py
+++ b/compliance/gather_licenses.py
@@ -66,7 +66,7 @@ class AttrUsage:
         if kind == "bazel-contrib.supply-chain.attribute.license":
             self.process_license(attr)
             return
-        raise ValueError(f"Unknown attribute type: {kind}")
+        print(f"Unknown attribute type: {kind}")
 
     def process_package_metadata(self, package_metadata_file):
         """Process a package_metadata bundle file."""

--- a/compliance/gather_licenses.py
+++ b/compliance/gather_licenses.py
@@ -52,8 +52,8 @@ class AttrUsage:
             if kind == "build.bazel.rules_license.license":
                 self.process_license(json.load(attr_inp))
             else:
-                # TODO: When we start wrtigin other types than JSON, we have to be more careful about this
-                self.process_attribute_json(file, json.load(attr_inp), users)
+                # TODO: When we start writing other types than JSON, we have to be more careful about this
+                self.process_attribute_json(file, json.load(attr_inp))
 
     def process_attribute_json(self, file, attr):
         """Process a standalone attributes file."""
@@ -66,7 +66,8 @@ class AttrUsage:
         if kind == "bazel-contrib.supply-chain.attribute.license":
             self.process_license(attr)
             return
-        print(f"Unknown attribute type: {kind}")
+        # For now, log unknown things. In the future we can just gracefully ignore them.
+        print(f"Warning: Unhandled attribute type: {kind}")
 
     def process_package_metadata(self, package_metadata_file):
         """Process a package_metadata bundle file."""

--- a/compliance/license_csv.bzl
+++ b/compliance/license_csv.bzl
@@ -106,6 +106,9 @@ def _handle_attribute_provider(
             inputs.extend(metadata_provider.files.to_list())
             for f in metadata_provider.files.to_list():
                 report.append("    file: %s" % f.path)
+    elif DEBUG_LEVEL >= 0:  # NOTE: intentionally >= 0 for a few weeks, until this gels more.
+        # buildifier: disable=print
+        print("    No attributes")
 
     # Check for extras.
     # This is for debugging during early development. There should be no
@@ -131,7 +134,7 @@ def _handle_transitive_collector(t_m_i, args, inputs, report, attribute_to_consu
         attribute_kinds: Map of attribute files to their type.
     """
     if hasattr(t_m_i, "metadata"):
-        report.append("Target %s" % t_m_i.target)
+        report.append("Target %s. %d attributes" % (t_m_i.target, len(t_m_i.metadata.to_list())))
 
         for metadata in t_m_i.metadata.to_list():
             _handle_attribute_provider(

--- a/compliance/license_csv.bzl
+++ b/compliance/license_csv.bzl
@@ -15,8 +15,9 @@ load(
     "TransitiveMetadataInfo",
     "null_transitive_metadata_info",
 )
+load("//compliance/rules:ship_source_offer.bzl", "SHIP_SOURCE_ATTR_KIND")
 
-DEBUG_LEVEL = 0
+DEBUG_LEVEL = 1
 
 def update_attribute_to_consumers(attribute_to_consumers, file, target):
     """Maintains map of metadata attribute files to the targets using them.
@@ -95,6 +96,9 @@ def _handle_attribute_provider(
         print("##-- %s: %s" % (kind, str(metadata_provider)))
     if not kind:
         return
+    if kind == SHIP_SOURCE_ATTR_KIND:
+        # buildifier: disable=print
+        print("TODO: Couple this to creating the offer file.  Implementation TBD.")
 
     if hasattr(metadata_provider, "attributes"):
         update_attribute_to_consumers(attribute_to_consumers, metadata_provider.attributes, target)

--- a/compliance/rules/BUILD
+++ b/compliance/rules/BUILD
@@ -1,0 +1,6 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "ship_source_offer",
+    srcs = ["ship_source_offer.bzl"],
+)

--- a/compliance/rules/ship_source_offer.bzl
+++ b/compliance/rules/ship_source_offer.bzl
@@ -1,0 +1,50 @@
+"""Declares rule `ship_source_offer`.
+
+This is a package_metadata attribute that declares we must offer to ship
+the souce to the product if this package is used. The build process
+will include the a mention in the file offer.txt if it is used in the
+artifact we are building.
+"""
+
+load("@package_metadata//providers:package_attribute_info.bzl", "PackageAttributeInfo")
+
+# This must be public because we include it from external modules. There is no way to
+# represent that within the visibility syntax.
+visibility("public")
+
+KIND = "datadog.agent.attribute.ship_source_offer"
+
+def _ship_source_offer_impl(ctx):
+    attribute = {
+        "kind": KIND,
+        "label": str(ctx.label),
+    }
+    output = ctx.actions.declare_file("_{}_attribute.json".format(ctx.attr.name))
+    ctx.actions.write(
+        output = output,
+        content = json.encode(attribute),
+    )
+    files = depset(direct = [output])
+    return [
+        DefaultInfo(files = files),
+        PackageAttributeInfo(
+            kind = KIND,
+            attributes = output,
+        ),
+    ]
+
+_ship_source_offer = rule(
+    implementation = _ship_source_offer_impl,
+    doc = """Declares that we must offer to ship the source of our code if this package is used.""",
+)
+
+def ship_source_offer(
+        *,  # Disallow unnamed attributes.
+        name,
+        # Common attributes (subset since this target is non-configurable).
+        visibility = None):
+    _ship_source_offer(
+        name = name,
+        visibility = visibility,
+        package_metadata = [],
+    )

--- a/compliance/rules/ship_source_offer.bzl
+++ b/compliance/rules/ship_source_offer.bzl
@@ -4,6 +4,49 @@ This is a package_metadata attribute that declares we must offer to ship
 the souce to the product if this package is used. The build process
 will include the a mention in the file offer.txt if it is used in the
 artifact we are building.
+
+Usage:
+
+```
+load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
+load("@@//compliance/rules:ship_source_offer.bzl", "ship_source_offer")
+
+package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
+
+package_metadata(
+    name = "package_metadata",
+    attributes = [
+        ":ship_source_offer",
+        ...
+    ],
+    purl = PURL,
+)
+
+ship_source_offer(name = "ship_source_offer")
+```
+
+It seems unusual to put and attribute like :ship_source_offer in the
+package default rather than the package_metadata declaration. The
+reason for doing so is a combination.
+- Aspect traversal hits the top level package_metadata target and stops,
+  so that the aspect never sees the attributes directly. This is a bazel issue.
+- PackageMetadataInfo does not contain the kinds of the attributes, we
+  can't trigger on a special csae one without reading the metadata data
+  file itself.
+- Reading the file pushes detection from analysis time into execution,
+  making it harder to trigger new things at build time.
+
+We're working through opinions on the second point in the supply_chain project.
+The possible resolutions are:
+- Add the kinds to the provider in the core rule set
+- Add the kinds to the provider in our local fork. This is an expected path
+  for companies with special constraints.
+- Fix bazel
+- Push handling of ship_source_info down to execution phase.
+
+For now, the recommendation is to use the redundant declaration shown
+above, so that either way the rules change, we'll be covered without
+having to migrate first.
 """
 
 load("@package_metadata//providers:package_attribute_info.bzl", "PackageAttributeInfo")
@@ -12,11 +55,20 @@ load("@package_metadata//providers:package_attribute_info.bzl", "PackageAttribut
 # represent that within the visibility syntax.
 visibility("public")
 
-KIND = "datadog.agent.attribute.ship_source_offer"
+SHIP_SOURCE_ATTR_KIND = "datadog.agent.attribute.ship_source_offer"
+
+def _init_ssi():
+    return {}
+
+ShipSourceOfferInfo, _create = provider(
+    doc = "Indicate we must include an offer to ship our source if this pacakge is used.",
+    fields = {},
+    init = _init_ssi,
+)
 
 def _ship_source_offer_impl(ctx):
     attribute = {
-        "kind": KIND,
+        "kind": SHIP_SOURCE_ATTR_KIND,
         "label": str(ctx.label),
     }
     output = ctx.actions.declare_file("_{}_attribute.json".format(ctx.attr.name))
@@ -28,14 +80,19 @@ def _ship_source_offer_impl(ctx):
     return [
         DefaultInfo(files = files),
         PackageAttributeInfo(
-            kind = KIND,
+            kind = SHIP_SOURCE_ATTR_KIND,
             attributes = output,
         ),
+        ShipSourceOfferInfo(),
     ]
 
 _ship_source_offer = rule(
     implementation = _ship_source_offer_impl,
     doc = """Declares that we must offer to ship the source of our code if this package is used.""",
+    provides = [
+        PackageAttributeInfo,
+        ShipSourceOfferInfo,
+    ],
 )
 
 def ship_source_offer(

--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -1,4 +1,5 @@
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@@//compliance/rules:ship_source_offer.bzl", "ship_source_offer")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
@@ -20,6 +21,7 @@ package_metadata(
     name = "package_metadata",
     attributes = [
         ":license",
+        ":ship_source_offer",
     ],
     purl = PURL,
 )
@@ -30,6 +32,8 @@ license(
     license_text = "doc/COPYING.LGPL",
     visibility = ["//visibility:public"],
 )
+
+ship_source_offer(name = "ship_source_offer")
 
 copy_file(
     name = "copy_config_h",

--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -8,7 +8,7 @@ load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
-package(default_package_metadata = [":package_metadata"])
+package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
 
 _VERSION = "2.5.1"
 


### PR DESCRIPTION
[ABLD-295] Add ability to specify the ship_source_offer constraint.

- Adds the `ship_source_offer` rule, which is a package metadata provider.
- Update the licnense gathering tools to detect its use
- Use it in one example dependency.

Next steps:
- Tie detection of the condition to creation of the file.
- Add the declartion to similar deps (e.g. libacl)

Note to reviewer: If the code seems like there are too many ways to specify this, that is intentional. See the explanation in the rule documentation.

[ABLD-295]: https://datadoghq.atlassian.net/browse/ABLD-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ