### PR TITLE
[ABLD-300] Generalize `bazel` configuration in CI

### DIFF
--- a/.gitlab/bazel/build-deps.yaml
+++ b/.gitlab/bazel/build-deps.yaml
@@ -1,5 +1,4 @@
 .bazel:build-deps:
-  extends: .bazel:defs
   rules:
     - !reference [ .except_mergequeue ]
     - when: on_success

--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -43,7 +43,7 @@
 .bazel:defs:cache:windows:
   extends: .bazel:defs
   variables:
-    XDG_CACHE_HOME: c:\bzl
+    XDG_CACHE_HOME: c:/bzl
 
 .bazel:runner:linux-amd64:
   extends: .bazel:defs:cache:persistent

--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -1,51 +1,72 @@
 .bazel:defs:
+  needs: [ ]
+  variables:
+    BAZELISK_HOME: "$XDG_CACHE_HOME/bazelisk" # not all bazelisk versions may honor $XDG_CACHE_HOME
+
+.bazel:defs:cache:ephemeral:
+  extends: .bazel:defs
   cache:
-    - key:
+    - &bazelversion_cache
+      key:
         prefix: bazelversion-$CI_RUNNER_DESCRIPTION
         files: [ .bazelversion ]
       paths:
         - .cache/bazelisk
-        - .cache/bazel/install
+        - .cache/bazel/*/install
       policy: pull-push
       when: on_success
-    - key: bazel-$CI_RUNNER_DESCRIPTION
+    - &bazel_cache
+      key: bazel-$CI_RUNNER_DESCRIPTION
       paths:
-        - .cache/bazel/cache
-        - .cache/bazel/disk
-        - .cache/bazel/repo-contents
+        - .cache/bazel/*/cache
+        - .cache/bazel/*/*/external
+        - .cache/pip
       policy: pull-push
       when: on_success
-  needs: [ ]
   variables:
-    BAZELISK_HOME: "$XDG_CACHE_HOME/bazelisk"
-    BAZEL_DISK_CACHE: "$BAZEL_OUTPUT_USER_ROOT/disk"
-    BAZEL_OUTPUT_USER_ROOT: "$XDG_CACHE_HOME/bazel"
-    BAZEL_REPO_CONTENTS_CACHE: "$BAZEL_OUTPUT_USER_ROOT/repo-contents"
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
 
-.bazel:runner:linux-amd64:
-  cache: []
+.bazel:defs:cache:omnibus-transition:
+  extends: .bazel:defs
+  cache:
+    - !reference [ .cache_omnibus_ruby_deps, cache ]
+    - *bazelversion_cache
+    - *bazel_cache
+  variables:
+    XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
+
+.bazel:defs:cache:persistent:
+  extends: .bazel:defs
   variables:
     XDG_CACHE_HOME: /data/bzl
+
+.bazel:defs:cache:windows:
+  extends: .bazel:defs
+  variables:
+    XDG_CACHE_HOME: c:\bzl
+
+.bazel:runner:linux-amd64:
+  extends: .bazel:defs:cache:persistent
   tags: [ "k8s-persistent:amd64", "specific:true" ]
 
 .bazel:runner:linux-arm64:
-  extends: .linux_arm64
+  extends: .bazel:defs:cache:persistent
+  tags: [ "k8s-persistent:arm64", "specific:true" ]
 
 .bazel:runner:macos-amd64:
+  extends: .bazel:defs:cache:ephemeral
   tags: [ "macos:sonoma-amd64", "specific:true" ]
 
 .bazel:runner:macos-arm64:
+  extends: .bazel:defs:cache:ephemeral
   tags: [ "macos:sonoma-arm64", "specific:true" ]
 
 .bazel:runner:windows-amd64:
-  extends: .windows_docker_default
+  extends: [ .bazel:defs:cache:windows, .windows_docker_default ]
   timeout: 60m # pulling images alone can take more than 30m
-  cache: []
   variables:
     ARCH: x64
     GIT_DEPTH: 2
-    XDG_CACHE_HOME: c:\bzl
   script:
     - |-
       $FailFast = @'
