### PR TITLE
[CSPM] extract sysprobe client into interface and add local version

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -136,8 +136,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 						return status.NewInformationProvider(nil), nil, err
 					}
 
+					var sysProbeClient compliance.SysProbeClient
+					if cfg := sysprobeconfig.SysProbeObject(); cfg != nil && cfg.SocketAddress != "" {
+						sysProbeClient = compliance.NewRemoteSysProbeClient(cfg.SocketAddress)
+					}
+
 					// start compliance security agent
-					complianceAgent, err := compliance.StartCompliance(log, config, sysprobeconfig, hostnameDetected, stopper, statsdClient, wmeta, compression, ipc)
+					complianceAgent, err := compliance.StartCompliance(log, config, hostnameDetected, stopper, statsdClient, wmeta, compression, ipc, sysProbeClient)
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -11,15 +11,10 @@ package compliance
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"hash/fnv"
-	"io"
 	"math/rand"
-	"net/http"
-	"net/url"
-	"strconv"
 	"sync"
 	"time"
 
@@ -90,9 +85,9 @@ type AgentOptions struct {
 	// enabled.
 	EnabledConfigurationExporters []ConfigurationExporter
 
-	// SysProbeClient is the HTTP client to allow the execution of benchmarks
-	// from system-probe. see: cmd/system-probe/modules/compliance.go
-	SysProbeClient *http.Client
+	// SysProbeClient is the possibly remote client to allow the execution of benchmarks
+	// from system-probe.
+	SysProbeClient SysProbeClient
 }
 
 // ConfigurationExporter is an enum type defining all configuration export
@@ -490,37 +485,11 @@ func (a *Agent) reportDBConfigurationFromSystemProbe(ctx context.Context, contai
 		return fmt.Errorf("system-probe socket client was not created")
 	}
 
-	qs := make(url.Values)
-	qs.Add("pid", strconv.FormatInt(int64(pid), 10))
-	sysProbeComplianceModuleURL := &url.URL{
-		Scheme:   "http",
-		Host:     "unix",
-		Path:     "/compliance/dbconfig",
-		RawQuery: qs.Encode(),
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sysProbeComplianceModuleURL.String(), nil)
+	resource, err := a.opts.SysProbeClient.FetchDBConfig(ctx, pid)
 	if err != nil {
 		return err
 	}
 
-	resp, err := a.opts.SysProbeClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("error running cross-container benchmark: %s", resp.Status)
-	}
-
-	var resource *dbconfig.DBResource
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(body, &resource); err != nil {
-		return err
-	}
 	if resource != nil {
 		dbResourceLog := NewResourceLog(a.opts.Hostname+"_"+string(containerID), resource.Type, resource.Config)
 		dbResourceLog.Container = &CheckContainerMeta{

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/constants"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
@@ -32,13 +31,13 @@ import (
 // and checks.
 func StartCompliance(log log.Component,
 	config config.Component,
-	sysprobeconfig sysprobeconfig.Component,
 	hostname string,
 	stopper startstop.Stopper,
 	statsdClient ddgostatsd.ClientInterface,
 	wmeta workloadmeta.Component,
 	compression compression.Component,
 	ipc ipc.Component,
+	sysProbeClient SysProbeClient,
 ) (*Agent, error) {
 
 	enabled := config.GetBool("compliance_config.enabled")
@@ -65,11 +64,6 @@ func StartCompliance(log log.Component,
 
 	if metricsEnabled {
 		resolverOptions.StatsdClient = statsdClient
-	}
-
-	var sysProbeClient SysProbeClient
-	if config := sysprobeconfig.SysProbeObject(); config != nil && config.SocketAddress != "" {
-		sysProbeClient = NewRemoteSysProbeClient(config.SocketAddress)
 	}
 
 	enabledConfigurationsExporters := []ConfigurationExporter{

--- a/pkg/compliance/sysprobe.go
+++ b/pkg/compliance/sysprobe.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package compliance implements a specific part of the datadog-agent
+// responsible for scanning host and containers and report various
+// misconfigurations and compliance issues.
+package compliance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
+)
+
+// SysProbeClient is an interface for fetching database configuration from system probe
+type SysProbeClient interface {
+	FetchDBConfig(ctx context.Context, pid int32) (*dbconfig.DBResource, error)
+}
+
+type RemoteSysProbeClient struct {
+	client *http.Client
+}
+
+// NewRemoteSysProbeClient creates a new remote system probe client with the given Unix socket address
+func NewRemoteSysProbeClient(address string) *RemoteSysProbeClient {
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:    2,
+			IdleConnTimeout: 30 * time.Second,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", address)
+			},
+			TLSHandshakeTimeout:   1 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			ExpectContinueTimeout: 50 * time.Millisecond,
+		},
+	}
+
+	return &RemoteSysProbeClient{
+		client: httpClient,
+	}
+}
+
+// FetchDBConfig fetches database configuration for the given process ID from the remote system probe
+func (c *RemoteSysProbeClient) FetchDBConfig(ctx context.Context, pid int32) (*dbconfig.DBResource, error) {
+	qs := make(url.Values)
+	qs.Add("pid", strconv.FormatInt(int64(pid), 10))
+	sysProbeComplianceModuleURL := &url.URL{
+		Scheme:   "http",
+		Host:     "unix",
+		Path:     "/compliance/dbconfig",
+		RawQuery: qs.Encode(),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sysProbeComplianceModuleURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error running cross-container benchmark: %s", resp.Status)
+	}
+
+	var resource *dbconfig.DBResource
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(body, &resource); err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}
+
+var _ SysProbeClient = (*RemoteSysProbeClient)(nil)

--- a/pkg/compliance/sysprobe.go
+++ b/pkg/compliance/sysprobe.go
@@ -27,6 +27,10 @@ type SysProbeClient interface {
 	FetchDBConfig(ctx context.Context, pid int32) (*dbconfig.DBResource, error)
 }
 
+var _ SysProbeClient = (*RemoteSysProbeClient)(nil)
+var _ SysProbeClient = (*LocalSysProbeClient)(nil)
+
+// RemoteSysProbeClient is a client that fetches database configuration from a remote system probe instance
 type RemoteSysProbeClient struct {
 	client *http.Client
 }
@@ -89,4 +93,14 @@ func (c *RemoteSysProbeClient) FetchDBConfig(ctx context.Context, pid int32) (*d
 	return resource, nil
 }
 
-var _ SysProbeClient = (*RemoteSysProbeClient)(nil)
+// LocalSysProbeClient is a client that fetches database configuration locally without going through system probe
+type LocalSysProbeClient struct{}
+
+// FetchDBConfig fetches database configuration for the given process ID locally
+func (c *LocalSysProbeClient) FetchDBConfig(ctx context.Context, pid int32) (*dbconfig.DBResource, error) {
+	res, ok := dbconfig.LoadDBResourceFromPID(ctx, pid)
+	if !ok {
+		return nil, fmt.Errorf("DB resource not found for pid=%d", pid)
+	}
+	return res, nil
+}


### PR DESCRIPTION
### What does this PR do?

The CSPM agent can query the system-probe for some compliance data benchmarks. This PR extracts this capability into an interface, and adds a local version of this feature. This will allow the system-probe version of the CSPM agent to query the data locally instead of querying it through the endpoint.

No functional change intended.

### Motivation

### Describe how you validated your changes

### Additional Notes
