### PR TITLE
[CWS] Add a debug log and fix cgroup relative path issue

### DIFF
--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -623,6 +623,10 @@ func (p *EBPFResolver) insertForkEntry(entry *model.ProcessCacheEntry, inode uin
 	if entry.Pid != 1 {
 		parent := p.entryCache[entry.PPid]
 		if entry.PPid >= 1 && inode != 0 && (parent == nil || parent.FileEvent.Inode != inode) {
+			if parent != nil && parent.FileEvent.Inode != inode {
+				seclog.Debugf("parent is present but with different inodes (%d/%d), parent:%s and entry:%s",
+					parent.FileEvent.Inode, inode, parent.FileEvent.PathnameStr, entry.FileEvent.PathnameStr)
+			}
 			if candidate := p.resolve(entry.PPid, entry.PPid, inode, true, newEntryCb); candidate != nil {
 				parent = candidate
 			} else {

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -242,13 +242,11 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 			// in case of relative path use rootCgroupPath
 			if strings.HasPrefix(path, "/..") || path == "/" {
 				cgroupPath = filepath.Join(cfs.rootCGroupPath, path)
+				if mountpoint == cgroupPath { // if relative path == the relative mount point, it means that's our current cgroup
+					cgroupPath = cfs.rootCGroupPath
+				}
 			} else {
 				cgroupPath = filepath.Join(mountpoint, ctrlDirectory, path)
-			}
-
-			if mountpoint == cgroupPath { // should not happen
-				seclog.Errorf("failed to compute cgroup path with path:%s, mountpoint:%s, rootCGroupPath:%s, ctrlDirectory:%s", path, mountpoint, cfs.rootCGroupPath, ctrlDirectory)
-				continue
 			}
 
 			if exists, err = checkPidExists(cgroupPath, pid); err == nil && exists {


### PR DESCRIPTION
### What does this PR do?

This PR:
* add a debug log to investigate cases where parent is missing on a fork
* fix the mystery relative cgroup path being equal to the sys fs cgroup mount point: it just mean it's the system-probe current cgroup

### Motivation

### Describe how you validated your changes

### Additional Notes
