### PR TITLE
Factor out opaque context conversion for log package

### DIFF
--- a/pkg/util/log/init_seelog.go
+++ b/pkg/util/log/init_seelog.go
@@ -21,14 +21,18 @@ func parseShortFilePath(_ string) seelog.FormatterFunc {
 
 func createExtraJSONContext(_ string) seelog.FormatterFunc {
 	return func(_ string, _ seelog.LogLevel, context seelog.LogContextInterface) interface{} {
-		return formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs(context.CustomContext())))
+		return formatters.ExtraJSONContext(toAttrHolder(context.CustomContext()))
 	}
 }
 
 func createExtraTextContext(_ string) seelog.FormatterFunc {
 	return func(_ string, _ seelog.LogLevel, context seelog.LogContextInterface) interface{} {
-		return formatters.ExtraTextContext(attrHolderImpl(formatters.ToSlogAttrs(context.CustomContext())))
+		return formatters.ExtraTextContext(toAttrHolder(context.CustomContext()))
 	}
+}
+
+func toAttrHolder(context interface{}) formatters.AttrHolder {
+	return attrHolderImpl(formatters.ToSlogAttrs(context))
 }
 
 type attrHolderImpl []slog.Attr

--- a/pkg/util/log/init_seelog.go
+++ b/pkg/util/log/init_seelog.go
@@ -21,35 +21,14 @@ func parseShortFilePath(_ string) seelog.FormatterFunc {
 
 func createExtraJSONContext(_ string) seelog.FormatterFunc {
 	return func(_ string, _ seelog.LogLevel, context seelog.LogContextInterface) interface{} {
-		contextList, ok := context.CustomContext().([]interface{})
-		if len(contextList) == 0 || !ok || len(contextList)%2 != 0 {
-			return ""
-		}
-
-		return formatters.ExtraJSONContext(toSlogAttrs(contextList))
+		return formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs(context.CustomContext())))
 	}
 }
 
 func createExtraTextContext(_ string) seelog.FormatterFunc {
 	return func(_ string, _ seelog.LogLevel, context seelog.LogContextInterface) interface{} {
-		contextList, ok := context.CustomContext().([]interface{})
-		if len(contextList) == 0 || !ok || len(contextList)%2 != 0 {
-			return ""
-		}
-		return formatters.ExtraTextContext(toSlogAttrs(contextList))
+		return formatters.ExtraTextContext(attrHolderImpl(formatters.ToSlogAttrs(context.CustomContext())))
 	}
-}
-
-func toSlogAttrs(contextList []interface{}) attrHolderImpl {
-	attrs := make([]slog.Attr, 0, len(contextList)/2)
-	for i := 0; i < len(contextList); i += 2 {
-		key, val := contextList[i], contextList[i+1]
-		// Only add if key is string
-		if keyStr, ok := key.(string); ok {
-			attrs = append(attrs, slog.Attr{Key: keyStr, Value: slog.AnyValue(val)})
-		}
-	}
-	return attrHolderImpl(attrs)
 }
 
 type attrHolderImpl []slog.Attr

