### PR TITLE
[CHAOSPLT-1315] Move parser init inside fuzz harness

### DIFF
--- a/comp/dogstatsd/server/enrich_fuzz_test.go
+++ b/comp/dogstatsd/server/enrich_fuzz_test.go
@@ -14,16 +14,18 @@ import (
 
 // Run locally with `go test -fuzz=FuzzParseEventWithEnrich -run=FuzzParseEventWithEnrich -tags=test`
 func FuzzParseEventWithEnrich(f *testing.F) {
-	deps := newServerDeps(f)
-	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 
 	f.Add([]byte("_e{10,9}:test title|test text"), "origin", uint32(1), true, true)
 	f.Add([]byte("_e{10,24}:test|title|test\\line1\\nline2\\nline3"), "origin", uint32(1), true, true)
 	f.Add([]byte("_e{10,9}:test title|test text|s:this is the source"), "origin", uint32(1), true, true)
 	f.Add([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"), "origin", uint32(1), true, true)
 	f.Add([]byte("_e{10,0}:test title||t:warning"), "origin", uint32(1), true, true)
-	f.Fuzz(func(_ *testing.T, rawEvent []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+	f.Fuzz(func(t *testing.T, rawEvent []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+		// This needs to be done in the fuzz test because there's a log emitted
+		// and the fuzzer cannot call `f.Log()` inside here, it must be `t.Log()`, which we don't have access to if it's initialized once.
+		deps := newServerDeps(t)
+		stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+		parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 		parsed, err := parser.parseEvent(rawEvent)
 		if err != nil {
 			return
@@ -37,14 +39,17 @@ func FuzzParseEventWithEnrich(f *testing.F) {
 
 // Run locally with `go test -fuzz=FuzzParseMetricWithEnrich -run=FuzzParseMetricWithEnrich -tags=test`
 func FuzzParseMetricWithEnrich(f *testing.F) {
-	deps := newServerDeps(f)
-	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
-	filter := utilstrings.NewMatcher([]string{"custom.metric.a", "custom.metric.b"}, false)
 
 	f.Add([]byte("custom_counter:1|c|#protocol:http,bench"), "origin", uint32(1), true, true)
 	f.Add([]byte("custom_counter:1|c|#protocol:http,bench"), "origin", uint32(1), true, true)
-	f.Fuzz(func(_ *testing.T, rawMetric []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+	f.Fuzz(func(t *testing.T, rawMetric []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+		// This needs to be done in the fuzz test because there's a log emitted
+		// and the fuzzer cannot call `f.Log()` inside here, it must be `t.Log()`, which we don't have access to if it's initialized once.
+		deps := newServerDeps(t)
+		stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+		parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+		filter := utilstrings.NewMatcher([]string{"custom.metric.a", "custom.metric.b"}, false)
+
 		parsed, err := parser.parseMetricSample(rawMetric)
 		if err != nil {
 			return
@@ -59,13 +64,16 @@ func FuzzParseMetricWithEnrich(f *testing.F) {
 
 // Run locally with `go test -fuzz=FuzzParseServiceCheckWithEnrich -run=FuzzParseServiceCheckWithEnrich -tags=test`
 func FuzzParseServiceCheckWithEnrich(f *testing.F) {
-	deps := newServerDeps(f)
-	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 
 	f.Add([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"), "origin", uint32(1), true, true)
 	f.Add([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"), "origin", uint32(1), true, true)
-	f.Fuzz(func(_ *testing.T, rawServiceCheck []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+	f.Fuzz(func(t *testing.T, rawServiceCheck []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+		// This needs to be done in the fuzz test because there's a log emitted
+		// and the fuzzer cannot call `f.Log()` inside here, it must be `t.Log()`, which we don't have access to if it's initialized once.
+		deps := newServerDeps(t)
+		stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+		parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+
 		parsed, err := parser.parseServiceCheck(rawServiceCheck)
 		if err != nil {
 			return

--- a/comp/dogstatsd/server/parse_events_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_events_fuzz_test.go
@@ -11,16 +11,18 @@ import (
 
 // Run locally with `go test -fuzz=FuzzParseEvent -run=FuzzParseEvent -tags=test`
 func FuzzParseEvent(f *testing.F) {
-	deps := newServerDeps(f)
-	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 
 	f.Add([]byte("_e{10,9}:test title|test text"))
 	f.Add([]byte("_e{10,24}:test|title|test\\line1\\nline2\\nline3"))
 	f.Add([]byte("_e{10,9}:test title|test text|s:this is the source"))
 	f.Add([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
 	f.Add([]byte("_e{10,0}:test title||t:warning"))
-	f.Fuzz(func(_ *testing.T, rawEvent []byte) {
+	f.Fuzz(func(t *testing.T, rawEvent []byte) {
+		// This needs to be done in the fuzz test because there's a log emitted
+		// and the fuzzer cannot call `f.Log()` inside here, it must be `t.Log()`, which we don't have access to if it's initialized once.
+		deps := newServerDeps(t)
+		stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+		parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 		_, err := parser.parseEvent(rawEvent)
 		if err != nil {
 			// we expect errors, we just don't want to panic(), or timeout

--- a/comp/dogstatsd/server/parse_metrics_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_metrics_fuzz_test.go
@@ -11,16 +11,18 @@ import (
 
 // Run locally with `go test -fuzz=FuzzParseMetricSample -run=FuzzParseMetricSample -tags=test`
 func FuzzParseMetricSample(f *testing.F) {
-	deps := newServerDeps(f)
-	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 	f.Add([]byte("custom_counter:1|c|#protocol:http,bench"))
 	f.Add([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"))
 	f.Add([]byte("metric:1234|g|#onetag|T1657100430"))
 	f.Add([]byte("metric:1234|g|@0.21|T1657100440"))
 	f.Add([]byte("example.metric:2.39283|d|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f"))
 	f.Add([]byte("example.metric:2.39283|d|T1657100540|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f|f:wowthisisacoolfeature"))
-	f.Fuzz(func(_ *testing.T, rawSample []byte) {
+	f.Fuzz(func(t *testing.T, rawSample []byte) {
+		// This needs to be done in the fuzz test because there's a log emitted
+		// and the fuzzer cannot call `f.Log()` inside here, it must be `t.Log()`, which we don't have access to if it's initialized once.
+		deps := newServerDeps(t)
+		stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+		parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 		_, _ = parser.parseMetricSample(rawSample)
 	})
 }

--- a/comp/dogstatsd/server/parse_service_checks_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_service_checks_fuzz_test.go
@@ -11,9 +11,6 @@ import (
 
 // Run locally with `go test -fuzz=FuzzParseServiceCheck -run=FuzzParseServiceCheck -tags=test`
 func FuzzParseServiceCheck(f *testing.F) {
-	deps := newServerDeps(f)
-	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 
 	f.Add([]byte("_sc|agent.up|0"))
 	f.Add([]byte("_sc|agent.up|0|d:12345|h:some.host|#tag1,tag2:test"))
@@ -21,7 +18,12 @@ func FuzzParseServiceCheck(f *testing.F) {
 	f.Add([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"))
 	f.Add([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"))
 
-	f.Fuzz(func(_ *testing.T, rawServiceCheck []byte) {
+	f.Fuzz(func(t *testing.T, rawServiceCheck []byte) {
+		// This needs to be done in the fuzz test because there's a log emitted
+		// and the fuzzer cannot call `f.Log()` inside here, it must be `t.Log()`, which we don't have access to if it's initialized once.
+		deps := newServerDeps(t)
+		stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+		parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
 		_, _ = parser.parseServiceCheck(rawServiceCheck)
 	})
 }


### PR DESCRIPTION
### What does this PR do?
Moves a initialization inside the fuzz test case instead of a "only once".

Some changes in #42885 triggered the following failures:
```
panic: testing: f.Log was called inside the fuzz target, use t.Log instead [recovered]
    panic: testing: f.Log was called inside the fuzz target, use t.Log instead
```

This is slower (re-init the struct / deps many times instead of once), but real number tbd!

### Motivation

Fix a panic in the fuzzers

### Describe how you validated your changes
```
cd comp/dogstatsd/server
go test -fuzz=FuzzParseServiceCheck$ -run=FuzzParseServiceCheck$ -tags=test -fuzztime=5s
....

PASS
ok      github.com/DataDog/datadog-agent/comp/dogstatsd/server  6.191s
```

### Additional Notes
