### PR TITLE
Fix HTTP test flakiness in USM monitor

### DIFF
--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -369,6 +369,8 @@ func (s *HTTPTestSuite) TestSanity() {
 					srvDoneFn()
 
 					// Ensure USM captured all requests.
+					// Patching the recent change by testify
+					time.Sleep(time.Second)
 					assertAllRequestsExists(t, monitor, requests)
 				})
 			}

--- a/pkg/network/usm/usm_http_monitor_test.go
+++ b/pkg/network/usm/usm_http_monitor_test.go
@@ -175,6 +175,7 @@ func (s *usmHTTPSuite) testSimple(t *testing.T, isIPv6 bool) {
 				tt.runClients(t, clientCount)
 
 				res := make(map[usmhttp.Key]int)
+				time.Sleep(time.Second)
 				assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 					for key, stat := range getHTTPLikeProtocolStats(t, monitor, protocols.HTTP) {
 						if key.DstPort == httpSrvPort || key.SrcPort == httpSrvPort {


### PR DESCRIPTION
## Summary
Fixes flakiness in the HTTP sanity test by adding a 1-second sleep before asserting all requests exist.

## Test plan
This addresses timing issues where the USM monitor may not have captured all requests by the time assertions run.

## Changes
- Added 1-second sleep in `pkg/network/usm/monitor_test.go` before `assertAllRequestsExists` call
- Added comment explaining this is a patch for recent testify changes