### PR TITLE
[CONTP-1102] Optimize KSM Store Memory Allocation

### DIFF
--- a/pkg/kubestatemetrics/store/store_test.go
+++ b/pkg/kubestatemetrics/store/store_test.go
@@ -332,13 +332,7 @@ func TestPush(t *testing.T) {
 						},
 					},
 				},
-				"kube_pod_info": {
-					{
-						Name:        "kube_pod_info",
-						Type:        "*v1.Pods",
-						ListMetrics: []DDMetric{},
-					},
-				},
+				// kube_pod_info is no longer included, all metrics are filtered out
 			},
 		},
 		{

--- a/releasenotes/notes/optimize-ksm-store-memory-allocation-a0aac951c0f1ab05.yaml
+++ b/releasenotes/notes/optimize-ksm-store-memory-allocation-a0aac951c0f1ab05.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Optimize memory allocation in the KSM Core check by preallocating metric slices and skipping
+    empty metrics in the store's Push() method. This should reduce 15% - 20% memory usage by ksm
+    check, improving performance in clusters with large numbers of pods.


### PR DESCRIPTION
### What does this PR do?
Optimizes memory allocation in the KSM Core check's `MetricsStore.Push()` method by preallocating metric slices and skipping empty metric families.

### Motivation
During production profiling of large Kubernetes clusters (10K+ pods), we identified that the KSM store's `Push()` method was allocating significant memory due to:
1. **Unpreallocated slices** causing repeated reallocations as metrics are appended
2. **Empty metric families** being allocated and processed even when they contain no metrics after filtering

The `Push()` method is called **~200K+ times per check cycle** (every 15 seconds), making it one of the hottest paths in the KSM check.

Other stores in the agent codebase already follow this pattern:
- **Workloadmeta store** (`comp/core/workloadmeta/impl/store.go`) - Uses preallocation in `ListContainersWithFilter()`, `ListProcessesWithFilter()`, etc.
- **Orchestrator collectors** (`pkg/collector/corechecks/cluster/orchestrator/`) - Preallocates with `make([]collectors.K8sCollector, 0, 10)`

### Describe how you validated your changes
The function is covered by unit test. 
<img width="867" height="596" alt="Screenshot 2025-11-19 at 2 03 22 PM" src="https://github.com/user-attachments/assets/e5449d90-53b5-4e58-b40b-7aadaba1e896" />
Benchmark test with 14,000 pods shows memory usage improvement of 15% - 20%


### Additional Notes
Empty families no longer returned
The old code would include metric families with empty `ListMetrics` in the returned map. The new code skips them.
**Impact**: None - downstream code ([`processMetrics`](https://github.com/DataDog/datadog-agent/blob/1c3330de6fec01f37f31d3d0b6ab83abc8e0b8b2/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go#L737-L739), [`insertFamilies`](https://github.com/DataDog/datadog-agent/blob/1c3330de6fec01f37f31d3d0b6ab83abc8e0b8b2/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins.go#L206)) only iterates over metrics, so empty families would be no-ops anyway.
