### PR TITLE
`tests_macos_gitlab_arm64`: fix flaky `TestSlowReceiver`

### DIFF
--- a/pkg/config/remote/service/subscriptions.go
+++ b/pkg/config/remote/service/subscriptions.go
@@ -290,6 +290,8 @@ func (s *subscriptions) notify(
 		files := responseFiles
 		if !tracked.seenAny {
 			files = allFiles
+			tracked.seenAny = true
+			sub.trackedClients[runtimeID] = tracked
 		}
 		products := s.productsMappings[tracked.products]
 		files = filtered(files, func(file *pbgo.File) bool {
@@ -314,13 +316,9 @@ func (s *subscriptions) popUpdate(
 		update := sub.pendingQueue[0]
 		sub.pendingQueue[0], sub.pendingQueue = nil, sub.pendingQueue[1:]
 		runtimeID := getRuntimeIDFromClient(update.Client)
-		tracked, ok := sub.trackedClients[runtimeID]
-		if !ok {
-			continue
+		if _, ok := sub.trackedClients[runtimeID]; ok {
+			return update
 		}
-		tracked.seenAny = true
-		sub.trackedClients[runtimeID] = tracked
-		return update
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
This change aims at fixing a race condition in `TestSlowReceiver` ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1236940327)):
```diff
--- Expected
+++ Actual
@@ -1,4 +1,2 @@
-([]string) (len=1) {
- (string) (len=46) "datadog/2/LIVE_DEBUGGING/config-1/config1.json"
-}
+([]string) <nil>
```

This happened because:
1. first `ClientGetConfigs` call started,
2. between checking `seenAny` and calling `TargetFiles`, the subscription's `seenAny` changed from `false` to `true`,
3. this caused `subscriptionOnlyConfigs` to be empty when it should have included `config1Path`,
4. tesult: `TargetFiles(nil)` instead of `TargetFiles([config1Path])`.

The `seenAny` flag seems to determine if subsequent polls need to fetch complete files. Previously, it was set when updates were dequeued (`nextUpdate`), creating a race window where multiple polls could fetch complete files unnecessarily while an update sat in the queue.

Setting `seenAny` on enqueue (`notify`) eliminates this race. Behavior is otherwise unchanged:
- subscribers still receive the same files in the same order,
- queue overflow still correctly resets `seenAny` to `false`,
- untrack logic is unaffected.

### Describe how you validated your changes
Verified on Linux with 1000+ test runs (sequential, parallel, race detector). The race is platform-specific and manifested on macOS runners as mock ordering failures.

### Motivation
CI reliability.