### PR TITLE
[omnibus] Add probes-no-procfs patch to OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/probes-no-procfs.patch
+++ b/omnibus/config/patches/openscap/probes-no-procfs.patch
@@ -1,0 +1,39 @@
+--- a/src/OVAL/probes/independent/environmentvariable58_probe.c
++++ b/src/OVAL/probes/independent/environmentvariable58_probe.c
+@@ -266,7 +266,7 @@ static int read_environment(SEXP_t *pid_ent, SEXP_t *name_ent, probe_ctx *ctx)
+ 	SEXP_t *item, *pid_sexp;
+ 	DIR *d;
+ 	struct dirent *d_entry;
+-	char *buffer, *null_char, path[PATH_MAX] = {0};
++	char *buffer, *null_char, path[PATH_MAX] = {0}, initpath[PATH_MAX] = {0};
+ 	ssize_t buffer_used;
+ 	size_t buffer_size;
+ 
+@@ -291,6 +291,13 @@ static int read_environment(SEXP_t *pid_ent, SEXP_t *name_ent, probe_ctx *ctx)
+ 	}
+ 
+ 	const char *prefix = getenv("OSCAP_PROBE_ROOT");
++
++	snprintf(initpath, PATH_MAX, "%s/proc/1", prefix ? prefix : "");
++	if (access(initpath, F_OK) < 0) {
++		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
++		return 0;
++	}
++
+ 	snprintf(path, PATH_MAX, "%s/proc", prefix ? prefix : "");
+ 	d = opendir(path);
+ 	if (d == NULL) {
+--- a/src/OVAL/probes/unix/linux/partition_probe.c
++++ b/src/OVAL/probes/unix/linux/partition_probe.c
+@@ -274,6 +274,11 @@ int partition_probe_main(probe_ctx *ctx, void *probe_arg)
+         const char *prefix = getenv("OSCAP_PROBE_ROOT");
+         snprintf(mnt_path, PATH_MAX, "%s"MTAB_PATH, prefix ? prefix : "");
+ 
++	if (access(mnt_path, F_OK) < 0) {
++		probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_NOT_APPLICABLE);
++		return 0;
++	}
++
+ #if defined(OS_LINUX)
+         int   mnt_fd;
+         struct statfs stfs;

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -43,6 +43,7 @@ build do
   patch source: "memusage-cgroup.patch", env: env # consider cgroup when determining memory usage
   patch source: "oval_probe_session_reset.patch", env: env # use oval_probe_session_reset instead of oval_probe_session_reinit
   patch source: "sysctl-probe-offline-skip.patch", env: env # skip sysctl probe in offline mode
+  patch source: "probes-no-procfs.patch", env: env # handle systems with no procfs available
 
   patch source: "oscap-io.patch", env: env # add new oscap-io tool
 


### PR DESCRIPTION
### What does this PR do?

This change adds probes-no-procfs patch to OpenSCAP. This patch modifies the environmentvariable58 and
partition probes to return SYSCHAR_FLAG_NOT_APPLICABLE when procfs is unavailable.

This should allow OpenSCAP to run checks on disk file systems, without runtime environment available.

### Motivation

### Describe how you validated your changes

### Additional Notes
