### PR TITLE
add DD_INSTALL_ONLY flag to MSI

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -58,6 +58,7 @@
       - E2E_MSI_TEST: TestInstallAltDirAndCorruptForUninstall
       - E2E_MSI_TEST: TestInstallFail
       - E2E_MSI_TEST: TestInstallWithLanmanServerDisabled
+      - E2E_MSI_TEST: TestInstallWithInstallOnlyFlag
       # These tests are v7 only
       - E2E_MSI_TEST: TestNPMUpgradeToNPM
       - E2E_MSI_TEST: TestNPMUpgradeNPMToNPM

--- a/releasenotes/notes/windows-msi-dd-install-only-flag-3d53b89e59c35e88.yaml
+++ b/releasenotes/notes/windows-msi-dd-install-only-flag-3d53b89e59c35e88.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds a new argument, DD_INSTALL_ONLY, to the Windows MSI. Set DD_INSTALL_ONLY=1 to install the Agent without starting the services.

--- a/releasenotes/notes/windows-msi-dd-install-only-flag-3d53b89e59c35e88.yaml
+++ b/releasenotes/notes/windows-msi-dd-install-only-flag-3d53b89e59c35e88.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Adds a new argument, DD_INSTALL_ONLY, to the Windows MSI. Set DD_INSTALL_ONLY=1 to install the Agent without starting the services.
+    Adds a new argument, DD_INSTALL_ONLY, to the Windows MSI. Set DD_INSTALL_ONLY=true to install the Agent without starting the services.

--- a/test/new-e2e/tests/windows/common/agent/agent_install_params.go
+++ b/test/new-e2e/tests/windows/common/agent/agent_install_params.go
@@ -51,6 +51,7 @@ type InstallAgentParams struct {
 	APMEnabled              string `installer_arg:"APM_ENABLED"`
 	RemoteUpdates           string `installer_arg:"DD_REMOTE_UPDATES"`
 	InfrastructureMode      string `installer_arg:"DD_INFRASTRUCTURE_MODE"`
+	InstallOnly             string `installer_arg:"DD_INSTALL_ONLY"`
 }
 
 // InstallAgentOption is an optional function parameter type for InstallAgentParams options
