### PR TITLE
make more fx components available to system-probe modules

### DIFF
--- a/pkg/system-probe/api/module/common.go
+++ b/pkg/system-probe/api/module/common.go
@@ -12,8 +12,10 @@ import (
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -35,6 +37,8 @@ type Module interface {
 type FactoryDependencies struct {
 	fx.In
 
+	CoreConfig  config.Component
+	Log         log.Component
 	WMeta       workloadmeta.Component
 	Tagger      tagger.Component
 	Telemetry   telemetry.Component


### PR DESCRIPTION
### What does this PR do?

This PR makes the log and core config components (2 very core fx components) available to system-probe modules. The use part will come in another PR.

### Motivation

### Describe how you validated your changes

### Additional Notes
