### PR TITLE
[chore] replace deprecated golang.org/x/net/context

### DIFF
--- a/pkg/security/probe/selftests/ebpfless.go
+++ b/pkg/security/probe/selftests/ebpfless.go
@@ -9,13 +9,13 @@
 package selftests
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"golang.org/x/net/context"
 )
 
 // EBPFLessSelfTest defines an ebpf less self test

--- a/pkg/security/probe/selftests/open_registry_key_windows.go
+++ b/pkg/security/probe/selftests/open_registry_key_windows.go
@@ -9,13 +9,13 @@
 package selftests
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"golang.org/x/net/context"
 )
 
 // WindowsOpenRegistryKeyTest defines a windows open registry key self test


### PR DESCRIPTION
### What does this PR do?
replace `golang.org/x/net/context` with `context`

### Motivation
> SA1019: "golang.org/x/net/context" is deprecated: Use the standard library context package instead. (staticcheck)

### Describe how you validated your changes

### Additional Notes
