### PR TITLE
CONS-7845 fix orchestrator check memory leak

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -211,27 +211,14 @@ func (o *OrchestratorCheck) Configure(senderManager sender.SenderManager, integr
 
 // Run runs the orchestrator check
 func (o *OrchestratorCheck) Run() error {
-	// If the check is configured as a cluster check, the cluster check worker needs to skip the leader election section.
-	// we also do a safety check for dedicated runners to avoid trying the leader election
-	if !o.isCLCRunner || !o.instance.LeaderSkip {
-		// Only run if Leader Election is enabled.
-		if !pkgconfigsetup.Datadog().GetBool("leader_election") {
-			return log.Errorc("Leader Election not enabled. The cluster-agent will not run the check.", orchestrator.ExtraLogContext...)
-		}
-
-		leader, errLeader := cluster.RunLeaderElection()
-		if errLeader != nil {
-			if errLeader == apiserver.ErrNotLeader {
-				log.Debugf("Not leader (leader is %q). Skipping the Orchestrator check", leader)
-				return nil
-			}
-
-			_ = o.Warn("Leader Election error. Not running the Orchestrator check.")
-			return errLeader
-		}
-
-		log.Tracef("Current leader: %q, running the Orchestrator check", leader)
+	if ok, err := o.IsLeader(); !ok {
+		// Disable terminated resource bundle if not leader so we don't buffer terminated resources by informer DeleteFunc
+		o.collectorBundle.GetTerminatedResourceBundle().Disable()
+		return err
 	}
+
+	// Enable terminated resource bundle to start buffering terminated resources
+	o.collectorBundle.EnableTerminatedResourceBundle()
 
 	// Initialize collectors
 	o.collectorBundle.Initialize()
@@ -252,9 +239,9 @@ func (o *OrchestratorCheck) Run() error {
 func (o *OrchestratorCheck) Cancel() {
 	log.Infoc(fmt.Sprintf("Shutting down informers used by the check '%s'", o.ID()), orchestrator.ExtraLogContext...)
 	close(o.stopCh)
-	// send all terminated resources
+	// flush and disable terminated resource bundle
 	if o.collectorBundle != nil {
-		o.collectorBundle.GetTerminatedResourceBundle().Stop()
+		o.collectorBundle.GetTerminatedResourceBundle().Disable()
 	}
 }
 
@@ -307,4 +294,31 @@ func getTags(initConfig, config integration.Data) ([]string, error) {
 	}
 
 	return tags, nil
+}
+
+// IsLeader checks if the orchestrator check is running on the leader node
+func (o *OrchestratorCheck) IsLeader() (bool, error) {
+	// If the check is configured as a cluster check, the cluster check worker needs to skip the leader election section.
+	// we also do a safety check for dedicated runners to avoid trying the leader election
+	if o.isCLCRunner && o.instance.LeaderSkip {
+		return true, nil
+	}
+
+	// Only run if Leader Election is enabled.
+	if !pkgconfigsetup.Datadog().GetBool("leader_election") {
+		return false, log.Errorc("Leader Election not enabled. The cluster-agent will not run the check.", orchestrator.ExtraLogContext...)
+	}
+
+	leader, err := cluster.RunLeaderElection()
+	if err != nil {
+		if err == apiserver.ErrNotLeader {
+			log.Debugf("Not leader (leader is %q). Skipping the Orchestrator check", leader)
+			return false, nil
+		}
+		log.Warn("Leader Election error. Not running the Orchestrator check.")
+		return false, err
+	}
+
+	log.Tracef("Current leader: %q, running the Orchestrator check", leader)
+	return true, nil
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -211,15 +211,6 @@ func (o *OrchestratorCheck) Configure(senderManager sender.SenderManager, integr
 
 // Run runs the orchestrator check
 func (o *OrchestratorCheck) Run() error {
-	// Initialize collectors
-	o.collectorBundle.Initialize()
-
-	// access serializer
-	sender, err := o.GetSender()
-	if err != nil {
-		return err
-	}
-
 	// If the check is configured as a cluster check, the cluster check worker needs to skip the leader election section.
 	// we also do a safety check for dedicated runners to avoid trying the leader election
 	if !o.isCLCRunner || !o.instance.LeaderSkip {
@@ -236,10 +227,19 @@ func (o *OrchestratorCheck) Run() error {
 			}
 
 			_ = o.Warn("Leader Election error. Not running the Orchestrator check.")
-			return err
+			return errLeader
 		}
 
 		log.Tracef("Current leader: %q, running the Orchestrator check", leader)
+	}
+
+	// Initialize collectors
+	o.collectorBundle.Initialize()
+
+	// access serializer
+	sender, err := o.GetSender()
+	if err != nil {
+		return err
 	}
 
 	// Run all collectors.

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
@@ -24,6 +24,7 @@ import (
 // TerminatedResourceBundle buffers terminated resources
 type TerminatedResourceBundle struct {
 	mu                  sync.Mutex
+	enabled             bool
 	runCfg              *collectors.CollectorRunConfig
 	check               *OrchestratorCheck
 	terminatedResources map[collectors.K8sCollector][]interface{}
@@ -46,6 +47,11 @@ func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, ob
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
+	// do not buffer terminated resources if the bundle is not enabled
+	if !tb.enabled {
+		return
+	}
+
 	if _, ok := tb.terminatedResources[k8sCollector]; !ok {
 		tb.terminatedResources[k8sCollector] = make([]interface{}, 0, tb.runCfg.Config.MaxPerMessage)
 	}
@@ -63,6 +69,11 @@ func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, ob
 func (tb *TerminatedResourceBundle) Run() {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
+
+	// do not send terminated resources if the bundle is not enabled
+	if !tb.enabled {
+		return
+	}
 
 	orchSender, err := tb.check.GetSender()
 	if err != nil {
@@ -100,10 +111,22 @@ func (tb *TerminatedResourceBundle) Run() {
 	}
 }
 
-// Stop stops TerminatedResourceBundle
-func (tb *TerminatedResourceBundle) Stop() {
+// Enable enables the TerminatedResourceBundle to start buffering terminated resources.
+func (tb *TerminatedResourceBundle) Enable() {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.enabled = true
+}
+
+// Disable flushes any buffered terminated resources and then disables the bundle
+// from accepting new terminated resources.
+func (tb *TerminatedResourceBundle) Disable() {
 	// send all buffered terminated resources
 	tb.Run()
+
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.enabled = false
 }
 
 func toTypedSlice(k8sCollector collectors.K8sCollector, list []interface{}) interface{} {

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
@@ -47,7 +47,7 @@ func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, ob
 	defer tb.mu.Unlock()
 
 	if _, ok := tb.terminatedResources[k8sCollector]; !ok {
-		tb.terminatedResources[k8sCollector] = []interface{}{}
+		tb.terminatedResources[k8sCollector] = make([]interface{}, 0, tb.runCfg.Config.MaxPerMessage)
 	}
 
 	resource, err := getResource(obj)
@@ -96,7 +96,7 @@ func (tb *TerminatedResourceBundle) Run() {
 			orchSender.OrchestratorManifest(result.Result.ManifestMessages, tb.runCfg.ClusterID)
 		}
 
-		tb.terminatedResources[collector] = tb.terminatedResources[collector][:0]
+		tb.terminatedResources[collector] = make([]interface{}, 0, tb.runCfg.Config.MaxPerMessage)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR does
* `orchestrator.go` : Moved collector initialization after the leader check to avoid starting informer on non-leader pods.

* `terminated_resource_bundle.go` : Replaced [:0] with make() to ensure consistent  slice allocation.

### Motivation

We identified the root cause in the orchestrator check. The collectorBundle is initialized first, and then we check whether the pod is the leader. If it's not the leader, the check is skipped.
https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go#L215-L243

However, during initialization we start the informers, whose deleteFunc buffers all deleted resources.
https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go#L326-L327

Because the cluster agent pod is not the leader, it never flushes the buffered resources, which causes the memory leak issue.


### Describe how you validated your changes

Deploy the cluster agent with multiple replicas, then create a large number of custom resources (e.g., karpenter.sh/v1/NodePool). Delete all of them and repeat this operation several times, while monitoring the memory usage of the cluster agent pods.

### Additional Notes