@@ -56,14 +77,12 @@
       Invoke-Expression $FailFast
       $Utf8Script = [Text.Encoding]::UTF8.GetString([Text.Encoding]::GetEncoding([Console]::OutputEncoding.CodePage).GetBytes($POWERSHELL_SCRIPT))
       $EncodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("$FailFast`n$Utf8Script"))
-      New-Item -ItemType Directory -Path "$XDG_CACHE_HOME" -Force | Out-Null
+      mkdir "$XDG_CACHE_HOME" -Force | Out-Null
     - >-
       docker run
       --env=BAZELISK_HOME
-      --env=BAZEL_DISK_CACHE
-      --env=BAZEL_OUTPUT_USER_ROOT
-      --env=BAZEL_REPO_CONTENTS_CACHE
-      --env=CI_PROJECT_DIR
+      --env=CI
+      --env=XDG_CACHE_HOME
       --rm
       --volume="${CI_PROJECT_DIR}:$CI_PROJECT_DIR"
       --volume="${XDG_CACHE_HOME}:$XDG_CACHE_HOME"

--- a/.gitlab/bazel/lint.yaml
+++ b/.gitlab/bazel/lint.yaml
@@ -1,6 +1,6 @@
 bazel:mod-deps:
   allow_failure: true  #incident-46079
-  extends: [ .bazel:defs, .bazel:runner:linux-amd64 ]
+  extends: .bazel:runner:linux-amd64
   stage: lint
   script:
     - bazel mod deps --lockfile_mode=error
@@ -13,7 +13,7 @@ bazel:mod-deps:
       fi
 
 bazel:run-buildifier-test:
-  extends: [ .bazel:defs, .bazel:runner:linux-amd64 ]
+  extends: .bazel:runner:linux-amd64
   stage: lint
   script:
     - bazel run //bazel/buildifier:test

--- a/.gitlab/bazel/tests.yaml
+++ b/.gitlab/bazel/tests.yaml
@@ -1,5 +1,4 @@
 .bazel:tests:
-  extends: .bazel:defs
   rules:
     - !reference [ .except_mergequeue ]
     - when: on_success

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -22,6 +22,7 @@
     mkdir -p $GOMODCACHE
 
 .agent_dmg:
+  extends: .bazel:defs:cache:omnibus-transition
   stage: package_build
   needs: ["go_mod_tidy_check"]
   rules:
@@ -45,8 +46,6 @@
     NOTARIZATION_ATTEMPTS: 3
     NOTARIZATION_WAIT_TIME: 15s
   timeout: 2h
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
   before_script:
     # Since there is no virtualization on the macOS runners, we need to unmount the Agent dmg volume to avoid conflicts
     - sudo umount /Volumes/Agent || true

--- a/.gitlab/package_build/heroku.yml
+++ b/.gitlab/package_build/heroku.yml
@@ -1,5 +1,6 @@
 ---
 .heroku_build_base:
+  extends: .bazel:defs:cache:omnibus-transition
   stage: package_build
   rules:
     - !reference [.except_mergequeue]
@@ -29,8 +30,6 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 agent_heroku_deb-x64-a7:
   extends: .heroku_build_base

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -3,6 +3,7 @@
 # Datadog installer payloads
 #
 .common_build_oci:
+  extends: .bazel:defs:cache:omnibus-transition
   script:
     - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
     - export INSTALL_DIR=/opt/datadog-packages/datadog-agent/"$AGENT_VERSION"
@@ -31,8 +32,6 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 datadog-agent-oci-x64-a7:
   extends: .common_build_oci
@@ -141,6 +140,7 @@ powershell_script_signing:
 # The installer program
 #
 .installer_build_common:
+  extends: .bazel:defs:cache:omnibus-transition
   script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.cache_omnibus_ruby_deps, setup]
@@ -159,8 +159,6 @@ powershell_script_signing:
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 # We build a "regular" installer, meant to be packaged as deb/rpm, without a custom install path
 # and an artifact intended for OCI packaging, which has a custom install path

--- a/.gitlab/package_build/linux.yml
+++ b/.gitlab/package_build/linux.yml
@@ -16,6 +16,7 @@
   - !reference [.upload_sbom_artifacts]
 
 .agent_build_common:
+  extends: .bazel:defs:cache:omnibus-transition
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -30,8 +31,6 @@
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 .agent_build_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
@@ -127,6 +126,7 @@ iot-agent-armhf:
 # ----- Dogstatsd -----
 
 .dogstatsd_build_common:
