### PR TITLE
`tests_macos_gitlab_amd64`: tentatively fix flaky `TestAll`

### DIFF
--- a/pkg/linters/components/pkgconfigusage/pkgconfigusage_test.go
+++ b/pkg/linters/components/pkgconfigusage/pkgconfigusage_test.go
@@ -15,6 +15,11 @@ import (
 )
 
 func TestAll(t *testing.T) {
+	// Set environment variables to prevent go commands from accessing
+	// the module cache concurrently, which can cause timeouts on macOS.
+	t.Setenv("GOPRIVATE", "*")
+	t.Setenv("GOPROXY", "off")
+
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Failed to get wd: %s", err)


### PR DESCRIPTION
### Motivation
The `TestAll` test in pkg/linters/components/pkgconfigusage occasionally times out (3 minutes) on macOS, e.g.:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1246981481
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1242777754
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1236279145
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1236193101

The test calls `analysistest.Run` which verifies the "go" tool works by running `go build` on a simple program in a temp directory. When tests run with `-p 12 -parallel 12`, multiple concurrent `go build` commands access the shared module cache simultaneously. This probably triggers a deadlock in the Go toolchain's process management (similar to golang/go#59657).

The goroutine dumps from the CI logs showed the test hung in a kernel `syscall`, waiting for a child process that never completes:
```
TestAll
  -> analysistest.Run
    -> testenv.NeedsGoPackages
      -> testenv.HasTool("go")
        -> exec.Command("go", "build", ...).CombinedOutput()
          -> syscall.wait4  [BLOCKED - waiting for child process]
```

### What does this PR do?
Set environment variables to isolate module operations and minimize concurrent cache access:
- `GOPRIVATE=*` to treat all modules as private
- `GOPROXY=off` to prevent network/proxy access

This approach follows the precedent set in #39687 which aims at fixing a close "test occasionally times out when compiling" issue.

### Additional Notes
Other Go environment variables were considered but disregarded for the time being:
- `GO111MODULE`: already defaults to "on" in modern Go versions, which `analysistest` sets explicitly but it's redundant with the default,
- `GOWORK`: while `analysistest` sets this for `packages.Load`, the precedent from #39687 didn't require it to fix the timeout, suggesting it's not involved in the cache contention issue,
- `GOCACHE`: this would require an extra temporary directory - let's try without and come back to it should it fail again,
- `GOFLAGS=-modcacherw`: making the module cache writable instead of read-only could worsen concurrent access issues rather than fix them.
