### PR TITLE
[ AGNTLOG-403 ] Fix flaky windows tailer test

### DIFF
--- a/pkg/logs/tailers/file/tailer_windows_test.go
+++ b/pkg/logs/tailers/file/tailer_windows_test.go
@@ -101,8 +101,12 @@ func TestReadAvailableRotation(t *testing.T) {
 
 	tailer, _ := newTestTailer(t, mockFile.Name(), nil, nil, opener, mockDecoderOptions)
 	tailer.windowsOpenFileTimeout = 0
+
+	// Consume the first chunk immediately to allow it to complete,
+	// but block on the second chunk to force file close before rotation
 	go func() {
-		<-tailer.decoder.InputChan()
+		<-tailer.decoder.InputChan()      // Consume first chunk
+		time.Sleep(50 * time.Millisecond) // Let the second read attempt and hit timeout
 		<-tailer.decoder.InputChan()
 		tailer.decoder.Start()
 	}()
@@ -170,6 +174,8 @@ func TestReadAvailableFingerprintMismatchMidRead(t *testing.T) {
 	tailer.fingerprint = originalFingerprint
 	tailer.windowsOpenFileTimeout = 0
 	go func() {
+		// Wait for the decoder to attempt to read the first line
+		time.Sleep(50 * time.Millisecond)
 		<-tailer.decoder.InputChan()
 		tailer.decoder.Start()
 	}()


### PR DESCRIPTION
### What does this PR do?
Timeouts were errantly removed from the tests during their introduction, and they successful merged because they still flakily pass. This change re-introduces the necessary timeouts to force successful runs.

### Motivation

### Describe how you validated your changes

### Additional Notes
