### PR TITLE
Revert "[ACIX-1036] Bumped test infra to get new AMIs"

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/DataDog/datadog-agent/test/fakeintake v0.56.0-rc.3
 	github.com/DataDog/datadog-api-client-go v1.16.0
 	github.com/DataDog/datadog-api-client-go/v2 v2.48.0
-	github.com/DataDog/test-infra-definitions v0.0.6-0.20251119093242-958482005014
+	github.com/DataDog/test-infra-definitions v0.0.6-0.20251107170748-5d4ea60490c6
 	github.com/aws/aws-sdk-go-v2 v1.39.4
 	github.com/aws/aws-sdk-go-v2/config v1.31.15
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.259.0

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -32,8 +32,8 @@ github.com/DataDog/orchestrion v1.4.0 h1:A1qePK5sZAo1d3VbgPy5vXhlftCMsPbzyxImOuM
 github.com/DataDog/orchestrion v1.4.0/go.mod h1:0xkQCBMS/9mLCExmGlmN0aEwEdStZ8RttapVRQHt518=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=
 github.com/DataDog/sketches-go v1.4.7/go.mod h1:eAmQ/EBmtSO+nQp7IZMZVRPT4BQTmIc5RZQ+deGlTPM=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251119093242-958482005014 h1:wfpfuDb1/ipgnZkL+gqSIW/+i3PDsh4eS3mwjik4RMw=
-github.com/DataDog/test-infra-definitions v0.0.6-0.20251119093242-958482005014/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251107170748-5d4ea60490c6 h1:KnYKBqZNQEK2YVW2Mf2as18Wf2v8Yh55qfje41N7Rhw=
+github.com/DataDog/test-infra-definitions v0.0.6-0.20251107170748-5d4ea60490c6/go.mod h1:0AI8pYB1wDsD+brkIZh7SJiSaZMHUdCMThD7GZHgShQ=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=


### PR DESCRIPTION
Reverts DataDog/datadog-agent#43210

This break this [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1244454348) and another one