### PR TITLE
[ABLD-300] Treat Windows runner as persistent for `bazel`

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -41,9 +41,11 @@
 .bazel:runner:windows-amd64:
   extends: .windows_docker_default
   timeout: 60m # pulling images alone can take more than 30m
+  cache: []
   variables:
     ARCH: x64
     GIT_DEPTH: 2
+    XDG_CACHE_HOME: c:\bzl
   script:
     - |-
       $FailFast = @'
@@ -54,6 +56,7 @@
       Invoke-Expression $FailFast
       $Utf8Script = [Text.Encoding]::UTF8.GetString([Text.Encoding]::GetEncoding([Console]::OutputEncoding.CodePage).GetBytes($POWERSHELL_SCRIPT))
       $EncodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("$FailFast`n$Utf8Script"))
+      New-Item -ItemType Directory -Path "$XDG_CACHE_HOME" -Force | Out-Null
     - >-
       docker run
       --env=BAZELISK_HOME
@@ -61,10 +64,9 @@
       --env=BAZEL_OUTPUT_USER_ROOT
       --env=BAZEL_REPO_CONTENTS_CACHE
       --env=CI_PROJECT_DIR
-      --env=RUNNER_TEMP_PROJECT_DIR
       --rm
       --volume="${CI_PROJECT_DIR}:$CI_PROJECT_DIR"
-      --volume="${RUNNER_TEMP_PROJECT_DIR}:$RUNNER_TEMP_PROJECT_DIR"
+      --volume="${XDG_CACHE_HOME}:$XDG_CACHE_HOME"
       --workdir="$CI_PROJECT_DIR"
       "$WINBUILDIMAGE"
       powershell -NonInteractive -NoLogo -NoProfile -InputFormat Text -OutputFormat Text -EncodedCommand $EncodedCommand

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -29,7 +29,7 @@ if not defined CI_PROJECT_DIR (
 )
 
 :: In CI: first, verify directory environment variables are set and normalize their paths
-for %%v in (BAZEL_DISK_CACHE BAZEL_OUTPUT_USER_ROOT BAZEL_REPO_CONTENTS_CACHE RUNNER_TEMP_PROJECT_DIR VSTUDIO_ROOT) do (
+for %%v in (BAZEL_DISK_CACHE BAZEL_OUTPUT_USER_ROOT BAZEL_REPO_CONTENTS_CACHE VSTUDIO_ROOT) do (
   if not defined %%v (
     >&2 echo %~nx0: %%v: unbound variable
     exit /b 2
@@ -37,18 +37,7 @@ for %%v in (BAZEL_DISK_CACHE BAZEL_OUTPUT_USER_ROOT BAZEL_REPO_CONTENTS_CACHE RU
   :: Path separators: `bazel` is fine with both `/` and `\\` but fails with `\`, so the simplest is to favor `/`
   set "%%v=!%%v:\=/!"
 )
-:: TODO(regis, if later needed): set "BAZEL_SH=C:/tools/msys64/usr/bin/bash.exe"
 set "BAZEL_VS=!VSTUDIO_ROOT!"
-set "ext_repo_contents_cache=!RUNNER_TEMP_PROJECT_DIR!/bazel-repo-contents-cache"
-
-:: Externalize `--repo_contents_cache` to the job's sibling temporary directory created alongside $CI_PROJECT_DIR
-:: - https://github.com/bazelbuild/bazel/issues/26384 for why
-:: - https://docs.gitlab.com/runner/configuration/advanced-configuration/ for `RUNNER_TEMP_PROJECT_DIR`
-:: - https://sissource.ethz.ch/sispub/gitlab-ci-euler-image/-/blob/main/entrypoint.sh#L43 for inspiration
-if exist "!BAZEL_REPO_CONTENTS_CACHE!" (
-  call :robomove "!BAZEL_REPO_CONTENTS_CACHE!" "!ext_repo_contents_cache!"
-  if !errorlevel! neq 0 exit /b !errorlevel!
-)
 
 :: Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` and next `bazel shutdown` also honor them
 (
@@ -56,8 +45,8 @@ if exist "!BAZEL_REPO_CONTENTS_CACHE!" (
   echo startup --local_startup_timeout_secs=30  # instead of 120s, to fail faster for diagnostics
   echo startup --output_user_root=!BAZEL_OUTPUT_USER_ROOT!
   echo common --config=ci
-  echo common --repo_contents_cache=!ext_repo_contents_cache!
-  echo build --disk_cache=!BAZEL_DISK_CACHE!
+  echo common --disk_cache=!BAZEL_DISK_CACHE!
+  echo common --repo_contents_cache=!BAZEL_REPO_CONTENTS_CACHE!
 ) >"%~dp0..\user.bazelrc"
 
 :: Diagnostics: print any stalled client/server before `bazel` execution
@@ -90,23 +79,5 @@ if !bazel_exit! neq 0 exit /b !bazel_exit!
 >&2 "%BAZEL_REAL%" shutdown --ui_event_filters=-info
 >&2 del /f /q "%~dp0..\user.bazelrc"
 
-:: Reintegrate `--repo_contents_cache` to original directory
-if exist "!ext_repo_contents_cache!" (
-  call :robomove "!ext_repo_contents_cache!" "!BAZEL_REPO_CONTENTS_CACHE!"
-  if !errorlevel! neq 0 exit /b !errorlevel!
-)
-
 :: Done
 exit /b 0
-
-:robomove
-:: Contrarily to `copy`, `move` and `xcopy`, `robocopy` avoids messing up with recursive symlinks, thanks to `/xj`
->&2 robocopy "%~1" "%~2" /b /copyall /dcopy:dat /mir /move /ndl /nfl /njh /njs /np /secfix /sl /timfix /w:0 /xj
-:: See: https://ss64.com/nt/robocopy-exit.html
-set /a rc=!errorlevel! ^& (8 ^| 16)
-if exist "%~1" (
-  >&2 echo 🟡 Purging leftovers, most likely due to recursive symbolic links/junction points:
-  >&2 dir /a /b /s "%~1"
-  >&2 rmdir /q /s "%~1"
-)
-exit /b !rc!


### PR DESCRIPTION
### What does this PR do?
No longer use GitLab cache for `bazel`-built artifacts on Windows. Instead treat the runner as persistent with `c:\bzl` as a base directory for `bazel[isk]` storage.

### Motivation
- problems with long paths (msbuild)
- problems with repo contents cache (openssl)
- simplification