### PR TITLE
[tracer] Marshal resolv.conf into CollectorConnections

### DIFF
--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -49,7 +49,7 @@ func mergeDynamicTags(dynamicTags ...map[string]struct{}) (out map[string]struct
 }
 
 // FormatConnection converts a ConnectionStats into an model.Connection
-func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionStats, routes map[network.Via]RouteIdx, usmEncoders []USMEncoder, dnsFormatter *dnsFormatter, ipc ipCache, tagsSet *network.TagsSet, sysProbePid uint32) {
+func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionStats, routes map[network.Via]RouteIdx, usmEncoders []USMEncoder, dnsFormatter *dnsFormatter, ipc ipCache, resolvConfFormatter *resolvConfFormatter, tagsSet *network.TagsSet, sysProbePid uint32) {
 
 	builder.SetPid(int32(conn.Pid))
 
@@ -133,6 +133,8 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 		builder.AddTags(t)
 	}
 	builder.SetTagsChecksum(tagChecksum)
+
+	resolvConfFormatter.FormatResolvConfIdx(&conn, builder)
 
 	builder.SetSystemProbeConn(sysProbePid == conn.Pid)
 }

--- a/pkg/network/encoding/marshal/resolv_conf.go
+++ b/pkg/network/encoding/marshal/resolv_conf.go
@@ -40,6 +40,10 @@ func (f *resolvConfFormatter) FormatResolvConfIdx(nc *network.ConnectionStats, b
 }
 
 func (f *resolvConfFormatter) FormatResolvConfs(builder *model.ConnectionsBuilder) {
+	if len(f.resolvConfSet) == 0 {
+		return
+	}
+	// skip over the zero index
 	resolvConfList := make([]string, len(f.resolvConfSet)+1)
 	for resolvConf, idx := range f.resolvConfSet {
 		resolvConfList[idx] = resolvConf.Get()

--- a/pkg/network/encoding/marshal/resolv_conf.go
+++ b/pkg/network/encoding/marshal/resolv_conf.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package marshal
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+)
+
+type resolvConfFormatter struct {
+	conns         *network.Connections
+	resolvConfSet map[network.ResolvConf]int
+}
+
+func newResolvConfFormatter(conns *network.Connections) *resolvConfFormatter {
+	return &resolvConfFormatter{
+		conns:         conns,
+		resolvConfSet: make(map[network.ResolvConf]int),
+	}
+}
+
+func (f *resolvConfFormatter) FormatResolvConfIdx(nc *network.ConnectionStats, builder *model.ConnectionBuilder) {
+	containerID := nc.ContainerID.Source
+	resolvConf, ok := f.conns.ResolvConfs[containerID]
+	if !ok {
+		return
+	}
+
+	resolvConfIdx, ok := f.resolvConfSet[resolvConf]
+	if !ok {
+		resolvConfIdx = len(f.resolvConfSet) + 1
+		f.resolvConfSet[resolvConf] = resolvConfIdx
+	}
+
+	builder.SetResolvConfIdx(int32(resolvConfIdx))
+}
+
+func (f *resolvConfFormatter) FormatResolvConfs(builder *model.ConnectionsBuilder) {
+	resolvConfList := make([]string, len(f.resolvConfSet)+1)
+	for resolvConf, idx := range f.resolvConfSet {
+		resolvConfList[idx] = resolvConf.Get()
+	}
+
+	for _, resolvConf := range resolvConfList {
+		builder.AddResolvConfs(resolvConf)
+	}
+}

--- a/pkg/network/encoding/marshal/resolv_conf_test.go
+++ b/pkg/network/encoding/marshal/resolv_conf_test.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package marshal
+
+import (
+	"testing"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/stretchr/testify/require"
+	"go4.org/intern"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	utilintern "github.com/DataDog/datadog-agent/pkg/util/intern"
+)
+
+func mockConnWithContainer(containerID *intern.Value) *network.ConnectionStats {
+	conn := &network.ConnectionStats{}
+	conn.ContainerID.Source = containerID
+
+	return conn
+}
+
+func getResolvConfIndex(t *testing.T, rcf *resolvConfFormatter, nc *network.ConnectionStats) int32 {
+	streamer := NewProtoTestStreamer[*model.Connection]()
+	builder := model.NewConnectionBuilder(streamer)
+
+	rcf.FormatResolvConfIdx(nc, builder)
+
+	conn := streamer.Unwrap(t, &model.Connection{})
+	return conn.ResolvConfIdx
+}
+
+func TestResolvConfBuilder(t *testing.T) {
+	stringInterner := utilintern.NewStringInterner()
+
+	containerPy1 := intern.GetByString("test-python-container-1")
+	containerPy2 := intern.GetByString("test-python-container-2")
+	containerJava1 := intern.GetByString("test-java-container-2")
+
+	resolvConfData1234 := stringInterner.GetString("nameserver 1.2.3.4")
+	resolvConfData5678 := stringInterner.GetString("nameserver 5.6.7.8")
+
+	resolvConfFormatter := newResolvConfFormatter(&network.Connections{
+		ResolvConfs: map[network.ContainerID]network.ResolvConf{
+			containerPy1:   resolvConfData1234,
+			containerPy2:   resolvConfData1234,
+			containerJava1: resolvConfData5678,
+		},
+	})
+
+	py1Idx := getResolvConfIndex(t, resolvConfFormatter, mockConnWithContainer(containerPy1))
+	require.Equal(t, int32(1), py1Idx, "first connection should have idx=1")
+
+	py2Idx := getResolvConfIndex(t, resolvConfFormatter, mockConnWithContainer(containerPy2))
+	require.Equal(t, int32(1), py2Idx, "second connection with same resolv.conf should have idx=1 too")
+
+	java1Idx := getResolvConfIndex(t, resolvConfFormatter, mockConnWithContainer(containerJava1))
+	require.Equal(t, int32(2), java1Idx, "third connection has a new resolv.conf and should have idx=2")
+
+	streamer := NewProtoTestStreamer[*model.Connections]()
+	builder := model.NewConnectionsBuilder(streamer)
+
+	resolvConfFormatter.FormatResolvConfs(builder)
+
+	conns := streamer.Unwrap(t, &model.Connections{})
+
+	expectedStrings := []string{"", resolvConfData1234.Get(), resolvConfData5678.Get()}
+	require.Equal(t, expectedStrings, conns.ResolvConfs, "resolv.confs should appear in the order of connections")
+}

--- a/pkg/network/encoding/marshal/resolv_conf_test.go
+++ b/pkg/network/encoding/marshal/resolv_conf_test.go
@@ -70,3 +70,16 @@ func TestResolvConfBuilder(t *testing.T) {
 	expectedStrings := []string{"", resolvConfData1234.Get(), resolvConfData5678.Get()}
 	require.Equal(t, expectedStrings, conns.ResolvConfs, "resolv.confs should appear in the order of connections")
 }
+
+func TestResolvConfEmptyBuilder(t *testing.T) {
+	resolvConfFormatter := newResolvConfFormatter(&network.Connections{})
+
+	streamer := NewProtoTestStreamer[*model.Connections]()
+	builder := model.NewConnectionsBuilder(streamer)
+
+	resolvConfFormatter.FormatResolvConfs(builder)
+
+	conns := streamer.Unwrap(t, &model.Connections{})
+
+	require.Nil(t, conns.ResolvConfs)
+}


### PR DESCRIPTION
This PR is stacked on top of [\[tracer\] Collect resolv.conf and attach it to Connections](https://github.com/DataDog/datadog-agent/pull/43099).
### What does this PR do?
This PR marshals resolv.conf data into `CollectorConnections`, to be sent to the intake.

`CollectorConnections` uses a string-indexing based encoding, which is handled by `resolvConfFormatter`.

### Motivation
We want to send this through ultimately to network-dns-logger

### Describe how you validated your changes
New resolv.conf test should pass:
```
go test -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/network/encoding/marshal
```
