### PR TITLE
ci(fips): Add the new required dependency for fips e2e tests

### DIFF
--- a/tasks/fips.py
+++ b/tasks/fips.py
@@ -55,6 +55,7 @@ def generate_fips_e2e_pipeline(ctx, generate_config=False):
                 job["needs"],
                 deps_to_keep=[
                     "go_e2e_deps",
+                    "go_tools_deps",
                     "tests_windows_sysprobe_x64",
                     "tests_windows_secagent_x64",
                     "go_e2e_test_binaries",


### PR DESCRIPTION
### What does this PR do?
- Add the needed `go_tools_deps` dependency when generating the fips pipeline jobs

### Motivation
Since we merged #42832 we added a new dependency for e2e tests. As we are using `needs` this dep was not available for `fips` tests leading in an [error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1246768909)

### Describe how you validated your changes
I must trigger the fips child pipeline manually

### Additional Notes
