### PR TITLE
Build libxml2 & libxslt with bazel, take 2

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -24,6 +24,8 @@ filegroup(
             "@gcrypt",
             "@gpg-error",
             "@libsepol//:sepol",
+            "@libxml2",
+            "@libxslt",
             "@nghttp2",
             "@pcre2",
             "@popt",

--- a/deps/libxml2/config-linux-arm64.h
+++ b/deps/libxml2/config-linux-arm64.h
@@ -1,0 +1,109 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the declaration of `getentropy', and to 0 if you
+   don't. */
+#define HAVE_DECL_GETENTROPY 0
+
+/* Define to 1 if you have the declaration of `glob', and to 0 if you don't.
+   */
+#define HAVE_DECL_GLOB 1
+
+/* Define to 1 if you have the declaration of `mmap', and to 0 if you don't.
+   */
+#define HAVE_DECL_MMAP 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Have dlopen based dso */
+#define HAVE_DLOPEN /**/
+
+/* Define to 1 if the system has the `destructor' function attribute */
+#define HAVE_FUNC_ATTRIBUTE_DESTRUCTOR 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if history library is available */
+/* #undef HAVE_LIBHISTORY */
+
+/* Define if readline library is available */
+/* #undef HAVE_LIBREADLINE */
+
+/* Define to 1 if you have the <lzma.h> header file. */
+#define HAVE_LZMA_H 1
+
+/* Define to 1 if you have the <poll.h> header file. */
+/* #undef HAVE_POLL_H */
+
+/* Define to 1 if you have the <pthread.h> header file. */
+#define HAVE_PTHREAD_H 1
+
+/* Have shl_load based dso */
+/* #undef HAVE_SHLLOAD */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <zlib.h> header file. */
+#define HAVE_ZLIB_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "libxml2"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libxml2"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libxml2 2.14.5"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libxml2"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.14.5"
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "2.14.5"
+
+/* System configuration directory (/etc) */
+#define XML_SYSCONFDIR "/opt/datadog-agent/embedded/etc"
+
+/* TLS specifier */
+/* #undef XML_THREAD_LOCAL */

--- a/deps/libxml2/config-linux-x86_64.h
+++ b/deps/libxml2/config-linux-x86_64.h
@@ -1,0 +1,109 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the declaration of `getentropy', and to 0 if you
+   don't. */
+#define HAVE_DECL_GETENTROPY 0
+
+/* Define to 1 if you have the declaration of `glob', and to 0 if you don't.
+   */
+#define HAVE_DECL_GLOB 1
+
+/* Define to 1 if you have the declaration of `mmap', and to 0 if you don't.
+   */
+#define HAVE_DECL_MMAP 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Have dlopen based dso */
+#define HAVE_DLOPEN /**/
+
+/* Define to 1 if the system has the `destructor' function attribute */
+#define HAVE_FUNC_ATTRIBUTE_DESTRUCTOR 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if history library is available */
+/* #undef HAVE_LIBHISTORY */
+
+/* Define if readline library is available */
+/* #undef HAVE_LIBREADLINE */
+
+/* Define to 1 if you have the <lzma.h> header file. */
+#define HAVE_LZMA_H 1
+
+/* Define to 1 if you have the <poll.h> header file. */
+/* #undef HAVE_POLL_H */
+
+/* Define to 1 if you have the <pthread.h> header file. */
+#define HAVE_PTHREAD_H 1
+
+/* Have shl_load based dso */
+/* #undef HAVE_SHLLOAD */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <zlib.h> header file. */
+#define HAVE_ZLIB_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "libxml2"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libxml2"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libxml2 2.14.5"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libxml2"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.14.5"
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "2.14.5"
+
+/* System configuration directory (/etc) */
+#define XML_SYSCONFDIR "/opt/datadog-agent/embedded/etc"
+
+/* TLS specifier */
+/* #undef XML_THREAD_LOCAL */

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -127,6 +127,7 @@ cc_library(
     ],
     copts = [
         "-O2",
+        "-std=gnu11",
     ],
     local_defines = [
         "NDEBUG",

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -6,9 +6,9 @@ load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
-_VERSION = "2.15.1"
+VERSION = "2.15.1"
 
-_PUBLIC_HEADERS = glob(["include/libxml/*.h"]) + [":xmlversion_h"]
+PUBLIC_HEADERS = glob(["include/libxml/*.h"]) + [":xmlversion_h"]
 
 license(
     name = "license",
@@ -31,7 +31,7 @@ expand_template(
     template = "include/libxml/xmlversion.h.in",
     out = "include/libxml/xmlversion.h",
     substitutions = {
-        "@VERSION@": _VERSION,
+        "@VERSION@": VERSION,
         "@LIBXML_VERSION_NUMBER@": "21501",
         "@LIBXML_VERSION_EXTRA@": "",
         "@WITH_THREADS@": "1",
@@ -115,7 +115,7 @@ cc_library(
         "html5ent.inc",
         "c14n.c",
     ] + glob(["include/private/*.h"]),
-    hdrs = _PUBLIC_HEADERS,
+    hdrs = PUBLIC_HEADERS,
     deps = [
         "@zlib//:zlib",
         "@xz//:liblzma",
@@ -150,7 +150,7 @@ so_symlink(
 
 pkg_files(
     name = "headers",
-    srcs = _PUBLIC_HEADERS,
+    srcs = PUBLIC_HEADERS,
     prefix = "include/libxml2/libxml",
 )
 
@@ -171,7 +171,7 @@ expand_template(
         "@XML_PC_LIBS_PRIVATE@": "-lz",
         "@XML_PC_LIBS@": "",
         "@LIBS@": "",
-        "@VERSION@": _VERSION,
+        "@VERSION@": VERSION,
         "@XML_INCLUDEDIR@": "-I${includedir}",
         "@XML_PC_CFLAGS_PRIVATE@": "",
         "@XML_STATIC_CFLAGS@": "",

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -140,6 +140,10 @@ cc_shared_library(
     name = "xml2",
     deps = [":libxml2"],
     visibility = ["//visibility:public"],
+    dynamic_deps = [
+        "@zlib//:z",
+        "@xz//:lzma",
+    ]
 )
 
 so_symlink(

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -6,7 +6,7 @@ load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
-VERSION = "2.15.1"
+VERSION = "2.14.5"
 
 PUBLIC_HEADERS = glob(["include/libxml/*.h"]) + [":xmlversion_h"]
 
@@ -32,7 +32,7 @@ expand_template(
     out = "include/libxml/xmlversion.h",
     substitutions = {
         "@VERSION@": VERSION,
-        "@LIBXML_VERSION_NUMBER@": "21501",
+        "@LIBXML_VERSION_NUMBER@": "21405",
         "@LIBXML_VERSION_EXTRA@": "",
         "@WITH_THREADS@": "1",
         "@WITH_THREAD_ALLOC@": "0",

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -54,7 +54,7 @@ expand_template(
         "@WITH_REGEXPS@": "1",
         "@WITH_RELAXNG@": "1",
         "@WITH_SCHEMAS@": "1",
-        "@WITH_SCHEMATRON@": "0",
+        "@WITH_SCHEMATRON@": "1",
         "@WITH_MODULES@": "1",
         "@WITH_ZLIB@": "1",
         # Enabled for now but very likely not needed

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -1,0 +1,195 @@
+load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+_VERSION = "2.15.1"
+
+_PUBLIC_HEADERS = glob(["include/libxml/*.h"]) + [":xmlversion_h"]
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "Copyright",
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "copy_config_h",
+    src = select({
+        "@@//:linux_x86_64": "config-linux-x86_64.h",
+        "@@//:linux_arm64": "config-linux-arm64.h",
+    }),
+    out = "config.h",
+)
+
+expand_template(
+    name = "xmlversion_h",
+    template = "include/libxml/xmlversion.h.in",
+    out = "include/libxml/xmlversion.h",
+    substitutions = {
+        "@VERSION@": _VERSION,
+        "@LIBXML_VERSION_NUMBER@": "21501",
+        "@LIBXML_VERSION_EXTRA@": "",
+        "@WITH_THREADS@": "1",
+        "@WITH_THREAD_ALLOC@": "0",
+        "@WITH_PATTERN@": "1",
+        "@WITH_READER@": "1",
+        "@WITH_SAX1@": "1",
+        "@WITH_HTTP@": "0",
+        "@WITH_VALID@": "1",
+        "@WITH_HTML@": "1",
+        "@WITH_C14N@": "1",
+        "@WITH_CATALOG@": "0",
+        "@WITH_XPATH@": "1",
+        "@WITH_XPTR@": "1",
+        "@WITH_XINCLUDE@": "1",
+        "@WITH_ICONV@": "0",
+        "@WITH_ICU@": "0",
+        "@WITH_ISO8859X@": "1",
+        "@WITH_DEBUG@": "0",
+        "@WITH_REGEXPS@": "1",
+        "@WITH_RELAXNG@": "1",
+        "@WITH_SCHEMAS@": "1",
+        "@WITH_SCHEMATRON@": "0",
+        "@WITH_MODULES@": "1",
+        "@WITH_ZLIB@": "1",
+        # Enabled for now but very likely not needed
+        "@WITH_OUTPUT@": "1",
+        "@WITH_PUSH@": "1",
+        "@WITH_WRITER@": "1",
+        "@WITH_LZMA@": "1",
+    } | select({
+        "@platforms//os:linux": {"@MODULE_EXTENSION@": ".so"},
+        "@platforms//os:macos": {"@MODULE_EXTENSION@": ".dylib"},
+    }),
+)
+
+cc_library(
+    name = "libxml2",
+    srcs = [
+        ":copy_config_h",
+        "buf.c",
+        "chvalid.c",
+        "dict.c",
+        "encoding.c",
+        "entities.c",
+        "error.c",
+        "globals.c",
+        "hash.c",
+        "libxml.h",
+        "list.c",
+        "parser.c",
+        "parserInternals.c",
+        "SAX2.c",
+        "threads.c",
+        "timsort.h",
+        "tree.c",
+        "uri.c",
+        "valid.c",
+        "xmlIO.c",
+        "xmlmemory.c",
+        "xmlstring.c",
+        "HTMLparser.c",
+        "HTMLtree.c",
+        "xmlmodule.c",
+        "xmlsave.c",
+        "pattern.c",
+        "xmlregexp.c",
+        "xmlunicode.c",
+        "xzlib.c",
+        "relaxng.c",
+        "xinclude.c",
+        "xlink.c",
+        "xpointer.c",
+        "xmlschemas.c",
+        "xmlschemastypes.c",
+        "schematron.c",
+        "xmlreader.c",
+        "xmlwriter.c",
+        "xpath.c",
+        "iso8859x.inc",
+        "html5ent.inc",
+        "c14n.c",
+    ] + glob(["include/private/*.h"]),
+    hdrs = _PUBLIC_HEADERS,
+    deps = [
+        "@zlib//:zlib",
+        "@xz//:liblzma",
+    ],
+    includes = [
+        "include/libxml",
+        "include",
+        "codegen",
+    ],
+    copts = [
+        "-O2",
+    ],
+    local_defines = [
+        "NDEBUG",
+    ],
+    strip_include_prefix = "include/",
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "xml2",
+    deps = [":libxml2"],
+    visibility = ["//visibility:public"],
+)
+
+so_symlink(
+    name = "lib_files",
+    src = ":xml2",
+    libname = "libxml2",
+    version = "16.0.5",
+)
+
+pkg_files(
+    name = "headers",
+    srcs = _PUBLIC_HEADERS,
+    prefix = "include/libxml2/libxml",
+)
+
+expand_template(
+    name = "gen_pkgconfig",
+    template = "libxml-2.0.pc.in",
+    out = "libxml-2.0.pc",
+    substitutions = {
+        "@prefix@": "##PREFIX##",
+        "@exec_prefix@": "${prefix}",
+        "@libdir@": "${prefix}/lib",
+        "@includedir@": "${prefix}/include",
+        "@WITH_MODULES@": "1",
+        "@XML_PC_PRIVATE@": "",
+        "@XML_PC_REQUIRES@": "",
+        "@XML_LIBDIR@": "-L${libdir}",
+        "@XML_LIBS@": "-lxml2",
+        "@XML_PC_LIBS_PRIVATE@": "-lz",
+        "@XML_PC_LIBS@": "",
+        "@LIBS@": "",
+        "@VERSION@": _VERSION,
+        "@XML_INCLUDEDIR@": "-I${includedir}",
+        "@XML_PC_CFLAGS_PRIVATE@": "",
+        "@XML_STATIC_CFLAGS@": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+pkg_files(
+    name = "pkgconfig",
+    srcs = [":gen_pkgconfig"],
+    prefix = "lib/pkgconfig",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":headers",
+        ":pkgconfig",
+        ":lib_files",
+    ],
+)

--- a/deps/libxslt/config-linux-arm64.h
+++ b/deps/libxslt/config-linux-arm64.h
@@ -1,0 +1,221 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the `ftime' function. */
+#define HAVE_FTIME 1
+
+/* Define if gcrypt library is available. */
+/* #undef HAVE_GCRYPT */
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the `gmtime_r' function. */
+#define HAVE_GMTIME_R 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if pthread library is there (-lpthread) */
+#define HAVE_LIBPTHREAD /**/
+
+/* Define to 1 if you have the <locale.h> header file. */
+#define HAVE_LOCALE_H 1
+
+/* Define to 1 if you have the `localtime_r' function. */
+#define HAVE_LOCALTIME_R 1
+
+/* Define to 1 if you have the <minix/config.h> header file. */
+/* #undef HAVE_MINIX_CONFIG_H */
+
+/* Define if <pthread.h> is there */
+#define HAVE_PTHREAD_H /**/
+
+/* Define to 1 if you have the `snprintf' function. */
+#define HAVE_SNPRINTF 1
+
+/* Define to 1 if you have the `stat' function. */
+#define HAVE_STAT 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strxfrm_l' function. */
+#define HAVE_STRXFRM_L 1
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#define HAVE_SYS_SELECT_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/timeb.h> header file. */
+#define HAVE_SYS_TIMEB_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `vsnprintf' function. */
+#define HAVE_VSNPRINTF 1
+
+/* Define to 1 if you have the <wchar.h> header file. */
+#define HAVE_WCHAR_H 1
+
+/* Define to 1 if you have the <xlocale.h> header file. */
+#define HAVE_XLOCALE_H 1
+
+/* Define to 1 if you have the `_stat' function. */
+/* #undef HAVE__STAT */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* plugin file extension */
+/* #undef MODULE_EXTENSION */
+
+/* Name of package */
+#define PACKAGE "libxslt"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libxslt"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libxslt 1.1.43"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libxslt"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.1.43"
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable general extensions on macOS.  */
+#ifndef _DARWIN_C_SOURCE
+# define _DARWIN_C_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable X/Open compliant socket functions that do not require linking
+   with -lxnet on HP-UX 11.11.  */
+#ifndef _HPUX_ALT_XOPEN_SOCKET_API
+# define _HPUX_ALT_XOPEN_SOCKET_API 1
+#endif
+/* Identify the host operating system as Minix.
+   This macro does not affect the system headers' behavior.
+   A future release of Autoconf may stop defining this macro.  */
+#ifndef _MINIX
+/* # undef _MINIX */
+#endif
+/* Enable general extensions on NetBSD.
+   Enable NetBSD compatibility extensions on Minix.  */
+#ifndef _NETBSD_SOURCE
+# define _NETBSD_SOURCE 1
+#endif
+/* Enable OpenBSD compatibility extensions on NetBSD.
+   Oddly enough, this does nothing on OpenBSD.  */
+#ifndef _OPENBSD_SOURCE
+# define _OPENBSD_SOURCE 1
+#endif
+/* Define to 1 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_SOURCE
+/* # undef _POSIX_SOURCE */
+#endif
+/* Define to 2 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_1_SOURCE
+/* # undef _POSIX_1_SOURCE */
+#endif
+/* Enable POSIX-compatible threading on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
+#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+# define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
+#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
+# define __STDC_WANT_IEC_60559_BFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
+#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
+# define __STDC_WANT_IEC_60559_DFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
+#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
+# define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-3:2015.  */
+#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
+# define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
+#ifndef __STDC_WANT_LIB_EXT2__
+# define __STDC_WANT_LIB_EXT2__ 1
+#endif
+/* Enable extensions specified by ISO/IEC 24747:2009.  */
+#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
+# define __STDC_WANT_MATH_SPEC_FUNCS__ 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable X/Open extensions.  Define to 500 only if necessary
+   to make mbstate_t available.  */
+#ifndef _XOPEN_SOURCE
+/* # undef _XOPEN_SOURCE */
+#endif
+
+
+/* Version number of package */
+#define VERSION "1.1.43"
+
+/* Define if debugging support is enabled */
+/* #undef WITH_DEBUGGER */
+
+/* Define if profiling support is enabled */
+/* #undef WITH_PROFILER */

--- a/deps/libxslt/config-linux-x86_64.h
+++ b/deps/libxslt/config-linux-x86_64.h
@@ -1,0 +1,221 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the `ftime' function. */
+#define HAVE_FTIME 1
+
+/* Define if gcrypt library is available. */
+/* #undef HAVE_GCRYPT */
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the `gmtime_r' function. */
+#define HAVE_GMTIME_R 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if pthread library is there (-lpthread) */
+#define HAVE_LIBPTHREAD /**/
+
+/* Define to 1 if you have the <locale.h> header file. */
+#define HAVE_LOCALE_H 1
+
+/* Define to 1 if you have the `localtime_r' function. */
+#define HAVE_LOCALTIME_R 1
+
+/* Define to 1 if you have the <minix/config.h> header file. */
+/* #undef HAVE_MINIX_CONFIG_H */
+
+/* Define if <pthread.h> is there */
+#define HAVE_PTHREAD_H /**/
+
+/* Define to 1 if you have the `snprintf' function. */
+#define HAVE_SNPRINTF 1
+
+/* Define to 1 if you have the `stat' function. */
+#define HAVE_STAT 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strxfrm_l' function. */
+#define HAVE_STRXFRM_L 1
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#define HAVE_SYS_SELECT_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/timeb.h> header file. */
+#define HAVE_SYS_TIMEB_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `vsnprintf' function. */
+#define HAVE_VSNPRINTF 1
+
+/* Define to 1 if you have the <wchar.h> header file. */
+#define HAVE_WCHAR_H 1
+
+/* Define to 1 if you have the <xlocale.h> header file. */
+#define HAVE_XLOCALE_H 1
+
+/* Define to 1 if you have the `_stat' function. */
+/* #undef HAVE__STAT */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* plugin file extension */
+/* #undef MODULE_EXTENSION */
+
+/* Name of package */
+#define PACKAGE "libxslt"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libxslt"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libxslt 1.1.43"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libxslt"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.1.43"
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable general extensions on macOS.  */
+#ifndef _DARWIN_C_SOURCE
+# define _DARWIN_C_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable X/Open compliant socket functions that do not require linking
+   with -lxnet on HP-UX 11.11.  */
+#ifndef _HPUX_ALT_XOPEN_SOCKET_API
+# define _HPUX_ALT_XOPEN_SOCKET_API 1
+#endif
+/* Identify the host operating system as Minix.
+   This macro does not affect the system headers' behavior.
+   A future release of Autoconf may stop defining this macro.  */
+#ifndef _MINIX
+/* # undef _MINIX */
+#endif
+/* Enable general extensions on NetBSD.
+   Enable NetBSD compatibility extensions on Minix.  */
+#ifndef _NETBSD_SOURCE
+# define _NETBSD_SOURCE 1
+#endif
+/* Enable OpenBSD compatibility extensions on NetBSD.
+   Oddly enough, this does nothing on OpenBSD.  */
+#ifndef _OPENBSD_SOURCE
+# define _OPENBSD_SOURCE 1
+#endif
+/* Define to 1 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_SOURCE
+/* # undef _POSIX_SOURCE */
+#endif
+/* Define to 2 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_1_SOURCE
+/* # undef _POSIX_1_SOURCE */
+#endif
+/* Enable POSIX-compatible threading on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
+#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+# define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
+#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
+# define __STDC_WANT_IEC_60559_BFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
+#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
+# define __STDC_WANT_IEC_60559_DFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
+#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
+# define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-3:2015.  */
+#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
+# define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
+#ifndef __STDC_WANT_LIB_EXT2__
+# define __STDC_WANT_LIB_EXT2__ 1
+#endif
+/* Enable extensions specified by ISO/IEC 24747:2009.  */
+#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
+# define __STDC_WANT_MATH_SPEC_FUNCS__ 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable X/Open extensions.  Define to 500 only if necessary
+   to make mbstate_t available.  */
+#ifndef _XOPEN_SOURCE
+/* # undef _XOPEN_SOURCE */
+#endif
+
+
+/* Version number of package */
+#define VERSION "1.1.43"
+
+/* Define if debugging support is enabled */
+/* #undef WITH_DEBUGGER */
+
+/* Define if profiling support is enabled */
+/* #undef WITH_PROFILER */

--- a/deps/libxslt/overlay.BUILD.bazel
+++ b/deps/libxslt/overlay.BUILD.bazel
@@ -1,0 +1,254 @@
+load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+_XSLT_VERSION = "1.1.43"
+_EXSLT_VERSION = "0.8.25"
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "Copyright",
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "copy_config_h",
+    src = select({
+        "@@//:linux_x86_64": "config-linux-x86_64.h",
+        "@@//:linux_arm64": "config-linux-arm64.h",
+    }),
+    out = "config.h",
+)
+
+expand_template(
+    name = "xsltconfig_h",
+    template = "libxslt/xsltconfig.h.in",
+    out = "libxslt/xsltconfig.h",
+    substitutions = {
+        "@VERSION@": _XSLT_VERSION,
+        "@LIBXSLT_VERSION_NUMBER@": "10143",
+        "@LIBXSLT_VERSION_EXTRA@": "",
+        "@WITH_XSLT_DEBUG@": "0",
+        "@WITH_TRIO@": "0",
+        "@WITH_DEBUGGER@": "0",
+        "@WITH_PROFILER@": "0",
+        "@WITH_MODULES@": "0",
+    },
+)
+
+_PUBLIC_XSLT_HDRS = [
+    "libxslt/attributes.h",
+    "libxslt/documents.h",
+    "libxslt/extensions.h",
+    "libxslt/extra.h",
+    "libxslt/functions.h",
+    "libxslt/imports.h",
+    "libxslt/keys.h",
+    "libxslt/namespaces.h",
+    "libxslt/numbersInternals.h",
+    "libxslt/pattern.h",
+    "libxslt/preproc.h",
+    "libxslt/security.h",
+    "libxslt/templates.h",
+    "libxslt/transform.h",
+    "libxslt/variables.h",
+    "libxslt/xslt.h",
+    "libxslt/xsltexports.h",
+    "libxslt/xsltInternals.h",
+    "libxslt/xsltlocale.h",
+    "libxslt/xsltutils.h",
+    ":xsltconfig_h",
+]
+
+cc_library(
+    name = "libxslt",
+    hdrs = _PUBLIC_XSLT_HDRS,
+    srcs = [
+        "libxslt/attributes.c",
+        "libxslt/attrvt.c",
+        "libxslt/documents.c",
+        "libxslt/extensions.c",
+        "libxslt/extra.c",
+        "libxslt/functions.c",
+        "libxslt/imports.c",
+        "libxslt/keys.c",
+        "libxslt/namespaces.c",
+        "libxslt/numbers.c",
+        "libxslt/pattern.c",
+        "libxslt/preproc.c",
+        "libxslt/security.c",
+        "libxslt/templates.c",
+        "libxslt/transform.c",
+        "libxslt/variables.c",
+        "libxslt/xslt.c",
+        "libxslt/xsltlocale.c",
+        "libxslt/xsltutils.c",
+        "libxslt/libxslt.h",
+        ":copy_config_h",
+    ],
+    includes = [
+        ".",
+    ],
+    deps = [
+        "@libxml2",
+    ],
+    copts = [
+        "-O2",
+    ],
+    local_defines = [
+        "HAVE_CONFIG_H",
+        "NDEBUG",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "xslt",
+    deps = [":libxslt"],
+    additional_linker_inputs = ["libxslt/libxslt.syms"],
+    user_link_flags = [
+        "-Wl,--version-script=$(location libxslt/libxslt.syms)",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+so_symlink(
+    name = "xslt_lib_files",
+    src = ":xslt",
+    libname = "libxslt",
+    version = "1.1.43",
+)
+
+pkg_files(
+    name = "xslt_headers",
+    srcs = _PUBLIC_XSLT_HDRS,
+    prefix = "include/libxslt",
+)
+
+expand_template(
+    name = "gen_xslt_pkgconfig",
+    template = "libxslt.pc.in",
+    out = "libxslt.pc",
+    substitutions = {
+        "@prefix@": "##PREFIX##",
+        "@exec_prefix@": "${prefix}",
+        "@libdir@": "${prefix}/lib",
+        "@includedir@": "${prefix}/include",
+        "@VERSION@": _XSLT_VERSION,
+        "@XSLT_INCLUDEDIR@": "-I${includedir}",
+        "@LIBXSLT_CFLAGS@": "",
+        "@XSLT_LIBDIR@": "-L${libdir}",
+        "@XSLT_PRIVATE_LIBS@": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+expand_template(
+    name = "exsltconfig_h",
+    template = "libexslt/exsltconfig.h.in",
+    out = "libexslt/exsltconfig.h",
+    substitutions = {
+        "@VERSION@": _EXSLT_VERSION,
+        "@LIBEXSLT_VERSION_NUMBER@": "825",
+        "@LIBEXSLT_VERSION_EXTRA@": "",
+        "@WITH_CRYPTO@": "0",
+    },
+)
+
+_PUBLIC_EXSLT_HDRS = [
+    "libexslt/exslt.h",
+    "libexslt/exsltexports.h",
+    ":exsltconfig_h",
+]
+
+cc_library(
+    name = "libexslt",
+    hdrs = _PUBLIC_EXSLT_HDRS,
+    srcs = [
+        "libexslt/common.c",
+        "libexslt/crypto.c",
+        "libexslt/date.c",
+        "libexslt/dynamic.c",
+        "libexslt/exslt.c",
+        "libexslt/functions.c",
+        "libexslt/libexslt.h",
+        "libexslt/math.c",
+        "libexslt/saxon.c",
+        "libexslt/sets.c",
+        "libexslt/strings.c",
+    ],
+    includes = [
+        ".",
+    ],
+    deps = [
+        "@libxml2",
+        ":libxslt",
+    ],
+    copts = [
+        "-O2",
+    ],
+    local_defines = [
+        "HAVE_CONFIG_H",
+        "NDEBUG",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "exslt",
+    deps = [":libexslt"],
+    visibility = ["//visibility:public"],
+)
+
+so_symlink(
+    name = "exslt_lib_files",
+    src = ":exslt",
+    libname = "libexslt",
+    version = "0.8.24",
+)
+
+pkg_files(
+    name = "exslt_headers",
+    srcs = _PUBLIC_EXSLT_HDRS,
+    prefix = "include/libexslt",
+)
+
+expand_template(
+    name = "gen_exslt_pkgconfig",
+    template = "libexslt.pc.in",
+    out = "libexslt.pc",
+    substitutions = {
+        "@prefix@": "##PREFIX##",
+        "@exec_prefix@": "${prefix}",
+        "@libdir@": "${prefix}/lib",
+        "@includedir@": "${prefix}/include",
+        "@LIBEXSLT_VERSION@": _EXSLT_VERSION,
+        "@EXSLT_INCLUDEDIR@": "-I${includedir}",
+        "@LIBEXSLT_CFLAGS@": "",
+        "@EXSLT_LIBDIR@": "-L${libdir}",
+        "@EXSLT_PRIVATE_LIBS@": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+pkg_files(
+    name = "pkgconfig",
+    srcs = [":gen_xslt_pkgconfig", ":gen_exslt_pkgconfig"],
+    prefix = "lib/pkgconfig",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":xslt_headers",
+        ":exslt_headers",
+        ":pkgconfig",
+        ":xslt_lib_files",
+        ":exslt_lib_files",
+    ],
+)

--- a/deps/libxslt/overlay.BUILD.bazel
+++ b/deps/libxslt/overlay.BUILD.bazel
@@ -204,7 +204,7 @@ cc_library(
 cc_shared_library(
     name = "exslt",
     deps = [":libexslt"],
-    dynamic_deps = ["@libxml2//:xml2"],
+    dynamic_deps = ["@libxml2//:xml2", ":xslt"],
     visibility = ["//visibility:public"],
 )
 

--- a/deps/libxslt/overlay.BUILD.bazel
+++ b/deps/libxslt/overlay.BUILD.bazel
@@ -110,6 +110,8 @@ cc_library(
 cc_shared_library(
     name = "xslt",
     deps = [":libxslt"],
+    # Ensure we don't statically link with libxml2
+    dynamic_deps = ["@libxml2//:xml2"],
     additional_linker_inputs = ["libxslt/libxslt.syms"],
     user_link_flags = [
         "-Wl,--version-script=$(location libxslt/libxslt.syms)",
@@ -202,6 +204,7 @@ cc_library(
 cc_shared_library(
     name = "exslt",
     deps = [":libexslt"],
+    dynamic_deps = ["@libxml2//:xml2"],
     visibility = ["//visibility:public"],
 )
 

--- a/deps/libxslt/overlay.BUILD.bazel
+++ b/deps/libxslt/overlay.BUILD.bazel
@@ -6,8 +6,8 @@ load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
-_XSLT_VERSION = "1.1.43"
-_EXSLT_VERSION = "0.8.25"
+XSLT_VERSION = "1.1.43"
+EXSLT_VERSION = "0.8.25"
 
 license(
     name = "license",
@@ -30,7 +30,7 @@ expand_template(
     template = "libxslt/xsltconfig.h.in",
     out = "libxslt/xsltconfig.h",
     substitutions = {
-        "@VERSION@": _XSLT_VERSION,
+        "@VERSION@": XSLT_VERSION,
         "@LIBXSLT_VERSION_NUMBER@": "10143",
         "@LIBXSLT_VERSION_EXTRA@": "",
         "@WITH_XSLT_DEBUG@": "0",
@@ -141,7 +141,7 @@ expand_template(
         "@exec_prefix@": "${prefix}",
         "@libdir@": "${prefix}/lib",
         "@includedir@": "${prefix}/include",
-        "@VERSION@": _XSLT_VERSION,
+        "@VERSION@": XSLT_VERSION,
         "@XSLT_INCLUDEDIR@": "-I${includedir}",
         "@LIBXSLT_CFLAGS@": "",
         "@XSLT_LIBDIR@": "-L${libdir}",
@@ -155,7 +155,7 @@ expand_template(
     template = "libexslt/exsltconfig.h.in",
     out = "libexslt/exsltconfig.h",
     substitutions = {
-        "@VERSION@": _EXSLT_VERSION,
+        "@VERSION@": EXSLT_VERSION,
         "@LIBEXSLT_VERSION_NUMBER@": "825",
         "@LIBEXSLT_VERSION_EXTRA@": "",
         "@WITH_CRYPTO@": "0",
@@ -230,7 +230,7 @@ expand_template(
         "@exec_prefix@": "${prefix}",
         "@libdir@": "${prefix}/lib",
         "@includedir@": "${prefix}/include",
-        "@LIBEXSLT_VERSION@": _EXSLT_VERSION,
+        "@LIBEXSLT_VERSION@": EXSLT_VERSION,
         "@EXSLT_INCLUDEDIR@": "-I${includedir}",
         "@LIBEXSLT_CFLAGS@": "",
         "@EXSLT_LIBDIR@": "-L${libdir}",

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -265,3 +265,27 @@ http_archive(
         "https://www.unixodbc.org/unixODBC-2.3.9.tar.gz",
     ],
 )
+
+http_archive(
+    name = "libxml2",
+    sha256 = "03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b",
+    url = "https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.5.tar.xz",
+    strip_prefix = "libxml2-2.14.5",
+    files = {
+        "config-linux-x86_64.h": "//deps:libxml2/config-linux-x86_64.h",
+        "config-linux-arm64.h": "//deps:libxml2/config-linux-arm64.h",
+        "BUILD.bazel": "//deps:libxml2/overlay.BUILD.bazel",
+    },
+)
+
+http_archive(
+    name = "libxslt",
+    sha256 = "5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a",
+    url = "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.tar.xz",
+    strip_prefix = "libxslt-1.1.43",
+    files = {
+        "config-linux-x86_64.h": "//deps:libxslt/config-linux-x86_64.h",
+        "config-linux-arm64.h": "//deps:libxslt/config-linux-arm64.h",
+        "BUILD.bazel": "//deps:libxslt/overlay.BUILD.bazel",
+    },
+)

--- a/omnibus/config/software/libxml2.rb
+++ b/omnibus/config/software/libxml2.rb
@@ -22,8 +22,6 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 dependency "zlib"
-dependency "liblzma"
-dependency "config_guess"
 
 # version_list: url=https://download.gnome.org/sources/libxml2/2.14/ filter=*.tar.xz
 version("2.14.5") { source sha256: "03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b" }
@@ -33,28 +31,8 @@ source url: "https://download.gnome.org/sources/libxml2/2.14/libxml2-#{version}.
 relative_path "libxml2-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  configure_command = [
-    "--with-zlib=#{install_dir}/embedded",
-    "--with-lzma=#{install_dir}/embedded",
-    "--with-sax1", # required for nokogiri to compile
-    "--without-iconv",
-    "--without-python",
-    "--without-icu",
-    "--without-debug",
-    "--without-mem-debug",
-    "--without-run-debug",
-    "--without-legacy", # we don't need legacy interfaces
-    "--without-catalog",
-    "--without-docbook",
-    "--disable-static",
-  ]
-
-  update_config_guess
-
-  configure(*configure_command, env: env)
-
-  make "-j #{workers}", env: env
-  make "install", env: env
+  command_on_repo_root "bazelisk run -- @libxml2//:install --destdir='#{install_dir}/embedded'"
+  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+    " #{install_dir}/embedded/lib/pkgconfig/libxml-2.0.pc" \
+    " #{install_dir}/embedded/lib/libxml2.so"
 end

--- a/omnibus/config/software/xmlsec.rb
+++ b/omnibus/config/software/xmlsec.rb
@@ -44,6 +44,7 @@ build do
   configure_options = [
     "--disable-static",
     "--disable-pedantic",
+    "--with-libxml=#{install_dir}/embedded/"
   ]
   configure(*configure_options, env: env)
   make "-j #{workers}", env: env


### PR DESCRIPTION
### What does this PR do?

Reintroduce the changes from  #42523 but without statically linking lib(e)xslt with libxml, causing libxml2 to be essentially shipped 3 times.

### Motivation

Migrating our native dependencies to bazel

### Describe how you validated your changes

### Additional Notes
