### PR TITLE
[CSPM] move `StartCompliance` to pkg/compliance

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/compliance"
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit"
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit/autoexitimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -54,7 +53,7 @@ import (
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
-	pkgCompliance "github.com/DataDog/datadog-agent/pkg/compliance"
+	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -131,7 +130,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					// TODO - components: Do not remove runtimeAgent ref until "github.com/DataDog/datadog-agent/pkg/security/agent" is a component so they're not GCed
 					return status.NewInformationProvider(runtimeAgent.StatusProvider()), runtimeAgent, nil
 				}),
-				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component, compression logscompression.Component, ipc ipc.Component) (status.InformationProvider, *pkgCompliance.Agent, error) {
+				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component, compression logscompression.Component, ipc ipc.Component) (status.InformationProvider, *compliance.Agent, error) {
 					hostnameDetected, err := hostnameutils.GetHostnameWithContextAndFallback(context.TODO(), ipc)
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package compliance implements a specific part of the datadog-agent
+// responsible for scanning host and containers and report various
+// misconfigurations and compliance issues.
 package compliance
 
 import (
@@ -22,7 +25,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/constants"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
-	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -40,7 +42,7 @@ func StartCompliance(log log.Component,
 	wmeta workloadmeta.Component,
 	compression compression.Component,
 	ipc ipc.Component,
-) (*compliance.Agent, error) {
+) (*Agent, error) {
 
 	enabled := config.GetBool("compliance_config.enabled")
 	configDir := config.GetString("compliance_config.dir")
@@ -57,11 +59,11 @@ func StartCompliance(log log.Component,
 	}
 	stopper.Add(context)
 
-	resolverOptions := compliance.ResolverOptions{
+	resolverOptions := ResolverOptions{
 		Hostname:           hostname,
 		HostRoot:           os.Getenv("HOST_ROOT"),
-		DockerProvider:     compliance.DefaultDockerProvider,
-		LinuxAuditProvider: compliance.DefaultLinuxAuditProvider,
+		DockerProvider:     DefaultDockerProvider,
+		LinuxAuditProvider: DefaultLinuxAuditProvider,
 	}
 
 	if metricsEnabled {
@@ -73,17 +75,17 @@ func StartCompliance(log log.Component,
 		sysProbeClient = newSysProbeClient(config.SocketAddress)
 	}
 
-	enabledConfigurationsExporters := []compliance.ConfigurationExporter{
-		compliance.KubernetesExporter,
+	enabledConfigurationsExporters := []ConfigurationExporter{
+		KubernetesExporter,
 	}
 	if config.GetBool("compliance_config.database_benchmarks.enabled") {
-		enabledConfigurationsExporters = append(enabledConfigurationsExporters, compliance.DBExporter)
+		enabledConfigurationsExporters = append(enabledConfigurationsExporters, DBExporter)
 	}
 
-	reporter := compliance.NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression)
+	reporter := NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression)
 	telemetrySender := telemetry.NewSimpleTelemetrySenderFromStatsd(statsdClient)
 
-	agent := compliance.NewAgent(telemetrySender, wmeta, ipc, compliance.AgentOptions{
+	agent := NewAgent(telemetrySender, wmeta, ipc, AgentOptions{
 		ResolverOptions:               resolverOptions,
 		ConfigDir:                     configDir,
 		Reporter:                      reporter,


### PR DESCRIPTION
### What does this PR do?

Simple code move to extract some compliance code from being put in cmd/security-agent since we want to use it from the system-probe in the end. No functional change expected.

### Motivation

### Describe how you validated your changes

### Additional Notes
