### PR TITLE
Scrub auth_key and priv_key.

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -167,8 +167,8 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	consumerKeyAndTokenIDReplacer.LastUpdated = parseVersion("7.70.0") // https://github.com/DataDog/datadog-agent/pull/40345
 
 	snmpReplacer := matchYAMLKey(
-		`(community_string|auth[Kk]ey|priv[Kk]ey|community|authentication_key|privacy_key|Authorization|authorization)`,
-		[]string{"community_string", "authKey", "authkey", "privKey", "privkey", "community", "authentication_key", "privacy_key", "Authorization", "authorization"},
+		`(community_string|auth_?[Kk]ey|priv_?[Kk]ey|community|authentication_key|privacy_key|Authorization|authorization)`,
+		[]string{"community_string", "authKey", "authkey", "auth_key", "privKey", "privkey", "priv_key", "community", "authentication_key", "privacy_key", "Authorization", "authorization"},
 		[]byte(`$1 "********"`),
 	)
 	snmpReplacer.LastUpdated = parseVersion("7.64.0") // https://github.com/DataDog/datadog-agent/pull/33742

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -360,11 +360,17 @@ func TestSNMPConfig(t *testing.T) {
 		`authkey: password`,
 		`authkey: "********"`)
 	assertClean(t,
+		`auth_key: password`,
+		`auth_key: "********"`)
+	assertClean(t,
 		`privKey: password`,
 		`privKey: "********"`)
 	assertClean(t,
 		`privkey: password`,
 		`privkey: "********"`)
+	assertClean(t,
+		`priv_key: password`,
+		`priv_key: "********"`)
 	assertClean(t,
 		`community_string: p@ssw0r)`,
 		`community_string: "********"`)


### PR DESCRIPTION
### What does this PR do?

Expand the SNMP scrubbing regex to include `auth_key` and `priv_key`.

### Motivation
This is the key we use in SNMP configs.

### Describe how you validated your changes

I updated the unit test to cover the new case.
