### PR TITLE
[EBPF-931] gpu: emit high cardinality tags for Docker containers

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -321,8 +320,8 @@ func (c *Check) emitMetrics(snd sender.Sender, gpuToContainersMap map[string]*wo
 		c.telemetry.metricsSent.Add(float64(len(metrics)), string(collector.Name()))
 	}
 
-	// Cache container tags to avoid repeated tagger calls for the same container
-	containerTagsCache := make(map[string][]string)
+	// tag cache is for repeated calls during a single check run, not preserved between runs
+	containerTagCache := newContainerTagCache(c.tagger)
 
 	//iterate through devices to emit its metrics
 	for deviceUUID, deviceData := range perDeviceMetrics {
@@ -332,24 +331,8 @@ func (c *Check) emitMetrics(snd sender.Sender, gpuToContainersMap map[string]*wo
 
 		var containerTags []string
 		if container := gpuToContainersMap[deviceUUID]; container != nil {
-			containerID := container.EntityID.ID
-
-			// Check cache first
-			if cachedTags, exists := containerTagsCache[containerID]; exists {
-				containerTags = cachedTags // Direct reference, no copy
-			} else {
-				// Fetch and cache container tags
-				entityID := taggertypes.NewEntityID(taggertypes.ContainerID, containerID)
-				// we use orchestrator cardinality here to ensure we get the pod_name tag
-				// ref: https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator#out-of-the-box-tags
-				tags, err := c.tagger.Tag(entityID, taggertypes.OrchestratorCardinality)
-				if err != nil {
-					multiErr = multierror.Append(multiErr, fmt.Errorf("error collecting container tags for GPU %s: %w", deviceUUID, err))
-					containerTagsCache[containerID] = nil // Cache the error state to avoid repeated calls
-				} else {
-					containerTagsCache[containerID] = tags
-					containerTags = tags // Direct reference, no copy
-				}
+			if containerTags, err = containerTagCache.getContainerTags(container); err != nil {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("error collecting container tags for GPU %s: %w", deviceUUID, err))
 			}
 		}
 

--- a/pkg/collector/corechecks/gpu/tags.go
+++ b/pkg/collector/corechecks/gpu/tags.go
@@ -13,6 +13,8 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
+// containerTagCache encapsulates the logic for retrieving and caching container tags, to
+// add as workload tags for GPU monitoring metrics.
 type containerTagCache struct {
 	cache  map[string][]string
 	tagger tagger.Component
@@ -25,6 +27,8 @@ func newContainerTagCache(tagger tagger.Component) *containerTagCache {
 	}
 }
 
+// getContainerTags retrieves the tags for a container from the cache or the tagger, and caches the result.
+// It can return "nil, nil" if there was a previous error retrieving the tags for the container.
 func (c *containerTagCache) getContainerTags(container *workloadmeta.Container) ([]string, error) {
 	containerID := container.EntityID.ID
 	if tags, exists := c.cache[containerID]; exists {
@@ -40,7 +44,7 @@ func (c *containerTagCache) getContainerTags(container *workloadmeta.Container) 
 
 	tags, err := c.tagger.Tag(entityID, cardinality)
 	if err != nil {
-		// Cache the error state to avoid repeated calls
+		// Cache the error state to avoid repeated calls in case of errors
 		c.cache[containerID] = nil
 		return nil, err
 	}

--- a/pkg/collector/corechecks/gpu/tags.go
+++ b/pkg/collector/corechecks/gpu/tags.go
@@ -37,8 +37,13 @@ func (c *containerTagCache) getContainerTags(container *workloadmeta.Container) 
 
 	entityID := taggertypes.NewEntityID(taggertypes.ContainerID, containerID)
 
+	// we use orchestrator cardinality here to ensure we get the pod_name tag
+	// ref: https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator#out-of-the-box-tags
 	cardinality := taggertypes.OrchestratorCardinality
 	if container.Runtime == workloadmeta.ContainerRuntimeDocker {
+		// For Docker, we use high cardinality to get the container_name and container_id tags
+		// that uniquely identify the container.
+		// ref: https://docs.datadoghq.com/containers/docker/tag/#out-of-the-box-tagging
 		cardinality = taggertypes.HighCardinality
 	}
 

--- a/pkg/collector/corechecks/gpu/tags.go
+++ b/pkg/collector/corechecks/gpu/tags.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package gpu
+
+import (
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+type containerTagCache struct {
+	cache  map[string][]string
+	tagger tagger.Component
+}
+
+func newContainerTagCache(tagger tagger.Component) *containerTagCache {
+	return &containerTagCache{
+		cache:  make(map[string][]string),
+		tagger: tagger,
+	}
+}
+
+func (c *containerTagCache) getContainerTags(container *workloadmeta.Container) ([]string, error) {
+	containerID := container.EntityID.ID
+	if tags, exists := c.cache[containerID]; exists {
+		return tags, nil
+	}
+
+	entityID := taggertypes.NewEntityID(taggertypes.ContainerID, containerID)
+
+	cardinality := taggertypes.OrchestratorCardinality
+	if container.Runtime == workloadmeta.ContainerRuntimeDocker {
+		cardinality = taggertypes.HighCardinality
+	}
+
+	tags, err := c.tagger.Tag(entityID, cardinality)
+	if err != nil {
+		// Cache the error state to avoid repeated calls
+		c.cache[containerID] = nil
+		return nil, err
+	}
+
+	c.cache[containerID] = tags
+	return tags, nil
+}

--- a/pkg/collector/corechecks/gpu/tags_test.go
+++ b/pkg/collector/corechecks/gpu/tags_test.go
@@ -53,9 +53,9 @@ func TestContainerTagCache(t *testing.T) {
 
 			containerID := "test-container-id"
 			cardinalityToTags := map[taggertypes.TagCardinality][]string{
-				taggertypes.HighCardinality:         []string{"type:high"},
-				taggertypes.OrchestratorCardinality: []string{"type:orchestrator"},
-				taggertypes.LowCardinality:          []string{"type:low"},
+				taggertypes.HighCardinality:         {"type:high"},
+				taggertypes.OrchestratorCardinality: {"type:orchestrator"},
+				taggertypes.LowCardinality:          {"type:low"},
 			}
 
 			// Set up the mock tagger with expected tags

--- a/pkg/collector/corechecks/gpu/tags_test.go
+++ b/pkg/collector/corechecks/gpu/tags_test.go
@@ -78,14 +78,14 @@ func TestContainerTagCache(t *testing.T) {
 
 			var expectedTags []string
 			for cardinality, tags := range cardinalityToTags {
-				if tt.expectedCardnlty <= cardinality {
+				if tt.expectedCardnlty >= cardinality {
 					expectedTags = append(expectedTags, tags...)
 				}
 			}
 
 			tags, err := cache.getContainerTags(container)
 			require.NoError(t, err)
-			assert.Equal(t, expectedTags, tags)
+			assert.ElementsMatch(t, expectedTags, tags)
 		})
 	}
 }

--- a/pkg/collector/corechecks/gpu/tags_test.go
+++ b/pkg/collector/corechecks/gpu/tags_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func TestContainerTagCache(t *testing.T) {
+	tests := []struct {
+		name             string
+		runtime          workloadmeta.ContainerRuntime
+		expectedCardnlty taggertypes.TagCardinality
+	}{
+		{
+			name:             "docker runtime uses high cardinality",
+			runtime:          workloadmeta.ContainerRuntimeDocker,
+			expectedCardnlty: taggertypes.HighCardinality,
+		},
+		{
+			name:             "containerd runtime uses orchestrator cardinality",
+			runtime:          workloadmeta.ContainerRuntimeContainerd,
+			expectedCardnlty: taggertypes.OrchestratorCardinality,
+		},
+		{
+			name:             "crio runtime uses orchestrator cardinality",
+			runtime:          workloadmeta.ContainerRuntimeCRIO,
+			expectedCardnlty: taggertypes.OrchestratorCardinality,
+		},
+		{
+			name:             "podman runtime uses orchestrator cardinality",
+			runtime:          workloadmeta.ContainerRuntimePodman,
+			expectedCardnlty: taggertypes.OrchestratorCardinality,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeTagger := taggerfxmock.SetupFakeTagger(t)
+			cache := newContainerTagCache(fakeTagger)
+
+			containerID := "test-container-id"
+			expectedTags := []string{"service:my-service", "env:prod", "version:1.0"}
+
+			// Set up the mock tagger with expected tags
+			fakeTagger.SetTags(
+				taggertypes.NewEntityID(taggertypes.ContainerID, containerID),
+				"foo",
+				expectedTags,
+				nil,
+				nil,
+				nil,
+			)
+
+			container := &workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					ID:   containerID,
+					Kind: workloadmeta.KindContainer,
+				},
+				Runtime: tt.runtime,
+			}
+
+			// First call should retrieve from tagger
+			tags, err := cache.getContainerTags(container)
+			require.NoError(t, err)
+			assert.Equal(t, expectedTags, tags)
+
+			// Verify the correct cardinality was used by checking the mock
+			// The fakeTagger should have been called with the correct entity and cardinality
+			retrievedTags, err := fakeTagger.Tag(
+				taggertypes.NewEntityID(taggertypes.ContainerID, containerID),
+				tt.expectedCardnlty,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, expectedTags, retrievedTags)
+		})
+	}
+}
+
+func TestContainerTagCacheCaching(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	cache := newContainerTagCache(fakeTagger)
+
+	containerID := "test-container-id"
+	expectedTags := []string{"service:my-service", "env:prod"}
+
+	fakeTagger.SetTags(
+		taggertypes.NewEntityID(taggertypes.ContainerID, containerID),
+		"foo",
+		expectedTags,
+		nil,
+		nil,
+		nil,
+	)
+
+	container := &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			ID:   containerID,
+			Kind: workloadmeta.KindContainer,
+		},
+		Runtime: workloadmeta.ContainerRuntimeContainerd,
+	}
+
+	// First call - should cache
+	tags1, err1 := cache.getContainerTags(container)
+	require.NoError(t, err1)
+	assert.Equal(t, expectedTags, tags1)
+
+	// Verify tags are in cache
+	cachedTags, exists := cache.cache[containerID]
+	require.True(t, exists)
+	assert.Equal(t, expectedTags, cachedTags)
+
+	// Second call - should return from cache
+	tags2, err2 := cache.getContainerTags(container)
+	require.NoError(t, err2)
+	assert.Equal(t, expectedTags, tags2)
+	assert.Equal(t, tags1, tags2, "cached tags should be identical")
+}


### PR DESCRIPTION
### What does this PR do?

Changes the GPU check so that we collect high cardinality tags for Docker containers. It also refactors the code to take a way the tag retrieval  and caching code to a separate structure for clarity and improved testing.

### Motivation

Docker containers are uniquely identified by `container_id` and `container_name`, without these two tags we cannot link the tags on GPU metrics to specific containers.

### Describe how you validated your changes

Manually validated that the correct tags are emitted, unit tests included too.

### Additional Notes