### PR TITLE
Add custom user tests for Windows Fleet Config

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -224,6 +224,9 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestRevertsConfigExperimentWhenServiceDies$"
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestRevertsConfigExperimentWhenTimeout$"
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestManagedConfigActiveAfterUpgrade$"
+      - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigAltDir$"
+      - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigCustomUser$"
+      - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigCustomUserAndAltDir$"
       # install-exe
       - EXTRA_PARAMS: --run "TestInstallExe$/TestInstallAgentPackage$"
       - EXTRA_PARAMS: --run "TestInstallExeWithProxy$/TestInstallAgentPackageWithProxy$"

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
@@ -246,11 +246,18 @@ func (r *RemoteWindowsHostAssertions) HasDatadogInstaller() *RemoteWindowsInstal
 // HasDDAgentUserFileAccess verifies that ddagentuser has appropriate permissions
 // on key Agent files and directories. This is to verify that config updates
 // or upgrades haven't broken file permissions.
-func (r *RemoteWindowsHostAssertions) HasDDAgentUserFileAccess() *RemoteWindowsHostAssertions {
+func (r *RemoteWindowsHostAssertions) HasDDAgentUserFileAccess(args ...string) *RemoteWindowsHostAssertions {
 	r.context.T().Helper()
 
+	var agentUserName string
+	if len(args) > 0 {
+		agentUserName = args[0]
+	} else {
+		agentUserName = windowsagent.DefaultAgentUserName
+	}
+
 	// Get ddagentuser identity
-	ddAgentUser, err := common.GetIdentityForUser(r.remoteHost, windowsagent.DefaultAgentUserName)
+	ddAgentUser, err := common.GetIdentityForUser(r.remoteHost, agentUserName)
 	r.require.NoError(err, "should get ddagentuser identity")
 
 	// Get config root from registry

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -387,6 +387,110 @@ func (s *testAgentConfigSuite) TestConfigAltDir() {
 		WithValueEqual("InstallPath", altInstallPath+`\`)
 }
 
+func (s *testAgentConfigSuite) TestConfigCustomUser() {
+	// Arrange
+	agentUser := "customuser"
+	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
+	s.installCurrentAgentVersion(
+		installerwindows.WithOption(installerwindows.WithAgentUser(agentUser)),
+	)
+	// sanity check that the agent is running as the custom user
+	identity, err := windowscommon.GetIdentityForUser(s.Env().RemoteHost, agentUser)
+	s.Require().NoError(err)
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().
+		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("installedUser", agentUser).
+		HasAService("datadogagent").
+		WithIdentity(identity)
+
+	// Assert that setup was successful
+	s.AssertSuccessfulConfigPromoteExperiment("empty")
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
+		WithValueEqual("log_to_console", true)
+
+	// Act
+	config := installerwindows.ConfigExperiment{
+		ID: "config-1",
+		Files: []installerwindows.ConfigExperimentFile{
+			{
+				Path:     "/datadog.yaml",
+				Contents: json.RawMessage(`{"log_to_console": false}`),
+			},
+		},
+	}
+
+	// Start config experiment
+	s.mustStartConfigExperiment(config)
+
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
+		WithValueEqual("log_to_console", false)
+
+	// Promote config experiment
+	s.mustPromoteConfigExperiment(config)
+
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig("all").
+		WithValueEqual("log_to_console", false).
+		WithValueEqual("installedUser", agentUser).
+		HasDDAgentUserFileAccess().
+		HasAService("datadogagent").
+		WithIdentity(identity)
+}
+
+func (s *testAgentConfigSuite) TestConfigCustomUserAndAltDir() {
+	// Arrange
+	altConfigRoot := `C:\ddconfig`
+	altInstallPath := `C:\ddinstall`
+	agentUser := "customuser"
+	s.Installer().SetBinaryPath(altInstallPath + `\bin\` + consts.BinaryName)
+	s.setAgentConfigWithAltDir(altConfigRoot)
+	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
+	s.installPreviousAgentVersion(
+		installerwindows.WithOption(installerwindows.WithAgentUser(agentUser)),
+		installerwindows.WithMSIArg("PROJECTLOCATION="+altInstallPath),
+		installerwindows.WithMSIArg("APPLICATIONDATADIRECTORY="+altConfigRoot),
+	)
+
+	// Assert that setup was successful
+	s.AssertSuccessfulConfigPromoteExperiment("empty")
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
+		WithValueEqual("log_to_console", true)
+
+	// Act
+	config := installerwindows.ConfigExperiment{
+		ID: "config-1",
+		Files: []installerwindows.ConfigExperimentFile{
+			{
+				Path:     "/datadog.yaml",
+				Contents: json.RawMessage(`{"log_to_console": false}`),
+			},
+		},
+	}
+
+	// Start config experiment
+	s.mustStartConfigExperiment(config)
+
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig("--all").
+		WithValueEqual("log_to_console", false)
+
+	// Promote config experiment
+	s.mustPromoteConfigExperiment(config)
+
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig("all").
+		WithValueEqual("log_to_console", false).
+		WithValueEqual("installedUser", agentUser).
+		HasDDAgentUserFileAccess().
+		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("ConfigRoot", altConfigRoot+`\`).
+		WithValueEqual("InstallPath", altInstallPath+`\`)
+}
+
 func (s *testAgentConfigSuite) mustStartConfigExperiment(config installerwindows.ConfigExperiment) {
 	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().StartConfigExperiment(consts.AgentPackage, config)

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -434,7 +434,7 @@ func (s *testAgentConfigSuite) TestConfigCustomUser() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("all").
 		WithValueEqual("log_to_console", false).
-		HasDDAgentUserFileAccess().
+		HasDDAgentUserFileAccess(agentUser).
 		HasRegistryKey(consts.RegistryKeyPath).
 		WithValueEqual("installedUser", agentUser).
 		HasAService("datadogagent").
@@ -485,7 +485,7 @@ func (s *testAgentConfigSuite) TestConfigCustomUserAndAltDir() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("all").
 		WithValueEqual("log_to_console", false).
-		HasDDAgentUserFileAccess().
+		HasDDAgentUserFileAccess(agentUser).
 		HasRegistryKey(consts.RegistryKeyPath).
 		WithValueEqual("installedUser", agentUser).
 		WithValueEqual("ConfigRoot", altConfigRoot+`\`).

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -434,8 +434,9 @@ func (s *testAgentConfigSuite) TestConfigCustomUser() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("all").
 		WithValueEqual("log_to_console", false).
-		WithValueEqual("installedUser", agentUser).
 		HasDDAgentUserFileAccess().
+		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("installedUser", agentUser).
 		HasAService("datadogagent").
 		WithIdentity(identity)
 }
@@ -448,7 +449,7 @@ func (s *testAgentConfigSuite) TestConfigCustomUserAndAltDir() {
 	s.Installer().SetBinaryPath(altInstallPath + `\bin\` + consts.BinaryName)
 	s.setAgentConfigWithAltDir(altConfigRoot)
 	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
-	s.installPreviousAgentVersion(
+	s.installCurrentAgentVersion(
 		installerwindows.WithOption(installerwindows.WithAgentUser(agentUser)),
 		installerwindows.WithMSIArg("PROJECTLOCATION="+altInstallPath),
 		installerwindows.WithMSIArg("APPLICATIONDATADIRECTORY="+altConfigRoot),
@@ -484,9 +485,9 @@ func (s *testAgentConfigSuite) TestConfigCustomUserAndAltDir() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("all").
 		WithValueEqual("log_to_console", false).
-		WithValueEqual("installedUser", agentUser).
 		HasDDAgentUserFileAccess().
 		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("installedUser", agentUser).
 		WithValueEqual("ConfigRoot", altConfigRoot+`\`).
 		WithValueEqual("InstallPath", altInstallPath+`\`)
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds new tests for Fleet Config for Windows:
- `TestConfigCustomUser`
- `TestConfigCustomUserAndAltDir`

This PR also enables a previously added test: `TestConfigAltDir`

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2005

### Describe how you validated your changes
Check the results of e2e tests in the CI

### Additional Notes
