### PR TITLE
Add extra replaces to modules.add-all-replace

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -352,6 +352,9 @@ def add_all_replace(ctx: Context):
     After months of pain and manually editing our 150+ go.mod in this repo we have come to this.
     """
 
+    # Avoid circular import
+    from tasks.go import check_go_mod_replaces
+
     # First we find all go.mod in comp and pkg
     gomods = [
         mods for mods in get_default_modules().values() if mods.path.split(os.sep)[0] not in ["tools", "internal"]
@@ -363,6 +366,9 @@ def add_all_replace(ctx: Context):
     for mod in gomods:
         if mod.should_replace_internal_modules:
             update_go_mod(mod_to_replace, mod.path)
+
+    # Add extra replaces
+    check_go_mod_replaces(ctx, fix=True)
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

I noticed that this task was missing some replaces and it turns out that the `check-go-mod-replaces --fix` task adds the necessary replaces.

### Motivation

### Describe how you validated your changes

### Additional Notes
