### PR TITLE
[OTAGENT-671] remove deprecated otel ecstaskobserver extension

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1566,8 +1566,6 @@ core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observe
 core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver/internal/errctx,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver/internal/metadata,Apache-2.0,Copyright The OpenTelemetry Authors
-core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver,Apache-2.0,Copyright The OpenTelemetry Authors
-core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver/internal/metadata,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/endpointswatcher,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver/internal/metadata,Apache-2.0,Copyright The OpenTelemetry Authors

--- a/comp/otelcol/collector-contrib/impl/components.go
+++ b/comp/otelcol/collector-contrib/impl/components.go
@@ -16,7 +16,6 @@ import (
 	healthcheckextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	dockerobserver "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver"
 	ecsobserver "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver"
-	ecstaskobserver "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver"
 	hostobserver "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver"
 	k8sobserver "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
 	pprofextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
@@ -67,7 +66,6 @@ func components() (otelcol.Factories, error) {
 		pprofextension.NewFactory(),
 		dockerobserver.NewFactory(),
 		ecsobserver.NewFactory(),
-		ecstaskobserver.NewFactory(),
 		hostobserver.NewFactory(),
 		k8sobserver.NewFactory(),
 		datadogextension.NewFactory(),
@@ -82,7 +80,6 @@ func components() (otelcol.Factories, error) {
 	factories.ExtensionModules[pprofextension.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.139.0"
 	factories.ExtensionModules[dockerobserver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.139.0"
 	factories.ExtensionModules[ecsobserver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.139.0"
-	factories.ExtensionModules[ecstaskobserver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.139.0"
 	factories.ExtensionModules[hostobserver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.139.0"
 	factories.ExtensionModules[k8sobserver.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.139.0"
 	factories.ExtensionModules[datadogextension.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension v0.139.0"

--- a/comp/otelcol/collector-contrib/impl/go.mod
+++ b/comp/otelcol/collector-contrib/impl/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.139.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.139.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.139.0

--- a/comp/otelcol/collector-contrib/impl/go.sum
+++ b/comp/otelcol/collector-contrib/impl/go.sum
@@ -557,8 +557,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/doc
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.139.0/go.mod h1:StCwXbhgQmG30PV5mBxX1O99l+yYJy+BZNisuOz7USk=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.139.0 h1:mU2fHKOt2m/x3fw8FO5HLlCQ0sInRLdr9RUqUZOTXTk=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.139.0/go.mod h1:0H0eEKhl4bjCSxJFU2O6xsW++Tju8H1WfvTBVMfc9VI=
-github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.139.0 h1:jDSDkdf6E/mgp63xzlCN4KZ2uZVPjCZe2b4uAl+AgLk=
-github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.139.0/go.mod h1:k6F3G1uU+7JPbQvBt3gNVRIc8y28ewCSkNWKKr7f3r4=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.139.0 h1:YXZvS2GytjrTvrvRsdeGNJOQv10EV9p3+j61lFulIZs=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.139.0/go.mod h1:JTjgDh4psDOvsb5XLlc4v6ev6xCUBUytCmea622nviE=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.139.0 h1:zV33tKHmU8OXBTUfTl8TioFIJof5uQ+RVHL6SbUxV6w=

--- a/comp/otelcol/collector-contrib/impl/manifest.yaml
+++ b/comp/otelcol/collector-contrib/impl/manifest.yaml
@@ -28,8 +28,6 @@ extensions:
     v0.139.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
     v0.139.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver
-    v0.139.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
     v0.139.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver

--- a/go.mod
+++ b/go.mod
@@ -730,7 +730,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.139.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.139.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.139.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.139.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.139.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.139.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.139.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1288,8 +1288,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/doc
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.139.0/go.mod h1:StCwXbhgQmG30PV5mBxX1O99l+yYJy+BZNisuOz7USk=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.139.0 h1:mU2fHKOt2m/x3fw8FO5HLlCQ0sInRLdr9RUqUZOTXTk=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.139.0/go.mod h1:0H0eEKhl4bjCSxJFU2O6xsW++Tju8H1WfvTBVMfc9VI=
-github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.139.0 h1:jDSDkdf6E/mgp63xzlCN4KZ2uZVPjCZe2b4uAl+AgLk=
-github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.139.0/go.mod h1:k6F3G1uU+7JPbQvBt3gNVRIc8y28ewCSkNWKKr7f3r4=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.139.0 h1:YXZvS2GytjrTvrvRsdeGNJOQv10EV9p3+j61lFulIZs=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.139.0/go.mod h1:JTjgDh4psDOvsb5XLlc4v6ev6xCUBUytCmea622nviE=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.139.0 h1:zV33tKHmU8OXBTUfTl8TioFIJof5uQ+RVHL6SbUxV6w=

--- a/releasenotes/notes/ddot-remove-ecs-ext-210addd77b5.yaml
+++ b/releasenotes/notes/ddot-remove-ecs-ext-210addd77b5.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    Remove the OpenTelemetry Collector ecstaskobserver extension from DDOT.
+    This extension has been removed from upstream OpenTelemetry Collector Contrib repo.

--- a/tasks/unit_tests/testdata/collector/valid_datadog_manifest.yaml
+++ b/tasks/unit_tests/testdata/collector/valid_datadog_manifest.yaml
@@ -13,7 +13,6 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver v0.139.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.139.0
 

--- a/test/otel/testdata/builder-config.yaml
+++ b/test/otel/testdata/builder-config.yaml
@@ -36,8 +36,6 @@ extensions:
     v0.139.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
     v0.139.0
-- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver
-    v0.139.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
     v0.139.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver


### PR DESCRIPTION
### What does this PR do?
Remove the OpenTelemetry Collector ecstaskobserver extension from DDOT.
 
### Motivation
This extension has been removed from upstream OpenTelemetry Collector Contrib repo. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43818
