### PR TITLE
Adjust `remote-config` PR review channel

### DIFF
--- a/tasks/libs/pipeline/github_slack_review_map.yaml
+++ b/tasks/libs/pipeline/github_slack_review_map.yaml
@@ -46,7 +46,7 @@
 '@datadog/cloud-network-monitoring': '#cloud-network-monitoring'
 '@datadog/opentelemetry': '#opentelemetry-ops'
 '@datadog/opentelemetry-agent': '#opentelemetry-agent-ops'
-'@datadog/remote-config': '#remote-config-monitoring'
+'@datadog/remote-config': '#remote-config-platform'
 '@datadog/sdlc-security': '#sit'
 '@datadog/serverless': '#serverless-agent'
 '@datadog/serverless-azure-gcp': '#serverless-azure-gcp-team'


### PR DESCRIPTION
### What does this PR do?
Unless I'm mistaken, colleagues happen to send their `remote-config` PRs to [#remote-config-platform](https://dd.enterprise.slack.com/archives/C01HVED6Q1M) instead of [#remote-config-monitoring](https://dd.enterprise.slack.com/archives/C02TFJNLYJC).

### Motivation
The latter seems to be mainly used for alerts, which leaves little chance for PR review requests to get noticed there.