### PR TITLE
[NCM] Support additional SSH configurations

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2710,6 +2710,7 @@ core,golang.org/x/crypto/scrypt,BSD-3-Clause,Copyright 2009 The Go Authors
 core,golang.org/x/crypto/sha3,BSD-3-Clause,Copyright 2009 The Go Authors
 core,golang.org/x/crypto/ssh,BSD-3-Clause,Copyright 2009 The Go Authors
 core,golang.org/x/crypto/ssh/internal/bcrypt_pbkdf,BSD-3-Clause,Copyright 2009 The Go Authors
+core,golang.org/x/crypto/ssh/knownhosts,BSD-3-Clause,Copyright 2009 The Go Authors
 core,golang.org/x/exp/constraints,BSD-3-Clause,Copyright 2009 The Go Authors
 core,golang.org/x/exp/maps,BSD-3-Clause,Copyright 2009 The Go Authors
 core,golang.org/x/exp/mmap,BSD-3-Clause,Copyright 2009 The Go Authors

--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement.go
@@ -122,14 +122,14 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	// Load/parse the configuration for the device instance
 	c.checkContext, err = ncmconfig.NewNcmCheckContext(rawInstance, rawInitConfig)
 	if err != nil {
-		return fmt.Errorf("build config failed: %s", err)
+		return fmt.Errorf("build config failed: %w", err)
 	}
 
 	// Must be called before v.CommonConfigure
 	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 	err = c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
 	if err != nil {
-		return fmt.Errorf("common configure failed: %s", err)
+		return fmt.Errorf("common configure failed: %w", err)
 	}
 
 	// Initialize the clock
@@ -146,7 +146,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	// TODO: add check to see the device's credentials type (SSH/Telnet) and create appropriate client factory
 	c.remoteClient, err = ncmremote.NewSSHClient(c.checkContext.Device)
 	if err != nil {
-		return err
+		return fmt.Errorf("create remote SSH client failed: %w", err)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement.go
@@ -144,7 +144,10 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	c.sender = ncmSender
 
 	// TODO: add check to see the device's credentials type (SSH/Telnet) and create appropriate client factory
-	c.remoteClient = ncmremote.NewSSHClient(c.checkContext.Device)
+	c.remoteClient, err = ncmremote.NewSSHClient(c.checkContext.Device)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
@@ -162,6 +162,11 @@ var invalidConfigMissingAuth = []byte(`
 ip_address: 10.0.0.1
 `)
 
+var baseInitConfig = []byte(`
+ssh:
+  insecure_skip_verify: true
+`)
+
 // Unit Tests
 
 func TestCheck_Configure_ValidConfig(t *testing.T) {
@@ -169,7 +174,7 @@ func TestCheck_Configure_ValidConfig(t *testing.T) {
 	senderManager := mocksender.CreateDefaultDemultiplexer()
 
 	profile.SetConfdPathAndCleanProfiles()
-	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, []byte{}, "test")
+	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, baseInitConfig, "test")
 
 	require.NoError(t, err)
 	assert.NotNil(t, check.checkContext)
@@ -207,7 +212,7 @@ func TestCheck_Configure_InvalidConfig(t *testing.T) {
 			check := createTestCheck(t)
 			senderManager := mocksender.CreateDefaultDemultiplexer()
 
-			err := check.Configure(senderManager, integration.FakeConfigHash, tt.config, []byte{}, "test")
+			err := check.Configure(senderManager, integration.FakeConfigHash, tt.config, baseInitConfig, "test")
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedError)
@@ -218,7 +223,7 @@ func TestCheck_Configure_InvalidConfig(t *testing.T) {
 func TestCheck_Run_Success(t *testing.T) {
 	check := createTestCheck(t)
 
-	id := checkid.BuildID(CheckName, integration.FakeConfigHash, validConfig, []byte(``))
+	id := checkid.BuildID(CheckName, integration.FakeConfigHash, validConfig, baseInitConfig)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
 	mockSender := mocksender.NewMockSenderWithSenderManager(id, senderManager)
 
@@ -229,7 +234,7 @@ func TestCheck_Run_Success(t *testing.T) {
 
 	// Configure the check
 	profile.SetConfdPathAndCleanProfiles()
-	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, []byte{}, "test")
+	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, baseInitConfig, "test")
 	require.NoError(t, err)
 
 	// mock the time
@@ -291,7 +296,7 @@ func TestCheck_Run_ConnectionFailure(t *testing.T) {
 
 	// Configure the check
 	profile.SetConfdPathAndCleanProfiles()
-	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, []byte{}, "test")
+	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, baseInitConfig, "test")
 	require.NoError(t, err)
 
 	// Set up mock remote client factory that fails to connect
@@ -312,7 +317,7 @@ func TestCheck_Run_ConfigRetrievalFailure(t *testing.T) {
 
 	// Configure the check
 	profile.SetConfdPathAndCleanProfiles()
-	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, []byte{}, "test")
+	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, baseInitConfig, "test")
 	require.NoError(t, err)
 
 	// Set up a mock remote client that fails config retrieval