+  extends: .bazel:defs:cache:omnibus-transition
   needs: ["go_mod_tidy_check", "go_deps"]
   rules:
     - !reference [.except_mergequeue]
@@ -148,8 +148,6 @@ iot-agent-armhf:
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 dogstatsd-x64:
   extends: [.dogstatsd_build_common, .toolchain-common-x64]
@@ -160,6 +158,7 @@ dogstatsd-arm64:
 # ----- DDOT -----
 
 .otel_build_common:
+  extends: .bazel:defs:cache:omnibus-transition
   needs: ["go_mod_tidy_check", "go_deps"]
   rules:
     - !reference [.except_mergequeue]
@@ -181,8 +180,6 @@ dogstatsd-arm64:
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 datadog-otel-agent-x64:
   extends: [.otel_build_common, .toolchain-common-x64, .agent_base_flavor]

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -1,17 +1,21 @@
 ---
 .windows_msi_base:
   stage: package_build
-  extends: .windows_docker_default
+  extends: [.windows_docker_default, .bazel:defs:cache:windows]  # the latter for `bazel run @openssl//:install`
   needs: ["go_deps"]
   script:
     - $ErrorActionPreference = 'Stop'
     - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
     - mkdir omnibus\pkg
+    - mkdir "$XDG_CACHE_HOME" -Force | Out-Null
     - >
       docker run --rm
       -m 24576M
       -v "$(Get-Location):c:\mnt"
-      -e CI=true
+      -v "${XDG_CACHE_HOME}:$XDG_CACHE_HOME"
+      -e XDG_CACHE_HOME
+      -e BAZELISK_HOME
+      -e CI
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS="${DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS}"
       -e CI_JOB_ID=${CI_JOB_ID}
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -98,6 +98,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
       docker run --rm
       -m 24576M
       -v "$(Get-Location):c:\mnt"
+      -e CI
       -e CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
       -e CI_PROJECT_NAME=${CI_PROJECT_NAME}

--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -3,6 +3,7 @@ include:
   - .gitlab/packaging/common.yml
 
 .package_deb_common:
+  extends: .bazel:defs:cache:omnibus-transition
   stage: packaging
   script:
     - !reference [.cache_omnibus_ruby_deps, setup]
@@ -21,8 +22,6 @@ include:
     KUBERNETES_MEMORY_REQUEST: "32Gi"
     KUBERNETES_MEMORY_LIMIT: "32Gi"
     PACKAGE_REQUIRED_FILES_LIST: "test/required_files/agent-deb.txt"
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 .package_deb_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
@@ -132,6 +131,7 @@ installer_deb-arm64:
     PACKAGE_REQUIRED_FILES_LIST: ""
 
 .package_iot_deb_common:
+  extends: .bazel:defs:cache:omnibus-transition
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -154,8 +154,6 @@ installer_deb-arm64:
     OMNIBUS_PACKAGE_ARTIFACT_DIR: $OMNIBUS_PACKAGE_DIR
     PACKAGE_REQUIRED_FILES_LIST: "test/required_files/iot-agent-deb.txt"
     DD_PROJECT: iot-agent
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 iot_agent_deb-x64:
   extends: [.package_iot_deb_common, .package_deb_x86]

--- a/.gitlab/packaging/rpm.yml
+++ b/.gitlab/packaging/rpm.yml
@@ -3,6 +3,7 @@ include:
   - .gitlab/packaging/common.yml
 
 .package_rpm_common:
+  extends: .bazel:defs:cache:omnibus-transition
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -27,8 +28,6 @@ include:
     OMNIBUS_PACKAGE_ARTIFACT_DIR: $OMNIBUS_PACKAGE_DIR
     PACKAGE_REQUIRED_FILES_LIST: "test/required_files/agent-rpm.txt"
     OMNIBUS_EXTRA_ARGS: "--host-distribution=rhel"
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 .package_rpm_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
@@ -205,6 +204,7 @@ installer_suse_rpm-arm64:
     DD_ENABLE_VPA: false
 
 .package_iot_rpm_common:
