### PR TITLE
[EBPF-903] gpu: refresh agent PID on cgroup reapplication

### DIFF
--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -8,7 +8,6 @@
 package gpu
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -23,15 +22,13 @@ import (
 
 	"github.com/containerd/cgroups/v3"
 
-	"time"
-
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ConfigureDeviceCgroups configures the cgroups for a process to allow access to the NVIDIA character devices
 // reapplyInfinitely controls whether the configuration should be reapplied infinitely (true) or only once (false)
-func ConfigureDeviceCgroups(ctx context.Context, pid uint32, hostRoot string, reapplyInterval time.Duration, reapplyInfinitely bool) error {
+func ConfigureDeviceCgroups(pid uint32, hostRoot string) error {
 	cgroupMode := cgroups.Mode()
 	cgroupPath, err := getAbsoluteCgroupForProcess("/", hostRoot, uint32(os.Getpid()), pid, cgroupMode)
 	if err != nil {
@@ -44,48 +41,19 @@ func ConfigureDeviceCgroups(ctx context.Context, pid uint32, hostRoot string, re
 		return fmt.Errorf("failed to configure systemd device allow for cgroup %s: %w", cgroupPath, err)
 	}
 
-	// Now configure the cgroup device allow, depending on the cgroup version
-	if err := doCgroupDeviceConfig(pid, hostRoot, cgroupPath, cgroupMode); err != nil {
-		return fmt.Errorf("failed to configure cgroup device allow for cgroup path %s: %w", cgroupPath, err)
+	if cgroupMode == cgroups.Legacy {
+		log.Debugf("Configuring PID %d cgroupv1 device allow, cgroup path %s", pid, cgroupPath)
+		err = configureCgroupV1DeviceAllow(hostRoot, cgroupPath, nvidiaDeviceMajor)
+	} else {
+		log.Debugf("Configuring PID %d cgroupv2 device programs, cgroup path %s", pid, cgroupPath)
+		err = detachAllDeviceCgroupPrograms(hostRoot, cgroupPath)
 	}
 
-	// Schedule background re-application if configured
-	if reapplyInterval > 0 {
-		log.Infof("Scheduling background re-application of cgroup device configuration for pid %d in %v, infinite repeats: %t", pid, reapplyInterval, reapplyInfinitely)
-		go func() {
-			ticker := time.NewTicker(reapplyInterval)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					err := doCgroupDeviceConfig(pid, hostRoot, cgroupPath, cgroupMode)
-					if err != nil {
-						log.Warnf("Failed to re-apply cgroup device configuration for pid %d: %v", pid, err)
-					} else {
-						log.Debugf("Successfully re-applied cgroup device configuration for pid %d", pid)
-					}
-
-					if !reapplyInfinitely {
-						return
-					}
-				}
-			}
-		}()
+	if err != nil {
+		return fmt.Errorf("failed to configure cgroup device allow for cgroup path %s of PID %d: %w", cgroupPath, pid, err)
 	}
 
 	return nil
-}
-
-func doCgroupDeviceConfig(pid uint32, hostRoot, cgroupPath string, cgroupMode cgroups.CGMode) error {
-	if cgroupMode == cgroups.Legacy {
-		log.Debugf("Configuring PID %d cgroupv1 device allow, cgroup path %s", pid, cgroupPath)
-		return configureCgroupV1DeviceAllow(hostRoot, cgroupPath, nvidiaDeviceMajor)
-	}
-
-	log.Debugf("Configuring PID %d cgroupv2 device programs, cgroup path %s", pid, cgroupPath)
-	return detachAllDeviceCgroupPrograms(hostRoot, cgroupPath)
 }
 
 const (


### PR DESCRIPTION
### What does this PR do?

This PR changes the cgroup reapplication code so that the agent PID is refreshed. If the agent restarts, the PID and the cgroup will not be the same so we cannot reuse the same parameters.

### Motivation

Fix the reapplication code.

### Describe how you validated your changes

Locally ran system-probe and the agent, validated that the PID was refreshed if the agent restarted.

### Additional Notes
