### PR TITLE
Wrap visual studio installation in a repository rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -109,6 +109,7 @@ register_toolchains(
 visual_studio(
     name = "visual_studio",
     path = r"C:\devtools\vstudio",
+    version = "17.14.36705.20",
 )
 
 # =========================================

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,7 @@
 # Foundational packages
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
-new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
-
+visual_studio = use_repo_rule("//bazel/rules:visual_studio.bzl", "visual_studio")
 
 # package_metadata and rules_license are dependencies of every module in the
 # Bazel ecosystem.  We pin those first to get the versions we require.
@@ -107,17 +106,8 @@ register_toolchains(
 )
 
 # Visual Studio / MSBuild tooling, taken from the local installation
-new_local_repository(
+visual_studio(
     name = "visual_studio",
-    build_file_content = """
-exports_files(["MSBuild/Current/Bin/msbuild.exe"])
-
-alias(
-    name="msbuild",
-    actual="MSBuild/Current/Bin/msbuild.exe",
-    visibility = ["//visibility:public"],
-)
-""",
     path = r"C:\devtools\vstudio",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 # Foundational packages
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
+
 visual_studio = use_repo_rule("//bazel/rules:visual_studio.bzl", "visual_studio")
 
 # package_metadata and rules_license are dependencies of every module in the
@@ -108,7 +109,7 @@ register_toolchains(
 # Visual Studio / MSBuild tooling, taken from the local installation
 visual_studio(
     name = "visual_studio",
-    path = r"C:\devtools\vstudio",
+    path_variable = "VSTUDIO_ROOT",
     version = "17.14.36705.20",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,8 @@
 # Foundational packages
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
-visual_studio = use_repo_rule("//bazel/rules:visual_studio.bzl", "visual_studio")
+new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
+
 
 # package_metadata and rules_license are dependencies of every module in the
 # Bazel ecosystem.  We pin those first to get the versions we require.
@@ -105,11 +106,19 @@ register_toolchains(
     "//bazel/toolchains/mingw:mingw_cc_toolchain",
 )
 
-# Visual Studio / MSBuild tooling
-visual_studio(
-    name="visual_studio",
-    url="https://download.visualstudio.microsoft.com/download/pr/e98d75fa-91b1-47a1-9cb7-b6556de592c5/6319a322aec87401661ec138427946ca6ab0373c917364a4abf17556ff7aef91/vs_Community.exe",
-    sha256="6319A322AEC87401661EC138427946CA6AB0373C917364A4ABF17556FF7AEF91",
+# Visual Studio / MSBuild tooling, taken from the local installation
+new_local_repository(
+    name = "visual_studio",
+    build_file_content = """
+exports_files(["MSBuild/Current/Bin/msbuild.exe"])
+
+alias(
+    name="msbuild",
+    actual="MSBuild/Current/Bin/msbuild.exe",
+    visibility = ["//visibility:public"],
+)
+""",
+    path = r"C:\devtools\vstudio",
 )
 
 # =========================================

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 # Foundational packages
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
+visual_studio = use_repo_rule("//bazel/rules:visual_studio.bzl", "visual_studio")
 
 # package_metadata and rules_license are dependencies of every module in the
 # Bazel ecosystem.  We pin those first to get the versions we require.
@@ -102,6 +103,13 @@ register_toolchains(
     "@gcc_toolchain_x86_64//:cc_toolchain",
     "@gcc_toolchain_aarch64//:cc_toolchain",
     "//bazel/toolchains/mingw:mingw_cc_toolchain",
+)
+
+# Visual Studio / MSBuild tooling
+visual_studio(
+    name="visual_studio",
+    url="https://download.visualstudio.microsoft.com/download/pr/e98d75fa-91b1-47a1-9cb7-b6556de592c5/6319a322aec87401661ec138427946ca6ab0373c917364a4abf17556ff7aef91/vs_Community.exe",
+    sha256="6319A322AEC87401661EC138427946CA6AB0373C917364A4ABF17556FF7AEF91",
 )
 
 # =========================================

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -110,7 +110,7 @@ register_toolchains(
 visual_studio(
     name = "visual_studio",
     path_variable = "VSTUDIO_ROOT",
-    version = "17.14.36705.20",
+    version = "17.14.36623.8",
 )
 
 # =========================================

--- a/bazel/rules/visual_studio.bzl
+++ b/bazel/rules/visual_studio.bzl
@@ -84,7 +84,7 @@ visual_studio = repository_rule(
             doc = "Path to Visual Studio's installation root",
         ),
         "path_variable": attr.string(
-            doc = "Environment variable pointint to Visual Studio's installation root path",
+            doc = "Environment variable pointing to Visual Studio's installation root path",
         ),
         "version": attr.string(
             doc = "Installation Version. If set, it must match the version for the installation pointed at by path",

--- a/bazel/rules/visual_studio.bzl
+++ b/bazel/rules/visual_studio.bzl
@@ -1,8 +1,4 @@
 """Wrapping Visual Studio and MSBuild to let Bazel track it.
-
-We're very probably never going to get nothing close to hermetic for these tools (less so considering
-sandboxing limitations in Windows); this provides a best-effort attempt at at least making Bazel
-manage and track these tools.
 """
 
 def _visual_studio_impl(ctx):
@@ -10,62 +6,17 @@ def _visual_studio_impl(ctx):
     ctx.report_progress("Download vswhere.exe")
     ctx.download(
         "https://github.com/microsoft/vswhere/releases/download/3.1.7/vswhere.exe",
-        output="vswhere.exe",
-        sha256="c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662",
-        executable=True,
+        output = "vswhere.exe",
+        sha256 = "c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662",
+        executable = True,
     )
 
-    ctx.report_progress("Downloading VS installer")
-    ctx.download(
-        ctx.attr.url,
-        output='vs_buildtools.exe',
-        sha256=ctx.attr.sha256,
-        executable=True,
-    )
+    # Get identifying properties to use for reproducibility metatada
+    # We stick to the version for now
+    vs_version = _get_vs_property(ctx, ctx.attr.path, "installationVersion")
 
-    installer_path = str(ctx.path("vs_buildtools.exe")).replace("/", "\\")
-    install_folder = "VisualStudio"
-    install_path = str(ctx.path(install_folder)).replace("/", "\\")
-
-    # Check for an existing installation
-    instance_id = _get_vs_instance(ctx, install_path)
-
-    if instance_id:
-        # We need to clean up the existing installation as otherwise the installer won't do anything
-        print("Found existing VS instance id: %s. This will be uninstalled before proceeding." % instance_id)
-        ctx.report_progress("Cleaning up existing installation")
-
-        result = ctx.execute(
-            _vs_installer_command(
-                installer_path, ["uninstall", "--installPath", install_path]
-            )
-        )
-        if result.return_code:
-            fail("Failed to remove existing VS: %s" % result.stderr)
-
-    vs_packages = [
-        "Microsoft.Component.MSBuild",
-        "Microsoft.VisualStudio.Workload.NativeDesktop",
-        "Microsoft.VisualStudio.Workload.VCTools",
-        "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-    ]
-    vs_packages_args = []
-    for pkg in vs_packages:
-        vs_packages_args += ["--add", pkg]
-
-    ctx.report_progress("Installing Visual Studio")
-
-    result = ctx.execute(
-        _vs_installer_command(
-            installer_path, ["--installPath", install_path] + vs_packages_args
-        )
-    )
-
-    if result.return_code:
-        fail("Failed to install VS: %s" % result.stderr)
-
-    if not ctx.path("VisualStudio").is_dir:
-        fail("Failed to install VS: expected VisualStudio folder was not created.")
+    # Symlink to existing installation
+    ctx.symlink(ctx.attr.path, "VisualStudio")
 
     build_file_content = """
 exports_files(["VisualStudio/MSBuild/Current/Bin/msbuild.exe"])
@@ -78,67 +29,34 @@ alias(
 """
     ctx.file("BUILD.bazel", build_file_content)
 
-    # This makes changes to the system so it's not really reproducible.
-    # The rule itself will take care of avoiding reinstalling if we think we're already set
-    return ctx.repo_metadata(reproducible=False)
+    return ctx.repo_metadata(attrs_for_reproducibility = {"version": vs_version})
 
-
-def windows_path(path):
-    return str(path).replace("/", "\\")
-
-
-def _get_vs_instance(ctx, install_path):
+def _get_vs_property(ctx, install_path, property):
+    """Query a property of a VS installation using vswhere"""
     result = ctx.execute([
-        windows_path(ctx.path("vswhere.exe")),
+        ctx.path("vswhere.exe"),
         "-nologo",
         "-nocolor",
         "-property",
-        "instanceId",
+        property,
         "-path",
         install_path,
     ])
-    return result.stdout
+    if result.return_code:
+        fail("Failed to query property '%s' for '%s': %s" % property, install_path, result.stderr)
 
-
-def _vs_installer_command(installer_path, args):
-    """Helper to construct a list of command args for ctx.execute for the VS installer,
-    with the required wrapping.
-
-    Trying to execute the installer directly doesn't work and just hangs.
-    """
-    arg_list = ["--wait", "--quiet", "--norestart", "--nocache"] + args
-
-    return [
-        "powershell.exe",
-        "-Command", "Start-Process",
-        "-FilePath", installer_path,
-        "-NoNewWindow",
-        "-Wait",
-        "-ArgumentList", ",".join(arg_list),
-    ]
-
+    return result.stdout.strip()
 
 visual_studio = repository_rule(
     implementation = _visual_studio_impl,
     attrs = {
-        "url": attr.string(
-            mandatory=True,
-            doc="URL of Visual Studio installer",
-        ),
-        "sha256": attr.string(
-            mandatory=True,
-            doc="Expected SHA-256 of VS installer",
-        ),
-        "extra_packages": attr.string_list(
-            doc="Additional components and workloads to install on top of the default ones",
+        "path": attr.string(
+            mandatory = True,
+            doc = "Path to Visual Studio's installation root",
         ),
     },
+    local = True,
     configure = True,
     doc =
-    """Installs Visual Studio and MSBuild.
-
-    Note that this will never be truly hermetic. In particular, Visual Studio instances,
-    even if to some extent isolated, also write to a folder they own under
-    %LOCALAPPDATA%\\Microsoft\\VisualStudio.
-    """
+        """Wraps an existing Visual Studio installation.""",
 )

--- a/bazel/rules/visual_studio.bzl
+++ b/bazel/rules/visual_studio.bzl
@@ -1,0 +1,144 @@
+"""Wrapping Visual Studio and MSBuild to let Bazel track it.
+
+We're very probably never going to get nothing close to hermetic for these tools (less so considering
+sandboxing limitations in Windows); this provides a best-effort attempt at at least making Bazel
+manage and track these tools.
+"""
+
+def _visual_studio_impl(ctx):
+    # vswhere is a tool that lets us inspect existing Visual Studio installations
+    ctx.report_progress("Download vswhere.exe")
+    ctx.download(
+        "https://github.com/microsoft/vswhere/releases/download/3.1.7/vswhere.exe",
+        output="vswhere.exe",
+        sha256="c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662",
+        executable=True,
+    )
+
+    ctx.report_progress("Downloading VS installer")
+    ctx.download(
+        ctx.attr.url,
+        output='vs_buildtools.exe',
+        sha256=ctx.attr.sha256,
+        executable=True,
+    )
+
+    installer_path = str(ctx.path("vs_buildtools.exe")).replace("/", "\\")
+    install_folder = "VisualStudio"
+    install_path = str(ctx.path(install_folder)).replace("/", "\\")
+
+    # Check for an existing installation
+    instance_id = _get_vs_instance(ctx, install_path)
+
+    if instance_id:
+        # We need to clean up the existing installation as otherwise the installer won't do anything
+        print("Found existing VS instance id: %s. This will be uninstalled before proceeding." % instance_id)
+        ctx.report_progress("Cleaning up existing installation")
+
+        result = ctx.execute(
+            _vs_installer_command(
+                installer_path, ["uninstall", "--installPath", install_path]
+            )
+        )
+        if result.return_code:
+            fail("Failed to remove existing VS: %s" % result.stderr)
+
+    vs_packages = [
+        "Microsoft.Component.MSBuild",
+        "Microsoft.VisualStudio.Workload.NativeDesktop",
+        "Microsoft.VisualStudio.Workload.VCTools",
+        "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    ]
+    vs_packages_args = []
+    for pkg in vs_packages:
+        vs_packages_args += ["--add", pkg]
+
+    ctx.report_progress("Installing Visual Studio")
+
+    result = ctx.execute(
+        _vs_installer_command(
+            installer_path, ["--installPath", install_path] + vs_packages_args
+        )
+    )
+
+    if result.return_code:
+        fail("Failed to install VS: %s" % result.stderr)
+
+    if not ctx.path("VisualStudio").is_dir:
+        fail("Failed to install VS: expected VisualStudio folder was not created.")
+
+    build_file_content = """
+exports_files(["VisualStudio/MSBuild/Current/Bin/msbuild.exe"])
+
+alias(
+    name="msbuild",
+    actual="VisualStudio/MSBuild/Current/Bin/msbuild.exe",
+    visibility = ["//visibility:public"],
+)
+"""
+    ctx.file("BUILD.bazel", build_file_content)
+
+    # This makes changes to the system so it's not really reproducible.
+    # The rule itself will take care of avoiding reinstalling if we think we're already set
+    return ctx.repo_metadata(reproducible=False)
+
+
+def windows_path(path):
+    return str(path).replace("/", "\\")
+
+
+def _get_vs_instance(ctx, install_path):
+    result = ctx.execute([
+        windows_path(ctx.path("vswhere.exe")),
+        "-nologo",
+        "-nocolor",
+        "-property",
+        "instanceId",
+        "-path",
+        install_path,
+    ])
+    return result.stdout
+
+
+def _vs_installer_command(installer_path, args):
+    """Helper to construct a list of command args for ctx.execute for the VS installer,
+    with the required wrapping.
+
+    Trying to execute the installer directly doesn't work and just hangs.
+    """
+    arg_list = ["--wait", "--quiet", "--norestart", "--nocache"] + args
+
+    return [
+        "powershell.exe",
+        "-Command", "Start-Process",
+        "-FilePath", installer_path,
+        "-NoNewWindow",
+        "-Wait",
+        "-ArgumentList", ",".join(arg_list),
+    ]
+
+
+visual_studio = repository_rule(
+    implementation = _visual_studio_impl,
+    attrs = {
+        "url": attr.string(
+            mandatory=True,
+            doc="URL of Visual Studio installer",
+        ),
+        "sha256": attr.string(
+            mandatory=True,
+            doc="Expected SHA-256 of VS installer",
+        ),
+        "extra_packages": attr.string_list(
+            doc="Additional components and workloads to install on top of the default ones",
+        ),
+    },
+    configure = True,
+    doc =
+    """Installs Visual Studio and MSBuild.
+
+    Note that this will never be truly hermetic. In particular, Visual Studio instances,
+    even if to some extent isolated, also write to a folder they own under
+    %LOCALAPPDATA%\\Microsoft\\VisualStudio.
+    """
+)

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -42,6 +42,7 @@ run_binary(
             "libffi_win_dir",
             "openssl-bin_win_dir",
             "tcltk_win_dir",
+            "@visual_studio//:msbuild",
         ]
     ),
     env = {
@@ -59,8 +60,7 @@ run_binary(
         "OPENSSL_DIR": r"$(location openssl-bin_win_dir)\amd64",
         "TCLTK_DIR": r"$(location tcltk_win_dir)\amd64",
         "TCL_VERSION": python_externals["tcltk"],
-        # This sets up vs toolchain and depends on the system
-        "MSBUILD": r"C:\devtools\vstudio\MSBuild\Current\Bin\MSBuild.exe",
+        "MSBUILD": "$(location @visual_studio//:msbuild)",
     },
     out_dirs = ["python_win"],
     tool = "build_python.bat",

--- a/deps/cpython/build_python.bat
+++ b/deps/cpython/build_python.bat
@@ -1,7 +1,8 @@
 :: Retrieve the directory from the given input file
 for %%F in (%SRCFILE%) do set sourcedir=%%~dpF
-:: Make sure the destdir is a proper Windows path
+:: Make sure input paths are proper Windows paths as needed
 for %%F in (%OUTDIR%) do set destdir=%%~fF\\
+for %%F in (%MSBUILD%) do set MSBUILD=%%~fF
 
 set build_outdir=%sourcedir%\PCbuild\amd64
 


### PR DESCRIPTION
### What does this PR do?

It implements a repository rule to work with a local Visual Studio installation, and makes the Windows Python build use it.

### Motivation

[ABLD-179](https://datadoghq.atlassian.net/browse/ABLD-179)

This is a follow up to https://github.com/DataDog/datadog-agent/pull/42848 (the Python build for Windows) in an attempt to make Bazel more aware of the VS tools being used for that Python build which runs based on MSBuild.

### Describe how you validated your changes

Locally and on CI.

### Additional Notes

I also explored the idea of having Bazel install Visual Studio and try to fully manage it like that. Even though I got that to work at one point, there were two significant caveats:

- Path length issues: The installation would only work with an output root of `C:\bzl` and not, for example `C:\bazel\bzl`, despite the OS-level setting. This would cause brittleness.
- Visual Studio installations, even if "isolated" to some extent (a feature added in VS 2017), still write configuration and stuff to directories out of Bazel's purview (under `%LOCALAPPDATA%`). I think this could be enough to make it mostly unfeasible to make it work with Bazel caching.

The way this PR implements things, I believe that the Python build is seeing the msbuild.exe executable as an input. This is probably _good enough_ for now, even though it doesn't guarantee that a lot of other things are equal. We can of course revisit all of this as requirements change or are better understood.

This PR's implementation is meant to provide enough flexibility such that it should be possible to build outside of the build image by supplying the appropriate environment variable to point to an existing installation.

[ABLD-179]: https://datadoghq.atlassian.net/browse/ABLD-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