### PR TITLE
[CWS] Recover panic when getting variable instances

### DIFF
--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -407,16 +407,25 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 
 	seclVariableStates := make(map[string]*api.SECLVariableState)
 
+	addVariableState := func(name string, instance eval.VariableInstance) {
+		defer func() {
+			if err := recover(); err != nil {
+				seclog.Errorf("recovered panic while getting value of variable '%s': %v", name, err)
+			}
+		}()
+		seclVariableStates[name] = &api.SECLVariableState{
+			Name:  name,
+			Value: fmt.Sprintf("%+v", instance.GetValue()),
+		}
+	}
+
 	rs.IterVariables(func(definition eval.VariableDefinition, instances map[string]eval.VariableInstance) {
 		name := definition.VariableName(true)
 		switch definition.Scoper().Type() {
 		case eval.GlobalScoperType:
 			globalInstance, ok := instances[rules.GlobalScopeKey]
 			if ok && !globalInstance.IsExpired() { // skip variables that expired but are yet to be cleaned up
-				seclVariableStates[name] = &api.SECLVariableState{
-					Name:  name,
-					Value: fmt.Sprintf("%+v", globalInstance.GetValue()),
-				}
+				addVariableState(name, globalInstance)
 			}
 		case eval.ProcessScoperType, eval.CGroupScoperType, eval.ContainerScoperType:
 			for scopeKey, instance := range instances {
@@ -424,10 +433,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 					continue
 				}
 				scopedName := fmt.Sprintf("%s.%s", name, scopeKey)
-				seclVariableStates[scopedName] = &api.SECLVariableState{
-					Name:  scopedName,
-					Value: fmt.Sprintf("%+v", instance.GetValue()),
-				}
+				addVariableState(scopedName, instance)
 			}
 		}
 	})


### PR DESCRIPTION
### What does this PR do?

Recover panic when getting variable instances

### Motivation

- Print the name of the variable that's causing the panic for investigation purposes
- Recover execution flow as this part of the code is only useful for debugging purposes so there's no need to crash the whole process for that

### Describe how you validated your changes

### Additional Notes
