### PR TITLE
[WIP] - update cloud providers to log and return non errors when not enabled

### DIFF
--- a/pkg/util/cloudproviders/alibaba/alibaba.go
+++ b/pkg/util/cloudproviders/alibaba/alibaba.go
@@ -15,6 +15,7 @@ import (
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // declare these as vars not const to ease testing
@@ -38,7 +39,8 @@ var instanceIDFetcher = cachedfetch.Fetcher{
 	Name: "Alibaba InstanceID",
 	Attempt: func(ctx context.Context) (interface{}, error) {
 		if !configutils.IsCloudProviderEnabled(CloudProviderName, pkgconfigsetup.Datadog()) {
-			return nil, fmt.Errorf("cloud provider is disabled by configuration")
+			log.Debugf("Alibaba cloud provider is disabled by configuration")
+			return nil, nil
 		}
 
 		endpoint := metadataURL + "/latest/meta-data/instance-id"

--- a/pkg/util/cloudproviders/alibaba/alibaba.go
+++ b/pkg/util/cloudproviders/alibaba/alibaba.go
@@ -40,7 +40,7 @@ var instanceIDFetcher = cachedfetch.Fetcher{
 	Attempt: func(ctx context.Context) (interface{}, error) {
 		if !configutils.IsCloudProviderEnabled(CloudProviderName, pkgconfigsetup.Datadog()) {
 			log.Debugf("Alibaba cloud provider is disabled by configuration")
-			return nil, nil
+			return []string{}, nil
 		}
 
 		endpoint := metadataURL + "/latest/meta-data/instance-id"

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // declare these as vars not const to ease testing
@@ -125,7 +126,8 @@ func getResponseWithMaxLength(ctx context.Context, endpoint string, maxLength in
 
 func getResponse(ctx context.Context, url string) (string, error) {
 	if !configutils.IsCloudProviderEnabled(CloudProviderName, pkgconfigsetup.Datadog()) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
+		log.Debugf("Azure cloud provider is disabled by configuration")
+		return "", nil
 	}
 
 	timeout := time.Duration(pkgconfigsetup.Datadog().GetInt("azure_metadata_timeout")) * time.Millisecond

--- a/pkg/util/cloudproviders/gce/gce.go
+++ b/pkg/util/cloudproviders/gce/gce.go
@@ -272,7 +272,8 @@ func getResponseWithMaxLength(ctx context.Context, endpoint string, maxLength in
 
 func getResponse(ctx context.Context, url string) (string, error) {
 	if !configutils.IsCloudProviderEnabled(CloudProviderName, pkgconfigsetup.Datadog()) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
+		log.Debugf("GCP cloud provider is disabled by configuration")
+		return "", nil
 	}
 
 	res, err := httputils.Get(ctx, url, map[string]string{"Metadata-Flavor": "Google"}, pkgconfigsetup.Datadog().GetDuration("gce_metadata_timeout")*time.Millisecond, pkgconfigsetup.Datadog())

--- a/pkg/util/cloudproviders/ibm/ibm.go
+++ b/pkg/util/cloudproviders/ibm/ibm.go
@@ -85,7 +85,7 @@ var instanceIDFetcher = cachedfetch.Fetcher{
 	Attempt: func(ctx context.Context) (interface{}, error) {
 		if !configutils.IsCloudProviderEnabled(CloudProviderName, pkgconfigsetup.Datadog()) {
 			log.Debugf("IBM cloud provider is disabled by configuration")
-			return nil, nil
+			return []string{}, nil
 		}
 
 		t, err := token.Get(ctx)

--- a/pkg/util/cloudproviders/ibm/ibm.go
+++ b/pkg/util/cloudproviders/ibm/ibm.go
@@ -84,7 +84,8 @@ var instanceIDFetcher = cachedfetch.Fetcher{
 	Name: "IBM instance name",
 	Attempt: func(ctx context.Context) (interface{}, error) {
 		if !configutils.IsCloudProviderEnabled(CloudProviderName, pkgconfigsetup.Datadog()) {
-			return "", fmt.Errorf("IBM cloud provider is disabled by configuration")
+			log.Debugf("IBM cloud provider is disabled by configuration")
+			return nil, nil
 		}
 
 		t, err := token.Get(ctx)

--- a/pkg/util/cloudproviders/oracle/oracle.go
+++ b/pkg/util/cloudproviders/oracle/oracle.go
@@ -14,6 +14,7 @@ import (
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // declare these as vars not const to ease testing
@@ -71,7 +72,8 @@ func GetNTPHosts(ctx context.Context) []string {
 
 func getResponse(ctx context.Context, url string) (string, error) {
 	if !configutils.IsCloudProviderEnabled(CloudProviderName, pkgconfigsetup.Datadog()) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
+		log.Debugf("Oracle cloud provider is disabled by configuration")
+		return "", nil
 	}
 
 	res, err := httputils.Get(ctx, url, map[string]string{"Authorization": "Bearer Oracle"}, timeout, pkgconfigsetup.Datadog())

--- a/pkg/util/cloudproviders/tencent/tencent.go
+++ b/pkg/util/cloudproviders/tencent/tencent.go
@@ -14,6 +14,7 @@ import (
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // declare these as vars not const to ease testing
@@ -81,7 +82,8 @@ func getMetadataItemWithMaxLength(ctx context.Context, endpoint string, maxLengt
 
 func getMetadataItem(ctx context.Context, endpoint string) (string, error) {
 	if !configutils.IsCloudProviderEnabled(CloudProviderName, pkgconfigsetup.Datadog()) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
+		log.Debugf("Tencent cloud provider is disabled by configuration")
+		return "", nil
 	}
 
 	res, err := httputils.Get(ctx, endpoint, nil, timeout, pkgconfigsetup.Datadog())


### PR DESCRIPTION
### What does this PR do?
During this PR: https://github.com/DataDog/datadog-agent/pull/42940#discussion_r2538541311 we noticed that an error was being returned when it was actually expected behavior. Instead of returning an error, we now log and return a non-error.

### Motivation

### Describe how you validated your changes

### Additional Notes