@@ -342,6 +343,15 @@ func WithRemoteUpdates(remoteUpdates string) InstallAgentOption {
 func WithInfrastructureMode(infrastructureMode string) InstallAgentOption {
 	return func(i *InstallAgentParams) error {
 		i.InfrastructureMode = infrastructureMode
+		return nil
+	}
+}
+
+// WithInstallOnly specifies the DD_INSTALL_ONLY parameter.
+// When set to "1", the MSI will skip starting the Agent services.
+func WithInstallOnly(installOnly string) InstallAgentOption {
+	return func(i *InstallAgentParams) error {
+		i.InstallOnly = installOnly
 		return nil
 	}
 }

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -535,7 +535,7 @@ func (s *testInstallWithInstallOnlyFlagSuite) TestInstallWithInstallOnlyFlag() {
 
 	// install the agent with DD_INSTALL_ONLY=1
 	_ = s.installAgentPackage(vm, s.AgentPackage,
-		windowsAgent.WithInstallOnly("1"),
+		windowsAgent.WithInstallOnly("true"),
 	)
 
 	// Verify the agent was installed

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -17,6 +17,7 @@ import (
 	boundport "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/bound-port"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+	servicetest "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test/service-test"
 
 	"testing"
 
@@ -518,4 +519,53 @@ func (s *testInstallWithLanmanServerDisabledSuite) TestInstallWithLanmanServerDi
 
 	_ = s.installAgentPackage(vm, s.AgentPackage)
 	RequireAgentRunningWithNoErrors(s.T(), s.NewTestClientForHost(vm))
+}
+
+func TestInstallWithInstallOnlyFlag(t *testing.T) {
+	s := &testInstallWithInstallOnlyFlagSuite{}
+	Run(t, s)
+}
+
+type testInstallWithInstallOnlyFlagSuite struct {
+	baseAgentMSISuite
+}
+
+func (s *testInstallWithInstallOnlyFlagSuite) TestInstallWithInstallOnlyFlag() {
+	vm := s.Env().RemoteHost
+
+	// install the agent with DD_INSTALL_ONLY=1
+	_ = s.installAgentPackage(vm, s.AgentPackage,
+		windowsAgent.WithInstallOnly("1"),
+	)
+
+	// Verify the agent was installed
+	productCode, err := windowsAgent.GetDatadogAgentProductCode(vm)
+	s.Require().NoError(err, "should find installed agent")
+	s.Require().NotEmpty(productCode, "product code should not be empty")
+
+	// Check that services are NOT running
+	// Use the standard list of expected installed services
+	for _, service := range servicetest.ExpectedInstalledServices() {
+		status, err := windowsCommon.GetServiceStatus(vm, service)
+		s.Require().NoError(err, "service %s should exist", service)
+		s.Assert().NotEqual("Running", status,
+			"service %s should not be running when DD_INSTALL_ONLY=1", service)
+	}
+
+	// Verify services can be started manually
+	s.Run("services can be started manually", func() {
+		err := windowsCommon.StartService(vm, "datadogagent")
+		s.Require().NoError(err, "should be able to start datadogagent service")
+
+		// Wait for service to start
+		s.Assert().EventuallyWithT(func(c *assert.CollectT) {
+			status, err := windowsCommon.GetServiceStatus(vm, "datadogagent")
+			assert.NoError(c, err, "should get service status")
+			assert.Equal(c, "Running", status, "datadogagent should be running after manual start")
+		}, 30*time.Second, 1*time.Second, "datadogagent service should start within 30 seconds")
+	})
+
+	// Clean up
+	t := s.newTester(vm)
+	s.uninstallAgentAndRunUninstallTests(t)
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -431,6 +431,14 @@ namespace Datadog.CustomActions
 
         private ActionResult StartDDServices()
         {
+            // Check if DD_INSTALL_ONLY flag is set
+            var installOnly = _session.Property("DD_INSTALL_ONLY");
+            if (!string.IsNullOrEmpty(installOnly) && (installOnly == "1" || installOnly.ToLower() == "true"))
+            {
+                _session.Log("DD_INSTALL_ONLY is set, skipping service start.");
+                return ActionResult.Success;
+            }
+
             try
             {
                 var ddservices = new[]

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -632,7 +632,8 @@ namespace WixSetup.Datadog_Agent
             {
                 Execute = Execute.deferred,
                 Impersonate = false
-            };
+            }
+                .SetProperties("DD_INSTALL_ONLY=[DD_INSTALL_ONLY]");
 
             // Rollback StartDDServices stops the the services so that any file locks are released.
             StartDDServicesRollback = new CustomAction<CustomActions>(

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -114,7 +114,7 @@ namespace WixSetup.Datadog_Agent
                 {
                     AttributesDefinition = "Secure=yes"
                 },
-                new Property("DD_INSTALL_ONLY", "0")
+                new Property("DD_INSTALL_ONLY")
                 {
                     AttributesDefinition = "Secure=yes"
                 },

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -114,6 +114,10 @@ namespace WixSetup.Datadog_Agent
                 {
                     AttributesDefinition = "Secure=yes"
                 },
+                new Property("DD_INSTALL_ONLY", "0")
+                {
+                    AttributesDefinition = "Secure=yes"
+                },
                 // Set the flavor so CustomActions can adjust their behavior.
                 // For example, we only run openssl fipsinstall in the FIPS flavor.
                 new Property("AgentFlavor", _agentFlavor.FlavorName),


### PR DESCRIPTION
### What does this PR do?
Add `DD_INSTALL_ONLY` flag to the Windows Agent MSI

Set `DD_INSTALL_ONLY=true` to install the Agent without starting the services.
```PowerShell
msiexec.exe /qn /i C:\ddagent.msi DD_INSTALL_ONLY=true
```


### Motivation
https://datadoghq.atlassian.net/browse/WINA-1270
- simplify onboarding workflows that install first then configure the Agent
- feature compatibility with [linux install script](https://github.com/DataDog/agent-linux-install-script/blob/main/install_script.sh.template)

### Additional Notes
fleet installer setup has `DD_INSTALL_ONLY` in the unsupported env var list. Will have to follow up with the fleet team about this.

Datadog Agent Manager (gui/ddtray/systray) does not work if the Agent is not running, so this new option isn't a good fit if you intend to use the gui to configure the Agent (https://datadoghq.atlassian.net/browse/WINA-448). In the meantime, the option will provide more control to scripts that wrap the MSI, like fleet, ansible, chef, and user's custom install scripts.