--- a/pkg/util/log/init_seelog_test.go
+++ b/pkg/util/log/init_seelog_test.go
@@ -38,16 +38,16 @@ func BenchmarkLogFormatShortFilePath(b *testing.B) {
 }
 
 func TestExtractContextString(t *testing.T) {
-	assert.Equal(t, `,"foo":"bar"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar"}))))
-	assert.Equal(t, `foo:bar | `, formatters.ExtraTextContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar"}))))
-	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar", "bar", "buzz"}))))
-	assert.Equal(t, `foo:bar,bar:buzz | `, formatters.ExtraTextContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar", "bar", "buzz"}))))
-	assert.Equal(t, `,"foo":"b\"a\"r"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "b\"a\"r"}))))
-	assert.Equal(t, `,"foo":"3"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", 3}))))
-	assert.Equal(t, `,"foo":"4.131313131"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", float64(4.131313131)}))))
-	assert.Equal(t, "", formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs(nil))))
-	assert.Equal(t, "", formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{2, 3}))))
-	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar", 2, 3, "bar", "buzz"}))))
+	assert.Equal(t, `,"foo":"bar"`, formatters.ExtraJSONContext(toAttrHolder([]interface{}{"foo", "bar"})))
+	assert.Equal(t, `foo:bar | `, formatters.ExtraTextContext(toAttrHolder([]interface{}{"foo", "bar"})))
+	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, formatters.ExtraJSONContext(toAttrHolder([]interface{}{"foo", "bar", "bar", "buzz"})))
+	assert.Equal(t, `foo:bar,bar:buzz | `, formatters.ExtraTextContext(toAttrHolder([]interface{}{"foo", "bar", "bar", "buzz"})))
+	assert.Equal(t, `,"foo":"b\"a\"r"`, formatters.ExtraJSONContext(toAttrHolder([]interface{}{"foo", "b\"a\"r"})))
+	assert.Equal(t, `,"foo":"3"`, formatters.ExtraJSONContext(toAttrHolder([]interface{}{"foo", 3})))
+	assert.Equal(t, `,"foo":"4.131313131"`, formatters.ExtraJSONContext(toAttrHolder([]interface{}{"foo", float64(4.131313131)})))
+	assert.Equal(t, "", formatters.ExtraJSONContext(toAttrHolder(nil)))
+	assert.Equal(t, "", formatters.ExtraJSONContext(toAttrHolder([]interface{}{2, 3})))
+	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, formatters.ExtraJSONContext(toAttrHolder([]interface{}{"foo", "bar", 2, 3, "bar", "buzz"})))
 }
 
 func benchmarkLogFormatWithContext(logFormat string, b *testing.B) {

--- a/pkg/util/log/init_seelog_test.go
+++ b/pkg/util/log/init_seelog_test.go
@@ -38,16 +38,16 @@ func BenchmarkLogFormatShortFilePath(b *testing.B) {
 }
 
 func TestExtractContextString(t *testing.T) {
-	assert.Equal(t, `,"foo":"bar"`, formatters.ExtraJSONContext(toSlogAttrs([]interface{}{"foo", "bar"})))
-	assert.Equal(t, `foo:bar | `, formatters.ExtraTextContext(toSlogAttrs([]interface{}{"foo", "bar"})))
-	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, formatters.ExtraJSONContext(toSlogAttrs([]interface{}{"foo", "bar", "bar", "buzz"})))
-	assert.Equal(t, `foo:bar,bar:buzz | `, formatters.ExtraTextContext(toSlogAttrs([]interface{}{"foo", "bar", "bar", "buzz"})))
-	assert.Equal(t, `,"foo":"b\"a\"r"`, formatters.ExtraJSONContext(toSlogAttrs([]interface{}{"foo", "b\"a\"r"})))
-	assert.Equal(t, `,"foo":"3"`, formatters.ExtraJSONContext(toSlogAttrs([]interface{}{"foo", 3})))
-	assert.Equal(t, `,"foo":"4.131313131"`, formatters.ExtraJSONContext(toSlogAttrs([]interface{}{"foo", float64(4.131313131)})))
-	assert.Equal(t, "", formatters.ExtraJSONContext(toSlogAttrs(nil)))
-	assert.Equal(t, "", formatters.ExtraJSONContext(toSlogAttrs([]interface{}{2, 3})))
-	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, formatters.ExtraJSONContext(toSlogAttrs([]interface{}{"foo", "bar", 2, 3, "bar", "buzz"})))
+	assert.Equal(t, `,"foo":"bar"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar"}))))
+	assert.Equal(t, `foo:bar | `, formatters.ExtraTextContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar"}))))
+	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar", "bar", "buzz"}))))
+	assert.Equal(t, `foo:bar,bar:buzz | `, formatters.ExtraTextContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar", "bar", "buzz"}))))
+	assert.Equal(t, `,"foo":"b\"a\"r"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "b\"a\"r"}))))
+	assert.Equal(t, `,"foo":"3"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", 3}))))
+	assert.Equal(t, `,"foo":"4.131313131"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", float64(4.131313131)}))))
+	assert.Equal(t, "", formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs(nil))))
+	assert.Equal(t, "", formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{2, 3}))))
+	assert.Equal(t, `,"foo":"bar","bar":"buzz"`, formatters.ExtraJSONContext(attrHolderImpl(formatters.ToSlogAttrs([]interface{}{"foo", "bar", 2, 3, "bar", "buzz"}))))
 }
 
 func benchmarkLogFormatWithContext(logFormat string, b *testing.B) {

--- a/pkg/util/log/slog/wrapper.go
+++ b/pkg/util/log/slog/wrapper.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log/slog/formatters"
 	"github.com/DataDog/datadog-agent/pkg/util/log/types"
 )
 
@@ -191,25 +192,5 @@ func (w *Wrapper) SetAdditionalStackDepth(depth int) error {
 
 // SetContext sets context which will be added to every log records
 func (w *Wrapper) SetContext(context interface{}) {
-	if context == nil {
-		w.attrs = nil
-		return
-	}
-
-	// See `extractContextString` in pkg/util/log/setup/log.go:
-	// the context is a slice of interface{}, it contains an even number of elements,
-	// and keys are strings.
-	//
-	// We can lift the restrictions and/or change the API later, but for now we want
-	// the exact same behavior as we have with seelog
-
-	ctx := context.([]interface{})
-	var attrs []slog.Attr
-	for i := 0; i < len(ctx); i += 2 {
-		key, val := ctx[i], ctx[i+1]
-		if keyStr, ok := key.(string); ok {
-			attrs = append(attrs, slog.Attr{Key: keyStr, Value: slog.AnyValue(val)})
-		}
-	}
-	w.attrs = attrs
+	w.attrs = formatters.ToSlogAttrs(context)
 }


### PR DESCRIPTION
### What does this PR do?
Factor out opaque context conversion from `interface{}` to `[]slog.Attr` in the log package.

### Motivation
Unify the implementation, and ensure they behave exactly the same. In particular the slog one was missing a check on whether the context slice was odd, which made it fail.

### Describe how you validated your changes
CI

### Additional Notes
