### PR TITLE
errors: Support wrapped errors

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -6,7 +6,10 @@
 // Package errors provides custom errors for the agent
 package errors
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type errorReason int
 
@@ -33,7 +36,7 @@ func (e AgentError) Error() string {
 }
 
 // NewNotFound returns a new error which indicates that the object passed in parameter was not found.
-func NewNotFound(notFoundObject string) *AgentError {
+func NewNotFound(notFoundObject any) *AgentError {
 	return &AgentError{
 		message:     fmt.Sprintf("%q not found", notFoundObject),
 		errorReason: notFoundError,
@@ -105,9 +108,9 @@ func IsTimeout(err error) bool {
 }
 
 func reasonForError(err error) errorReason {
-	switch t := err.(type) {
-	case *AgentError:
-		return t.errorReason
+	var agentErr *AgentError
+	if errors.As(err, &agentErr) {
+		return agentErr.errorReason
 	}
 	return unknownError
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -23,6 +23,11 @@ func TestNotFound(t *testing.T) {
 	require.True(t, IsNotFound(err))
 	require.False(t, IsNotFound(fmt.Errorf("fake")))
 	require.False(t, IsNotFound(fmt.Errorf(`"foo" not found`)))
+
+	// Wrapped
+	errWrapped := fmt.Errorf("context: %w", err)
+	require.True(t, IsNotFound(errWrapped))
+	require.True(t, IsNotFound(fmt.Errorf("outer: %w", fmt.Errorf("middle: %w", err))))
 }
 
 func TestRetriable(t *testing.T) {
@@ -36,6 +41,11 @@ func TestRetriable(t *testing.T) {
 	require.True(t, IsRetriable(errFunc()))
 	require.False(t, IsRetriable(fmt.Errorf("fake")))
 	require.False(t, IsRetriable(fmt.Errorf(`couldn't fetch "foo": bar`)))
+
+	// Wrapped
+	errWrapped := fmt.Errorf("context: %w", err)
+	require.True(t, IsRetriable(errWrapped))
+	require.True(t, IsRetriable(fmt.Errorf("outer: %w", fmt.Errorf("middle: %w", err))))
 }
 
 func TestRemoteService(t *testing.T) {
@@ -48,6 +58,11 @@ func TestRemoteService(t *testing.T) {
 	require.True(t, IsRemoteService(err))
 	require.False(t, IsRemoteService(errors.New("fake")))
 	require.False(t, IsRemoteService(errors.New(`"datadog cluster agent" is unavailable: 500 Internal Server Error`)))
+
+	// Wrapped
+	errWrapped := fmt.Errorf("context: %w", err)
+	require.True(t, IsRemoteService(errWrapped))
+	require.True(t, IsRemoteService(fmt.Errorf("outer: %w", fmt.Errorf("middle: %w", err))))
 }
 
 func TestTimeout(t *testing.T) {
@@ -60,4 +75,9 @@ func TestTimeout(t *testing.T) {
 	require.True(t, IsTimeout(err))
 	require.False(t, IsTimeout(errors.New("fake")))
 	require.False(t, IsTimeout(errors.New(`timeout calling "datadog cluster agent": context deadline exceeded`)))
+
+	// Wrapped
+	errWrapped := fmt.Errorf("context: %w", err)
+	require.True(t, IsTimeout(errWrapped))
+	require.True(t, IsTimeout(fmt.Errorf("outer: %w", fmt.Errorf("middle: %w", err))))
 }


### PR DESCRIPTION
### What does this PR do?

Changes the `reasonForError` logic to support wrapped errors.

### Motivation

If an error coming from the constructors in the package is wrapped, the rest of the `IsX` functions will not work. 

### Describe how you validated your changes

Unit tests added to cover the new case. I checked existing usage of the `IsX` functions to ensure that we are not activating code paths that weren't being used before. `IsNotFound` is the only one used more broadly, with the rest being either unused or only in tests.

### Additional Notes

I found some places in the code that are using this agent-specific logic to check for errors that come from other packages:
* `pkg/clusteragent/appsec/istio/detection.go:21` 
* `pkg/util/kubernetes/apiserver/controllers/hpa_controller.go:157` 
* `pkg/util/kubernetes/apiserver/controllers/wpa_controller.go:209` - although there's a check above it for `err != nil` already