### PR TITLE
[AGTMETRICS-393] Utilize generic data plane settings for determining JMXFetch DSD configuration.

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2257,7 +2257,7 @@ func findUnknownEnvVars(config pkgconfigmodel.Config, environ []string, addition
 		// these variables are used by source code integration
 		"DD_GIT_COMMIT_SHA":     {},
 		"DD_GIT_REPOSITORY_URL": {},
-		// signals whether or not ADP is enabled
+		// signals whether or not ADP is enabled (deprecated)
 		"DD_ADP_ENABLED": {},
 		// trace-loader socket file descriptors
 		"DD_APM_NET_RECEIVER_FD":  {},

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -524,13 +524,9 @@ func (j *JMXFetch) ConfigureFromInstance(instance integration.Data) error {
 
 func (j *JMXFetch) getDSDStatus() DSDStatus {
 	// Three possible states: DSD is running in the Core Agent, DSD is running via ADP, or the DSD status is unknown.
-	//
-	// We detect these through the `use_dogstatsd` configuration and the `DD_ADP_ENABLED` environment variable, and we
-	// detect whether or not we're listening on UDS or UDP via the configuration settings that define their listening
-	// address.
 	dsdEnabledInternally := pkgconfigsetup.Datadog().GetBool("use_dogstatsd")
-	adpEnabled := os.Getenv("DD_ADP_ENABLED") == "true"
-	dsdEnabled := dsdEnabledInternally || adpEnabled
+	dsdEnabledDataPlane := isDsdEnabledViaDataPlane()
+	dsdEnabled := dsdEnabledInternally || dsdEnabledDataPlane
 	udsEnabled := pkgconfigsetup.Datadog().GetString("dogstatsd_socket") != ""
 	udpEnabled := pkgconfigsetup.Datadog().GetInt("dogstatsd_port") != 0
 
@@ -541,4 +537,17 @@ func (j *JMXFetch) getDSDStatus() DSDStatus {
 	} else {
 		return DSDStatusUnknown
 	}
+}
+
+func isDsdEnabledViaDataPlane() bool {
+	// `DD_ADP_ENABLED` is a deprecated environment variable for signaling that Agent Data Plane is running _and_ that
+	// it's handling DogStatsD traffic.
+	//
+	// This is now split into two separate settings: `data_plane.enabled` and `data_plane.dogstatsd.enabled`, which
+	// indicate whether ADP is enabled at all and whether it's handling DogStatsD traffic, respectively.
+	adpDsdEnabledOldStyle := os.Getenv("DD_ADP_ENABLED") == "true"
+	adpEnabled := pkgconfigsetup.Datadog().GetBool("data_plane.enabled")
+	adpDsdEnabled := pkgconfigsetup.Datadog().GetBool("data_plane.dogstatsd.enabled")
+
+	return adpDsdEnabledOldStyle || (adpEnabled && adpDsdEnabled)
 }


### PR DESCRIPTION
### What does this PR do?

Updates the JMXFetch configuration logic to additionally consider `data_plane.enabled`/`data_plane.dogstatsd.enabled` when determining how to configure the StatsD reporter.

### Motivation

Currently, the logic looks solely at the `DD_ADP_ENABLED` environment variable to determine if ADP is running. In a [previous PR](https://github.com/DataDog/datadog-agent/pull/41393/s), we added new configuration settings to more generically control whether or not the "data plane" was enabled, including a subsection specifically for DogStatsD (and, eventually, subsections for other features.)

As these new settings are preferred going forward, and more precise, we want to additionally evaluate them when deciding how to configure the StatsD reporter in JMXFetch.

### Describe how you validated your changes

### Additional Notes
