### PR TITLE
`tests_nodetreemodel`: fix `TestConfigAssignAtPathForIntMapKeys` failure

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2652,6 +2652,13 @@ func configAssignAtPath(config pkgconfigmodel.Config, settingPath []string, newV
 			}
 		case map[interface{}]interface{}:
 			if k == len(trailingElements)-1 {
+				// use integer key when it exists in map to avoid mixing string and integer keys (e.g., "2" and 2)
+				if index, err := strconv.Atoi(elem); err == nil {
+					if _, exists := modifyValue[index]; exists {
+						modifyValue[index] = newValue
+						continue
+					}
+				}
 				modifyValue[elem] = newValue
 			} else {
 				iterateValue = modifyValue[elem]


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in `configAssignAtPath` that caused `TestConfigAssignAtPathForIntMapKeys` to fail when run multiple times with the nodetreemodel config backend:
```diff
--- Expected
+++ Actual
@@ -3,3 +3,3 @@
  (string) (len=1) "1": (string) (len=6) "banana",
- (string) (len=1) "2": (string) (len=6) "cherry"
+ (string) (len=1) "2": (string) (len=6) "carrot"
 }
```
([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1245802081#L2057))

### Motivation
When `configAssignAtPath` modifies a `map[interface{}]interface{}` with integer keys (e.g., from YAML `{0: apple, 1: banana, 2: carrot}`), it was using string keys for modifications (e.g., adding `"2": "cherry"` instead of replacing the value at key `2`). This resulted in maps with both integer and string keys, and when `GetStringMapString` retrieved the map, the string key modification was invisible since only integer keys were converted.

### Describe how you validated your changes
Stress tested with 50 runs:
- before fix: 7/50 failures
- after fix: 0/50 failures