### PR TITLE
omnibus: include the deps folder in the cache key computation

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -182,6 +182,7 @@ def omnibus_compute_cache_key(ctx, env: dict[str, str]) -> str:
             'omnibus/python-scripts',
             'omnibus/resources',
             'omnibus/omnibus.rb',
+            'deps',
         ],
     )
     print(f'Current hash value: {h.hexdigest()}')


### PR DESCRIPTION
### What does this PR do?

Add the `deps` folder to the list of path used to compute the cache key.
This folder contains the rules for our dependencies built with bazel but it is currently ignored when computing the cache key. This means that once migrated to bazel, all modifications to the bazel BUILD files are ignored and will cause the previously created cache to be restored

### Motivation

Avoid using stalled caches

### Describe how you validated your changes

Rebased https://github.com/DataDog/datadog-agent/pull/43178 on top of this PR and verified that it does rebuild libxml2 & libxslt

### Additional Notes
