### PR TITLE
[tracer] Collect resolv.conf and attach it to Connections

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -350,6 +350,9 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// process event monitoring data limits for network tracer
 	eventMonitorBindEnv(cfg, join(evNS, "network_process", "max_processes_tracked"))
 
+	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "container_store", "enabled"), true)
+	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "container_store", "max_containers_tracked"), 512)
+
 	cfg.BindEnvAndSetDefault(join(compNS, "enabled"), false)
 
 	// enable/disable use of root net namespace

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -351,7 +351,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	eventMonitorBindEnv(cfg, join(evNS, "network_process", "max_processes_tracked"))
 
 	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "container_store", "enabled"), true)
-	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "container_store", "max_containers_tracked"), 512)
+	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "container_store", "max_containers_tracked"), 1024)
 
 	cfg.BindEnvAndSetDefault(join(compNS, "enabled"), false)
 

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -171,6 +171,12 @@ type Config struct {
 	// MaxProcessesTracked is the maximum number of processes whose information is stored in the network module
 	MaxProcessesTracked int
 
+	// EnableContainerStore enables reading resolv.conf out of container filesystems. Requires EnableProcessEventMonitoring.
+	EnableContainerStore bool
+
+	// MaxContainersTracked is the maximum number of containers whose resolv.conf information is stored in the network module
+	MaxContainersTracked int
+
 	// EnableRootNetNs disables using the network namespace of the root process (1)
 	// for things like creating netlink sockets for conntrack updates, etc.
 	EnableRootNetNs bool
@@ -275,6 +281,9 @@ func New() *Config {
 
 		EnableProcessEventMonitoring: cfg.GetBool(sysconfig.FullKeyPath(evNS, "network_process", "enabled")),
 		MaxProcessesTracked:          cfg.GetInt(sysconfig.FullKeyPath(evNS, "network_process", "max_processes_tracked")),
+
+		EnableContainerStore: cfg.GetBool(sysconfig.FullKeyPath(evNS, "network_process", "container_store", "enabled")),
+		MaxContainersTracked: cfg.GetInt(sysconfig.FullKeyPath(evNS, "network_process", "container_store", "max_containers_tracked")),
 
 		EnableRootNetNs: cfg.GetBool(sysconfig.FullKeyPath(netNS, "enable_root_netns")),
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -539,20 +539,20 @@ func TestMaxContainersTracked(t *testing.T) {
 		mock.NewSystemProbe(t)
 		cfg := New()
 
-		assert.Equal(t, 512, cfg.MaxContainersTracked)
+		assert.Equal(t, 1024, cfg.MaxContainersTracked)
 	})
 	t.Run("via YAML", func(t *testing.T) {
 		mockSystemProbe := mock.NewSystemProbe(t)
-		mockSystemProbe.SetWithoutSource("event_monitoring_config.network_process.container_store.max_containers_tracked", 1024)
+		mockSystemProbe.SetWithoutSource("event_monitoring_config.network_process.container_store.max_containers_tracked", 42)
 		cfg := New()
 
-		assert.Equal(t, 1024, cfg.MaxContainersTracked)
+		assert.Equal(t, 42, cfg.MaxContainersTracked)
 	})
 	t.Run("via ENV variable", func(t *testing.T) {
 		mock.NewSystemProbe(t)
-		t.Setenv("DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_CONTAINER_STORE_MAX_CONTAINERS_TRACKED", "1024")
+		t.Setenv("DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_CONTAINER_STORE_MAX_CONTAINERS_TRACKED", "42")
 		cfg := New()
 
-		assert.Equal(t, 1024, cfg.MaxContainersTracked)
+		assert.Equal(t, 42, cfg.MaxContainersTracked)
 	})
 }

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -510,3 +510,49 @@ func TestEnableCertCollectionMapCleanerInterval(t *testing.T) {
 		assert.Equal(t, 42*time.Second, cfg.CertCollectionMapCleanerInterval)
 	})
 }
+
+func TestEnableContainerStore(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.Equal(t, true, cfg.EnableContainerStore)
+	})
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("event_monitoring_config.network_process.container_store.enabled", true)
+		cfg := New()
+
+		assert.Equal(t, true, cfg.EnableContainerStore)
+	})
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_CONTAINER_STORE_ENABLED", "true")
+		cfg := New()
+
+		assert.Equal(t, true, cfg.EnableContainerStore)
+	})
+}
+
+func TestMaxContainersTracked(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.Equal(t, 512, cfg.MaxContainersTracked)
+	})
+	t.Run("via YAML", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("event_monitoring_config.network_process.container_store.max_containers_tracked", 1024)
+		cfg := New()
+
+		assert.Equal(t, 1024, cfg.MaxContainersTracked)
+	})
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_CONTAINER_STORE_MAX_CONTAINERS_TRACKED", "1024")
+		cfg := New()
+
+		assert.Equal(t, 1024, cfg.MaxContainersTracked)
+	})
+}

