### PR TITLE
[AMCC-158]dogstatsd workers share filterlist matcher

### DIFF
--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -554,13 +554,13 @@ func (s *server) SetFilterList(metricNames []string, matchPrefix bool) {
 
 	// send the complete filterlist to all workers, the listening part of dogstatsd
 	for _, worker := range s.workers {
-		worker.FilterListUpdate <- &matcher
+		worker.FilterListUpdate <- matcher
 	}
 
 	// send the histogram filterlist used right before flushing to the serializer
 	histoMatcher := utilstrings.NewMatcher(histoMetricNames, matchPrefix)
 
-	s.demultiplexer.SetSamplersFilterList(&matcher, &histoMatcher)
+	s.demultiplexer.SetSamplersFilterList(matcher, histoMatcher)
 }
 
 // create a list based on all `metricNames` but only containing metric names

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -550,19 +550,17 @@ func (s *server) SetFilterList(metricNames []string, matchPrefix bool) {
 
 	// only histogram metric names (including their aggregates suffixes)
 	histoMetricNames := s.createHistogramsFilterList(metricNames)
+	matcher := utilstrings.NewMatcher(metricNames, matchPrefix)
 
 	// send the complete filterlist to all workers, the listening part of dogstatsd
 	for _, worker := range s.workers {
-		matcher := utilstrings.NewMatcher(metricNames, matchPrefix)
-		worker.FilterListUpdate <- matcher
+		worker.FilterListUpdate <- &matcher
 	}
 
-	filterList := utilstrings.NewMatcher(metricNames, matchPrefix)
-
 	// send the histogram filterlist used right before flushing to the serializer
-	histoFilterList := utilstrings.NewMatcher(histoMetricNames, matchPrefix)
+	histoMatcher := utilstrings.NewMatcher(histoMetricNames, matchPrefix)
 
-	s.demultiplexer.SetSamplersFilterList(&filterList, &histoFilterList)
+	s.demultiplexer.SetSamplersFilterList(&matcher, &histoMatcher)
 }
 
 // create a list based on all `metricNames` but only containing metric names

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -36,8 +36,8 @@ type worker struct {
 
 	packetsTelemetry *packets.TelemetryStore
 
-	FilterListUpdate chan utilstrings.Matcher
-	filterList       utilstrings.Matcher
+	FilterListUpdate chan *utilstrings.Matcher
+	filterList       *utilstrings.Matcher
 }
 
 func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Component], packetsTelemetry *packets.TelemetryStore, stringInternerTelemetry *stringInternerTelemetry) *worker {
@@ -54,7 +54,7 @@ func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Compon
 		parser:           newParser(s.config, s.sharedFloat64List, workerNum, wmeta, stringInternerTelemetry),
 		samples:          make(metrics.MetricSampleBatch, 0, defaultSampleSize),
 		packetsTelemetry: packetsTelemetry,
-		FilterListUpdate: make(chan utilstrings.Matcher),
+		FilterListUpdate: make(chan *utilstrings.Matcher),
 	}
 }
 
@@ -73,7 +73,7 @@ func (w *worker) run() {
 			w.samples = w.samples[0:0]
 			// we return the samples in case the slice was extended
 			// when parsing the packets
-			w.samples = w.server.parsePackets(w.batcher, w.parser, ps, w.samples, &w.filterList)
+			w.samples = w.server.parsePackets(w.batcher, w.parser, ps, w.samples, w.filterList)
 		}
 
 	}

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -36,8 +36,8 @@ type worker struct {
 
 	packetsTelemetry *packets.TelemetryStore
 
-	FilterListUpdate chan *utilstrings.Matcher
-	filterList       *utilstrings.Matcher
+	FilterListUpdate chan utilstrings.Matcher
+	filterList       utilstrings.Matcher
 }
 
 func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Component], packetsTelemetry *packets.TelemetryStore, stringInternerTelemetry *stringInternerTelemetry) *worker {
@@ -54,7 +54,7 @@ func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Compon
 		parser:           newParser(s.config, s.sharedFloat64List, workerNum, wmeta, stringInternerTelemetry),
 		samples:          make(metrics.MetricSampleBatch, 0, defaultSampleSize),
 		packetsTelemetry: packetsTelemetry,
-		FilterListUpdate: make(chan *utilstrings.Matcher),
+		FilterListUpdate: make(chan utilstrings.Matcher),
 	}
 }
 
@@ -73,7 +73,7 @@ func (w *worker) run() {
 			w.samples = w.samples[0:0]
 			// we return the samples in case the slice was extended
 			// when parsing the packets
-			w.samples = w.server.parsePackets(w.batcher, w.parser, ps, w.samples, w.filterList)
+			w.samples = w.server.parsePackets(w.batcher, w.parser, ps, w.samples, &w.filterList)
 		}
 
 	}

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -273,8 +273,8 @@ type BufferedAggregator struct {
 	flushAndSerializeInParallel FlushAndSerializeInParallel
 
 	// use this chan to trigger a filterList reconfiguration
-	filterListChan  chan *utilstrings.Matcher
-	flushFilterList *utilstrings.Matcher
+	filterListChan  chan utilstrings.Matcher
+	flushFilterList utilstrings.Matcher
 }
 
 // FlushAndSerializeInParallel contains options for flushing metrics and serializing in parallel.
