### PR TITLE
Add a all-artifacts job to gather flakefinder dependency

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -174,6 +174,7 @@ e2e_pre_test*                     @DataDog/agent-devx
 new-e2e*                          @DataDog/multiple
 go_e2e_test_binaries              @DataDog/agent-devx
 dynamic_test-evaluate-e2e         @DataDog/agent-devx
+all-artifacts                     @DataDog/agent-devx
 
 # Kernel matrix testing
 upload_dependencies*              @DataDog/ebpf-platform

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -964,6 +964,27 @@ new-e2e-gpu:
       - EXTRA_PARAMS: "--run TestGPUHostSuiteUbuntu1804Driver430" # This driver is not supported by the agent, but we can check that the agent does not crash. No need to test in k8s this one.
   allow_failure: true
 
+all-artifacts: # This job is used to collect all artifacts needed in the flake finder pipeline, because we are limited to 5 cross pipelines needs: https://forum.gitlab.com/t/needs-pipeline-job-limit-on-premise/88731
+  stage: e2e
+  tags: ["arch:amd64", "specific:true"]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  rules:
+    - !reference [.except_disable_e2e_tests]
+    - !reference [.on_deploy_nightly_repo_branch]
+    - !reference [.manual]
+  needs:
+    - agent_deb-x64-a7
+    - agent_deb-x64-a7-fips
+    - windows_msi_and_bosh_zip_x64-a7-fips
+    - windows_msi_and_bosh_zip_x64-a7
+    - agent_rpm-x64-a7
+    - agent_suse-x64-a7
+  script:
+    - exit 0
+  artifacts:
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
+    expire_in: 1 day
 generate-flakes-finder-pipeline:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   stage: e2e
@@ -971,7 +992,9 @@ generate-flakes-finder-pipeline:
     - !reference [.except_disable_e2e_tests]
     - !reference [.on_deploy_nightly_repo_branch]
     - !reference [.manual]
+  dependencies: [compute_gitlab_ci_config]
   needs:
+    - all-artifacts
     - compute_gitlab_ci_config
     - deploy_deb_testing-a7_arm64
     - deploy_deb_testing-a7_x64

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -1047,6 +1047,7 @@ generate-fips-e2e-pipeline:
     - !reference [.on_deploy_nightly_repo_branch]
     - !reference [.manual]
   needs:
+    - all-artifacts
     - agent_deb-x64-a7-fips
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7-fips

--- a/tasks/fips.py
+++ b/tasks/fips.py
@@ -54,6 +54,7 @@ def generate_fips_e2e_pipeline(ctx, generate_config=False):
             job["needs"] = update_needs_parent(
                 job["needs"],
                 deps_to_keep=[
+                    # Warning: if you want to add a dependency here you will hit a gitlab limit (no more than 5 needs https://forum.gitlab.com/t/needs-pipeline-job-limit-on-premise/88731)
                     "go_e2e_deps",
                     "go_tools_deps",
                     "tests_windows_sysprobe_x64",

--- a/tasks/fips.py
+++ b/tasks/fips.py
@@ -55,20 +55,18 @@ def generate_fips_e2e_pipeline(ctx, generate_config=False):
                 job["needs"],
                 deps_to_keep=[
                     "go_e2e_deps",
+                    "go_tools_deps",
                     "tests_windows_sysprobe_x64",
                     "tests_windows_secagent_x64",
                     "go_e2e_test_binaries",
                 ],
                 package_deps=[
-                    "agent_deb-x64-a7-fips",
-                    "agent_deb-x64-a7",
-                    "windows_msi_and_bosh_zip_x64-a7-fips",
-                    "windows_msi_and_bosh_zip_x64-a7",
                     "agent_rpm-x64-a7",
                     "agent_suse-x64-a7",
                 ],
                 package_deps_suffix="-fips",
             )
+    job["needs"].append({"pipeline": "$PARENT_PIPELINE_ID", "job": "all-artifacts"})
 
     new_jobs = {}
     new_jobs['variables'] = copy.deepcopy(config['variables'])

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -258,15 +258,9 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
                     "tests_windows_secagent_x64",
                     "go_e2e_test_binaries",
                 ],
-                package_deps=[
-                    "agent_deb-x64-a7-fips",
-                    "agent_deb-x64-a7",
-                    "windows_msi_and_bosh_zip_x64-a7-fips",
-                    "windows_msi_and_bosh_zip_x64-a7",
-                    "agent_rpm-x64-a7",
-                    "agent_suse-x64-a7",
-                ],
+                package_deps=[],
             )
+        job["needs"].append({"pipeline": "$PARENT_PIPELINE_ID", "job": "all-artifacts"})
 
     new_jobs = {}
     new_jobs['variables'] = copy.deepcopy(config['variables'])


### PR DESCRIPTION
### What does this PR do?

There is a strict gitlab limit of 5 cross pipelines jobs needs: https://forum.gitlab.com/t/needs-pipeline-job-limit-on-premise/88731
To avoid that issue we group the artifacts in one job that we use in the flake finder pipeline, otherwise some jobs in the sub pipelines have more than 5 needs and break the config: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/82855946


### Motivation

### Describe how you validated your changes

### Additional Notes
