### PR TITLE
Use docker disk for security agent tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -734,6 +734,7 @@
 /test/new-e2e/pkg/testcommon/check            @DataDog/agent-runtimes
 /test/new-e2e/test-infra-definition           @DataDog/agent-devx
 /test/new-e2e/system-probe                    @DataDog/ebpf-platform
+/test/new-e2e/system-probe/config/vmconfig-security-agent.json @DataDog/ebpf-platform @Datadog/agent-security
 /test/new-e2e/scenarios/system-probe          @DataDog/ebpf-platform
 /test/new-e2e/tests/agent-platform            @DataDog/agent-onboarding @DataDog/agent-devx
 /test/new-e2e/tests/agent-platform/common/agent_integration.go @DataDog/agent-integrations

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -504,7 +504,7 @@
       "kernel": "4.12.14-122.231.1",
       "os_version": "12.5",
       "image": "suse-12.5-arm64.qcow2.xz",
-      "image_version": "20251015_301103a6"
+      "image_version": "usama.saqib/no-checksumming"
     },
     "fedora_40": {
       "os_name": "Fedora Linux",

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -226,7 +226,7 @@
       "kernel": "4.12.14-122.231.1",
       "os_version": "12.5",
       "image": "suse-12.5-x86_64.qcow2.xz",
-      "image_version": "usama.saqib/no-checksumming"
+      "image_version": "20251120_7497a561"
     },
     "debian_9": {
       "os_name": "Debian GNU/Linux",
@@ -504,7 +504,7 @@
       "kernel": "4.12.14-122.231.1",
       "os_version": "12.5",
       "image": "suse-12.5-arm64.qcow2.xz",
-      "image_version": "usama.saqib/no-checksumming"
+      "image_version": "20251120_7497a561"
     },
     "fedora_40": {
       "os_name": "Fedora Linux",

--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -226,7 +226,7 @@
       "kernel": "4.12.14-122.231.1",
       "os_version": "12.5",
       "image": "suse-12.5-x86_64.qcow2.xz",
-      "image_version": "20251015_301103a6"
+      "image_version": "usama.saqib/no-checksumming"
     },
     "debian_9": {
       "os_name": "Debian GNU/Linux",

--- a/test/new-e2e/system-probe/config/vmconfig-security-agent.json
+++ b/test/new-e2e/system-probe/config/vmconfig-security-agent.json
@@ -8,7 +8,14 @@
             "arch": "x86_64",
             "console_type": "file",
             "kernels": [],
-            "disks": []
+            "disks": [
+                {
+                    "mount_point": "/mnt/docker",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-x86_64.qcow2.xz",
+                    "target": "%KMTDIR%/rootfs/docker-x86_64.qcow2",
+                    "type": "default"
+                }
+            ]
         },
         {
             "tags": [
@@ -19,7 +26,14 @@
             "console_type": "file",
             "kernels": [],
             "machine": "virt",
-            "disks": []
+            "disks": [
+                {
+                    "mount_point": "/mnt/docker",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-arm64.qcow2.xz",
+                    "target": "%KMTDIR%/rootfs/docker-arm64.qcow2",
+                    "type": "default"
+                }
+            ]
         }
     ]
 }

--- a/test/new-e2e/system-probe/config/vmconfig-security-agent.json
+++ b/test/new-e2e/system-probe/config/vmconfig-security-agent.json
@@ -11,7 +11,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/usama.saqib/no-checksumming/docker-x86_64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-x86_64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-x86_64.qcow2",
                     "type": "default"
                 }
@@ -29,7 +29,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/usama.saqib/no-checksumming/docker-arm64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-arm64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-arm64.qcow2",
                     "type": "default"
                 }

--- a/test/new-e2e/system-probe/config/vmconfig-security-agent.json
+++ b/test/new-e2e/system-probe/config/vmconfig-security-agent.json
@@ -11,7 +11,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-x86_64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/usama.saqib/no-checksumming/docker-x86_64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-x86_64.qcow2",
                     "type": "default"
                 }
@@ -29,7 +29,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-arm64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/usama.saqib/no-checksumming/docker-arm64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-arm64.qcow2",
                     "type": "default"
                 }


### PR DESCRIPTION
### What does this PR do?
This PR configures CWS KMT tests to use prebuilt docker disk.

### Motivation

### Describe how you validated your changes
Changes tested by existing KMT infrastructure.

### Additional Notes
PR required to fix docker disk mounting for suse 12.5 https://github.com/DataDog/ami-builder/pull/256
