### PR TITLE
`tests_windows-x64`: fix unclosed file in `TestTailerEncodings`

### DIFF
--- a/pkg/logs/tailers/file/tailer_integration_test.go
+++ b/pkg/logs/tailers/file/tailer_integration_test.go
@@ -121,6 +121,7 @@ func (suite *TailerIntegrationTestSuite) encodingTestRunner(encoding string, enc
 	suite.testFile, err = os.Create(suite.testPath)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(suite.testFile)
+	defer suite.testFile.Close()
 
 	tailer := suite.createTailerWithEncoding(encoding)
 	defer tailer.Stop()


### PR DESCRIPTION
### What does this PR do?
Fixes `TestTailerEncodings` test that was failing on Windows with a file handle leak.

### Motivation
The test has been failing in `main` CI with:
```
TempDir RemoveAll cleanup: remove [...]\tailer-integration.log:
The process cannot access the file because it is being used by another process.
```
Examples:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1244994755
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1244904254
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1244802688

Cause: the test file created in `encodingTestRunner` was never closed, preventing Windows from deleting it during test cleanup. Unlike Unix systems, Windows cannot delete files that are still open.

Added `defer suite.testFile.Close()` after successful file creation, which ensures the file handle is properly released before test cleanup runs. The fix is straightforward and follows standard Go cleanup patterns.

### Additional Notes
This only affects Windows runners. The test was passing on Linux/macOS because those systems allow deleting open files.