### PR TITLE
[EBPF-910] gpu: exclude datadog containers from GPU device mapping

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -258,6 +258,11 @@ func (c *Check) getGPUToContainersMap() map[string]*workloadmeta.Container {
 	gpuToContainers := make(map[string]*workloadmeta.Container, len(allPhysicalDevices))
 
 	for _, container := range c.wmeta.ListContainersWithFilter(containers.HasGPUs) {
+		if containers.IsDatadogAgentContainer(c.wmeta, container) {
+			log.Debugf("Container %s is a Datadog container, skipping for device assignment", container.Name)
+			continue
+		}
+
 		containerDevices, err := containers.MatchContainerDevices(container, allPhysicalDevices)
 		if err != nil {
 			c.telemetry.missingContainerGpuMapping.Inc(container.Name)

--- a/pkg/gpu/containers/containers.go
+++ b/pkg/gpu/containers/containers.go
@@ -12,6 +12,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"slices"
 	"strconv"
@@ -190,4 +191,24 @@ func findDeviceByIndex(devices []ddnvml.Device, index string) (ddnvml.Device, er
 	}
 
 	return nil, fmt.Errorf("%w with index %s", ErrCannotMatchDevice, index)
+}
+
+// IsDatadogAgentContainer checks if a container belong to the Datadog Agent (might be the agent, but also system-probe or other components)
+func IsDatadogAgentContainer(wmeta workloadmeta.Component, container *workloadmeta.Container) bool {
+	currentPID := os.Getpid()
+	runningContainer, err := wmeta.GetContainerForProcess(strconv.Itoa(currentPID))
+	if err != nil {
+		return false // errors might happen if the process is not running in a container, or if the process is not accounted for by workloadmeta
+	}
+
+	// If the container is the same as the running container, it is a Datadog container
+	if runningContainer.EntityID == container.EntityID {
+		return true
+	}
+
+	// However, we might have multiple containers as part of the same pod (e.g., agent and system-probe)
+	// In this case, we need to check if the container is part of the same pod as the running container
+	// Compare the struct as a value, not as a pointer, because the pointers might be different if they're created
+	// in different places
+	return runningContainer.Owner != nil && container.Owner != nil && *runningContainer.Owner == *container.Owner
 }


### PR DESCRIPTION
### What does this PR do?

This PR ensures that Datadog containers are excluded from the GPU mapping assignments.

### Motivation

Agent containers can have access to the GPU, and in some cases such as Docker, they can use it in the same way as regular workloads. This would make the agent show up as a consumer of GPUs in the UI, which could cause confusion.

### Describe how you validated your changes

Unit tests included.

### Additional Notes