### PR TITLE
smp: update cli from v0.24.1 to v0.25.1

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -97,7 +97,7 @@ single-machine-performance-regression_detector:
       - outputs/decision_record.md # for posterity, this is appended to final PR comment
     when: always
   variables:
-    SMP_VERSION: 0.24.1
+    SMP_VERSION: 0.25.1
   # See 'decision_record.md' for the determination of whether this job passes or fails.
   allow_failure: false
   retry: !reference [.retry_only_infra_failure, retry]


### PR DESCRIPTION
### What does this PR do?

This pull request updates the SMP CLI version used in Agent CI from v0.24.1 to v0.25.1.

### Motivation

To keep the SMP CLI version used up-to-date with the most recent stable version of backend services.

### Describe how you validated your changes

Via this pull request.

### Additional Notes

Supersedes #43011.
