### PR TITLE
[AGTMETRICS-393] Gate ADP checks in E2E install script tests to only run for regular Agent build flavor.

### DIFF
--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -185,11 +185,12 @@ func (is *installScriptSuite) AgentTest(flavor string) {
 		if is.cwsSupported {
 			common.CheckCWSBehaviour(is.T(), client)
 		}
+
+		time.Sleep(5 * time.Second) // Restarting the agent too fast will cause systemctl to fail
+		common.CheckADPEnabled(is.T(), client)
+		time.Sleep(5 * time.Second) // Restarting the agent too fast will cause systemctl to fail
+		common.CheckADPDisabled(is.T(), client)
 	}
-	time.Sleep(5 * time.Second) // Restarting the agent too fast will cause systemctl to fail
-	common.CheckADPEnabled(is.T(), client)
-	time.Sleep(5 * time.Second) // Restarting the agent too fast will cause systemctl to fail
-	common.CheckADPDisabled(is.T(), client)
 	common.CheckInstallationInstallScript(is.T(), client)
 	is.testUninstall(client, flavor)
 }


### PR DESCRIPTION
### What does this PR do?

Should fix the `TestInstallAgent` E2E test to not run ADP-specific checks on Heroku.

### Motivation

### Describe how you validated your changes

### Additional Notes
