### PR TITLE
`tests_windows-x64`: fix unclosed channel in `TestRunnerRealtime`

### DIFF
--- a/comp/process/runner/runnerimpl/runner_test.go
+++ b/comp/process/runner/runnerimpl/runner_test.go
@@ -45,6 +45,7 @@ func TestRunnerRealtime(t *testing.T) {
 
 	t.Run("rt allowed", func(t *testing.T) {
 		rtChan := make(chan types.RTResponse)
+		defer close(rtChan)
 
 		deps := createDeps(t,
 			map[string]interface{}{"process_config.disable_realtime_checks": false},
@@ -69,6 +70,7 @@ func TestRunnerRealtime(t *testing.T) {
 	t.Run("rt disallowed", func(t *testing.T) {
 		// Buffer the channel because the runner will never consume from it, otherwise we will deadlock
 		rtChan := make(chan types.RTResponse, 1)
+		defer close(rtChan)
 
 		deps := createDeps(t,
 			map[string]interface{}{"process_config.disable_realtime_checks": true},


### PR DESCRIPTION
### What does this PR do?
Propose a fix to the `TestRunnerRealtime` test that was timing out during shutdown on Windows by properly closing the RT notification channel.

### Motivation
The test has been in `main` CI with:
```
app.go:73: application didn't stop cleanly: context deadline exceeded
=== FAIL: comp/process/runner/runnerimpl TestRunnerRealtime/rt_allowed (15.11s)
```
Examples:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1244994755#L2120
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1244802688#L2119

Probable cause: the test creates an `rtChan` channel that is provided to the runner's `listenForRTUpdates` goroutine. This goroutine blocks reading from the channel until either:
1. the channel is closed (`!ok` case)
2. the `stop` channel is signaled

However, the test never closes `rtChan`, so even though the stop signal is sent during shutdown, the goroutine remains blocked waiting for a message on `rtChan`. This causes the `WaitGroup.Wait` in `Stop` to block for the full 15-second FX stop timeout.

Added `defer close(rtChan)` in both test cases (`rt_allowed` and `rt_disallowed`), which should ensure the `listenForRTUpdates` goroutine exits cleanly when the channel is closed and the runner to shut down immediately without having to wait for the timeout to expire.

### Additional Notes
The production code properly manages channel lifetimes.