@@ -335,7 +340,7 @@ func TestCheck_FindMatchingProfile(t *testing.T) {
 
 	// Configure the check
 	profile.SetConfdPathAndCleanProfiles()
-	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, []byte{}, "test")
+	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, baseInitConfig, "test")
 	require.NoError(t, err)
 
 	// mock the time
@@ -405,7 +410,7 @@ func TestCheck_FindMatchingProfile_Error(t *testing.T) {
 
 	// Configure the check
 	profile.SetConfdPathAndCleanProfiles()
-	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, []byte{}, "test")
+	err := check.Configure(senderManager, integration.FakeConfigHash, validConfig, baseInitConfig, "test")
 	require.NoError(t, err)
 
 	// mock the time

--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -72,6 +72,8 @@ type SSHConfig struct {
 	Ciphers           []string `yaml:"ciphers"`
 	KeyExchanges      []string `yaml:"key_exchanges"`
 	HostKeyAlgorithms []string `yaml:"host_key_algorithms"`
+	// Allow weak/legacy algorithms (from above) be used for older devices that do not support recommended algorithms (insecure)
+	AllowLegacyAlgorithms bool `yaml:"allow_legacy_algorithms"`
 }
 
 // NcmCheckContext holds the processed config needed for an integration instance to run

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -166,7 +166,7 @@ func TestSSHConfig_Validation(t *testing.T) {
 			name:           "missing both known_hosts path and insecure_skip_verify",
 			config:         &SSHConfig{},
 			expectedConfig: &SSHConfig{},
-			errMsg:         "no SSH host key configured: set known_hosts_path or enable insecure_skip_verify",
+			errMsg:         "no SSH host key verification configured: set known_hosts_path or enable insecure_skip_verify",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -77,7 +77,7 @@ func TestDeviceInstance_Validation(t *testing.T) {
 			errorMsg:    "auth is required: missing username",
 		},
 		{
-			name: "missing password",
+			name: "missing auth method (no password/private key)",
 			config: DeviceInstance{
 				IPAddress: "100.1.1.1",
 				Auth: AuthCredentials{
@@ -87,7 +87,7 @@ func TestDeviceInstance_Validation(t *testing.T) {
 				},
 			},
 			expectValid: false,
-			errorMsg:    "auth is required: missing password",
+			errorMsg:    "auth is required: missing auth method (either password or private key) for device 100.1.1.1",
 		},
 		{
 			name: "invalid port",
@@ -121,7 +121,7 @@ func TestDeviceInstance_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.ValidateDeviceInstance()
+			err := tt.config.Validate()
 			if tt.expectValid {
 				assert.NoError(t, err)
 			} else {
@@ -171,7 +171,7 @@ func TestSSHConfig_Validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.validateSSHConfig()
+			err := tt.config.validate()
 			if tt.errMsg != "" {
 				assert.EqualError(t, err, tt.errMsg)
 			} else {

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -275,6 +275,9 @@ func (s *SSHSession) Close() error {
 
 // connectToHost establishes an SSH connection to the specified IP address using the provided authentication credentials
 func connectToHost(ipAddress string, auth ncmconfig.AuthCredentials, config *ncmconfig.SSHConfig) (*ssh.Client, error) {
+	if config == nil {
+		return nil, fmt.Errorf("SSH configuration is required (host verification) but not provided for device %s", ipAddress)
+	}
 	callback, err := buildHostKeyCallback(config)
 	if err != nil {
 		return nil, err

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -53,7 +53,7 @@ type SSHSession struct {
 func NewSSHClient(device *ncmconfig.DeviceInstance) (*SSHClient, error) {
 	if device.Auth.SSH != nil {
 		if err := validateClientConfig(device.Auth.SSH); err != nil {
-			return nil, fmt.Errorf("error validating ssh client config: %s", err)
+			return nil, fmt.Errorf("error validating ssh client config: %w", err)
 		}
 	}
 
@@ -66,7 +66,7 @@ func buildHostKeyCallback(config *ncmconfig.SSHConfig) (ssh.HostKeyCallback, err
 	if config.KnownHostsPath != "" {
 		callbackFn, err := knownhosts.New(config.KnownHostsPath)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing known_hosts file from path: %s", err)
+			return nil, fmt.Errorf("error parsing known_hosts file from path: %w", err)
 		}
 		return callbackFn, nil
 	}

--- a/pkg/networkconfigmanagement/remote/ssh_test.go
+++ b/pkg/networkconfigmanagement/remote/ssh_test.go
@@ -8,9 +8,21 @@
 package remote
 
 import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
 	"fmt"
-	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
 	"testing"
+
+	ncmconfig "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 )
 
 func TestSSHClient_RetrieveRunningConfig_Success(t *testing.T) {
@@ -111,4 +123,157 @@ func TestSSHClient_MultipleCommands(t *testing.T) {
 	assert.Contains(t, results, "GigabitEthernet0/1 is up, line protocol is up")
 	assert.Contains(t, results, "Gateway of last resort is not set")
 	assert.True(t, session.closed, "Session should be closed after use")
+}
+
+func TestBuildHostKeyCallback(t *testing.T) {
+	// Create a temporary known_hosts file for testing
+	tmpDir := t.TempDir()
+	knownHostsPath := filepath.Join(tmpDir, "known_hosts")
+
+	// Generate a real test key pair
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// Convert to SSH public key format
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	require.NoError(t, err)
+
+	// Create a properly formatted known_hosts entry
+	// Format: hostname keytype base64key
+	knownHostsContent := fmt.Sprintf("testhost.example.com %s %s\n",
+		publicKey.Type(),
+		base64.StdEncoding.EncodeToString(publicKey.Marshal()))
+
+	err = os.WriteFile(knownHostsPath, []byte(knownHostsContent), 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		config *ncmconfig.SSHConfig
+		logMsg string
+		errMsg string
+	}{
+		{
+			name: "success: valid known_hosts path",
+			config: &ncmconfig.SSHConfig{
+				KnownHostsPath: knownHostsPath,
+			},
+		},
+		{
+			name: "error: invalid known_hosts path",
+			config: &ncmconfig.SSHConfig{
+				KnownHostsPath: "/not_real_path",
+			},
+			errMsg: "error parsing known_hosts file from path: open /not_real_path",
+		},
+		{
+			name: "success + warn log: use insecure ignore host key",
+			config: &ncmconfig.SSHConfig{
+				InsecureSkipVerify: true,
+			},
+			logMsg: "SSH host key verification is disabled - connects are insecure",
+		},
+		{
+			name:   "error: no host key verification configured",
+			config: &ncmconfig.SSHConfig{},
+			errMsg: "No SSH host key configured: set known_hosts file path or enable insecure_skip_verify",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprint(tt.name), func(t *testing.T) {
+			// initialize capturing logging if part of testing
+			var b bytes.Buffer
+			w := bufio.NewWriter(&b)
+			l, err := log.LoggerFromWriterWithMinLevelAndLvlFuncMsgFormat(w, log.DebugLvl)
+			require.NoError(t, err)
+			log.SetupLogger(l, "debug")
+
+			callback, err := buildHostKeyCallback(tt.config)
+			if tt.errMsg != "" {
+				assert.ErrorContains(t, err, tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, callback)
+			}
+
+			if tt.logMsg != "" {
+				w.Flush()
+				logOutput := b.String()
+				assert.Contains(t, logOutput, tt.logMsg)
+			}
+
+		})
+	}
+}
+
+func TestValidateClientConfig(t *testing.T) {
+	supportedAlgos := ssh.SupportedAlgorithms()
+	validCipher := supportedAlgos.Ciphers[0]
+	validKex := supportedAlgos.KeyExchanges[0]
+	validHostKey := supportedAlgos.HostKeys[0]
+
+	tests := []struct {
+		name        string
+		config      *ncmconfig.SSHConfig
+		errContains string
+	}{
+		{
+			name: "valid config with all algorithms",
+			config: &ncmconfig.SSHConfig{
+				Ciphers:           []string{validCipher},
+				KeyExchanges:      []string{validKex},
+				HostKeyAlgorithms: []string{validHostKey},
+			},
+		},
+		{
+			name: "valid config with empty algorithms",
+			config: &ncmconfig.SSHConfig{
+				Ciphers:           []string{},
+				KeyExchanges:      []string{},
+				HostKeyAlgorithms: []string{},
+			},
+		},
+		{
+			name: "invalid cipher",
+			config: &ncmconfig.SSHConfig{
+				Ciphers:           []string{"bad-cipher"},
+				KeyExchanges:      []string{validKex},
+				HostKeyAlgorithms: []string{validHostKey},
+			},
+			errContains: "unsupported cipher",
+		},
+		{
+			name: "invalid key exchange",
+			config: &ncmconfig.SSHConfig{
+				Ciphers:           []string{validCipher},
+				KeyExchanges:      []string{"bad-kex"},
+				HostKeyAlgorithms: []string{validHostKey},
+			},
+			errContains: "unsupported key exchange",
+		},
+		{
+			name: "invalid host key algorithm",
+			config: &ncmconfig.SSHConfig{
+				Ciphers:           []string{validCipher},
+				KeyExchanges:      []string{validKex},
+				HostKeyAlgorithms: []string{"bad-host-key"},
+			},
+			errContains: "unsupported host key algorithm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateClientConfig(tt.config)
+
+			if tt.errContains != "" {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?
https://datadoghq.atlassian.net/browse/NDMII-3595

Following up on old TODO in the code, changes include:
* Supporting checking key exchanges, ciphers, etc. according to what is recommended via the `crypto/ssh` library
* Support `known_hosts` for verification of server identities + insecure (not recommended but just in case)
  * Condensing SSH-related configurations together
  * Falling back if a device instance doesn't have any configurations, default to the `init_config` if available (otherwise will eventually fail for not specifying a host key verification method)
* Add private key and/or passphrase authentication support (additional functionality beyond username/password combo)
* Add some unit tests for additional functions from above

### Motivation

### Describe how you validated your changes

Example configs:
```
init_config:
  namespace: 'cml-test-ssh'
  min_collection_interval: 900
  ssh:
    insecure_skip_verify: true
    ciphers: [aes256-ctr, aes192-ctr, aes128-ctr]
    key_exchanges: [diffie-hellman-group14-sha1, diffie-hellman-group-exchange-sha1]
    host_key_algorithms: [ssh-rsa]

instances:
  - ip_address: '10.10.1.1'
    namespace: 'cml-test-ssh'
    auth:
      username: 'cisco'
      password: 'cisco'
```

### Additional Notes