--- a/pkg/network/containers/container_item_linux.go
+++ b/pkg/network/containers/container_item_linux.go
@@ -97,6 +97,7 @@ func readResolvConf(entry *events.Process) (string, error) {
 func StripResolvConf(resolvConf string) string {
 	lines := strings.Split(resolvConf, "\n")
 	var sb strings.Builder
+	sb.Grow(len(resolvConf))
 
 	for _, rawLine := range lines {
 		line := strings.TrimSpace(rawLine)

--- a/pkg/network/containers/container_item_linux.go
+++ b/pkg/network/containers/container_item_linux.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package containers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/process"
+
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/network/events"
+	"github.com/DataDog/datadog-agent/pkg/util/funcs"
+	utilintern "github.com/DataDog/datadog-agent/pkg/util/intern"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var hostRoot = funcs.MemoizeNoError(func() string {
+	if v := os.Getenv("HOST_ROOT"); v != "" {
+		return v
+	}
+	if env.IsContainerized() {
+		if _, err := os.Stat("/host"); err == nil {
+			return "/host"
+		}
+	}
+	return "/"
+})
+
+var stringInterner = utilintern.NewStringInterner()
+
+var errProcessNotRunning = &containerItemNoDataError{Err: fmt.Errorf("process is no longer running")}
+
+func readContainerItem(ctx context.Context, entry *events.Process) (containerStoreItem, error) {
+	resolvConf, err := readResolvConf(entry)
+	if err != nil {
+		return containerStoreItem{}, err
+	}
+
+	// we must check this last, to guarantee the result of readResolvConf is valid
+	isRunning, err := isProcessStillRunning(ctx, entry)
+	if err != nil {
+		return containerStoreItem{}, err
+	}
+	if !isRunning {
+		return containerStoreItem{}, errProcessNotRunning
+	}
+
+	// limit the size of payload sent, and give the intake some statistics
+	if len(resolvConf) > resolvConfMaxSizeBytes {
+		resolvConf = fmt.Sprintf("<too big: %d>", len(resolvConf))
+	}
+
+	item := containerStoreItem{
+		timestamp:  time.Now(),
+		resolvConf: stringInterner.GetString(resolvConf),
+	}
+
+	return item, nil
+}
+
+func readResolvConf(entry *events.Process) (string, error) {
+	rootPath := hostRoot()
+	if entry.ContainerID != nil {
+		rootPath = kernel.HostProc(strconv.Itoa(int(entry.Pid)), "root")
+	}
+
+	resolvConfPath := filepath.Join(rootPath, "etc/resolv.conf")
+	data, err := os.ReadFile(resolvConfPath)
+	if errors.Is(err, os.ErrNotExist) {
+		// report no data. don't turn this into an error, since if the process exited
+		// that will be checked later by isProcessStillRunning
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("readResolvConf failed to read %s: %w", resolvConfPath, err)
+	}
+
+	resolvConf := StripResolvConf(string(data))
+
+	return resolvConf, nil
+}
+
+// StripResolvConf removes comments from resolv.conf
+func StripResolvConf(resolvConf string) string {
+	lines := strings.Split(resolvConf, "\n")
+	var sb strings.Builder
+
+	for _, rawLine := range lines {
+		line := strings.TrimSpace(rawLine)
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == ';' || line[0] == '#' {
+			continue
+		}
+		sb.WriteString(line)
+	}
+
+	return sb.String()
+}
+
+func isProcessStillRunning(ctx context.Context, entry *events.Process) (bool, error) {
+	proc, err := process.NewProcessWithContext(ctx, int32(entry.Pid))
+	if errors.Is(err, process.ErrorProcessNotRunning) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("isProcessStillRunning failed to create NewProcessWithContext: %w", err)
+	}
+
+	createTime, err := proc.CreateTimeWithContext(ctx)
+	if errors.Is(err, process.ErrorProcessNotRunning) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("isProcessStillRunning failed to get createTime: %w", err)
+	}
+	// StartTime is recorded as nanoseconds by security's EBPFResolver
+	createTime *= int64(time.Millisecond)
+
+	// detect (rare) PID reuse by comparing the StartTime
+	if entry.StartTime != createTime {
+		log.Debugf("CNM ContainerStore detected process reuse on pid=%d: timestamps %d vs %d", entry.Pid, entry.StartTime, createTime)
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/network/containers/container_item_linux.go
+++ b/pkg/network/containers/container_item_linux.go
@@ -141,7 +141,7 @@ func (r *resolvStripper) stripResolvConf(size int, f io.Reader) (string, error) 
 	scanner.Buffer(r.buf, cap(r.buf))
 	var sb strings.Builder
 
-	if size > cap(r.buf) {
+	if size >= cap(r.buf) {
 		return resolvConfTooBig("input", size), nil
 	}
 	sb.Grow(size)

--- a/pkg/network/containers/container_item_linux_test.go
+++ b/pkg/network/containers/container_item_linux_test.go
@@ -8,6 +8,7 @@
 package containers
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,9 +20,13 @@ func TestStripResolvConf(t *testing.T) {
 # other comment goes here
 nameserver 8.8.8.8
 	# indented comment with spaces
-	nameserver 8.8.4.4
+	nameserver 8.8.4.4  
 `
-	stripped := StripResolvConf(resolvConf)
+	reader := strings.NewReader(resolvConf)
+
+	rs := makeResolvStripper(resolvConfInputMaxSizeBytes)
+	stripped, err := rs.stripResolvConf(len(resolvConf), reader)
+	require.NoError(t, err)
 
 	require.Equal(t, "nameserver 8.8.8.8\nnameserver 8.8.4.4", stripped)
 }

--- a/pkg/network/containers/container_item_linux_test.go
+++ b/pkg/network/containers/container_item_linux_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripResolvConf(t *testing.T) {
+	resolvConf := `
+; comment goes here
+# other comment goes here
+nameserver 8.8.8.8
+	# indented comment with spaces
+	nameserver 8.8.4.4
+`
+	stripped := StripResolvConf(resolvConf)
+
+	require.Equal(t, "nameserver 8.8.8.8\nnameserver 8.8.4.4", stripped)
+}

--- a/pkg/network/containers/container_item_linux_test.go
+++ b/pkg/network/containers/container_item_linux_test.go
@@ -37,7 +37,7 @@ type errorReader struct {
 	err error
 }
 
-func (er *errorReader) Read(p []byte) (n int, err error) {
+func (er *errorReader) Read(_ []byte) (n int, err error) {
 	return 0, er.err
 }
 func TestStripResolvConfReaderError(t *testing.T) {

--- a/pkg/network/containers/container_store_linux.go
+++ b/pkg/network/containers/container_store_linux.go
@@ -240,6 +240,7 @@ func (cs *ContainerStore) GetResolvConfMap(conns []network.ConnectionStats) map[
 	allContainers := make(map[network.ContainerID]struct{})
 	resolvConfs := make(map[network.ContainerID]network.ResolvConf)
 	for i := range conns {
+		// if containerID is nil, this represents the host
 		containerID := conns[i].ContainerID.Source
 		allContainers[containerID] = struct{}{}
 		if _, ok := resolvConfs[containerID]; ok {

--- a/pkg/network/containers/container_store_linux.go
+++ b/pkg/network/containers/container_store_linux.go
@@ -1,0 +1,236 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package containers has logic extracting network information from containers (currently, resolv.conf)
+package containers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"go4.org/intern"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/events"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// containerItemNoDataError is returned when readContainerItem() didn't fail, but doesn't
+// have data to share. This can happen when the process exited at the same time, or on unsupported platforms
+type containerItemNoDataError struct {
+	Err error
+}
+
+func (e *containerItemNoDataError) Error() string {
+	return fmt.Sprintf("readContainerItem() doesn't have data: %s", e.Err)
+}
+func (e *containerItemNoDataError) Unwrap() error {
+	return e.Err
+}
+
+const (
+	resolvConfMaxSizeBytes = 1024
+	maxProcessQueueLen     = 100
+	moduleName             = "network_tracer__containerStore"
+
+	// containerStaleTime: when to re-fetch a container's resolv.conf
+	containerStaleTime = 2 * time.Minute
+	// containerTTL: when to evict a container
+	containerTTL = 5 * time.Minute
+	// cleanerInterval: how often to evict old containers
+	cleanerInterval = 2 * time.Minute
+)
+
+var containerStoreTelemetry = struct {
+	liveEvictions telemetry.Counter
+	eventsDropped telemetry.Counter
+	readFailures  telemetry.Counter
+}{
+	telemetry.NewCounter(moduleName, "live_evicts", []string{}, "Counter measuring the number of evictions of live containers in the container store (this is bad)"),
+	telemetry.NewCounter(moduleName, "events_dropped", []string{}, "Counter measuring the number of dropped process events"),
+	telemetry.NewCounter(moduleName, "read_failures", []string{}, "Counter measuring the number of failures to read container data such as resolv.conf"),
+}
+
+type containerStoreItem struct {
+	timestamp  time.Time
+	resolvConf network.ResolvConf
+}
+
+// ContainerStore reads container data (currently just resolv.conf) into a hashmap
+// which is later attached to connections via the ResolvConf field
+type ContainerStore struct {
+	ctx       context.Context
+	cancelCtx func()
+
+	cache *lru.Cache[network.ContainerID, containerStoreItem]
+
+	in chan *events.Process
+
+	warnLimit  *log.Limit
+	errorLimit *log.Limit
+
+	readContainerItem func(ctx context.Context, entry *events.Process) (containerStoreItem, error)
+}
+
+func (csi containerStoreItem) isStale() bool {
+	return time.Since(csi.timestamp) > containerStaleTime
+}
+func (csi containerStoreItem) isExpired() bool {
+	return time.Since(csi.timestamp) > containerTTL
+}
+
+// NewContainerStore initializes the container store
+func NewContainerStore(maxContainers int) (*ContainerStore, error) {
+	warnLimit := log.NewLogLimit(5, 10*time.Second)
+	errorLimit := log.NewLogLimit(5, 10*time.Second)
+
+	cache, err := lru.NewWithEvict(maxContainers, func(_key *intern.Value, item containerStoreItem) {
+		if !item.isStale() {
+			log.Errorf("CNM ContainerStore has more than %d live containers, was forced to evict a live container", maxContainers)
+			containerStoreTelemetry.liveEvictions.Add(1)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	cs := &ContainerStore{
+		ctx:       ctx,
+		cancelCtx: cancelCtx,
+
+		cache: cache,
+		in:    make(chan *events.Process, maxProcessQueueLen),
+
+		warnLimit:  warnLimit,
+		errorLimit: errorLimit,
+
+		readContainerItem: readContainerItem,
+	}
+
+	cleanTicker := time.NewTicker(cleanerInterval)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				cleanTicker.Stop()
+				return
+			case <-cleanTicker.C:
+				cs.cleanMap()
+			case p := <-cs.in:
+				cs.addProcess(p)
+			}
+		}
+	}()
+
+	return cs, nil
+}
+
+// HandleProcessEvent passes a process event from CWS into a channel for
+// later processing (to avoid blocking CWS)
+func (cs *ContainerStore) HandleProcessEvent(entry *events.Process) {
+	if cs.ctx.Err() != nil {
+		return
+	}
+
+	select {
+	case cs.in <- entry:
+	default:
+		if cs.warnLimit.ShouldLog() {
+			log.Warn("CNM ContainerStore dropped a process event (too many in queue)")
+		}
+		containerStoreTelemetry.eventsDropped.Inc()
+	}
+}
+
+func (cs *ContainerStore) addProcess(entry *events.Process) {
+	prevItem, ok := cs.cache.Get(entry.ContainerID)
+	if ok && !prevItem.isStale() {
+		// we already pulled resolv.conf recently, so skip
+		return
+	}
+
+	item, err := cs.readContainerItem(cs.ctx, entry)
+	log.Debugf("CNM ContainerStore handled ID=%v with item=%v, err=%v", entry.ContainerID, item, err)
+	var noData *containerItemNoDataError
+	if cs.ctx.Err() != nil || errors.As(err, &noData) {
+		return
+	}
+	if err != nil {
+		if cs.errorLimit.ShouldLog() {
+			log.Errorf("CNM ContainerStore failed to readContainerItem: %s", err)
+		}
+		containerStoreTelemetry.readFailures.Add(1)
+
+		// remember the failure so that we don't spam reading
+		cs.cache.Add(entry.ContainerID, containerStoreItem{
+			timestamp: time.Now(),
+		})
+
+		return
+	}
+
+	log.Debugf("CNM ContainerStore successfully read resolv.conf of size %d", len(item.resolvConf.Get()))
+
+	cs.cache.Add(entry.ContainerID, item)
+}
+
+func (cs *ContainerStore) cleanMap() {
+	for _, containerID := range cs.cache.Keys() {
+		item, ok := cs.cache.Get(containerID)
+		if !ok {
+			continue
+		}
+		if item.isExpired() {
+			cs.cache.Remove(containerID)
+		}
+	}
+}
+
+// Stop stops the ContainerStore from running
+func (cs *ContainerStore) Stop() {
+	cs.cancelCtx()
+}
+
+// GetResolvConf returns the resolv.conf for a containerID.
+func (cs *ContainerStore) GetResolvConf(containerID network.ContainerID) network.ResolvConf {
+	item, ok := cs.cache.Get(containerID)
+	if !ok {
+		return nil
+	}
+	return item.resolvConf
+}
+
+// GetResolvConfMap scans a slice of connections for containers and returns
+// a mapping to resolv.conf
+func (cs *ContainerStore) GetResolvConfMap(conns []network.ConnectionStats) map[network.ContainerID]network.ResolvConf {
+	allContainers := make(map[network.ContainerID]struct{})
+	resolvConfs := make(map[network.ContainerID]network.ResolvConf)
+	for i := range conns {
+		containerID := conns[i].ContainerID.Source
+		allContainers[containerID] = struct{}{}
+		if _, ok := resolvConfs[containerID]; ok {
+			continue
+		}
+
+		resolvConf := cs.GetResolvConf(containerID)
+
+		if resolvConf != nil {
+			resolvConfs[containerID] = resolvConf
+		}
+	}
+
+	log.Debugf("CNM ContainerStore mapped %d out of %d containerIDs", len(resolvConfs), len(allContainers))
+
+	return resolvConfs
+}

--- a/pkg/network/containers/container_store_linux_test.go
+++ b/pkg/network/containers/container_store_linux_test.go
@@ -1,0 +1,210 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package containers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go4.org/intern"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/events"
+)
+
+func mockReadContainerItem(resolvConfs map[network.ContainerID]network.ResolvConf) func(context.Context, *events.Process) (containerStoreItem, error) {
+	return func(_ context.Context, entry *events.Process) (containerStoreItem, error) {
+		return containerStoreItem{
+			timestamp:  time.Now(),
+			resolvConf: resolvConfs[entry.ContainerID],
+		}, nil
+	}
+}
+
+func mockConnection(sourceID *intern.Value) network.ConnectionStats {
+	return network.ConnectionStats{
+		ContainerID: struct {
+			Source, Dest *intern.Value
+		}{Source: sourceID},
+	}
+}
+
+func TestContainerStoreMapping(t *testing.T) {
+	t.Parallel()
+	// basic test of container store behavior
+	cs, err := NewContainerStore(10)
+	require.NoError(t, err)
+	defer cs.Stop()
+
+	containerID := intern.GetByString("container-1")
+	processEvent := &events.Process{
+		Pid:         12345,
+		ContainerID: containerID,
+		StartTime:   time.Now().UnixNano(),
+	}
+
+	resolvConf := stringInterner.GetString("nameserver 8.8.8.8\nnameserver 8.8.4.4")
+	mockMap := map[network.ContainerID]network.ResolvConf{
+		containerID: resolvConf,
+	}
+	cs.readContainerItem = mockReadContainerItem(mockMap)
+
+	initialSize := cs.cache.Len()
+	require.Equal(t, 0, initialSize, "Cache should start empty")
+
+	cs.HandleProcessEvent(processEvent)
+
+	require.Eventually(t, func() bool {
+		return cs.cache.Len() == 1
+	}, 2*time.Second, 50*time.Millisecond, "Cache size should increase to 1 after adding a process")
+
+	// if a connection is there, it should get mapped
+	resolveConfs := cs.GetResolvConfMap([]network.ConnectionStats{
+		mockConnection(containerID),
+		mockConnection(intern.GetByString("unrelated-connection-1")),
+	})
+
+	require.Equal(t, mockMap, resolveConfs)
+
+	// unrelated connections should not get mapped
+	resolveConfs = cs.GetResolvConfMap([]network.ConnectionStats{
+		mockConnection(intern.GetByString("unrelated-connection-1")),
+	})
+	require.Empty(t, resolveConfs)
+}
+
+func TestContainerStoreErrorHandling(t *testing.T) {
+	t.Parallel()
+	// checks that an error causes the cache to be populated (so it doesn't spam attempts to read procfs)
+	cs, err := NewContainerStore(10)
+	require.NoError(t, err)
+	defer cs.Stop()
+
+	containerID := intern.GetByString("container-1")
+	processEvent := &events.Process{
+		Pid:         12345,
+		ContainerID: containerID,
+		StartTime:   time.Now().UnixNano(),
+	}
+
+	// mock an error result
+	cs.readContainerItem = func(_ context.Context, _ *events.Process) (containerStoreItem, error) {
+		return containerStoreItem{}, errors.New("failed to read container item")
+	}
+
+	cs.HandleProcessEvent(processEvent)
+
+	require.Eventually(t, func() bool {
+		return cs.cache.Len() == 1
+	}, 2*time.Second, 50*time.Millisecond, "Cache size should increase to 1 after error")
+
+	item, ok := cs.cache.Get(containerID)
+	require.True(t, ok, "Container should be in cache after error")
+	require.Nil(t, item.resolvConf, "ResolvConf should be empty after error")
+	require.False(t, item.timestamp.IsZero(), "Timestamp should be set")
+
+	// since this is an error entry, there should be no data
+	resolveConfs := cs.GetResolvConfMap([]network.ConnectionStats{
+		mockConnection(containerID),
+	})
+	require.Empty(t, resolveConfs, "GetResolvConfMap should not return for error entry")
+}
+
+func TestContainerStoreNoData(t *testing.T) {
+	t.Parallel()
+	// makes sure that the "no data" case doesn't populate the cache
+	cs, err := NewContainerStore(10)
+	require.NoError(t, err)
+	defer cs.Stop()
+
+	containerID := intern.GetByString("container-1")
+	processEvent := &events.Process{
+		Pid:         12345,
+		ContainerID: containerID,
+		StartTime:   time.Now().UnixNano(),
+	}
+
+	callCount := 0
+	resolvConf := stringInterner.GetString("nameserver 1.1.1.1\nnameserver 1.0.0.1")
+	cs.readContainerItem = func(_ context.Context, _ *events.Process) (containerStoreItem, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return containerStoreItem{}, &containerItemNoDataError{Err: errors.New("process exited")}
+		case 2:
+			return containerStoreItem{
+				timestamp:  time.Now(),
+				resolvConf: resolvConf,
+			}, nil
+		default:
+			require.Fail(t, "Should only be called twice")
+			return containerStoreItem{}, errors.New("shouldn't get here")
+		}
+	}
+
+	// send two events, first one should be dropped
+	cs.HandleProcessEvent(processEvent)
+	cs.HandleProcessEvent(processEvent)
+
+	require.Eventually(t, func() bool {
+		return cs.cache.Len() == 1
+	}, 2*time.Second, 50*time.Millisecond, "Cache size should increase to 1 after valid data")
+
+	require.Equal(t, 2, callCount, "readContainerItem should be called twice")
+
+	item, ok := cs.cache.Get(containerID)
+	require.True(t, ok, "Container should be in cache")
+	require.Equal(t, resolvConf, item.resolvConf, "ResolvConf should match")
+}
+func TestContainerStoreDuplicate(t *testing.T) {
+	t.Parallel()
+	// makes sure that nothing weird happens when you repeat a process entry
+	cs, err := NewContainerStore(10)
+	require.NoError(t, err)
+	defer cs.Stop()
+
+	containerID := intern.GetByString("container-1")
+	processEvent := &events.Process{
+		Pid:         12345,
+		ContainerID: containerID,
+		StartTime:   time.Now().UnixNano(),
+	}
+
+	callCount := 0
+	resolvConf := stringInterner.GetString("nameserver 1.1.1.1\nnameserver 1.0.0.1")
+	cs.readContainerItem = func(_ context.Context, _ *events.Process) (containerStoreItem, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return containerStoreItem{
+				timestamp:  time.Now(),
+				resolvConf: resolvConf,
+			}, nil
+		default:
+			require.Fail(t, "Should only be called once")
+			return containerStoreItem{}, errors.New("shouldn't get here")
+		}
+	}
+
+	// send two events, second one should be dropped
+	cs.HandleProcessEvent(processEvent)
+	cs.HandleProcessEvent(processEvent)
+
+	require.Eventually(t, func() bool {
+		return cs.cache.Len() == 1
+	}, 2*time.Second, 50*time.Millisecond, "Cache size should increase to 1 after valid data")
+
+	require.Equal(t, 1, callCount, "readContainerItem should be called once")
+
+	item, ok := cs.cache.Get(containerID)
+	require.True(t, ok, "Container should be in cache")
+	require.Equal(t, resolvConf, item.resolvConf, "ResolvConf should match")
+}

--- a/pkg/network/dns/stats.go
+++ b/pkg/network/dns/stats.go
@@ -190,9 +190,10 @@ func (d *dnsStatKeeper) WaitForDomain(domain string) error {
 
 	tick := time.NewTicker(10 * time.Millisecond)
 	defer tick.Stop()
+	timeout := time.After(waitForDomainTimeout)
 	for {
 		select {
-		case <-time.After(waitForDomainTimeout):
+		case <-timeout:
 			return fmt.Errorf("domain %v did not appear within %v", domain, waitForDomainTimeout)
 		case <-tick.C:
 			if d.hasDomain(domain) {

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/tls"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	utilintern "github.com/DataDog/datadog-agent/pkg/util/intern"
 )
 
 const (
@@ -114,10 +115,17 @@ type BufferedData struct {
 	buffer *ClientBuffer
 }
 
+// ContainerID uniquely represents a container. Nil represents the host.
+type ContainerID = *intern.Value
+
+// ResolvConf is an interned string representing the contents of resolv.conf
+type ResolvConf = *utilintern.StringValue
+
 // Connections wraps a collection of ConnectionStats
 type Connections struct {
 	BufferedData
 	DNS                         map[util.Address][]dns.Hostname
+	ResolvConfs                 map[ContainerID]ResolvConf
 	ConnTelemetry               map[ConnTelemetryType]int64
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry
 	KernelHeaderFetchResult     int32

--- a/pkg/network/tracer/testdata/dnsworkload/Corefile
+++ b/pkg/network/tracer/testdata/dnsworkload/Corefile
@@ -1,0 +1,14 @@
+.:53 {
+    template IN A my-server.local {
+        answer "{{ .Name }} 60 IN A 1.2.3.4"
+        fallthrough
+    }
+
+    template IN ANY {
+        rcode NXDOMAIN
+    }
+
+    log
+    errors
+}
+

--- a/pkg/network/tracer/testdata/dnsworkload/dnsworkload.py
+++ b/pkg/network/tracer/testdata/dnsworkload/dnsworkload.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import signal
+import socket
+import sys
+import time
+
+
+def signal_handler(signum, frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGTERM, signal_handler)
+signal.signal(signal.SIGINT, signal_handler)
+
+# resolv.conf will expand this to my-server.local
+hostname = "my-server"
+
+while True:
+    try:
+        result = socket.getaddrinfo(hostname, None, socket.AF_INET)
+
+        for res in result:
+            ip_address = res[4][0]
+            print(f"Name:      {hostname}")
+            print(f"Address: {ip_address}")
+            print()
+    except socket.gaierror as e:
+        print(f"DNS lookup failed for {hostname}: {e}")
+
+    time.sleep(0.1)

--- a/pkg/network/tracer/testdata/dnsworkload/docker-compose.yml
+++ b/pkg/network/tracer/testdata/dnsworkload/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+name: dnsworkload
+services:
+  coredns:
+    image: coredns/coredns:1.13.1
+    command: -conf /etc/coredns/Corefile
+    ports:
+      - 127.0.0.1:53:53/udp
+      - 127.0.0.1:53:53/tcp
+    volumes:
+      - type: bind
+        source: ${TESTDIR}/testdata/dnsworkload/Corefile
+        target: /etc/coredns/Corefile
+    networks:
+      dns_test:
+        ipv4_address: 172.25.0.2
+
+  python-client:
+    image: python:3-alpine
+    command: python3 -u /dnsworkload.py
+    depends_on:
+      - coredns
+    volumes:
+      - type: bind
+        source: ${TESTDIR}/testdata/dnsworkload/dnsworkload.py
+        target: /dnsworkload.py
+      - type: bind
+        source: ${TESTDIR}/testdata/dnsworkload/resolv.conf
+        target: /etc/resolv.conf
+    networks:
+      dns_test:
+        ipv4_address: 172.25.0.3
+
+networks:
+  dns_test:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.25.0.0/16
+

--- a/pkg/network/tracer/testdata/dnsworkload/resolv.conf
+++ b/pkg/network/tracer/testdata/dnsworkload/resolv.conf
@@ -1,0 +1,3 @@
+nameserver 172.25.0.2
+search local
+options ndots:1

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -202,6 +202,9 @@ func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Compone
 		}
 	}
 
+	if !cfg.EnableProcessEventMonitoring && cfg.EnableContainerStore {
+		log.Warnf("not starting resolv.conf container store, because it depends on process event monitoring which is disabled")
+	}
 	if cfg.EnableProcessEventMonitoring {
 		if tr.processCache, err = newProcessCache(cfg.MaxProcessesTracked); err != nil {
 			return nil, fmt.Errorf("could not create process cache; %w", err)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -51,7 +51,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/config/sysctl"
-	"github.com/DataDog/datadog-agent/pkg/network/containers"
 	"github.com/DataDog/datadog-agent/pkg/network/events"
 	netlinktestutil "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
@@ -3316,14 +3315,11 @@ func (s *TracerSuite) TestDNSWorkload() {
 
 	tr := setupTracer(t, cfg)
 
-	curDir, err := usmtestutil.CurDir()
-	require.NoError(t, err)
+	trueResolvConf := `nameserver 172.25.0.2
+search local
+options ndots:1`
 
-	resolvConfBytes, err := os.ReadFile(filepath.Join(curDir, "testdata/dnsworkload/resolv.conf"))
-	require.NoError(t, err)
-	trueResolvConf := containers.StripResolvConf(string(resolvConfBytes))
-
-	err = RunDNSWorkload(t)
+	err := RunDNSWorkload(t)
 	require.NoError(t, err, "failed to start DNS workload")
 
 	require.NoError(t, tr.reverseDNS.WaitForDomain("my-server.local"), "failed to wait for my-server.local domain")

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3311,6 +3311,15 @@ func (s *TracerSuite) TestDNSWorkload() {
 	cfg.DNSTimeout = 1 * time.Second
 	cfg.CollectLocalDNS = true
 
+	// Container ID resolution (not resolv.conf resolution) fails in this test before 5.11.
+	// I think it's related to this patch:
+	// https://github.com/torvalds/linux/commit/3ae700ecfae913316e3b4fe5f60c72b6131aaa1f#diff-360c5854af72f475f4ebbf588f1c163c9b9694f618088f5ff1e399b36e339901
+	// It changes the way that timestamps are offered in /proc/<pid>/stat.
+	// It's likely my test's injection of process events via HandleEvents is wrong on older kernels
+	if kv < kernel.VersionCode(5, 11, 0) {
+		t.Skip("Not supported before 5.11")
+	}
+
 	skipOnEbpflessNotSupported(t, cfg)
 
 	tr := setupTracer(t, cfg)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3312,6 +3312,8 @@ func (s *TracerSuite) TestDNSWorkload() {
 	cfg.DNSTimeout = 1 * time.Second
 	cfg.CollectLocalDNS = true
 
+	skipOnEbpflessNotSupported(t, cfg)
+
 	tr := setupTracer(t, cfg)
 
 	curDir, err := usmtestutil.CurDir()

--- a/pkg/network/tracer/tracer_linux_testutil.go
+++ b/pkg/network/tracer/tracer_linux_testutil.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf && test
+
+package tracer
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	usmtestutil "github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
+	dockerutils "github.com/DataDog/datadog-agent/pkg/util/testutil/docker"
+)
+
+// RunDNSWorkload runs a CoreDNS server and Python client in docker containers
+// The Python client continuously queries my-server.local against the CoreDNS server in a single process
+func RunDNSWorkload(t testing.TB) error {
+	t.Helper()
+
+	curDir, err := usmtestutil.CurDir()
+	require.NoError(t, err)
+
+	env := []string{
+		"TESTDIR=" + curDir,
+	}
+
+	// this regex indicates that the Python client got a response from CoreDNS
+	scanner, err := globalutils.NewScanner(regexp.MustCompile(`.*Address: 1\.2\.3\.4.*`), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
+
+	dockerCfg := dockerutils.NewComposeConfig(
+		dockerutils.NewBaseConfig(
+			"dnsworkload",
+			scanner,
+			dockerutils.WithEnv(env),
+		),
+		filepath.Join(curDir, "testdata", "dnsworkload", "docker-compose.yml"))
+	return dockerutils.Run(t, dockerCfg)
+}


### PR DESCRIPTION
### What does this PR do?
This PR introduces `ContainerStore`, which keeps track of the `resolv.conf` files within containers/the main host. It will periodically read `resolv.conf` and maintains a hashmap from container ID -> resolv.conf.

`ContainerStore` is used inside the tracer during `GetActiveConnections()`, where it populates a new map in the `network.Connections` struct, `ResolveConfs`. `ResolvConfs` is a reduced version of the container map that filters to only the container IDs that appear in the connections.

It's enabled by default, and controlled by the following config:
```
event_monitoring_config.network_process.container_store.enabled
event_monitoring_config.network_process.container_store.max_containers_tracked
```

### Motivation
We will use this to enrich DNS data, to detect NXDOMAINs which are caused by the container's ndots config.

### Describe how you validated your changes
Added the tracer test `TestDNSWorkload` for this. It works by creating a python container that runs local DNS queries to a coreDNS container:
```
PATH="$PATH" sudo -E  go test -count 1 -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run 'TestTracerSuite/CO-RE/TestDNSWorkload'
```
Also added a set of tests to check the store's behavior against mock events:
```
go test -tags linux,linux_bpf,npm,process,test ./pkg/network/containers
```
In addition, while it's running for real in the agent, you'll see the debug log `CNM ContainerStore mapped 3 out of 3 containerIDs` indicating it's working properly.

### Additional Notes
This does not get forwarded yet to CollectorConnections. I decided to do that in the next PR because this one is getting big.