### PR TITLE
[ABLD-238] Do not build libpcap with omnibus.

### DIFF
--- a/omnibus/config/software/libpcap.rb
+++ b/omnibus/config/software/libpcap.rb
@@ -17,32 +17,3 @@ license_file "LICENSE"
 relative_path "libpcap-#{version}"
 
 source url: "https://www.tcpdump.org/release/libpcap-#{version}.tar.xz"
-
-build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  configure_options = [
-    "--disable-largefile",
-    "--disable-instrument-functions",
-    "--disable-remote",
-    "--disable-usb",
-    "--disable-netmap",
-    "--disable-bluetooth",
-    "--disable-dbus",
-    "--disable-rdma",
-    "--without-dag",
-    "--without-dpdk",
-    "--without-libnl",
-    "--without-septel",
-    "--without-snf",
-    "--without-turbocap",
-  ]
-  configure(*configure_options, env: env)
-
-  make "-j #{workers}", env: env
-  make "install", env: env
-
-  delete "#{install_dir}/embedded/bin/pcap-config"
-  delete "#{install_dir}/embedded/lib/libpcap.a"
-
-end


### PR DESCRIPTION
No one uses this version. system-probe uses libpcap, but it builds it itself.
https://github.com/DataDog/datadog-agent/blob/36b5b42e45e48bd2e7eb3737f18cfc8ff86e2245/tasks/system_probe.py#L700

We are leaving the license grabbing in place for now. When we have moved the pcap build to bazel, we can collect it that way.

DO NOT SUBMIT... although the .so file is useless, it install pcap.h, which the go modules use. 