### PR TITLE
`tests_nodetreemodel_unmarshal`: fix flaky `TestCheckEvents_PauseContainers`

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/events_test.go
+++ b/pkg/collector/corechecks/containers/containerd/events_test.go
@@ -204,10 +204,6 @@ func TestCheckEvents_PauseContainers(t *testing.T) {
 		},
 	}
 
-	sub := createEventSubscriber("subscriberTestPauseContainers", containerdutil.ContainerdItf(itf), nil)
-	sub.CheckEvents()
-	assert.Eventually(t, sub.isRunning, testTimeout, testTicker) // Wait until it's processing events
-
 	tests := []struct {
 		name                   string
 		containerID            string
@@ -251,6 +247,11 @@ func TestCheckEvents_PauseContainers(t *testing.T) {
 			defaultExcludePauseContainers := mockConfig.GetBool("exclude_pause_container")
 			mockConfig.SetWithoutSource("exclude_pause_container", test.excludePauseContainers)
 
+			// Create a new subscriber for each test case so it picks up the correct config value
+			sub := createEventSubscriber("subscriberTestPauseContainers", containerdutil.ContainerdItf(itf), nil)
+			sub.CheckEvents()
+			assert.Eventually(t, sub.isRunning, testTimeout, testTicker) // Wait until it's processing events
+
 			if test.generateCreateEvent {
 				eventCreateContainer, err := createContainerEvent(testNamespace, test.containerID)
 				assert.NoError(t, err)
@@ -265,24 +266,22 @@ func TestCheckEvents_PauseContainers(t *testing.T) {
 			assert.NoError(t, err)
 			cha <- &eventContainerDelete
 
-			if test.expectsEvents {
-				var flushed []containerdEvent
-				assert.Eventually(t, func() bool {
-					flushed = sub.Flush(time.Now().Unix())
-					if test.generateCreateEvent {
-						return len(flushed) == 3 // create container + delete task + delete container
-					}
-					return len(flushed) == 2 // delete task + delete container
-				}, testTimeout, testTicker)
+			// Stop the subscriber before checking events to avoid race condition
+			errorsCh <- fmt.Errorf("stop subscriber")
+			assert.Eventually(t, func() bool { return !sub.isRunning() }, testTimeout, testTicker)
+
+			flushed := sub.Flush(time.Now().Unix())
+			if !test.expectsEvents {
+				assert.Empty(t, flushed)
+			} else if test.generateCreateEvent {
+				assert.Len(t, flushed, 3) // create container + delete task + delete container
 			} else {
-				assert.Empty(t, sub.Flush(time.Now().Unix()))
+				assert.Len(t, flushed, 2) // delete task + delete container
 			}
 
 			mockConfig.SetWithoutSource("exclude_pause_container", defaultExcludePauseContainers)
 		})
 	}
-
-	errorsCh <- fmt.Errorf("stop subscriber")
 }
 
 // TestComputeEvents checks the conversion of Containerd events to Datadog events


### PR DESCRIPTION
### What does this PR do?
Fix race condition in `TestCheckEvents_PauseContainers` causing it to fail intermittently ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1238217631)).

Instead of sharing one `subscriber` across all test cases, create a fresh one for each test case. This ensures each reads the `exclude_pause_container` config value _after_ the test has set it, eliminating the race without adding any overhead to production code.

### Motivation
CI reliability.

### Describe how you validated your changes
Verification with 100 runs each on my machine:
- without fix: 13-27% failure rate,
- with fix: 0% failure rate.

```
go test \
    -count=100 \
    -tags "trivy_no_javadb systemd zstd otlp docker clusterchecks kubelet oracle cri kubeapiserver crio orchestrator trivy no_dynamic_plugins systemprobechecks fargateprocess test containerd zlib zk jetson ec2 jmx netcgo etcd podman python nvml consul ncm cel grpcnotrace" \
    -run "^TestCheckEvents_PauseContainers$" \
    -short ./pkg/collector/corechecks/containers/containerd
```