### PR TITLE
omnibus: work around missing systemd headers when repackaging

### DIFF
--- a/omnibus/config/software/existing-agent-package.rb
+++ b/omnibus/config/software/existing-agent-package.rb
@@ -4,6 +4,8 @@ description 'A previously built artifact, unpacked'
 
 always_build true
 
+dependency 'systemd'
+
 source_url = ENV['OMNIBUS_REPACKAGE_SOURCE_URL']
 target_package = File.basename(source_url)
 source url: source_url,


### PR DESCRIPTION
### What does this PR do?

Fixes a build failure due to missing systemd headers when repackaging the agent.

The systemd headers are [excluded](https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/projects/agent.rb#L300) from the package, so we need to ensure they are present to be able to build code that requires them.

### Motivation

### Describe how you validated your changes

### Additional Notes
