### PR TITLE
[ AGNTLOG-349 ] streamline the agent status checks during the file_tailing e2e tests

### DIFF
--- a/test/new-e2e/tests/agent-log-pipelines/linux-log/file-tailing/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/linux-log/file-tailing/file_tailing_test.go
@@ -3,15 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// linuxfiletailing is a test suite for the log agent interacting with a virtual machine and fake intake.
 package linuxfiletailing
 
 import (
 	_ "embed"
 	"fmt"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/utils"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/utils"
 
 	"github.com/stretchr/testify/assert"
 
@@ -103,7 +105,7 @@ func (s *LinuxFakeintakeSuite) TestLinuxLogTailing() {
 
 func (s *LinuxFakeintakeSuite) testLogCollection() {
 	t := s.T()
-	// Create a new log file with permissionn inaccessible to the agent
+	// Create a new log file with permissions accessible to the agent
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo touch %s", logFilePath))
 
 	// Adjust permissions of new log file before log generation
@@ -112,7 +114,9 @@ func (s *LinuxFakeintakeSuite) testLogCollection() {
 	assert.NoErrorf(t, err, "Unable to adjust permissions for the log file '%s'.", logFilePath)
 	assert.Equalf(t, "true", strings.TrimSpace(output), "Unable to adjust permissions for the log file '%s'.", logFilePath)
 
-	// t.Logf("Permissions granted for new log file.")
+	// Verify the tailer is in OK state before generating logs
+	utils.AssertAgentTailerOK(s, logFileName)
+
 	// Generate log
 	utils.AppendLog(s, logFileName, "hello-world", 1)
 
@@ -139,21 +143,20 @@ func (s *LinuxFakeintakeSuite) testLogNoPermission() {
 	// => Restart the agent to force it to reopen the file
 	s.Env().RemoteHost.Execute("sudo service datadog-agent restart")
 
+	// Verify tailer is in Error state due to permission issue
+	utils.AssertAgentTailerError(s, logFileName)
+
 	// Generate logs and check the intake for no new logs because of revoked permissions
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		agentReady := s.Env().Agent.Client.IsReady()
-		if assert.Truef(c, agentReady, "Agent is not ready after restart") {
-			// Generate log
-			utils.AppendLog(s, logFileName, "access-denied", 1)
-			// Check intake for new logs
-			utils.CheckLogsNotExpected(s.T(), s.Env().FakeIntake, "hello", "access-denied")
-		}
-	}, 2*time.Minute, 5*time.Second)
+	utils.AppendLog(s, logFileName, "access-denied", 1)
+	utils.CheckLogsNotExpected(s.T(), s.Env().FakeIntake, "hello", "access-denied")
 }
 
 func (s *LinuxFakeintakeSuite) testLogCollectionAfterPermission() {
 	t := s.T()
 	utils.CheckLogFilePresence(s, logFileName)
+
+	// Verify the tailer is in an error state before granting permissions
+	utils.AssertAgentTailerError(s, logFileName)
 
 	// Generate logs
 	utils.AppendLog(s, logFileName, "hello-after-permission-world", 1)
@@ -163,6 +166,9 @@ func (s *LinuxFakeintakeSuite) testLogCollectionAfterPermission() {
 	assert.NoErrorf(t, err, "Unable to adjust permissions for the log file '%s'.", logFilePath)
 	assert.Equalf(t, "true", strings.TrimSpace(output), "Unable to adjust permissions for the log file '%s'.", logFilePath)
 	t.Logf("Permissions granted for log file.")
+
+	// Verify tailer transitions to OK state after permissions are granted
+	utils.AssertAgentTailerOK(s, logFileName)
 
 	// Check intake for new logs
 	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "hello", "hello-after-permission-world", []string{})
@@ -182,8 +188,9 @@ func (s *LinuxFakeintakeSuite) testLogCollectionBeforePermission() {
 	assert.NoErrorf(t, err, "Unable to adjust permissions for the log file '%s'.", logFilePath)
 	assert.Equalf(t, "true", strings.TrimSpace(output), "Unable to adjust permissions for the log file '%s'.", logFilePath)
 	t.Logf("Permissions granted.")
-	// Wait for the agent to tail the log file since there is a delay between permissions being granted and the agent tailing the log file
-	time.Sleep(1000 * time.Millisecond)
+
+	// Wait for the agent to tail the log file and verify it's in OK state
+	utils.AssertAgentTailerOK(s, logFileName)
 
 	// Generate logs
 	utils.AppendLog(s, logFileName, "access-granted", 1)
@@ -208,6 +215,9 @@ func (s *LinuxFakeintakeSuite) testLogRecreateRotation() {
 	assert.NoError(t, err, "Failed to find the old log file after rotation")
 	assert.Equalf(t, "true", strings.TrimSpace(output), "Unable to adjust permissions for the log file '%s'.", logFilePath)
 	t.Logf("Permissions granted for new log file.")
+
+	// Verify tailer is in OK state for the rotated file before generating logs
+	utils.AssertAgentTailerOK(s, logFileName)
 
 	// Generate new logs
 	utils.AppendLog(s, logFileName, "hello-world-new-content", 1)


### PR DESCRIPTION
### What does this PR do?
The log e2e utilities have been expanded with the capability to reliably detect when an agent's tailers have started. This is quite useful for some tests, such as the file_tailing test suite, which are racing the tailer's pickup of the file they are testing with the writes they are expecting the tailer to pick up. 

The expectation is that this new functionality will reduce the incident rate of test failures currently being experienced in the file_tailing test suite.

### Motivation

### Describe how you validated your changes

### Additional Notes