@@ -353,7 +353,7 @@ func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder
 		tagger:                      tagger,
 		flushAndSerializeInParallel: NewFlushAndSerializeInParallel(pkgconfigsetup.Datadog()),
 
-		filterListChan: make(chan *utilstrings.Matcher),
+		filterListChan: make(chan utilstrings.Matcher),
 	}
 
 	return aggregator
@@ -451,7 +451,7 @@ func (agg *BufferedAggregator) handleSenderSample(ss senderMetricSample) {
 
 	if checkSampler, ok := agg.checkSamplers[ss.id]; ok {
 		if ss.commit {
-			checkSampler.commit(timeNowNano(), agg.flushFilterList)
+			checkSampler.commit(timeNowNano(), &agg.flushFilterList)
 		} else {
 			ss.metricSample.Tags = sort.UniqInPlace(ss.metricSample.Tags)
 			checkSampler.addSample(ss.metricSample)

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -57,7 +57,7 @@ type Demultiplexer interface {
 
 	// SetSamplersFilterList triggers a reconfiguration of the filterlist
 	// applied in the time samplers.
-	SetSamplersFilterList(filterList *utilstrings.Matcher, histoFilterList *utilstrings.Matcher)
+	SetSamplersFilterList(filterList utilstrings.Matcher, histoFilterList utilstrings.Matcher)
 
 	// Senders API, mainly used by collectors/checks
 	// --

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -504,7 +504,7 @@ func (d *AgentDemultiplexer) GetEventPlatformForwarder() (eventplatform.Forwarde
 
 // SetSamplersFilterList triggers a reconfiguration of the filter list
 // applied in the samplers.
-func (d *AgentDemultiplexer) SetSamplersFilterList(filterList *utilstrings.Matcher, histoFilterList *utilstrings.Matcher) {
+func (d *AgentDemultiplexer) SetSamplersFilterList(filterList utilstrings.Matcher, histoFilterList utilstrings.Matcher) {
 
 	// Most metrics coming from dogstatsd will have already been filtered in the listeners.
 	// Histogram metrics need aggregating before we determine the correct name to be filtered.

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -185,7 +185,7 @@ func (d *ServerlessDemultiplexer) SendSamplesWithoutAggregation(_ metrics.Metric
 
 // SetSamplersFilterList is not supported in the Serverless Agent implementation.
 // Serverless does not run checks, so we don't need to set any filter list on checks here.
-func (d *ServerlessDemultiplexer) SetSamplersFilterList(_filterList *utilstrings.Matcher, histoFilterList *utilstrings.Matcher) {
+func (d *ServerlessDemultiplexer) SetSamplersFilterList(_filterList utilstrings.Matcher, histoFilterList utilstrings.Matcher) {
 	d.statsdWorker.filterListChan <- histoFilterList
 }
 

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -31,7 +31,7 @@ type timeSamplerWorker struct {
 	// flushFilterList is the filter applied when flushing metrics to the serializer.
 	// It's main use-case is to filter out some metrics after their aggregation
 	// process, such as histograms which create several metrics.
-	flushFilterList *utilstrings.Matcher
+	flushFilterList utilstrings.Matcher
 
 	// parallel serialization configuration
 	parallelSerialization FlushAndSerializeInParallel
@@ -42,7 +42,7 @@ type timeSamplerWorker struct {
 	// use this chan to trigger a flush of the time sampler
 	flushChan chan flushTrigger
 	// use this chan to trigger a filterList reconfiguration
-	filterListChan chan *utilstrings.Matcher
+	filterListChan chan utilstrings.Matcher
 	// use this chan to stop the timeSamplerWorker
 	stopChan chan struct{}
 	// channel to trigger interactive dump of the context resolver
@@ -72,7 +72,7 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 		stopChan:       make(chan struct{}),
 		flushChan:      make(chan flushTrigger),
 		dumpChan:       make(chan dumpTrigger),
-		filterListChan: make(chan *utilstrings.Matcher),
+		filterListChan: make(chan utilstrings.Matcher),
 
 		tagsStore: tagsStore,
 	}
@@ -116,7 +116,7 @@ func (w *timeSamplerWorker) stop() {
 }
 
 func (w *timeSamplerWorker) triggerFlush(trigger flushTrigger) {
-	w.sampler.flush(float64(trigger.time.Unix()), trigger.seriesSink, trigger.sketchesSink, w.flushFilterList, trigger.forceFlushAll)
+	w.sampler.flush(float64(trigger.time.Unix()), trigger.seriesSink, trigger.sketchesSink, &w.flushFilterList, trigger.forceFlushAll)
 	trigger.blockChan <- struct{}{}
 }
 


### PR DESCRIPTION
### What does this PR do?

The dogstatsd workers just have a pointer to their matcher so they can share the one instance.

### Motivation

The matcher is never mutated, so there shouldn't be any issues with them all using the same instance. This saves memory when the list is large.

### Describe how you validated your changes

I have tested manually that metrics can still be blocked adding and removing them from the list via remote config. It still works as before.

### Additional Notes