+  extends: .bazel:defs:cache:omnibus-transition
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -229,8 +229,6 @@ installer_suse_rpm-arm64:
     PACKAGE_REQUIRED_FILES_LIST: "test/required_files/iot-agent-rpm.txt"
     DD_PROJECT: iot-agent
     OMNIBUS_EXTRA_ARGS: "--host-distribution=rhel"
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
   retry: 2
 
 iot_agent_rpm-x64:
@@ -279,8 +277,6 @@ iot_agent_suse-x64:
   variables:
     OMNIBUS_EXTRA_ARGS: "--host-distribution=suse"
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_iot_agent_suse_amd64"
-  cache:
-    - !reference [.cache_omnibus_ruby_deps, cache]
 
 dogstatsd_rpm-x64:
   extends: [.package_rpm_common, .package_rpm_x86]

--- a/.gitlab/source_test/common.yml
+++ b/.gitlab/source_test/common.yml
@@ -8,5 +8,6 @@
   - dda inv -- -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
 
 .unit_test_base:
+  extends: .bazel:defs:cache:ephemeral
   variables:
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -85,6 +85,7 @@ prepare_sysprobe_ebpf_functional_tests_x64:
     DD_CXX: "x86_64-unknown-linux-gnu-g++"
 
 .prepare_secagent_ebpf_functional_tests:
+  extends: .bazel:defs:cache:ephemeral  # for `bazel run @libpcap//:install`
   stage: source_test
   rules:
     - !reference [.except_mergequeue]

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -79,6 +79,7 @@ tests_windows-x64:
       -m 16384M
       -v "$(Get-Location):c:\mnt"
       -e AWS_NETWORKING=true
+      -e CI
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
       -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
       -e SIGN_WINDOWS_DD_WCS=true
@@ -103,6 +104,7 @@ tests_windows-x64:
       -m 16384M
       -v "$(Get-Location):c:\mnt"
       -e AWS_NETWORKING=true
+      -e CI
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
       -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
       -e SIGN_WINDOWS_DD_WCS=true

--- a/omnibus/config/software/datadog-agent-mac-app.rb
+++ b/omnibus/config/software/datadog-agent-mac-app.rb
@@ -4,7 +4,10 @@ description "Generate mac app manifest and assets"
 
 dependency "datadog-agent"
 
-source path: "#{project.files_path}/#{name}"
+source path: "#{project.files_path}/#{name}",
+       options: {
+         exclude: ["**/.cache/**/*"],
+       }
 
 always_build true
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -24,7 +24,7 @@ end
 
 source path: '..',
        options: {
-         exclude: ["**/testdata/**/*"],
+         exclude: ["**/.cache/**/*", "**/testdata/**/*"],
        }
 relative_path 'src/github.com/DataDog/datadog-agent'
 

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -8,7 +8,10 @@ name 'datadog-dogstatsd'
 
 skip_transitive_dependency_licensing true
 
-source path: '..'
+source path: '..',
+       options: {
+         exclude: ["**/.cache/**/*"],
+       }
 relative_path 'src/github.com/DataDog/datadog-agent'
 
 build do

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -8,7 +8,10 @@ require 'pathname'
 
 name 'datadog-iot-agent'
 
