### PR TITLE
Update gohai macos min version runner

### DIFF
--- a/.github/workflows/gohai.yml
+++ b/.github/workflows/gohai.yml
@@ -21,11 +21,12 @@ jobs:
     strategy:
       matrix:
         # Use oldest and latest available ubuntu, macos and windows
+        # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         os:
           [
             ubuntu-22.04,
             ubuntu-latest,
-            macos-13,
+            macos-14,
             macos-latest,
             windows-2022,
             windows-latest,

--- a/.github/workflows/gohai.yml
+++ b/.github/workflows/gohai.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         # Use oldest and latest available ubuntu, macos and windows
-        # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        # https://github.com/actions/runner-images#available-images
         os:
           [
             ubuntu-22.04,


### PR DESCRIPTION
### What does this PR do?
Update gohai macos min version runner to 14.

### Motivation
Github will deprecate MacOS 13 runners

### Describe how you validated your changes
CI

### Additional Notes
