### PR TITLE
`tests_macos_gitlab_arm64`: fix "TOCTOU" race in `TestPodAutoscalerRemoteOwnerObjectsLimit`

### DIFF
--- a/pkg/clusteragent/autoscaling/max_heap.go
+++ b/pkg/clusteragent/autoscaling/max_heap.go
@@ -101,11 +101,6 @@ func NewHashHeap(maxSize int, store *store) *HashHeap {
 // InsertIntoHeap returns true if the key already exists in the max heap or was inserted correctly
 // Used as an ObserverFunc; accept sender as parameter to match ObserverFunc signature
 func (h *HashHeap) InsertIntoHeap(key, _sender string) {
-	// Already in heap, do not try to insert
-	if h.Exists(key) {
-		return
-	}
-
 	// Get object from store
 	podAutoscalerInternal, podAutoscalerInternalFound := h.store.Get(key)
 	if !podAutoscalerInternalFound {
@@ -123,6 +118,11 @@ func (h *HashHeap) InsertIntoHeap(key, _sender string) {
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	// Already in heap, do not try to insert
+	if h.Keys[key] {
+		return
+	}
 
 	if h.MaxHeap.Len() >= h.maxSize {
 		top := h.MaxHeap.Peek()

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -776,6 +778,9 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 	dpa, dpaTyped := newFakePodAutoscaler("default", "dpa-0", 1, dpaTime, dpaSpec, expectedStatus)
 	dpa1, dpaTyped1 := newFakePodAutoscaler("default", "dpa-1", 1, dpa1Time, dpa1Spec, expectedStatus)
 	dpa2, dpaTyped2 := newFakePodAutoscaler("default", "dpa-2", 1, dpa2Time, dpa2Spec, expectedStatus)
+
+	// Setup scaler mock to handle any get calls during concurrent processing
+	f.scaler.On("get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&autoscalingv1.Scale{}, schema.GroupResource{}, nil).Maybe()
 
 	f.Actions = nil
 	f.InformerObjects = append(f.InformerObjects, dpa, dpa1, dpa2)


### PR DESCRIPTION
### What does this PR do?
Fix a [Time-of-check Time-of-use](https://cwe.mitre.org/data/definitions/367.html) race condition in the heap insertion logic that caused flaky test failures on macOS runners:
```diff
--- Expected
+++ Actual
@@ -1 +1 @@
-default/dpa-1
+default/dpa-0
```
([example from `main`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1242868651/viewer#L1911))

The race occurred when multiple goroutines tried to insert the same key into the heap concurrently. The duplicate key check happened with only the read lock being acquired and immediately released (time of check), allowing both goroutines to pass the check and later attempt insertion inside the critical section (time of use), leading to heap "corruption".

Changes:
- move duplicate key check inside the critical section in `InsertIntoHeap`,
- change from `h.Exists(key)` to `h.Keys[key]` to avoid nested locking,
- add scaler `mock` to prevent panics during concurrent test execution:
```go
panic:
	assert: mock: I don't know what to return because the method call was unexpected.
		Either do Mock.On("get").Return(...) first, or remove the get() call.
		This method was unexpected:
			get(<nil>,string,string,schema.GroupVersionKind)
			0: <nil>
			1: "default"
			2: "app-0"
			3: schema.GroupVersionKind{Group:"apps", Version:"v1", Kind:"Deployment"}
```

### Motivation
CI reliability.

### Describe how you validated your changes
```sh
go test -count=1 -v -race -tags "kubeapiserver test" -run TestPodAutoscalerRemoteOwnerObjectsLimit ./pkg/clusteragent/autoscaling/workload
```
```sh
for i in {1..50}; do
    go test -count=1 -race -tags "kubeapiserver test" -run TestPodAutoscalerRemoteOwnerObjectsLimit ./pkg/clusteragent/autoscaling/workload || { echo "FAILED on run $i"; break; }
done
```
```sh
for i in {1..10}; do
    go test -count=1 -race -tags "kubeapiserver test" -run TestPodAutoscalerRemoteOwnerObjectsLimit ./pkg/clusteragent/autoscaling/workload &
done
wait
```