### PR TITLE
bazel: replace_prefix: rpath fixup & handle binaries

### DIFF
--- a/bazel/rules/replace_prefix.sh
+++ b/bazel/rules/replace_prefix.sh
@@ -39,6 +39,10 @@ for f in "$@"; do
             sed -ibak "s|##PREFIX##|$PREFIX|" "$f" && rm -f "${f}bak"
             ;;
         *)
-            echo "Ignoring $f"
+            if file "$f" | grep ELF; then
+                ${PATCHELF} --set-rpath "$PREFIX"/lib "$f"
+            else
+                echo "Ignoring $f"
+            fi
     esac
 done

--- a/bazel/rules/replace_prefix.sh
+++ b/bazel/rules/replace_prefix.sh
@@ -30,10 +30,10 @@ for f in "$@"; do
     fi
     case $f in
         *.so)
-            ${PATCHELF} --set-rpath "$PREFIX" "$f"
+            ${PATCHELF} --set-rpath "$PREFIX"/lib "$f"
             ;;
         *.dylib)
-            install_name_tool -add_rpath "$PREFIX/embedded/lib" "$f"
+            install_name_tool -add_rpath "$PREFIX/lib" "$f"
             ;;
         *.pc)
             sed -ibak "s|##PREFIX##|$PREFIX|" "$f" && rm -f "${f}bak"

--- a/bazel/rules/replace_prefix.sh
+++ b/bazel/rules/replace_prefix.sh
@@ -39,10 +39,10 @@ for f in "$@"; do
             sed -ibak "s|##PREFIX##|$PREFIX|" "$f" && rm -f "${f}bak"
             ;;
         *)
-            if file "$f" | grep ELF; then
+            if file "$f" | grep -q ELF; then
                 ${PATCHELF} --set-rpath "$PREFIX"/lib "$f"
             else
-                echo "Ignoring $f"
+                >&2 echo "Ignoring $f"
             fi
     esac
 done


### PR DESCRIPTION
### What does this PR do?

* Fix the rpath value which needs to point to the lib folder instead of the prefix
* handle ELF binaries in addition to .so

### Motivation

Having shared objects & binaries build with bazel that can load their dependencies

### Describe how you validated your changes

### Additional Notes

This lacks the support for mach-o binaries, but as I don't have a good way to test it currently I'd like to postpone the change, even though it should be trivial
