### PR TITLE
Expand context slice when calling log with context

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/processors/errors.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/errors.go
@@ -27,6 +27,6 @@ func NewMarshallingError(cause error) error {
 func RecoverOnPanic() {
 	if r := recover(); r != nil {
 		stack := debug.Stack()
-		log.Errorc(fmt.Sprintf("unable to process resources (panic!): %s", stack), orchestrator.ExtraLogContext)
+		log.Errorc(fmt.Sprintf("unable to process resources (panic!): %s", stack), orchestrator.ExtraLogContext...)
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -108,7 +108,7 @@ func (h *PodHandlers) BeforeCacheCheck(ctx processors.ProcessorContext, resource
 
 	// Custom resource version to work around kubelet issues.
 	if err := k8sTransformers.FillK8sPodResourceVersion(m); err != nil {
-		log.Warnc(fmt.Sprintf("Failed to compute pod resource version: %s", err.Error()), orchestrator.ExtraLogContext)
+		log.Warnc(fmt.Sprintf("Failed to compute pod resource version: %s", err.Error()), orchestrator.ExtraLogContext...)
 		skip = true
 		return
 	}


### PR DESCRIPTION
### What does this PR do?
Expand context slice when calling log with context in orchestrator.

### Motivation
Fix the call.
The current logger silently ignores contexts with odd size, I only noticed this while working on implementing the new logger.

### Describe how you validated your changes
CI

### Additional Notes