-source path: '..'
+source path: '..',
+       options: {
+         exclude: ["**/.cache/**/*"],
+       }
 relative_path 'src/github.com/DataDog/datadog-agent'
 
 build do

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -12,6 +12,7 @@ name 'datadog-otel-agent'
 source path: '..',
        options: {
          exclude: [
+           "**/.cache/**/*",
            "**/testdata/**/*",
          ],
        }

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -10,7 +10,7 @@ name 'installer'
 
 source path: '..',
        options: {
-         exclude: ["**/testdata/**/*"],
+         exclude: ["**/.cache/**/*", "**/testdata/**/*"],
        }
 relative_path 'src/github.com/DataDog/datadog-agent'
 

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -15,7 +15,8 @@ CACHE_VERSION = 2
 
 
 ENV_PASSHTROUGH = {
-    'CI': "dda may rely on this to be able to tell whether it's running on CI and adapt behavior",
+    'BAZELISK_HOME': "Runner-dependent cache path used by `bazelisk` to manage `bazel` installations",
+    'CI': "dda and `bazel` rely on this to be able to tell whether they're running on CI and adapt behavior",
     'DD_CC': 'Points at c compiler',
     'DD_CXX': 'Points at c++ compiler',
     'DD_CMAKE_TOOLCHAIN': 'Points at cmake toolchain',
@@ -42,6 +43,7 @@ ENV_PASSHTROUGH = {
     'S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS': 'Use to determine whether Omnibus can write to the artifact cache',
     'S3_OMNIBUS_CACHE_BUCKET': 'Points at bucket used for Omnibus source artifacts',
     'SSH_AUTH_SOCK': 'Developer environments configure Git to use SSH authentication',
+    'XDG_CACHE_HOME': "Runner-dependent cache path used by `bazel` (natively on POSIX OSes, emulated on Windows)",
     'rvm_path': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',
     'rvm_bin_path': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',
     'rvm_prefix': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',

--- a/tools/bazel
+++ b/tools/bazel
@@ -2,63 +2,22 @@
 set -euo pipefail
 
 # Check `bazelisk` properly bootstraps `bazel` or fail with instructions
-if [ -z "${BAZEL_REAL:-}" ] || [ "${BAZELISK_SKIP_WRAPPER:-}" != "true" ]; then
+if [ -z "${BAZEL_REAL:-}" ] || [ "${BAZELISK_SKIP_WRAPPER:-}" != true ]; then
   >&2 cat "$(dirname "$0")/bazelisk.md"
   exit 2
 fi
 
-# Not in CI: simply execute `bazel` - done
-if [ -z "${CI_PROJECT_DIR:-}" ]; then
-  exec "$BAZEL_REAL" "$@"
-  exit 2 # should not reach here
-fi
-
-if [[ -z "${BAZEL_REPO_CONTENTS_CACHE:-}" ]] ; then
-    export XDG_CACHE_HOME="$CI_PROJECT_DIR/.cache"
-    export BAZELISK_HOME="$XDG_CACHE_HOME/bazelisk"
-    export BAZEL_OUTPUT_USER_ROOT="$XDG_CACHE_HOME/bazel"
-    export BAZEL_DISK_CACHE="$BAZEL_OUTPUT_USER_ROOT/disk"
-    export BAZEL_REPO_CONTENTS_CACHE="$BAZEL_OUTPUT_USER_ROOT/repo-contents"
-fi
-
-# In CI
-if [[ "${BAZEL_REPO_CONTENTS_CACHE:-}" = "${CI_PROJECT_DIR:-}"* ]]; then
-  # Ephemeral runner: externalize `--repo_contents_cache` to the job's temp directory created alongside $CI_PROJECT_DIR
-  # - https://github.com/bazelbuild/bazel/issues/26384 for why
-  # - https://docs.gitlab.com/runner/configuration/advanced-configuration/ for `RUNNER_TEMP_PROJECT_DIR`
-  # - https://sissource.ethz.ch/sispub/gitlab-ci-euler-image/-/blob/main/entrypoint.sh#L43 for inspiration
-  is_persistent_runner=false
-  ext_repo_contents_cache=$RUNNER_TEMP_PROJECT_DIR/bazel-repo-contents-cache
-  if [ -e "${BAZEL_REPO_CONTENTS_CACHE:-}" ]; then
-    >&2 rm -frv "$ext_repo_contents_cache"
-    mv "$BAZEL_REPO_CONTENTS_CACHE" "$ext_repo_contents_cache"
+# CI specific setup
+if [ -n "${CI:-}" ]; then
+  if [ ! -d "${XDG_CACHE_HOME:-}" ]; then
+    >&2 echo "🔴 XDG_CACHE_HOME (${XDG_CACHE_HOME:-}) must denote a directory in CI!"
+    exit 2
   fi
-else
-  # Persistent runner: honor `$BAZEL_REPO_CONTENTS_CACHE` since it already points to an external path
-  is_persistent_runner=true
-  ext_repo_contents_cache=$BAZEL_REPO_CONTENTS_CACHE
-fi
 
-# Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` and next `bazel shutdown` also honor them
-cat >"$CI_PROJECT_DIR/user.bazelrc" <<EOF
-startup --output_user_root=$BAZEL_OUTPUT_USER_ROOT
+  # Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` also honor them
+  cat >"$(dirname "$(dirname "$0")")/user.bazelrc" <<EOF
 common --config=ci
-common --repo_contents_cache=$ext_repo_contents_cache
-build --disk_cache=$BAZEL_DISK_CACHE
 EOF
-
-# Payload: execute `bazel`, failing fast
-"$BAZEL_REAL" "$@"
-
-# Skip cleanup for persistent runners
-[ $is_persistent_runner = true ] && exit 0
-
-# Stop `bazel` (if still running) to close files and proceed with cleanup
-"$BAZEL_REAL" shutdown --ui_event_filters=-info || true
-rm "$CI_PROJECT_DIR/user.bazelrc"
-
-# Reintegrate `--repo_contents_cache` to original directory
-if [ -e "$ext_repo_contents_cache" ]; then
-  >&2 rm -frv "$BAZEL_REPO_CONTENTS_CACHE"
-  mv "$ext_repo_contents_cache" "$BAZEL_REPO_CONTENTS_CACHE"
 fi
+
+exec "$BAZEL_REAL" "$@"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -8,9 +8,18 @@ if defined BAZEL_REAL if "%BAZELISK_SKIP_WRAPPER%"=="true" goto :bazelisk_ok
 exit /b 2
 :bazelisk_ok
 
+:: Ensure `XDG_CACHE_HOME` denotes a directory
+if defined CI (
+  if not exist "!XDG_CACHE_HOME!" (
+    >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI!
+    exit /b 2
+  )
+) else if not defined XDG_CACHE_HOME (
+  set "XDG_CACHE_HOME=%~dp0..\.cache"
+)
+
 :: Check legacy max path length of 260 characters got lifted, or fail with instructions
-if defined XDG_CACHE_HOME (set "cache_home=%XDG_CACHE_HOME%") else (set "cache_home=%~dp0..\.cache")
-set "more_than_260_chars=!cache_home!\more-than-260-chars"
+set "more_than_260_chars=!XDG_CACHE_HOME!\more-than-260-chars"
 for /l %%i in (1,1,26) do set "more_than_260_chars=!more_than_260_chars!\123456789"
 if not exist "!more_than_260_chars!" (
   2>nul mkdir "!more_than_260_chars!"
@@ -23,30 +32,20 @@ if not exist "!more_than_260_chars!" (
 )
 
 :: Not in CI: simply execute `bazel` - done
-if not defined CI_PROJECT_DIR (
+if not defined CI (
   "%BAZEL_REAL%" %*
   exit /b !errorlevel!
 )
 
-:: In CI: first, verify directory environment variables are set and normalize their paths
-for %%v in (BAZEL_DISK_CACHE BAZEL_OUTPUT_USER_ROOT BAZEL_REPO_CONTENTS_CACHE VSTUDIO_ROOT) do (
-  if not defined %%v (
-    >&2 echo %~nx0: %%v: unbound variable
-    exit /b 2
-  )
-  :: Path separators: `bazel` is fine with both `/` and `\\` but fails with `\`, so the simplest is to favor `/`
-  set "%%v=!%%v:\=/!"
-)
-set "BAZEL_VS=!VSTUDIO_ROOT!"
+:: In CI: make `bazel` honor $XDG_CACHE_HOME as it does on POSIX OSes: https://github.com/bazelbuild/bazel/issues/27808
+set "bazel_home=!XDG_CACHE_HOME!\bazel"
 
 :: Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` and next `bazel shutdown` also honor them
 (
   echo startup --connect_timeout_secs=5  # instead of 30s, for quicker iterations in diagnostics
   echo startup --local_startup_timeout_secs=30  # instead of 120s, to fail faster for diagnostics
-  echo startup --output_user_root=!BAZEL_OUTPUT_USER_ROOT!
+  echo startup --output_user_root=!bazel_home:\=/!  # forward slashes: https://github.com/bazelbuild/bazel/issues/3275
   echo common --config=ci
-  echo common --disk_cache=!BAZEL_DISK_CACHE!
-  echo common --repo_contents_cache=!BAZEL_REPO_CONTENTS_CACHE!
 ) >"%~dp0..\user.bazelrc"
 
 :: Diagnostics: print any stalled client/server before `bazel` execution
@@ -59,10 +58,10 @@ set "bazel_exit=!errorlevel!"
 :: Diagnostics: dump logs on non-trivial failures (https://bazel.build/run/scripts#exit-codes)
 :: TODO(regis): adjust (probably `== 37`) next time a `cannot connect to Bazel server` error happens (#incident-42947)
 if !bazel_exit! geq 2 (
-  >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !BAZEL_OUTPUT_USER_ROOT! ^(excluding junctions^):
-  for /f "delims=" %%d in ('dir /a:d-l /b "!BAZEL_OUTPUT_USER_ROOT!"') do (
+  >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !bazel_home! ^(excluding junctions^):
+  for /f "delims=" %%d in ('dir /a:d-l /b "!bazel_home!"') do (
     >&2 echo 🟡 [%%d]
-    for %%f in ("!BAZEL_OUTPUT_USER_ROOT!\%%d\java.log.*" "!BAZEL_OUTPUT_USER_ROOT!\%%d\server\*") do (
+    for %%f in ("!bazel_home!\%%d\java.log.*" "!bazel_home!\%%d\server\*") do (
       if exist "%%f" (
         >&2 echo 🟡 %%f:
         >&2 type "%%f"


### PR DESCRIPTION
### What does this PR do?
It generalizes `bazel` CI configuration to make nested `bazel[isk]` invocations in `omnibus` scripts and `invoke` tasks automatically benefit from `bazel --config=ci` (single point of maintenance defined in `.bazelrc`) as well as applicable caching.

### Motivation
The GitLab cache used so far for ephemeral runners was only benefiting top-level `bazel` commands used in smoke tests and linters. It didn't benefit nested `bazel` invocations, nor were settings implied by `--config=ci` because `tools/bazel[.bat]` hook scripts had no clue they were running in CI.

The GitLab cache configuration used to be too tricky to generalize due to the many environment variables involved, that's why the present approach consists in limiting them to only 2 environment variables:
- `CI`: to trigger `bazel --config=ci`.
    The presence of this variable is anyway a _de facto_ standard leveraged by existing tools, of which in-house `dda`,
- `XDG_CACHE_HOME`: root directory for both `bazelisk` and `bazel` caches.
    Originating from Linux/BSD ecosystems, this variable is also honored by `bazel` (8.4.0+) on macOS and I filed a feature request to get it honored on Windows - meanwhile we "emulate" it there via `--output_user_root=$XDG_CACHE_HOME/bazel` (only remaining path explicitly passed to `bazel`).

### Additional Notes
1. simplified wrapper scripts:
    - require that `$XDG_CACHE_HOME` denotes a directory in CI,
    - shrunk down ephemeral `.user.bazelrc` to the bare minimum,
2. standardized cache location via `XDG_CACHE_HOME` per runner type:
    - persistent Linux runners (only used for top-level `bazel` commands): `/data/bzl` (on persistent volume), now also for AArch64 (aka ARM64),
    - "ephemeral" Linux/macOS runners: `$CI_PROJECT_DIR/.cache`, because GitLab requires cacheable paths to reside below `$CI_PROJECT_DIR`,
    - Windows runners: `c:/bzl` (but `$RUNNER_TEMP_PROJECT_DIR` should be fine too if we get rid of `msbuild`, @alopezz to confirm or deny),
3. replaced `omnibus` cache insertions by a combined cache extension comprising both `bazel` caches as well as the `omnibus` cache definition. The latter is of course aimed at vanishing at the end of the ongoing transition, hence the name: `omnibus-transition`,
4. passed `CI` to `docker run`s in order to fail if we forget to propagate `XDG_CACHE_HOME` when enabling `bazel` there.

References:
- CI environment variable semantics: https://stackoverflow.com/a/64289573
- Bazel directory structure: https://bazel.build/remote/output-directories#layout-diagram
- XDG Base Directory Specification: https://specifications.freedesktop.org/basedir/latest/
- Bazel XDG support (Linux): https://github.com/bazelbuild/bazel/pull/21817 (7.2.0)
- Bazel XDG support (macOS): https://github.com/bazelbuild/bazel/pull/26773 (8.4.0)
- Windows XDG feature request: https://github.com/bazelbuild/bazel/issues/27808
- Bazel Windows backslash issue: https://github.com/bazelbuild/bazel/issues/3275