### PR TITLE
[incident-45834] Cancel first stack locks on job tear down

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -309,7 +309,6 @@ new-e2e-agent-runtimes:
     TARGETS: ./tests/agent-runtimes
     TEAM: agent-runtimes
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-agent-subcommands:
   extends: .new_e2e_template_needs_deb_windows_x64
@@ -320,7 +319,6 @@ new-e2e-agent-subcommands:
     TARGETS: ./tests/agent-subcommands
     TEAM: agent-configuration
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run "Test(Linux|Windows)StatusSuite"
@@ -383,7 +381,6 @@ new-e2e-windows-service-test:
     TARGETS: ./tests/windows/service-test
     TEAM: windows-products
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestServiceBehaviorAgentCommand
@@ -411,7 +408,6 @@ new-e2e-windows-certificate:
     TARGETS: ./tests/windows/windows-certificate
     TEAM: windows-products
     EXTRA_PARAMS: --run "TestRemoteCertificates$"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-language-detection:
   extends: .new_e2e_template_needs_deb_x64
@@ -422,7 +418,6 @@ new-e2e-language-detection:
     TARGETS: ./tests/language-detection
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-npm-packages:
   extends: .new_e2e_template
@@ -600,7 +595,6 @@ new-e2e-process:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-orchestrator:
   extends:
@@ -658,7 +652,6 @@ new-e2e-apm:
     TEAM: fleet
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
-    REMOTE_STACK_CLEANING: "true"
     TARGETS: ./tests/fleet
 
 new-e2e-fleet-config:
@@ -693,7 +686,6 @@ new-e2e-installer-script:
     FLEET_INSTALL_METHOD: "install_script"
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer:
   extends: .new_e2e_template
@@ -721,7 +713,6 @@ new-e2e-installer:
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-installer-ansible:
   extends: .new_e2e_template
@@ -746,7 +737,6 @@ new-e2e-installer-ansible:
     FLEET_INSTALL_METHOD: "ansible"
     E2E_USE_AWS_PROFILE: "false"
     MAX_RETRIES_FLAG: "--max-retries=3"
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template
@@ -786,7 +776,6 @@ new-e2e-ha-agent:
     # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
     EXTRA_PARAMS: --skip TestHAAgentFailoverSuite
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-ha-agent-failover:
   extends: .new_e2e_template_needs_deb_x64
@@ -823,7 +812,6 @@ new-e2e-windows-systemprobe:
   variables:
     TARGETS: ./tests/sysprobe-functional
     TEAM: windows-products
-    REMOTE_STACK_CLEANING: "true"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestUSMAutoTaggingSuite
@@ -841,7 +829,6 @@ new-e2e-windows-security-agent:
   variables:
     TARGETS: ./tests/security-agent-functional
     TEAM: windows-products
-    REMOTE_STACK_CLEANING: "true"
 
 new-e2e-otel-eks-init:
   stage: e2e_init
@@ -954,7 +941,6 @@ new-e2e-gpu:
     TEAM: ebpf-platform
     E2E_PULUMI_LOG_LEVEL: 10 # incident-33572
     ON_NIGHTLY_FIPS: "true"
-    REMOTE_STACK_CLEANING: "true"
   needs: # list of required jobs. By default gitlab waits for any previous jobs.
     - !reference [.new_e2e_template_needs_container_deploy, needs]
     - agent_deb-x64-a7 # agent 7 debian package

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -753,7 +753,7 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 
 			// If we are within CI, we let the stack be destroyed by the stackcleaner-worker service
 			// After 10s, the API will time out without an error, this can happen on high workload but the stack will still be created from the agent-ci-api
-			cmd := exec.Command("dda", "inv", "agent-ci-api", "stackcleaner/stack", "--env", "prod", "--ty", "stackcleaner_workflow_request", "--attrs", fmt.Sprintf("stack_name=%s,job_name=%s,job_id=%s,pipeline_id=%s,ref=%s,ignore_lock=bool:true,ignore_not_found=bool:false", fullStackName, os.Getenv("CI_JOB_NAME"), os.Getenv("CI_JOB_ID"), os.Getenv("CI_PIPELINE_ID"), os.Getenv("CI_COMMIT_REF_NAME")), "--timeout", "10", "--ignore-timeout-error")
+			cmd := exec.Command("dda", "inv", "agent-ci-api", "stackcleaner/stack", "--env", "prod", "--ty", "stackcleaner_workflow_request", "--attrs", fmt.Sprintf("stack_name=%s,job_name=%s,job_id=%s,pipeline_id=%s,ref=%s,ignore_lock=bool:true,ignore_not_found=bool:false,cancel_first=bool:true", fullStackName, os.Getenv("CI_JOB_NAME"), os.Getenv("CI_JOB_ID"), os.Getenv("CI_PIPELINE_ID"), os.Getenv("CI_COMMIT_REF_NAME")), "--timeout", "10", "--ignore-timeout-error")
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				bs.T().Logf("WARNING: Unable to destroy stack %s: %s", stackName, out)


### PR DESCRIPTION
### What does this PR do?

This adds the `cancel_first` option when we want to destroy a stack for the first time.
This is used to avoid lock issues.

### Motivation

### Describe how you validated your changes

### Additional Notes
