### PR TITLE
Split notarization submission from status check to avoid too broad retries

### DIFF
--- a/tools/ci/retry.sh
+++ b/tools/ci/retry.sh
@@ -1,27 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 if [ "$#" -lt 1 ]; then
-    print "usage: $0 [-n <n-attempts>] <command> [arguments]"
-    print "The script will execute the provided commands and retry in case of failures"
+    >&2 echo "usage: $0 [-n <n-attempts>] <command> [arguments]"
+    >&2 echo "The script will execute the provided commands and retry in case of failures"
     exit 1
 fi
 
 if [ "$1" = "-n" ]; then
     shift
-    NB_ATTEMPTS="$1"
+    declare -i NB_ATTEMPTS="$1"
     shift
 else
-    NB_ATTEMPTS=5
+    declare -i NB_ATTEMPTS=5
 fi
 
-for i in $(seq 1 $NB_ATTEMPTS); do
-    "$@" && exit 0;
-    errorcode=$?
-    echo "Attempt #${i} failed with error code ${errorcode}"
-    # Don't bother sleeping before exiting with an error
-    if [ "$i" -lt $NB_ATTEMPTS ]; then
-        sleep $((i ** 2))
-    fi
+for i in $(seq 1 $((NB_ATTEMPTS - 1))); do
+    "$@" && exit 0
+    >&2 echo "Attempt #$i/$NB_ATTEMPTS failed with error code $?"
+    sleep $((i ** 2))
 done
 
-exit $errorcode
+"$@"


### PR DESCRIPTION
### What does this PR do?
The notarization process submits the DMG with `--wait`, which waits up to 15 minutes for Apple to process the notarization.
When either the request times out (error code `69`) or fetching the resulting log fails, the retry logic was submitting a new notarization request with a different submission ID, creating 3 separate submissions that each wait 15 minutes plus the time spent in fetching logs.

This change splits the process into two phases:
1. submit the DMG for notarization (still using `--wait`) and extract the submission ID from the output or fail right away,
2. check the resulting status of that same submission ID by fetching corresponding logs.

Each phase has its own retry logic, preventing too broad retries.

### Motivation
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1239403241
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1239335883
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1239312314
- https://github.com/DataDog/datadog-agent/pull/36810#discussion_r2084560158

### Additional Notes
Also made `retry.sh` more robust (fail-fast flags, etc.)