### PR TITLE
[SMP] Update lading to 0.29.1

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.29.0
+  version: 0.29.1
 
 target:
 


### PR DESCRIPTION
### What does this PR do?

Upgrade lading to version 0.29.1

### Motivation

We found a small bug in 0.29.0 that resulted in us asserting on agent behavior too early
