### PR TITLE
[CWS] Refactor User Session

### DIFF
--- a/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
+++ b/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
@@ -89,8 +89,7 @@ func injectUserSession(params *InjectCliParams) error {
 	sessionTypeString := params.SessionType
 	if sessionTypeString == "k8s" {
 		sessionType = usersession.UserSessionTypeK8S
-	}
-	if sessionType == 0 {
+	} else {
 		return fmt.Errorf("unknown user session type: %v", params.SessionType)
 	}
 

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -2187,9 +2187,9 @@ Workload Protection events for Linux systems have the following JSON schema:
                     "type": "string",
                     "description": "Unique identifier of the user session on the host"
                 },
-                "username": {
+                "identity": {
                     "type": "string",
-                    "description": "Username of the user session"
+                    "description": "Identity of the user session"
                 },
                 "k8s_session_id": {
                     "type": "string",
@@ -5643,9 +5643,9 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "string",
             "description": "Unique identifier of the user session on the host"
         },
-        "username": {
+        "identity": {
             "type": "string",
-            "description": "Username of the user session"
+            "description": "Identity of the user session"
         },
         "k8s_session_id": {
             "type": "string",
@@ -5708,7 +5708,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | ----- | ----------- |
 | `session_type` | Type of the user session |
 | `id` | Unique identifier of the user session on the host |
-| `username` | Username of the user session |
+| `identity` | Identity of the user session |
 | `k8s_session_id` | Unique identifier of the user session on the host |
 | `k8s_username` | Username of the Kubernetes "kubectl exec" session |
 | `k8s_uid` | UID of the Kubernetes "kubectl exec" session |

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -2179,13 +2179,13 @@ Workload Protection events for Linux systems have the following JSON schema:
         },
         "UserSessionContext": {
             "properties": {
-                "id": {
-                    "type": "string",
-                    "description": "Unique identifier of the user session on the host"
-                },
                 "session_type": {
                     "type": "string",
                     "description": "Type of the user session"
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifier of the user session on the host"
                 },
                 "k8s_username": {
                     "type": "string",
@@ -2211,6 +2211,10 @@ Workload Protection events for Linux systems have the following JSON schema:
                     },
                     "type": "object",
                     "description": "Extra of the Kubernetes \"kubectl exec\" session"
+                },
+                "ssh_session_id": {
+                    "type": "string",
+                    "description": "Unique identifier of the SSH session"
                 },
                 "ssh_port": {
                     "type": "integer",
@@ -5623,13 +5627,13 @@ Workload Protection events for Linux systems have the following JSON schema:
 {{< code-block lang="json" collapsible="true" >}}
 {
     "properties": {
-        "id": {
-            "type": "string",
-            "description": "Unique identifier of the user session on the host"
-        },
         "session_type": {
             "type": "string",
             "description": "Type of the user session"
+        },
+        "id": {
+            "type": "string",
+            "description": "Unique identifier of the user session on the host"
         },
         "k8s_username": {
             "type": "string",
@@ -5655,6 +5659,10 @@ Workload Protection events for Linux systems have the following JSON schema:
             },
             "type": "object",
             "description": "Extra of the Kubernetes \"kubectl exec\" session"
+        },
+        "ssh_session_id": {
+            "type": "string",
+            "description": "Unique identifier of the SSH session"
         },
         "ssh_port": {
             "type": "integer",
@@ -5682,12 +5690,13 @@ Workload Protection events for Linux systems have the following JSON schema:
 
 | Field | Description |
 | ----- | ----------- |
-| `id` | Unique identifier of the user session on the host |
 | `session_type` | Type of the user session |
+| `id` | Unique identifier of the user session on the host |
 | `k8s_username` | Username of the Kubernetes "kubectl exec" session |
 | `k8s_uid` | UID of the Kubernetes "kubectl exec" session |
 | `k8s_groups` | Groups of the Kubernetes "kubectl exec" session |
 | `k8s_extra` | Extra of the Kubernetes "kubectl exec" session |
+| `ssh_session_id` | Unique identifier of the SSH session |
 | `ssh_port` | Port of the SSH session |
 | `ssh_client_ip` | Client IP of the SSH session |
 | `ssh_auth_method` | Authentication method of the SSH session |

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -2187,6 +2187,14 @@ Workload Protection events for Linux systems have the following JSON schema:
                     "type": "string",
                     "description": "Unique identifier of the user session on the host"
                 },
+                "username": {
+                    "type": "string",
+                    "description": "Username of the user session"
+                },
+                "k8s_session_id": {
+                    "type": "string",
+                    "description": "Unique identifier of the user session on the host"
+                },
                 "k8s_username": {
                     "type": "string",
                     "description": "Username of the Kubernetes \"kubectl exec\" session"
@@ -2216,7 +2224,7 @@ Workload Protection events for Linux systems have the following JSON schema:
                     "type": "string",
                     "description": "Unique identifier of the SSH session"
                 },
-                "ssh_port": {
+                "ssh_client_port": {
                     "type": "integer",
                     "description": "Port of the SSH session"
                 },
@@ -5635,6 +5643,14 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "string",
             "description": "Unique identifier of the user session on the host"
         },
+        "username": {
+            "type": "string",
+            "description": "Username of the user session"
+        },
+        "k8s_session_id": {
+            "type": "string",
+            "description": "Unique identifier of the user session on the host"
+        },
         "k8s_username": {
             "type": "string",
             "description": "Username of the Kubernetes \"kubectl exec\" session"
@@ -5664,7 +5680,7 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "string",
             "description": "Unique identifier of the SSH session"
         },
-        "ssh_port": {
+        "ssh_client_port": {
             "type": "integer",
             "description": "Port of the SSH session"
         },
@@ -5692,12 +5708,14 @@ Workload Protection events for Linux systems have the following JSON schema:
 | ----- | ----------- |
 | `session_type` | Type of the user session |
 | `id` | Unique identifier of the user session on the host |
+| `username` | Username of the user session |
+| `k8s_session_id` | Unique identifier of the user session on the host |
 | `k8s_username` | Username of the Kubernetes "kubectl exec" session |
 | `k8s_uid` | UID of the Kubernetes "kubectl exec" session |
 | `k8s_groups` | Groups of the Kubernetes "kubectl exec" session |
 | `k8s_extra` | Extra of the Kubernetes "kubectl exec" session |
 | `ssh_session_id` | Unique identifier of the SSH session |
-| `ssh_port` | Port of the SSH session |
+| `ssh_client_port` | Port of the SSH session |
 | `ssh_client_ip` | Client IP of the SSH session |
 | `ssh_auth_method` | Authentication method of the SSH session |
 | `ssh_public_key` | Public key of the SSH session |

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -2176,6 +2176,14 @@
           "type": "string",
           "description": "Unique identifier of the user session on the host"
         },
+        "username": {
+          "type": "string",
+          "description": "Username of the user session"
+        },
+        "k8s_session_id": {
+          "type": "string",
+          "description": "Unique identifier of the user session on the host"
+        },
         "k8s_username": {
           "type": "string",
           "description": "Username of the Kubernetes \"kubectl exec\" session"
@@ -2205,7 +2213,7 @@
           "type": "string",
           "description": "Unique identifier of the SSH session"
         },
-        "ssh_port": {
+        "ssh_client_port": {
           "type": "integer",
           "description": "Port of the SSH session"
         },

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -2168,13 +2168,13 @@
     },
     "UserSessionContext": {
       "properties": {
-        "id": {
-          "type": "string",
-          "description": "Unique identifier of the user session on the host"
-        },
         "session_type": {
           "type": "string",
           "description": "Type of the user session"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the user session on the host"
         },
         "k8s_username": {
           "type": "string",
@@ -2200,6 +2200,10 @@
           },
           "type": "object",
           "description": "Extra of the Kubernetes \"kubectl exec\" session"
+        },
+        "ssh_session_id": {
+          "type": "string",
+          "description": "Unique identifier of the SSH session"
         },
         "ssh_port": {
           "type": "integer",

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -2176,9 +2176,9 @@
           "type": "string",
           "description": "Unique identifier of the user session on the host"
         },
-        "username": {
+        "identity": {
           "type": "string",
-          "description": "Username of the user session"
+          "description": "Identity of the user session"
         },
         "k8s_session_id": {
           "type": "string",

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -285,15 +285,15 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`process.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`process.ancestors.user`](#common-credentials-user-doc) | User of the process |
-| [`process.ancestors.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`process.ancestors.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`process.ancestors.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`process.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`process.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`process.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`process.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`process.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`process.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`process.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`process.ancestors.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`process.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`process.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`process.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -480,30 +480,30 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`process.parent.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`process.parent.user`](#common-credentials-user-doc) | User of the process |
-| [`process.parent.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`process.parent.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`process.parent.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`process.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`process.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`process.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`process.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`process.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`process.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`process.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`process.parent.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`process.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`process.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`process.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
 | [`process.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`process.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`process.user`](#common-credentials-user-doc) | User of the process |
-| [`process.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`process.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`process.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`process.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`process.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`process.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`process.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`process.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`process.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`process.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`process.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `accept`
 
@@ -873,15 +873,15 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`exec.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`exec.user`](#common-credentials-user-doc) | User of the process |
-| [`exec.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`exec.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`exec.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`exec.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`exec.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`exec.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`exec.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`exec.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`exec.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`exec.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`exec.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `exit`
 
@@ -987,15 +987,15 @@ A process was terminated
 | [`exit.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`exit.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`exit.user`](#common-credentials-user-doc) | User of the process |
-| [`exit.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`exit.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`exit.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`exit.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`exit.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`exit.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`exit.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`exit.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`exit.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`exit.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`exit.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `imds`
 
@@ -1443,15 +1443,15 @@ A ptrace command was executed
 | [`ptrace.tracee.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`ptrace.tracee.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`ptrace.tracee.ancestors.user`](#common-credentials-user-doc) | User of the process |
-| [`ptrace.tracee.ancestors.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`ptrace.tracee.ancestors.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`ptrace.tracee.ancestors.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`ptrace.tracee.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`ptrace.tracee.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`ptrace.tracee.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`ptrace.tracee.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`ptrace.tracee.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`ptrace.tracee.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`ptrace.tracee.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`ptrace.tracee.ancestors.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`ptrace.tracee.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`ptrace.tracee.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`ptrace.tracee.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -1638,30 +1638,30 @@ A ptrace command was executed
 | [`ptrace.tracee.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`ptrace.tracee.parent.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`ptrace.tracee.parent.user`](#common-credentials-user-doc) | User of the process |
-| [`ptrace.tracee.parent.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`ptrace.tracee.parent.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`ptrace.tracee.parent.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`ptrace.tracee.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`ptrace.tracee.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`ptrace.tracee.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`ptrace.tracee.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`ptrace.tracee.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`ptrace.tracee.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`ptrace.tracee.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`ptrace.tracee.parent.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`ptrace.tracee.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`ptrace.tracee.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`ptrace.tracee.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
 | [`ptrace.tracee.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`ptrace.tracee.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`ptrace.tracee.user`](#common-credentials-user-doc) | User of the process |
-| [`ptrace.tracee.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`ptrace.tracee.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`ptrace.tracee.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`ptrace.tracee.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`ptrace.tracee.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`ptrace.tracee.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`ptrace.tracee.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`ptrace.tracee.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`ptrace.tracee.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`ptrace.tracee.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`ptrace.tracee.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `removexattr`
 
@@ -1931,15 +1931,15 @@ A setrlimit command was executed
 | [`setrlimit.target.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`setrlimit.target.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`setrlimit.target.ancestors.user`](#common-credentials-user-doc) | User of the process |
-| [`setrlimit.target.ancestors.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`setrlimit.target.ancestors.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`setrlimit.target.ancestors.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`setrlimit.target.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`setrlimit.target.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`setrlimit.target.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`setrlimit.target.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`setrlimit.target.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`setrlimit.target.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`setrlimit.target.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`setrlimit.target.ancestors.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`setrlimit.target.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`setrlimit.target.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`setrlimit.target.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -2126,30 +2126,30 @@ A setrlimit command was executed
 | [`setrlimit.target.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`setrlimit.target.parent.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`setrlimit.target.parent.user`](#common-credentials-user-doc) | User of the process |
-| [`setrlimit.target.parent.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`setrlimit.target.parent.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`setrlimit.target.parent.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`setrlimit.target.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`setrlimit.target.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`setrlimit.target.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`setrlimit.target.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`setrlimit.target.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`setrlimit.target.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`setrlimit.target.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`setrlimit.target.parent.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`setrlimit.target.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`setrlimit.target.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`setrlimit.target.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
 | [`setrlimit.target.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`setrlimit.target.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`setrlimit.target.user`](#common-credentials-user-doc) | User of the process |
-| [`setrlimit.target.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`setrlimit.target.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`setrlimit.target.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`setrlimit.target.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`setrlimit.target.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`setrlimit.target.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`setrlimit.target.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`setrlimit.target.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`setrlimit.target.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`setrlimit.target.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`setrlimit.target.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `setsockopt`
 
@@ -2324,15 +2324,15 @@ A signal was sent
 | [`signal.target.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`signal.target.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`signal.target.ancestors.user`](#common-credentials-user-doc) | User of the process |
-| [`signal.target.ancestors.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`signal.target.ancestors.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`signal.target.ancestors.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`signal.target.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`signal.target.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`signal.target.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`signal.target.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`signal.target.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`signal.target.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`signal.target.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`signal.target.ancestors.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`signal.target.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`signal.target.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`signal.target.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -2519,30 +2519,30 @@ A signal was sent
 | [`signal.target.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`signal.target.parent.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`signal.target.parent.user`](#common-credentials-user-doc) | User of the process |
-| [`signal.target.parent.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`signal.target.parent.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`signal.target.parent.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`signal.target.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`signal.target.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`signal.target.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`signal.target.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`signal.target.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`signal.target.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`signal.target.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`signal.target.parent.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`signal.target.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`signal.target.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`signal.target.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
 | [`signal.target.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`signal.target.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`signal.target.user`](#common-credentials-user-doc) | User of the process |
-| [`signal.target.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session on the host |
 | [`signal.target.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`signal.target.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
 | [`signal.target.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`signal.target.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`signal.target.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
 | [`signal.target.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
 | [`signal.target.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
 | [`signal.target.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
 | [`signal.target.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`signal.target.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`signal.type`](#signal-type-doc) | Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc) |
 
 ### Event `splice`
@@ -3083,15 +3083,6 @@ Definition: ID of the container
 `exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container` `ptrace.tracee.ancestors.container` `ptrace.tracee.container` `ptrace.tracee.parent.container` `setrlimit.target.ancestors.container` `setrlimit.target.container` `setrlimit.target.parent.container` `signal.target.ancestors.container` `signal.target.container` `signal.target.parent.container`
 
 
-### `*.id` {#common-usersessioncontext-id-doc}
-Type: int
-
-Definition: Unique identifier of the user session on the host
-
-`*.id` has 14 possible prefixes:
-`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
-
-
 ### `*.ifname` {#common-networkdevicecontext-ifname-doc}
 Type: string
 
@@ -3170,6 +3161,15 @@ Type: string
 Definition: Kubernetes groups of the user that executed the process
 
 `*.k8s_groups` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
+
+
+### `*.k8s_session_id` {#common-usersessioncontext-k8s_session_id-doc}
+Type: int
+
+Definition: Kubernetes session ID of the user that executed the process
+
+`*.k8s_session_id` has 14 possible prefixes:
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 
@@ -3451,18 +3451,6 @@ Constants: [File mode constants](#file-mode-constants)
 
 
 
-### `*.session_type` {#common-usersessioncontext-session_type-doc}
-Type: int
-
-Definition: Type of the user session
-
-`*.session_type` has 14 possible prefixes:
-`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
-
-Constants: [UserSessionTypes](#usersessiontypes)
-
-
-
 ### `*.size` {#common-networkcontext-size-doc}
 Type: int
 
@@ -3508,6 +3496,15 @@ Type: string
 Definition: SSH public key used for authentication (if applicable)
 
 `*.ssh_public_key` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
+
+
+### `*.ssh_session_id` {#common-usersessioncontext-ssh_session_id-doc}
+Type: int
+
+Definition: Unique identifier of the SSH user session on the host
+
+`*.ssh_session_id` has 14 possible prefixes:
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -285,15 +285,18 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`process.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`process.ancestors.user`](#common-credentials-user-doc) | User of the process |
-| [`process.ancestors.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`process.ancestors.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`process.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`process.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`process.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`process.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`process.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`process.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`process.ancestors.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`process.ancestors.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`process.ancestors.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`process.ancestors.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`process.ancestors.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`process.ancestors.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`process.ancestors.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`process.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`process.ancestors.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`process.ancestors.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`process.ancestors.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`process.ancestors.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`process.ancestors.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`process.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`process.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`process.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -480,30 +483,36 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`process.parent.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`process.parent.user`](#common-credentials-user-doc) | User of the process |
-| [`process.parent.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`process.parent.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`process.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`process.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`process.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`process.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`process.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`process.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`process.parent.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`process.parent.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`process.parent.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`process.parent.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`process.parent.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`process.parent.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`process.parent.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`process.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`process.parent.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`process.parent.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`process.parent.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`process.parent.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`process.parent.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`process.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`process.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`process.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
 | [`process.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`process.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`process.user`](#common-credentials-user-doc) | User of the process |
-| [`process.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`process.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`process.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`process.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`process.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`process.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`process.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`process.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`process.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`process.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`process.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`process.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`process.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`process.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`process.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`process.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`process.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`process.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`process.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`process.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`process.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `accept`
 
@@ -873,15 +882,18 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`exec.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`exec.user`](#common-credentials-user-doc) | User of the process |
-| [`exec.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`exec.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`exec.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`exec.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`exec.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`exec.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`exec.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`exec.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`exec.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`exec.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`exec.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`exec.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`exec.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`exec.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`exec.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`exec.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`exec.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`exec.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`exec.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`exec.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`exec.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `exit`
 
@@ -987,15 +999,18 @@ A process was terminated
 | [`exit.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`exit.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`exit.user`](#common-credentials-user-doc) | User of the process |
-| [`exit.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`exit.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`exit.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`exit.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`exit.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`exit.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`exit.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`exit.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`exit.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`exit.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`exit.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`exit.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`exit.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`exit.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`exit.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`exit.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`exit.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`exit.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`exit.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`exit.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`exit.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `imds`
 
@@ -1443,15 +1458,18 @@ A ptrace command was executed
 | [`ptrace.tracee.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`ptrace.tracee.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`ptrace.tracee.ancestors.user`](#common-credentials-user-doc) | User of the process |
-| [`ptrace.tracee.ancestors.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`ptrace.tracee.ancestors.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`ptrace.tracee.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`ptrace.tracee.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`ptrace.tracee.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`ptrace.tracee.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`ptrace.tracee.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`ptrace.tracee.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`ptrace.tracee.ancestors.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`ptrace.tracee.ancestors.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`ptrace.tracee.ancestors.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`ptrace.tracee.ancestors.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`ptrace.tracee.ancestors.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`ptrace.tracee.ancestors.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`ptrace.tracee.ancestors.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`ptrace.tracee.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`ptrace.tracee.ancestors.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`ptrace.tracee.ancestors.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`ptrace.tracee.ancestors.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`ptrace.tracee.ancestors.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`ptrace.tracee.ancestors.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`ptrace.tracee.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`ptrace.tracee.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`ptrace.tracee.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -1638,30 +1656,36 @@ A ptrace command was executed
 | [`ptrace.tracee.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`ptrace.tracee.parent.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`ptrace.tracee.parent.user`](#common-credentials-user-doc) | User of the process |
-| [`ptrace.tracee.parent.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`ptrace.tracee.parent.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`ptrace.tracee.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`ptrace.tracee.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`ptrace.tracee.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`ptrace.tracee.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`ptrace.tracee.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`ptrace.tracee.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`ptrace.tracee.parent.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`ptrace.tracee.parent.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`ptrace.tracee.parent.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`ptrace.tracee.parent.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`ptrace.tracee.parent.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`ptrace.tracee.parent.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`ptrace.tracee.parent.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`ptrace.tracee.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`ptrace.tracee.parent.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`ptrace.tracee.parent.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`ptrace.tracee.parent.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`ptrace.tracee.parent.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`ptrace.tracee.parent.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`ptrace.tracee.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`ptrace.tracee.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`ptrace.tracee.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
 | [`ptrace.tracee.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`ptrace.tracee.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`ptrace.tracee.user`](#common-credentials-user-doc) | User of the process |
-| [`ptrace.tracee.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`ptrace.tracee.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`ptrace.tracee.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`ptrace.tracee.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`ptrace.tracee.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`ptrace.tracee.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`ptrace.tracee.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`ptrace.tracee.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`ptrace.tracee.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`ptrace.tracee.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`ptrace.tracee.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`ptrace.tracee.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`ptrace.tracee.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`ptrace.tracee.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`ptrace.tracee.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`ptrace.tracee.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`ptrace.tracee.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`ptrace.tracee.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`ptrace.tracee.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`ptrace.tracee.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`ptrace.tracee.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `removexattr`
 
@@ -1931,15 +1955,18 @@ A setrlimit command was executed
 | [`setrlimit.target.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`setrlimit.target.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`setrlimit.target.ancestors.user`](#common-credentials-user-doc) | User of the process |
-| [`setrlimit.target.ancestors.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`setrlimit.target.ancestors.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`setrlimit.target.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`setrlimit.target.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`setrlimit.target.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`setrlimit.target.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`setrlimit.target.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`setrlimit.target.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`setrlimit.target.ancestors.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`setrlimit.target.ancestors.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`setrlimit.target.ancestors.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`setrlimit.target.ancestors.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`setrlimit.target.ancestors.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`setrlimit.target.ancestors.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`setrlimit.target.ancestors.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`setrlimit.target.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`setrlimit.target.ancestors.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`setrlimit.target.ancestors.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`setrlimit.target.ancestors.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`setrlimit.target.ancestors.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`setrlimit.target.ancestors.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`setrlimit.target.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`setrlimit.target.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`setrlimit.target.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -2126,30 +2153,36 @@ A setrlimit command was executed
 | [`setrlimit.target.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`setrlimit.target.parent.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`setrlimit.target.parent.user`](#common-credentials-user-doc) | User of the process |
-| [`setrlimit.target.parent.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`setrlimit.target.parent.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`setrlimit.target.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`setrlimit.target.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`setrlimit.target.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`setrlimit.target.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`setrlimit.target.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`setrlimit.target.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`setrlimit.target.parent.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`setrlimit.target.parent.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`setrlimit.target.parent.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`setrlimit.target.parent.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`setrlimit.target.parent.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`setrlimit.target.parent.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`setrlimit.target.parent.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`setrlimit.target.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`setrlimit.target.parent.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`setrlimit.target.parent.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`setrlimit.target.parent.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`setrlimit.target.parent.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`setrlimit.target.parent.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`setrlimit.target.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`setrlimit.target.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`setrlimit.target.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
 | [`setrlimit.target.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`setrlimit.target.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`setrlimit.target.user`](#common-credentials-user-doc) | User of the process |
-| [`setrlimit.target.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`setrlimit.target.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`setrlimit.target.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`setrlimit.target.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`setrlimit.target.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`setrlimit.target.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`setrlimit.target.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`setrlimit.target.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`setrlimit.target.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`setrlimit.target.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`setrlimit.target.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`setrlimit.target.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`setrlimit.target.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`setrlimit.target.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`setrlimit.target.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`setrlimit.target.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`setrlimit.target.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`setrlimit.target.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`setrlimit.target.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`setrlimit.target.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`setrlimit.target.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 
 ### Event `setsockopt`
 
@@ -2324,15 +2357,18 @@ A signal was sent
 | [`signal.target.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`signal.target.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`signal.target.ancestors.user`](#common-credentials-user-doc) | User of the process |
-| [`signal.target.ancestors.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`signal.target.ancestors.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`signal.target.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`signal.target.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`signal.target.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`signal.target.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`signal.target.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`signal.target.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`signal.target.ancestors.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`signal.target.ancestors.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`signal.target.ancestors.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`signal.target.ancestors.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`signal.target.ancestors.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`signal.target.ancestors.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`signal.target.ancestors.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`signal.target.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`signal.target.ancestors.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`signal.target.ancestors.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`signal.target.ancestors.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`signal.target.ancestors.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`signal.target.ancestors.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`signal.target.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`signal.target.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`signal.target.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -2519,30 +2555,36 @@ A signal was sent
 | [`signal.target.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`signal.target.parent.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`signal.target.parent.user`](#common-credentials-user-doc) | User of the process |
-| [`signal.target.parent.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`signal.target.parent.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`signal.target.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`signal.target.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`signal.target.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`signal.target.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`signal.target.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`signal.target.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`signal.target.parent.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`signal.target.parent.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`signal.target.parent.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`signal.target.parent.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`signal.target.parent.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`signal.target.parent.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`signal.target.parent.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`signal.target.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`signal.target.parent.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`signal.target.parent.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`signal.target.parent.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`signal.target.parent.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`signal.target.parent.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`signal.target.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`signal.target.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`signal.target.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
 | [`signal.target.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
 | [`signal.target.uid`](#common-credentials-uid-doc) | UID of the process |
 | [`signal.target.user`](#common-credentials-user-doc) | User of the process |
-| [`signal.target.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
-| [`signal.target.user_session.k8s_session_id`](#common-usersessioncontext-k8s_session_id-doc) | Kubernetes session ID of the user that executed the process |
-| [`signal.target.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
-| [`signal.target.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
-| [`signal.target.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
-| [`signal.target.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
-| [`signal.target.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
-| [`signal.target.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
-| [`signal.target.user_session.ssh_session_id`](#common-usersessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
+| [`signal.target.user_session.id`](#common-usersessioncontext-id-doc) | Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type |
+| [`signal.target.user_session.identity`](#common-usersessioncontext-identity-doc) | User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type |
+| [`signal.target.user_session.k8s_groups`](#common-k8ssessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
+| [`signal.target.user_session.k8s_session_id`](#common-k8ssessioncontext-k8s_session_id-doc) | Unique identifier of the kubernetes session |
+| [`signal.target.user_session.k8s_uid`](#common-k8ssessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
+| [`signal.target.user_session.k8s_username`](#common-k8ssessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+| [`signal.target.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`signal.target.user_session.ssh_auth_method`](#common-sshsessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`signal.target.user_session.ssh_client_ip`](#common-sshsessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`signal.target.user_session.ssh_client_port`](#common-sshsessioncontext-ssh_client_port-doc) | SSH client port of the user that executed the process |
+| [`signal.target.user_session.ssh_public_key`](#common-sshsessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
+| [`signal.target.user_session.ssh_session_id`](#common-sshsessioncontext-ssh_session_id-doc) | Unique identifier of the SSH user session on the host |
 | [`signal.type`](#signal-type-doc) | Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc) |
 
 ### Event `splice`
@@ -3083,6 +3125,24 @@ Definition: ID of the container
 `exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container` `ptrace.tracee.ancestors.container` `ptrace.tracee.container` `ptrace.tracee.parent.container` `setrlimit.target.ancestors.container` `setrlimit.target.container` `setrlimit.target.parent.container` `signal.target.ancestors.container` `signal.target.container` `signal.target.parent.container`
 
 
+### `*.id` {#common-usersessioncontext-id-doc}
+Type: string
+
+Definition: Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type
+
+`*.id` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
+
+
+### `*.identity` {#common-usersessioncontext-identity-doc}
+Type: string
+
+Definition: User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type
+
+`*.identity` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
+
+
 ### `*.ifname` {#common-networkdevicecontext-ifname-doc}
 Type: string
 
@@ -3155,7 +3215,7 @@ Definition: Indicates whether the process is considered a thread (that is, a chi
 `exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `setrlimit.target` `setrlimit.target.ancestors` `setrlimit.target.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
 
 
-### `*.k8s_groups` {#common-usersessioncontext-k8s_groups-doc}
+### `*.k8s_groups` {#common-k8ssessioncontext-k8s_groups-doc}
 Type: string
 
 Definition: Kubernetes groups of the user that executed the process
@@ -3164,16 +3224,16 @@ Definition: Kubernetes groups of the user that executed the process
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 
-### `*.k8s_session_id` {#common-usersessioncontext-k8s_session_id-doc}
+### `*.k8s_session_id` {#common-k8ssessioncontext-k8s_session_id-doc}
 Type: int
 
-Definition: Kubernetes session ID of the user that executed the process
+Definition: Unique identifier of the kubernetes session
 
 `*.k8s_session_id` has 14 possible prefixes:
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 
-### `*.k8s_uid` {#common-usersessioncontext-k8s_uid-doc}
+### `*.k8s_uid` {#common-k8ssessioncontext-k8s_uid-doc}
 Type: string
 
 Definition: Kubernetes UID of the user that executed the process
@@ -3182,7 +3242,7 @@ Definition: Kubernetes UID of the user that executed the process
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 
-### `*.k8s_username` {#common-usersessioncontext-k8s_username-doc}
+### `*.k8s_username` {#common-k8ssessioncontext-k8s_username-doc}
 Type: string
 
 Definition: Kubernetes username of the user that executed the process
@@ -3451,6 +3511,15 @@ Constants: [File mode constants](#file-mode-constants)
 
 
 
+### `*.session_type` {#common-usersessioncontext-session_type-doc}
+Type: int
+
+Definition: Type of the user session
+
+`*.session_type` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
+
+
 ### `*.size` {#common-networkcontext-size-doc}
 Type: int
 
@@ -3460,7 +3529,7 @@ Definition: Size in bytes of the network packet
 `network` `packet`
 
 
-### `*.ssh_auth_method` {#common-usersessioncontext-ssh_auth_method-doc}
+### `*.ssh_auth_method` {#common-sshsessioncontext-ssh_auth_method-doc}
 Type: int
 
 Definition: SSH authentication method used by the user
@@ -3472,7 +3541,7 @@ Constants: [SSHAuthMethod](#sshauthmethod)
 
 
 
-### `*.ssh_client_ip` {#common-usersessioncontext-ssh_client_ip-doc}
+### `*.ssh_client_ip` {#common-sshsessioncontext-ssh_client_ip-doc}
 Type: IP/CIDR
 
 Definition: SSH client IP of the user that executed the process
@@ -3481,16 +3550,16 @@ Definition: SSH client IP of the user that executed the process
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 
-### `*.ssh_port` {#common-usersessioncontext-ssh_port-doc}
+### `*.ssh_client_port` {#common-sshsessioncontext-ssh_client_port-doc}
 Type: int
 
-Definition: SSH port of the user that executed the process
+Definition: SSH client port of the user that executed the process
 
-`*.ssh_port` has 14 possible prefixes:
+`*.ssh_client_port` has 14 possible prefixes:
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 
-### `*.ssh_public_key` {#common-usersessioncontext-ssh_public_key-doc}
+### `*.ssh_public_key` {#common-sshsessioncontext-ssh_public_key-doc}
 Type: string
 
 Definition: SSH public key used for authentication (if applicable)
@@ -3499,7 +3568,7 @@ Definition: SSH public key used for authentication (if applicable)
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 
-### `*.ssh_session_id` {#common-usersessioncontext-ssh_session_id-doc}
+### `*.ssh_session_id` {#common-sshsessioncontext-ssh_session_id-doc}
 Type: int
 
 Definition: Unique identifier of the SSH user session on the host

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -533,14 +533,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "process.ancestors.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "process.ancestors.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "process.ancestors.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "process.ancestors.user_session.k8s_uid",
@@ -551,11 +551,6 @@
           "name": "process.ancestors.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "process.ancestors.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "process.ancestors.user_session.ssh_auth_method",
@@ -576,6 +571,11 @@
           "name": "process.ancestors.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "process.ancestors.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "process.args",
@@ -1508,14 +1508,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "process.parent.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "process.parent.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "process.parent.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "process.parent.user_session.k8s_uid",
@@ -1526,11 +1526,6 @@
           "name": "process.parent.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "process.parent.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "process.parent.user_session.ssh_auth_method",
@@ -1551,6 +1546,11 @@
           "name": "process.parent.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "process.parent.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "process.pid",
@@ -1583,14 +1583,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "process.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "process.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "process.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "process.user_session.k8s_uid",
@@ -1601,11 +1601,6 @@
           "name": "process.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "process.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "process.user_session.ssh_auth_method",
@@ -1626,6 +1621,11 @@
           "name": "process.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "process.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -3141,14 +3141,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "exec.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "exec.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "exec.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "exec.user_session.k8s_uid",
@@ -3159,11 +3159,6 @@
           "name": "exec.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "exec.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "exec.user_session.ssh_auth_method",
@@ -3184,6 +3179,11 @@
           "name": "exec.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "exec.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -3685,14 +3685,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "exit.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "exit.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "exit.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "exit.user_session.k8s_uid",
@@ -3703,11 +3703,6 @@
           "name": "exit.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "exit.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "exit.user_session.ssh_auth_method",
@@ -3728,6 +3723,11 @@
           "name": "exit.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "exit.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -5643,14 +5643,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "ptrace.tracee.ancestors.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "ptrace.tracee.ancestors.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.k8s_uid",
@@ -5661,11 +5661,6 @@
           "name": "ptrace.tracee.ancestors.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "ptrace.tracee.ancestors.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.ssh_auth_method",
@@ -5686,6 +5681,11 @@
           "name": "ptrace.tracee.ancestors.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "ptrace.tracee.args",
@@ -6618,14 +6618,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "ptrace.tracee.parent.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "ptrace.tracee.parent.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.k8s_uid",
@@ -6636,11 +6636,6 @@
           "name": "ptrace.tracee.parent.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "ptrace.tracee.parent.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.ssh_auth_method",
@@ -6661,6 +6656,11 @@
           "name": "ptrace.tracee.parent.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "ptrace.tracee.pid",
@@ -6693,14 +6693,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "ptrace.tracee.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "ptrace.tracee.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "ptrace.tracee.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "ptrace.tracee.user_session.k8s_uid",
@@ -6711,11 +6711,6 @@
           "name": "ptrace.tracee.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "ptrace.tracee.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "ptrace.tracee.user_session.ssh_auth_method",
@@ -6736,6 +6731,11 @@
           "name": "ptrace.tracee.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "ptrace.tracee.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -7927,14 +7927,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "setrlimit.target.ancestors.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "setrlimit.target.ancestors.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.k8s_uid",
@@ -7945,11 +7945,6 @@
           "name": "setrlimit.target.ancestors.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "setrlimit.target.ancestors.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.ssh_auth_method",
@@ -7970,6 +7965,11 @@
           "name": "setrlimit.target.ancestors.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "setrlimit.target.args",
@@ -8902,14 +8902,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "setrlimit.target.parent.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "setrlimit.target.parent.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.k8s_uid",
@@ -8920,11 +8920,6 @@
           "name": "setrlimit.target.parent.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "setrlimit.target.parent.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.ssh_auth_method",
@@ -8945,6 +8940,11 @@
           "name": "setrlimit.target.parent.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "setrlimit.target.pid",
@@ -8977,14 +8977,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "setrlimit.target.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "setrlimit.target.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "setrlimit.target.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "setrlimit.target.user_session.k8s_uid",
@@ -8995,11 +8995,6 @@
           "name": "setrlimit.target.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "setrlimit.target.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "setrlimit.target.user_session.ssh_auth_method",
@@ -9020,6 +9015,11 @@
           "name": "setrlimit.target.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "setrlimit.target.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -9788,14 +9788,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "signal.target.ancestors.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "signal.target.ancestors.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "signal.target.ancestors.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.k8s_uid",
@@ -9806,11 +9806,6 @@
           "name": "signal.target.ancestors.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "signal.target.ancestors.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.ssh_auth_method",
@@ -9831,6 +9826,11 @@
           "name": "signal.target.ancestors.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "signal.target.ancestors.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "signal.target.args",
@@ -10763,14 +10763,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "signal.target.parent.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "signal.target.parent.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "signal.target.parent.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "signal.target.parent.user_session.k8s_uid",
@@ -10781,11 +10781,6 @@
           "name": "signal.target.parent.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "signal.target.parent.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "signal.target.parent.user_session.ssh_auth_method",
@@ -10806,6 +10801,11 @@
           "name": "signal.target.parent.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "signal.target.parent.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "signal.target.pid",
@@ -10838,14 +10838,14 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
-          "name": "signal.target.user_session.id",
-          "definition": "Unique identifier of the user session on the host",
-          "property_doc_link": "common-usersessioncontext-id-doc"
-        },
-        {
           "name": "signal.target.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+        },
+        {
+          "name": "signal.target.user_session.k8s_session_id",
+          "definition": "Kubernetes session ID of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
         },
         {
           "name": "signal.target.user_session.k8s_uid",
@@ -10856,11 +10856,6 @@
           "name": "signal.target.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
           "property_doc_link": "common-usersessioncontext-k8s_username-doc"
-        },
-        {
-          "name": "signal.target.user_session.session_type",
-          "definition": "Type of the user session",
-          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "signal.target.user_session.ssh_auth_method",
@@ -10881,6 +10876,11 @@
           "name": "signal.target.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
           "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
+          "name": "signal.target.user_session.ssh_session_id",
+          "definition": "Unique identifier of the SSH user session on the host",
+          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
         },
         {
           "name": "signal.type",
@@ -12572,31 +12572,6 @@
       "examples": []
     },
     {
-      "name": "*.id",
-      "link": "common-usersessioncontext-id-doc",
-      "type": "int",
-      "definition": "Unique identifier of the user session on the host",
-      "prefixes": [
-        "exec.user_session",
-        "exit.user_session",
-        "process.ancestors.user_session",
-        "process.parent.user_session",
-        "process.user_session",
-        "ptrace.tracee.ancestors.user_session",
-        "ptrace.tracee.parent.user_session",
-        "ptrace.tracee.user_session",
-        "setrlimit.target.ancestors.user_session",
-        "setrlimit.target.parent.user_session",
-        "setrlimit.target.user_session",
-        "signal.target.ancestors.user_session",
-        "signal.target.parent.user_session",
-        "signal.target.user_session"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
       "name": "*.ifname",
       "link": "common-networkdevicecontext-ifname-doc",
       "type": "string",
@@ -12858,6 +12833,31 @@
       "link": "common-usersessioncontext-k8s_groups-doc",
       "type": "string",
       "definition": "Kubernetes groups of the user that executed the process",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.k8s_session_id",
+      "link": "common-usersessioncontext-k8s_session_id-doc",
+      "type": "int",
+      "definition": "Kubernetes session ID of the user that executed the process",
       "prefixes": [
         "exec.user_session",
         "exit.user_session",
@@ -14081,31 +14081,6 @@
       "examples": []
     },
     {
-      "name": "*.session_type",
-      "link": "common-usersessioncontext-session_type-doc",
-      "type": "int",
-      "definition": "Type of the user session",
-      "prefixes": [
-        "exec.user_session",
-        "exit.user_session",
-        "process.ancestors.user_session",
-        "process.parent.user_session",
-        "process.user_session",
-        "ptrace.tracee.ancestors.user_session",
-        "ptrace.tracee.parent.user_session",
-        "ptrace.tracee.user_session",
-        "setrlimit.target.ancestors.user_session",
-        "setrlimit.target.parent.user_session",
-        "setrlimit.target.user_session",
-        "signal.target.ancestors.user_session",
-        "signal.target.parent.user_session",
-        "signal.target.user_session"
-      ],
-      "constants": "UserSessionTypes",
-      "constants_link": "usersessiontypes",
-      "examples": []
-    },
-    {
       "name": "*.size",
       "link": "common-networkcontext-size-doc",
       "type": "int",
@@ -14198,6 +14173,31 @@
       "link": "common-usersessioncontext-ssh_public_key-doc",
       "type": "string",
       "definition": "SSH public key used for authentication (if applicable)",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.ssh_session_id",
+      "link": "common-usersessioncontext-ssh_session_id-doc",
+      "type": "int",
+      "definition": "Unique identifier of the SSH user session on the host",
       "prefixes": [
         "exec.user_session",
         "exit.user_session",

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -533,49 +533,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "process.ancestors.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "process.ancestors.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "process.ancestors.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "process.ancestors.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "process.ancestors.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "process.ancestors.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "process.ancestors.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "process.ancestors.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "process.ancestors.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "process.ancestors.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "process.ancestors.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "process.ancestors.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "process.ancestors.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "process.args",
@@ -1508,49 +1523,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "process.parent.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "process.parent.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "process.parent.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "process.parent.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "process.parent.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "process.parent.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "process.parent.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "process.parent.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "process.parent.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "process.parent.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "process.parent.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "process.parent.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "process.parent.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "process.pid",
@@ -1583,49 +1613,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "process.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "process.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "process.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "process.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "process.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "process.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "process.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "process.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "process.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "process.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "process.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "process.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "process.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -3141,49 +3186,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "exec.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "exec.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "exec.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "exec.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "exec.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "exec.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "exec.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "exec.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "exec.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "exec.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "exec.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "exec.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "exec.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -3685,49 +3745,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "exit.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "exit.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "exit.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "exit.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "exit.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "exit.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "exit.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "exit.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "exit.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "exit.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "exit.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "exit.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "exit.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -5643,49 +5718,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "ptrace.tracee.ancestors.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "ptrace.tracee.ancestors.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "ptrace.tracee.ancestors.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "ptrace.tracee.ancestors.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "ptrace.tracee.args",
@@ -6618,49 +6708,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "ptrace.tracee.parent.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "ptrace.tracee.parent.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "ptrace.tracee.parent.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "ptrace.tracee.parent.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "ptrace.tracee.parent.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "ptrace.tracee.pid",
@@ -6693,49 +6798,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "ptrace.tracee.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "ptrace.tracee.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "ptrace.tracee.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "ptrace.tracee.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "ptrace.tracee.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "ptrace.tracee.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "ptrace.tracee.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "ptrace.tracee.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "ptrace.tracee.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "ptrace.tracee.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "ptrace.tracee.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "ptrace.tracee.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "ptrace.tracee.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -7927,49 +8047,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "setrlimit.target.ancestors.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "setrlimit.target.ancestors.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "setrlimit.target.ancestors.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "setrlimit.target.ancestors.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "setrlimit.target.ancestors.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "setrlimit.target.args",
@@ -8902,49 +9037,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "setrlimit.target.parent.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "setrlimit.target.parent.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "setrlimit.target.parent.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "setrlimit.target.parent.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "setrlimit.target.parent.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "setrlimit.target.pid",
@@ -8977,49 +9127,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "setrlimit.target.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "setrlimit.target.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "setrlimit.target.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "setrlimit.target.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "setrlimit.target.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "setrlimit.target.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "setrlimit.target.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "setrlimit.target.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "setrlimit.target.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "setrlimit.target.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "setrlimit.target.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "setrlimit.target.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "setrlimit.target.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         }
       ]
     },
@@ -9788,49 +9953,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "signal.target.ancestors.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "signal.target.ancestors.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "signal.target.ancestors.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "signal.target.ancestors.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "signal.target.ancestors.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "signal.target.ancestors.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "signal.target.ancestors.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "signal.target.args",
@@ -10763,49 +10943,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "signal.target.parent.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "signal.target.parent.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "signal.target.parent.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "signal.target.parent.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "signal.target.parent.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "signal.target.parent.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "signal.target.parent.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "signal.target.parent.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "signal.target.parent.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "signal.target.parent.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "signal.target.parent.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "signal.target.parent.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "signal.target.parent.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "signal.target.pid",
@@ -10838,49 +11033,64 @@
           "property_doc_link": "common-credentials-user-doc"
         },
         {
+          "name": "signal.target.user_session.id",
+          "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-id-doc"
+        },
+        {
+          "name": "signal.target.user_session.identity",
+          "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+          "property_doc_link": "common-usersessioncontext-identity-doc"
+        },
+        {
           "name": "signal.target.user_session.k8s_groups",
           "definition": "Kubernetes groups of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_groups-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_groups-doc"
         },
         {
           "name": "signal.target.user_session.k8s_session_id",
-          "definition": "Kubernetes session ID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_session_id-doc"
+          "definition": "Unique identifier of the kubernetes session",
+          "property_doc_link": "common-k8ssessioncontext-k8s_session_id-doc"
         },
         {
           "name": "signal.target.user_session.k8s_uid",
           "definition": "Kubernetes UID of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_uid-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_uid-doc"
         },
         {
           "name": "signal.target.user_session.k8s_username",
           "definition": "Kubernetes username of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-k8s_username-doc"
+          "property_doc_link": "common-k8ssessioncontext-k8s_username-doc"
+        },
+        {
+          "name": "signal.target.user_session.session_type",
+          "definition": "Type of the user session",
+          "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
           "name": "signal.target.user_session.ssh_auth_method",
           "definition": "SSH authentication method used by the user",
-          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_auth_method-doc"
         },
         {
           "name": "signal.target.user_session.ssh_client_ip",
           "definition": "SSH client IP of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_client_ip-doc"
         },
         {
-          "name": "signal.target.user_session.ssh_port",
-          "definition": "SSH port of the user that executed the process",
-          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+          "name": "signal.target.user_session.ssh_client_port",
+          "definition": "SSH client port of the user that executed the process",
+          "property_doc_link": "common-sshsessioncontext-ssh_client_port-doc"
         },
         {
           "name": "signal.target.user_session.ssh_public_key",
           "definition": "SSH public key used for authentication (if applicable)",
-          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_public_key-doc"
         },
         {
           "name": "signal.target.user_session.ssh_session_id",
           "definition": "Unique identifier of the SSH user session on the host",
-          "property_doc_link": "common-usersessioncontext-ssh_session_id-doc"
+          "property_doc_link": "common-sshsessioncontext-ssh_session_id-doc"
         },
         {
           "name": "signal.type",
@@ -12572,6 +12782,56 @@
       "examples": []
     },
     {
+      "name": "*.id",
+      "link": "common-usersessioncontext-id-doc",
+      "type": "string",
+      "definition": "Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.identity",
+      "link": "common-usersessioncontext-identity-doc",
+      "type": "string",
+      "definition": "User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
       "name": "*.ifname",
       "link": "common-networkdevicecontext-ifname-doc",
       "type": "string",
@@ -12830,7 +13090,7 @@
     },
     {
       "name": "*.k8s_groups",
-      "link": "common-usersessioncontext-k8s_groups-doc",
+      "link": "common-k8ssessioncontext-k8s_groups-doc",
       "type": "string",
       "definition": "Kubernetes groups of the user that executed the process",
       "prefixes": [
@@ -12855,9 +13115,9 @@
     },
     {
       "name": "*.k8s_session_id",
-      "link": "common-usersessioncontext-k8s_session_id-doc",
+      "link": "common-k8ssessioncontext-k8s_session_id-doc",
       "type": "int",
-      "definition": "Kubernetes session ID of the user that executed the process",
+      "definition": "Unique identifier of the kubernetes session",
       "prefixes": [
         "exec.user_session",
         "exit.user_session",
@@ -12880,7 +13140,7 @@
     },
     {
       "name": "*.k8s_uid",
-      "link": "common-usersessioncontext-k8s_uid-doc",
+      "link": "common-k8ssessioncontext-k8s_uid-doc",
       "type": "string",
       "definition": "Kubernetes UID of the user that executed the process",
       "prefixes": [
@@ -12905,7 +13165,7 @@
     },
     {
       "name": "*.k8s_username",
-      "link": "common-usersessioncontext-k8s_username-doc",
+      "link": "common-k8ssessioncontext-k8s_username-doc",
       "type": "string",
       "definition": "Kubernetes username of the user that executed the process",
       "prefixes": [
@@ -14081,6 +14341,31 @@
       "examples": []
     },
     {
+      "name": "*.session_type",
+      "link": "common-usersessioncontext-session_type-doc",
+      "type": "int",
+      "definition": "Type of the user session",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
       "name": "*.size",
       "link": "common-networkcontext-size-doc",
       "type": "int",
@@ -14095,7 +14380,7 @@
     },
     {
       "name": "*.ssh_auth_method",
-      "link": "common-usersessioncontext-ssh_auth_method-doc",
+      "link": "common-sshsessioncontext-ssh_auth_method-doc",
       "type": "int",
       "definition": "SSH authentication method used by the user",
       "prefixes": [
@@ -14120,7 +14405,7 @@
     },
     {
       "name": "*.ssh_client_ip",
-      "link": "common-usersessioncontext-ssh_client_ip-doc",
+      "link": "common-sshsessioncontext-ssh_client_ip-doc",
       "type": "IP/CIDR",
       "definition": "SSH client IP of the user that executed the process",
       "prefixes": [
@@ -14144,10 +14429,10 @@
       "examples": []
     },
     {
-      "name": "*.ssh_port",
-      "link": "common-usersessioncontext-ssh_port-doc",
+      "name": "*.ssh_client_port",
+      "link": "common-sshsessioncontext-ssh_client_port-doc",
       "type": "int",
-      "definition": "SSH port of the user that executed the process",
+      "definition": "SSH client port of the user that executed the process",
       "prefixes": [
         "exec.user_session",
         "exit.user_session",
@@ -14170,7 +14455,7 @@
     },
     {
       "name": "*.ssh_public_key",
-      "link": "common-usersessioncontext-ssh_public_key-doc",
+      "link": "common-sshsessioncontext-ssh_public_key-doc",
       "type": "string",
       "definition": "SSH public key used for authentication (if applicable)",
       "prefixes": [
@@ -14195,7 +14480,7 @@
     },
     {
       "name": "*.ssh_session_id",
-      "link": "common-usersessioncontext-ssh_session_id-doc",
+      "link": "common-sshsessioncontext-ssh_session_id-doc",
       "type": "int",
       "definition": "Unique identifier of the SSH user session on the host",
       "prefixes": [

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -284,11 +283,10 @@ func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher 
 				model.InitUserSessionTypes()
 			}
 			// Create the user session context serializer
-			userSessionCtx := &serializers.UserSessionContextSerializer{
-				SSHSessionID: fmt.Sprintf("%x", ev.ProcessContext.UserSession.SSHSessionID),
-				SessionType:  model.UserSessionTypeStrings[usersession.UserSessionTypeSSH],
-				SSHPort:      ev.ProcessContext.UserSession.SSHPort,
-				SSHClientIP:  ev.ProcessContext.UserSession.SSHClientIP.IP.String(),
+			userSessionCtx := &serializers.SSHSessionContextSerializer{
+				SSHSessionID:  fmt.Sprintf("%x", ev.ProcessContext.UserSession.SSHSessionID),
+				SSHClientPort: ev.ProcessContext.UserSession.SSHClientPort,
+				SSHClientIP:   ev.ProcessContext.UserSession.SSHClientIP.IP.String(),
 			}
 			return probe.NewSSHUserSessionPatcher(
 				userSessionCtx,

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -276,7 +276,8 @@ type sshSessionPatcher = *probe.SSHUserSessionPatcher
 
 // createSSHSessionPatcher creates an SSH session patcher for Linux
 func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher {
-	if ev.ProcessContext.UserSession.ID != 0 && ev.ProcessContext.UserSession.SessionType == int(usersession.UserSessionTypeSSH) {
+	// Check if SSH session exists
+	if ev.ProcessContext.UserSession.SSHSessionID != 0 {
 		// Access the EBPFProbe to get the UserSessionsResolver
 		if ebpfProbe, ok := p.PlatformProbe.(*probe.EBPFProbe); ok {
 			if model.UserSessionTypeStrings == nil {
@@ -284,10 +285,10 @@ func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher 
 			}
 			// Create the user session context serializer
 			userSessionCtx := &serializers.UserSessionContextSerializer{
-				ID:          fmt.Sprintf("%x", ev.ProcessContext.UserSession.ID),
-				SessionType: model.UserSessionTypeStrings[usersession.Type(ev.ProcessContext.UserSession.SessionType)],
-				SSHPort:     ev.ProcessContext.UserSession.SSHPort,
-				SSHClientIP: ev.ProcessContext.UserSession.SSHClientIP.IP.String(),
+				SSHSessionID: fmt.Sprintf("%x", ev.ProcessContext.UserSession.SSHSessionID),
+				SessionType:  model.UserSessionTypeStrings[usersession.UserSessionTypeSSH],
+				SSHPort:      ev.ProcessContext.UserSession.SSHPort,
+				SSHClientIP:  ev.ProcessContext.UserSession.SSHClientIP.IP.String(),
 			}
 			return probe.NewSSHUserSessionPatcher(
 				userSessionCtx,

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	sprocess "github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/security/utils/lru/simplelru"
@@ -634,14 +635,14 @@ func (fh *EBPFFieldHandlers) ResolveProcessCreatedAt(_ *model.Event, e *model.Pr
 	return int(e.ExecTime.UnixNano())
 }
 
-// ResolveUserSessionContext resolves and updates the provided user session context
-func (fh *EBPFFieldHandlers) ResolveUserSessionContext(event *model.Event, evtCtx *model.UserSessionContext) {
+// ResolveK8SUserSessionContext resolves and updates the provided user session context
+func (fh *EBPFFieldHandlers) ResolveK8SUserSessionContext(event *model.Event, evtCtx *model.K8SSessionContext) {
 	if !evtCtx.K8SResolved {
 		id := evtCtx.K8SSessionID
 		if id == 0 {
 			id = event.ProcessContext.UserSessionID
 		}
-		ctx := fh.resolvers.UserSessionsResolver.ResolveUserSession(id)
+		ctx := fh.resolvers.UserSessionsResolver.ResolveK8SUserSession(id)
 		if ctx != nil {
 			*evtCtx = *ctx
 		}
@@ -742,20 +743,20 @@ func (fh *EBPFFieldHandlers) ResolveFileMetadataIsGarbleObfuscated(event *model.
 }
 
 // ResolveK8SUsername resolves the k8s username of the event
-func (fh *EBPFFieldHandlers) ResolveK8SUsername(event *model.Event, evtCtx *model.UserSessionContext) string {
-	fh.ResolveUserSessionContext(event, evtCtx)
+func (fh *EBPFFieldHandlers) ResolveK8SUsername(event *model.Event, evtCtx *model.K8SSessionContext) string {
+	fh.ResolveK8SUserSessionContext(event, evtCtx)
 	return evtCtx.K8SUsername
 }
 
 // ResolveK8SUID resolves the k8s UID of the event
-func (fh *EBPFFieldHandlers) ResolveK8SUID(event *model.Event, evtCtx *model.UserSessionContext) string {
-	fh.ResolveUserSessionContext(event, evtCtx)
+func (fh *EBPFFieldHandlers) ResolveK8SUID(event *model.Event, evtCtx *model.K8SSessionContext) string {
+	fh.ResolveK8SUserSessionContext(event, evtCtx)
 	return evtCtx.K8SUID
 }
 
 // ResolveK8SGroups resolves the k8s groups of the event
-func (fh *EBPFFieldHandlers) ResolveK8SGroups(event *model.Event, evtCtx *model.UserSessionContext) []string {
-	fh.ResolveUserSessionContext(event, evtCtx)
+func (fh *EBPFFieldHandlers) ResolveK8SGroups(event *model.Event, evtCtx *model.K8SSessionContext) []string {
+	fh.ResolveK8SUserSessionContext(event, evtCtx)
 	return evtCtx.K8SGroups
 }
 
@@ -1040,11 +1041,59 @@ func (fh *EBPFFieldHandlers) ResolveCapabilitiesUsed(evt *model.Event, ce *model
 }
 
 // ResolveSSHClientIP resolves the ssh username of the event
-func (fh *EBPFFieldHandlers) ResolveSSHClientIP(_ *model.Event, evtCtx *model.UserSessionContext) net.IPNet {
+func (fh *EBPFFieldHandlers) ResolveSSHClientIP(_ *model.Event, evtCtx *model.SSHSessionContext) net.IPNet {
 	return evtCtx.SSHClientIP
 }
 
-// ResolveSSHPort resolves the public key of the event
-func (fh *EBPFFieldHandlers) ResolveSSHPort(_ *model.Event, evtCtx *model.UserSessionContext) int {
-	return evtCtx.SSHPort
+// ResolveSSHClientPort resolves the public key of the event
+func (fh *EBPFFieldHandlers) ResolveSSHClientPort(_ *model.Event, evtCtx *model.SSHSessionContext) int {
+	return evtCtx.SSHClientPort
+}
+
+// ResolveSessionType resolves the session type of the event
+func (fh *EBPFFieldHandlers) ResolveSessionType(e *model.Event, evtCtx *model.UserSessionContext) int {
+	// Resolve K8S user session to have the ID if it exists
+	fh.ResolveK8SUserSessionContext(e, &evtCtx.K8SSessionContext)
+	var sessionType int
+	if evtCtx.K8SSessionID != 0 {
+		sessionType = int(usersession.UserSessionTypeK8S)
+	} else if evtCtx.SSHSessionID != 0 {
+		sessionType = int(usersession.UserSessionTypeSSH)
+	} else {
+		sessionType = int(usersession.UserSessionTypeUnknown)
+	}
+	evtCtx.SessionType = sessionType
+	return sessionType
+}
+
+// ResolveSessionID resolves the session id of the event
+func (fh *EBPFFieldHandlers) ResolveSessionID(e *model.Event, evtCtx *model.UserSessionContext) string {
+	// Resolve K8S user session to have the ID if it exists
+	fh.ResolveK8SUserSessionContext(e, &evtCtx.K8SSessionContext)
+	var sessionID string
+	if evtCtx.K8SSessionID != 0 {
+		sessionID = fmt.Sprintf("%x", evtCtx.K8SSessionID)
+	} else if evtCtx.SSHSessionID != 0 {
+		sessionID = fmt.Sprintf("%x", evtCtx.SSHSessionID)
+	} else {
+		sessionID = ""
+	}
+	evtCtx.ID = sessionID
+	return sessionID
+}
+
+// ResolveSessionIdentity resolves the user of the event
+func (fh *EBPFFieldHandlers) ResolveSessionIdentity(e *model.Event, evtCtx *model.UserSessionContext) string {
+	// Resolve K8S user session to have the ID if it exists
+	fh.ResolveK8SUserSessionContext(e, &evtCtx.K8SSessionContext)
+	var sessionIdentity string
+	if evtCtx.K8SUsername != "" {
+		sessionIdentity = evtCtx.K8SUsername
+	} else if evtCtx.SSHClientPort != 0 {
+		sessionIdentity = fmt.Sprintf("%s:%d", evtCtx.SSHClientIP.String(), evtCtx.SSHClientPort)
+	} else {
+		sessionIdentity = e.ProcessContext.User
+	}
+	evtCtx.Identity = sessionIdentity
+	return sessionIdentity
 }

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -636,8 +636,8 @@ func (fh *EBPFFieldHandlers) ResolveProcessCreatedAt(_ *model.Event, e *model.Pr
 
 // ResolveUserSessionContext resolves and updates the provided user session context
 func (fh *EBPFFieldHandlers) ResolveUserSessionContext(event *model.Event, evtCtx *model.UserSessionContext) {
-	if !evtCtx.Resolved {
-		id := evtCtx.ID
+	if !evtCtx.K8SResolved {
+		id := evtCtx.K8SSessionID
 		if id == 0 {
 			id = event.ProcessContext.UserSessionID
 		}

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -299,17 +299,17 @@ func (fh *EBPFLessFieldHandlers) ResolveFileMetadataIsGarbleObfuscated(_ *model.
 }
 
 // ResolveK8SGroups resolves the k8s groups of the event
-func (fh *EBPFLessFieldHandlers) ResolveK8SGroups(_ *model.Event, e *model.UserSessionContext) []string {
+func (fh *EBPFLessFieldHandlers) ResolveK8SGroups(_ *model.Event, e *model.K8SSessionContext) []string {
 	return e.K8SGroups
 }
 
 // ResolveK8SUID resolves the k8s UID of the event
-func (fh *EBPFLessFieldHandlers) ResolveK8SUID(_ *model.Event, e *model.UserSessionContext) string {
+func (fh *EBPFLessFieldHandlers) ResolveK8SUID(_ *model.Event, e *model.K8SSessionContext) string {
 	return e.K8SUID
 }
 
 // ResolveK8SUsername resolves the k8s username of the event
-func (fh *EBPFLessFieldHandlers) ResolveK8SUsername(_ *model.Event, e *model.UserSessionContext) string {
+func (fh *EBPFLessFieldHandlers) ResolveK8SUsername(_ *model.Event, e *model.K8SSessionContext) string {
 	return e.K8SUsername
 }
 
@@ -438,8 +438,8 @@ func (fh *EBPFLessFieldHandlers) ResolveHashesFromEvent(ev *model.Event, f *mode
 	return fh.resolvers.HashResolver.ComputeHashesFromEvent(ev, f)
 }
 
-// ResolveUserSessionContext resolves and updates the provided user session context
-func (fh *EBPFLessFieldHandlers) ResolveUserSessionContext(_ *model.Event, _ *model.UserSessionContext) {
+// ResolveK8SUserSessionContext resolves and updates the provided user session context
+func (fh *EBPFLessFieldHandlers) ResolveK8SUserSessionContext(_ *model.Event, _ *model.K8SSessionContext) {
 }
 
 // ResolveProcessCmdArgv resolves the command line
@@ -624,11 +624,26 @@ func (fh *EBPFLessFieldHandlers) ResolveCapabilitiesUsed(_ *model.Event, _ *mode
 }
 
 // ResolveSSHClientIP resolves the ssh username of the event
-func (fh *EBPFLessFieldHandlers) ResolveSSHClientIP(_ *model.Event, _ *model.UserSessionContext) net.IPNet {
+func (fh *EBPFLessFieldHandlers) ResolveSSHClientIP(_ *model.Event, _ *model.SSHSessionContext) net.IPNet {
 	return net.IPNet{} // EBPFLess mode does not support SSH
 }
 
-// ResolveSSHPort resolves the public key of the event
-func (fh *EBPFLessFieldHandlers) ResolveSSHPort(_ *model.Event, _ *model.UserSessionContext) int {
-	return 0 //EBPFLess mode does not support SSH port
+// ResolveSSHClientPort resolves the public key of the event
+func (fh *EBPFLessFieldHandlers) ResolveSSHClientPort(_ *model.Event, _ *model.SSHSessionContext) int {
+	return 0 // EBPFLess mode does not support SSH port
+}
+
+// ResolveSessionType resolves the session type of the event
+func (fh *EBPFLessFieldHandlers) ResolveSessionType(_ *model.Event, _ *model.UserSessionContext) int {
+	return 0
+}
+
+// ResolveSessionID resolves the session id of the event
+func (fh *EBPFLessFieldHandlers) ResolveSessionID(_ *model.Event, _ *model.UserSessionContext) string {
+	return ""
+}
+
+// ResolveSessionIdentity resolves the user of the event
+func (fh *EBPFLessFieldHandlers) ResolveSessionIdentity(_ *model.Event, _ *model.UserSessionContext) string {
+	return ""
 }

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -47,7 +47,7 @@ func (p *EBPFProbe) HandleSSHUserSession(event *model.Event) {
 	// If the parent is a sshd process and the SSH_CLIENT environment variable is set, we consider it's a new ssh session
 	if parent != nil && parent.Comm == "sshd" && sshClientVar != "" {
 		sshSessionID := rand.Uint64()
-		event.ProcessContext.UserSession.ID = sshSessionID
+		event.ProcessContext.UserSession.SSHSessionID = sshSessionID
 		event.ProcessContext.UserSession.SessionType = int(usersession.UserSessionTypeSSH)
 		parts := strings.Fields(sshClientVar)
 		if len(parts) >= 2 {

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -51,6 +51,9 @@ func (e *UserSessionData) UnmarshalBinary(data []byte) error {
 	}
 
 	e.SessionType = usersession.Type(data[0])
+	if e.SessionType != usersession.UserSessionTypeK8S {
+		seclog.Debugf("not k8s session: %v", e.SessionType)
+	}
 	e.RawData += model.NullTerminatedString(data[1:240])
 	return nil
 }

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -3332,17 +3332,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "exec.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.Exec.Process.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "exec.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -3352,6 +3341,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.Exec.Process.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "exec.user_session.k8s_uid":
@@ -3374,17 +3374,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "exec.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.Exec.Process.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "exec.user_session.ssh_auth_method":
@@ -3426,6 +3415,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.Exec.Process.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exec.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.Exec.Process.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4667,17 +4667,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "exit.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.Exit.Process.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "exit.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -4687,6 +4676,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.Exit.Process.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "exit.user_session.k8s_uid":
@@ -4709,17 +4709,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "exit.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.Exit.Process.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "exit.user_session.ssh_auth_method":
@@ -4761,6 +4750,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.Exit.Process.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exit.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.Exit.Process.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -10800,33 +10800,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
-	case "process.ancestors.user_session.id":
-		return &eval.IntArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
-				if regID != "" {
-					element := iterator.At(ctx, regID, ctx.Registers[regID])
-					if element == nil {
-						return nil
-					}
-					result := int(element.ProcessContext.Process.UserSession.ID)
-					return []int{result}
-				}
-				if result, ok := ctx.IntCache[field]; ok {
-					return result
-				}
-				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.ID)
-				})
-				ctx.IntCache[field] = results
-				return results
-			},
-			Field:  field,
-			Weight: eval.IteratorWeight,
-			Offset: offset,
-		}, nil
 	case "process.ancestors.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -10848,6 +10821,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.user_session.k8s_session_id":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.K8SSessionID)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.K8SSessionID)
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -10902,33 +10902,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession)
 				})
 				ctx.StringCache[field] = results
-				return results
-			},
-			Field:  field,
-			Weight: eval.IteratorWeight,
-			Offset: offset,
-		}, nil
-	case "process.ancestors.user_session.session_type":
-		return &eval.IntArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
-				if regID != "" {
-					element := iterator.At(ctx, regID, ctx.Registers[regID])
-					if element == nil {
-						return nil
-					}
-					result := int(element.ProcessContext.Process.UserSession.SessionType)
-					return []int{result}
-				}
-				if result, ok := ctx.IntCache[field]; ok {
-					return result
-				}
-				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SessionType)
-				})
-				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -11037,6 +11010,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return current.ProcessContext.Process.UserSession.SSHPublicKey
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.user_session.ssh_session_id":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionID)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHSessionID)
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -13681,20 +13681,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "process.parent.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				if !ev.BaseEvent.ProcessContext.HasParent() {
-					return 0
-				}
-				return int(ev.BaseEvent.ProcessContext.Parent.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "process.parent.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -13707,6 +13693,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "process.parent.user_session.k8s_uid":
@@ -13735,20 +13735,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "process.parent.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				if !ev.BaseEvent.ProcessContext.HasParent() {
-					return 0
-				}
-				return ev.BaseEvent.ProcessContext.Parent.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "process.parent.user_session.ssh_auth_method":
@@ -13802,6 +13788,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return int(ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -13873,17 +13873,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "process.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.BaseEvent.ProcessContext.Process.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "process.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -13893,6 +13882,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "process.user_session.k8s_uid":
@@ -13915,17 +13915,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "process.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.BaseEvent.ProcessContext.Process.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "process.user_session.ssh_auth_method":
@@ -13967,6 +13956,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "process.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -16905,33 +16905,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
-	case "ptrace.tracee.ancestors.user_session.id":
-		return &eval.IntArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
-				if regID != "" {
-					element := iterator.At(ctx, regID, ctx.Registers[regID])
-					if element == nil {
-						return nil
-					}
-					result := int(element.ProcessContext.Process.UserSession.ID)
-					return []int{result}
-				}
-				if result, ok := ctx.IntCache[field]; ok {
-					return result
-				}
-				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.ID)
-				})
-				ctx.IntCache[field] = results
-				return results
-			},
-			Field:  field,
-			Weight: eval.IteratorWeight,
-			Offset: offset,
-		}, nil
 	case "ptrace.tracee.ancestors.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -16953,6 +16926,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.user_session.k8s_session_id":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.K8SSessionID)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.K8SSessionID)
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -17007,33 +17007,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession)
 				})
 				ctx.StringCache[field] = results
-				return results
-			},
-			Field:  field,
-			Weight: eval.IteratorWeight,
-			Offset: offset,
-		}, nil
-	case "ptrace.tracee.ancestors.user_session.session_type":
-		return &eval.IntArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
-				if regID != "" {
-					element := iterator.At(ctx, regID, ctx.Registers[regID])
-					if element == nil {
-						return nil
-					}
-					result := int(element.ProcessContext.Process.UserSession.SessionType)
-					return []int{result}
-				}
-				if result, ok := ctx.IntCache[field]; ok {
-					return result
-				}
-				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SessionType)
-				})
-				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -17142,6 +17115,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return current.ProcessContext.Process.UserSession.SSHPublicKey
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.user_session.ssh_session_id":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionID)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHSessionID)
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -19786,20 +19786,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "ptrace.tracee.parent.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				if !ev.PTrace.Tracee.HasParent() {
-					return 0
-				}
-				return int(ev.PTrace.Tracee.Parent.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "ptrace.tracee.parent.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -19812,6 +19798,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				return int(ev.PTrace.Tracee.Parent.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.parent.user_session.k8s_uid":
@@ -19840,20 +19840,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "ptrace.tracee.parent.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				if !ev.PTrace.Tracee.HasParent() {
-					return 0
-				}
-				return ev.PTrace.Tracee.Parent.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.parent.user_session.ssh_auth_method":
@@ -19907,6 +19893,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.PTrace.Tracee.Parent.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				return int(ev.PTrace.Tracee.Parent.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -19978,17 +19978,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "ptrace.tracee.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.PTrace.Tracee.Process.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "ptrace.tracee.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -19998,6 +19987,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.PTrace.Tracee.Process.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.user_session.k8s_uid":
@@ -20020,17 +20020,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "ptrace.tracee.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.PTrace.Tracee.Process.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.user_session.ssh_auth_method":
@@ -20072,6 +20061,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.PTrace.Tracee.Process.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.PTrace.Tracee.Process.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -24434,33 +24434,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
-	case "setrlimit.target.ancestors.user_session.id":
-		return &eval.IntArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
-				if regID != "" {
-					element := iterator.At(ctx, regID, ctx.Registers[regID])
-					if element == nil {
-						return nil
-					}
-					result := int(element.ProcessContext.Process.UserSession.ID)
-					return []int{result}
-				}
-				if result, ok := ctx.IntCache[field]; ok {
-					return result
-				}
-				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.ID)
-				})
-				ctx.IntCache[field] = results
-				return results
-			},
-			Field:  field,
-			Weight: eval.IteratorWeight,
-			Offset: offset,
-		}, nil
 	case "setrlimit.target.ancestors.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -24482,6 +24455,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.user_session.k8s_session_id":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.K8SSessionID)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.K8SSessionID)
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -24536,33 +24536,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession)
 				})
 				ctx.StringCache[field] = results
-				return results
-			},
-			Field:  field,
-			Weight: eval.IteratorWeight,
-			Offset: offset,
-		}, nil
-	case "setrlimit.target.ancestors.user_session.session_type":
-		return &eval.IntArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
-				if regID != "" {
-					element := iterator.At(ctx, regID, ctx.Registers[regID])
-					if element == nil {
-						return nil
-					}
-					result := int(element.ProcessContext.Process.UserSession.SessionType)
-					return []int{result}
-				}
-				if result, ok := ctx.IntCache[field]; ok {
-					return result
-				}
-				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SessionType)
-				})
-				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -24671,6 +24644,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return current.ProcessContext.Process.UserSession.SSHPublicKey
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.user_session.ssh_session_id":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionID)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHSessionID)
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -27315,20 +27315,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "setrlimit.target.parent.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				if !ev.Setrlimit.Target.HasParent() {
-					return 0
-				}
-				return int(ev.Setrlimit.Target.Parent.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "setrlimit.target.parent.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -27341,6 +27327,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				return int(ev.Setrlimit.Target.Parent.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.parent.user_session.k8s_uid":
@@ -27369,20 +27369,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "setrlimit.target.parent.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				if !ev.Setrlimit.Target.HasParent() {
-					return 0
-				}
-				return ev.Setrlimit.Target.Parent.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.parent.user_session.ssh_auth_method":
@@ -27436,6 +27422,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.Setrlimit.Target.Parent.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				return int(ev.Setrlimit.Target.Parent.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -27507,17 +27507,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "setrlimit.target.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.Setrlimit.Target.Process.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "setrlimit.target.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -27527,6 +27516,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.Setrlimit.Target.Process.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.user_session.k8s_uid":
@@ -27549,17 +27549,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "setrlimit.target.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.Setrlimit.Target.Process.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.user_session.ssh_auth_method":
@@ -27601,6 +27590,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.Setrlimit.Target.Process.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.Setrlimit.Target.Process.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -31060,33 +31060,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
-	case "signal.target.ancestors.user_session.id":
-		return &eval.IntArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
-				if regID != "" {
-					element := iterator.At(ctx, regID, ctx.Registers[regID])
-					if element == nil {
-						return nil
-					}
-					result := int(element.ProcessContext.Process.UserSession.ID)
-					return []int{result}
-				}
-				if result, ok := ctx.IntCache[field]; ok {
-					return result
-				}
-				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.ID)
-				})
-				ctx.IntCache[field] = results
-				return results
-			},
-			Field:  field,
-			Weight: eval.IteratorWeight,
-			Offset: offset,
-		}, nil
 	case "signal.target.ancestors.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -31108,6 +31081,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.user_session.k8s_session_id":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.K8SSessionID)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.K8SSessionID)
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -31162,33 +31162,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession)
 				})
 				ctx.StringCache[field] = results
-				return results
-			},
-			Field:  field,
-			Weight: eval.IteratorWeight,
-			Offset: offset,
-		}, nil
-	case "signal.target.ancestors.user_session.session_type":
-		return &eval.IntArrayEvaluator{
-			EvalFnc: func(ctx *eval.Context) []int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
-				if regID != "" {
-					element := iterator.At(ctx, regID, ctx.Registers[regID])
-					if element == nil {
-						return nil
-					}
-					result := int(element.ProcessContext.Process.UserSession.SessionType)
-					return []int{result}
-				}
-				if result, ok := ctx.IntCache[field]; ok {
-					return result
-				}
-				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SessionType)
-				})
-				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -31297,6 +31270,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return current.ProcessContext.Process.UserSession.SSHPublicKey
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.user_session.ssh_session_id":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionID)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHSessionID)
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -33941,20 +33941,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "signal.target.parent.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				if !ev.Signal.Target.HasParent() {
-					return 0
-				}
-				return int(ev.Signal.Target.Parent.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "signal.target.parent.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -33967,6 +33953,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				return int(ev.Signal.Target.Parent.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.parent.user_session.k8s_uid":
@@ -33995,20 +33995,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "signal.target.parent.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				if !ev.Signal.Target.HasParent() {
-					return 0
-				}
-				return ev.Signal.Target.Parent.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.parent.user_session.ssh_auth_method":
@@ -34062,6 +34048,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return ev.Signal.Target.Parent.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				return int(ev.Signal.Target.Parent.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -34133,17 +34133,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "signal.target.user_session.id":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return int(ev.Signal.Target.Process.UserSession.ID)
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "signal.target.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -34153,6 +34142,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.user_session.k8s_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.Signal.Target.Process.UserSession.K8SSessionID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.user_session.k8s_uid":
@@ -34175,17 +34175,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
-			Offset: offset,
-		}, nil
-	case "signal.target.user_session.session_type":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.Signal.Target.Process.UserSession.SessionType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.user_session.ssh_auth_method":
@@ -34227,6 +34216,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.Signal.Target.Process.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.user_session.ssh_session_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.Signal.Target.Process.UserSession.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -35648,15 +35648,15 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.tty_name",
 		"exec.uid",
 		"exec.user",
-		"exec.user_session.id",
 		"exec.user_session.k8s_groups",
+		"exec.user_session.k8s_session_id",
 		"exec.user_session.k8s_uid",
 		"exec.user_session.k8s_username",
-		"exec.user_session.session_type",
 		"exec.user_session.ssh_auth_method",
 		"exec.user_session.ssh_client_ip",
 		"exec.user_session.ssh_port",
 		"exec.user_session.ssh_public_key",
+		"exec.user_session.ssh_session_id",
 		"exit.args",
 		"exit.args_flags",
 		"exit.args_options",
@@ -35755,15 +35755,15 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.tty_name",
 		"exit.uid",
 		"exit.user",
-		"exit.user_session.id",
 		"exit.user_session.k8s_groups",
+		"exit.user_session.k8s_session_id",
 		"exit.user_session.k8s_uid",
 		"exit.user_session.k8s_username",
-		"exit.user_session.session_type",
 		"exit.user_session.ssh_auth_method",
 		"exit.user_session.ssh_client_ip",
 		"exit.user_session.ssh_port",
 		"exit.user_session.ssh_public_key",
+		"exit.user_session.ssh_session_id",
 		"imds.aws.is_imds_v2",
 		"imds.aws.security_credentials.type",
 		"imds.cloud_provider",
@@ -36124,15 +36124,15 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.tty_name",
 		"process.ancestors.uid",
 		"process.ancestors.user",
-		"process.ancestors.user_session.id",
 		"process.ancestors.user_session.k8s_groups",
+		"process.ancestors.user_session.k8s_session_id",
 		"process.ancestors.user_session.k8s_uid",
 		"process.ancestors.user_session.k8s_username",
-		"process.ancestors.user_session.session_type",
 		"process.ancestors.user_session.ssh_auth_method",
 		"process.ancestors.user_session.ssh_client_ip",
 		"process.ancestors.user_session.ssh_port",
 		"process.ancestors.user_session.ssh_public_key",
+		"process.ancestors.user_session.ssh_session_id",
 		"process.args",
 		"process.args_flags",
 		"process.args_options",
@@ -36319,30 +36319,30 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.tty_name",
 		"process.parent.uid",
 		"process.parent.user",
-		"process.parent.user_session.id",
 		"process.parent.user_session.k8s_groups",
+		"process.parent.user_session.k8s_session_id",
 		"process.parent.user_session.k8s_uid",
 		"process.parent.user_session.k8s_username",
-		"process.parent.user_session.session_type",
 		"process.parent.user_session.ssh_auth_method",
 		"process.parent.user_session.ssh_client_ip",
 		"process.parent.user_session.ssh_port",
 		"process.parent.user_session.ssh_public_key",
+		"process.parent.user_session.ssh_session_id",
 		"process.pid",
 		"process.ppid",
 		"process.tid",
 		"process.tty_name",
 		"process.uid",
 		"process.user",
-		"process.user_session.id",
 		"process.user_session.k8s_groups",
+		"process.user_session.k8s_session_id",
 		"process.user_session.k8s_uid",
 		"process.user_session.k8s_username",
-		"process.user_session.session_type",
 		"process.user_session.ssh_auth_method",
 		"process.user_session.ssh_client_ip",
 		"process.user_session.ssh_port",
 		"process.user_session.ssh_public_key",
+		"process.user_session.ssh_session_id",
 		"ptrace.request",
 		"ptrace.retval",
 		"ptrace.tracee.ancestors.args",
@@ -36442,15 +36442,15 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.ancestors.tty_name",
 		"ptrace.tracee.ancestors.uid",
 		"ptrace.tracee.ancestors.user",
-		"ptrace.tracee.ancestors.user_session.id",
 		"ptrace.tracee.ancestors.user_session.k8s_groups",
+		"ptrace.tracee.ancestors.user_session.k8s_session_id",
 		"ptrace.tracee.ancestors.user_session.k8s_uid",
 		"ptrace.tracee.ancestors.user_session.k8s_username",
-		"ptrace.tracee.ancestors.user_session.session_type",
 		"ptrace.tracee.ancestors.user_session.ssh_auth_method",
 		"ptrace.tracee.ancestors.user_session.ssh_client_ip",
 		"ptrace.tracee.ancestors.user_session.ssh_port",
 		"ptrace.tracee.ancestors.user_session.ssh_public_key",
+		"ptrace.tracee.ancestors.user_session.ssh_session_id",
 		"ptrace.tracee.args",
 		"ptrace.tracee.args_flags",
 		"ptrace.tracee.args_options",
@@ -36637,30 +36637,30 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.parent.tty_name",
 		"ptrace.tracee.parent.uid",
 		"ptrace.tracee.parent.user",
-		"ptrace.tracee.parent.user_session.id",
 		"ptrace.tracee.parent.user_session.k8s_groups",
+		"ptrace.tracee.parent.user_session.k8s_session_id",
 		"ptrace.tracee.parent.user_session.k8s_uid",
 		"ptrace.tracee.parent.user_session.k8s_username",
-		"ptrace.tracee.parent.user_session.session_type",
 		"ptrace.tracee.parent.user_session.ssh_auth_method",
 		"ptrace.tracee.parent.user_session.ssh_client_ip",
 		"ptrace.tracee.parent.user_session.ssh_port",
 		"ptrace.tracee.parent.user_session.ssh_public_key",
+		"ptrace.tracee.parent.user_session.ssh_session_id",
 		"ptrace.tracee.pid",
 		"ptrace.tracee.ppid",
 		"ptrace.tracee.tid",
 		"ptrace.tracee.tty_name",
 		"ptrace.tracee.uid",
 		"ptrace.tracee.user",
-		"ptrace.tracee.user_session.id",
 		"ptrace.tracee.user_session.k8s_groups",
+		"ptrace.tracee.user_session.k8s_session_id",
 		"ptrace.tracee.user_session.k8s_uid",
 		"ptrace.tracee.user_session.k8s_username",
-		"ptrace.tracee.user_session.session_type",
 		"ptrace.tracee.user_session.ssh_auth_method",
 		"ptrace.tracee.user_session.ssh_client_ip",
 		"ptrace.tracee.user_session.ssh_port",
 		"ptrace.tracee.user_session.ssh_public_key",
+		"ptrace.tracee.user_session.ssh_session_id",
 		"removexattr.file.change_time",
 		"removexattr.file.destination.name",
 		"removexattr.file.destination.namespace",
@@ -36888,15 +36888,15 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.ancestors.tty_name",
 		"setrlimit.target.ancestors.uid",
 		"setrlimit.target.ancestors.user",
-		"setrlimit.target.ancestors.user_session.id",
 		"setrlimit.target.ancestors.user_session.k8s_groups",
+		"setrlimit.target.ancestors.user_session.k8s_session_id",
 		"setrlimit.target.ancestors.user_session.k8s_uid",
 		"setrlimit.target.ancestors.user_session.k8s_username",
-		"setrlimit.target.ancestors.user_session.session_type",
 		"setrlimit.target.ancestors.user_session.ssh_auth_method",
 		"setrlimit.target.ancestors.user_session.ssh_client_ip",
 		"setrlimit.target.ancestors.user_session.ssh_port",
 		"setrlimit.target.ancestors.user_session.ssh_public_key",
+		"setrlimit.target.ancestors.user_session.ssh_session_id",
 		"setrlimit.target.args",
 		"setrlimit.target.args_flags",
 		"setrlimit.target.args_options",
@@ -37083,30 +37083,30 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.parent.tty_name",
 		"setrlimit.target.parent.uid",
 		"setrlimit.target.parent.user",
-		"setrlimit.target.parent.user_session.id",
 		"setrlimit.target.parent.user_session.k8s_groups",
+		"setrlimit.target.parent.user_session.k8s_session_id",
 		"setrlimit.target.parent.user_session.k8s_uid",
 		"setrlimit.target.parent.user_session.k8s_username",
-		"setrlimit.target.parent.user_session.session_type",
 		"setrlimit.target.parent.user_session.ssh_auth_method",
 		"setrlimit.target.parent.user_session.ssh_client_ip",
 		"setrlimit.target.parent.user_session.ssh_port",
 		"setrlimit.target.parent.user_session.ssh_public_key",
+		"setrlimit.target.parent.user_session.ssh_session_id",
 		"setrlimit.target.pid",
 		"setrlimit.target.ppid",
 		"setrlimit.target.tid",
 		"setrlimit.target.tty_name",
 		"setrlimit.target.uid",
 		"setrlimit.target.user",
-		"setrlimit.target.user_session.id",
 		"setrlimit.target.user_session.k8s_groups",
+		"setrlimit.target.user_session.k8s_session_id",
 		"setrlimit.target.user_session.k8s_uid",
 		"setrlimit.target.user_session.k8s_username",
-		"setrlimit.target.user_session.session_type",
 		"setrlimit.target.user_session.ssh_auth_method",
 		"setrlimit.target.user_session.ssh_client_ip",
 		"setrlimit.target.user_session.ssh_port",
 		"setrlimit.target.user_session.ssh_public_key",
+		"setrlimit.target.user_session.ssh_session_id",
 		"setsockopt.filter_hash",
 		"setsockopt.filter_instructions",
 		"setsockopt.filter_len",
@@ -37253,15 +37253,15 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.ancestors.tty_name",
 		"signal.target.ancestors.uid",
 		"signal.target.ancestors.user",
-		"signal.target.ancestors.user_session.id",
 		"signal.target.ancestors.user_session.k8s_groups",
+		"signal.target.ancestors.user_session.k8s_session_id",
 		"signal.target.ancestors.user_session.k8s_uid",
 		"signal.target.ancestors.user_session.k8s_username",
-		"signal.target.ancestors.user_session.session_type",
 		"signal.target.ancestors.user_session.ssh_auth_method",
 		"signal.target.ancestors.user_session.ssh_client_ip",
 		"signal.target.ancestors.user_session.ssh_port",
 		"signal.target.ancestors.user_session.ssh_public_key",
+		"signal.target.ancestors.user_session.ssh_session_id",
 		"signal.target.args",
 		"signal.target.args_flags",
 		"signal.target.args_options",
@@ -37448,30 +37448,30 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.parent.tty_name",
 		"signal.target.parent.uid",
 		"signal.target.parent.user",
-		"signal.target.parent.user_session.id",
 		"signal.target.parent.user_session.k8s_groups",
+		"signal.target.parent.user_session.k8s_session_id",
 		"signal.target.parent.user_session.k8s_uid",
 		"signal.target.parent.user_session.k8s_username",
-		"signal.target.parent.user_session.session_type",
 		"signal.target.parent.user_session.ssh_auth_method",
 		"signal.target.parent.user_session.ssh_client_ip",
 		"signal.target.parent.user_session.ssh_port",
 		"signal.target.parent.user_session.ssh_public_key",
+		"signal.target.parent.user_session.ssh_session_id",
 		"signal.target.pid",
 		"signal.target.ppid",
 		"signal.target.tid",
 		"signal.target.tty_name",
 		"signal.target.uid",
 		"signal.target.user",
-		"signal.target.user_session.id",
 		"signal.target.user_session.k8s_groups",
+		"signal.target.user_session.k8s_session_id",
 		"signal.target.user_session.k8s_uid",
 		"signal.target.user_session.k8s_username",
-		"signal.target.user_session.session_type",
 		"signal.target.user_session.ssh_auth_method",
 		"signal.target.user_session.ssh_client_ip",
 		"signal.target.user_session.ssh_port",
 		"signal.target.user_session.ssh_public_key",
+		"signal.target.user_session.ssh_session_id",
 		"signal.type",
 		"splice.file.change_time",
 		"splice.file.extension",
@@ -38143,16 +38143,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.user":
 		return "exec", reflect.String, "string", false, nil
-	case "exec.user_session.id":
-		return "exec", reflect.Int, "int", false, nil
 	case "exec.user_session.k8s_groups":
 		return "exec", reflect.String, "string", true, nil
+	case "exec.user_session.k8s_session_id":
+		return "exec", reflect.Int, "int", false, nil
 	case "exec.user_session.k8s_uid":
 		return "exec", reflect.String, "string", false, nil
 	case "exec.user_session.k8s_username":
 		return "exec", reflect.String, "string", false, nil
-	case "exec.user_session.session_type":
-		return "exec", reflect.Int, "int", false, nil
 	case "exec.user_session.ssh_auth_method":
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.user_session.ssh_client_ip":
@@ -38161,6 +38159,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.user_session.ssh_public_key":
 		return "exec", reflect.String, "string", false, nil
+	case "exec.user_session.ssh_session_id":
+		return "exec", reflect.Int, "int", false, nil
 	case "exit.args":
 		return "exit", reflect.String, "string", false, nil
 	case "exit.args_flags":
@@ -38357,16 +38357,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.user":
 		return "exit", reflect.String, "string", false, nil
-	case "exit.user_session.id":
-		return "exit", reflect.Int, "int", false, nil
 	case "exit.user_session.k8s_groups":
 		return "exit", reflect.String, "string", true, nil
+	case "exit.user_session.k8s_session_id":
+		return "exit", reflect.Int, "int", false, nil
 	case "exit.user_session.k8s_uid":
 		return "exit", reflect.String, "string", false, nil
 	case "exit.user_session.k8s_username":
 		return "exit", reflect.String, "string", false, nil
-	case "exit.user_session.session_type":
-		return "exit", reflect.Int, "int", false, nil
 	case "exit.user_session.ssh_auth_method":
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.user_session.ssh_client_ip":
@@ -38375,6 +38373,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.user_session.ssh_public_key":
 		return "exit", reflect.String, "string", false, nil
+	case "exit.user_session.ssh_session_id":
+		return "exit", reflect.Int, "int", false, nil
 	case "imds.aws.is_imds_v2":
 		return "imds", reflect.Bool, "bool", false, nil
 	case "imds.aws.security_credentials.type":
@@ -39095,16 +39095,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user":
 		return "", reflect.String, "string", false, nil
-	case "process.ancestors.user_session.id":
-		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user_session.k8s_groups":
 		return "", reflect.String, "string", true, nil
+	case "process.ancestors.user_session.k8s_session_id":
+		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user_session.k8s_uid":
 		return "", reflect.String, "string", false, nil
 	case "process.ancestors.user_session.k8s_username":
 		return "", reflect.String, "string", false, nil
-	case "process.ancestors.user_session.session_type":
-		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user_session.ssh_auth_method":
 		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user_session.ssh_client_ip":
@@ -39113,6 +39111,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user_session.ssh_public_key":
 		return "", reflect.String, "string", false, nil
+	case "process.ancestors.user_session.ssh_session_id":
+		return "", reflect.Int, "int", false, nil
 	case "process.args":
 		return "", reflect.String, "string", false, nil
 	case "process.args_flags":
@@ -39485,16 +39485,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.parent.user":
 		return "", reflect.String, "string", false, nil
-	case "process.parent.user_session.id":
-		return "", reflect.Int, "int", false, nil
 	case "process.parent.user_session.k8s_groups":
 		return "", reflect.String, "string", true, nil
+	case "process.parent.user_session.k8s_session_id":
+		return "", reflect.Int, "int", false, nil
 	case "process.parent.user_session.k8s_uid":
 		return "", reflect.String, "string", false, nil
 	case "process.parent.user_session.k8s_username":
 		return "", reflect.String, "string", false, nil
-	case "process.parent.user_session.session_type":
-		return "", reflect.Int, "int", false, nil
 	case "process.parent.user_session.ssh_auth_method":
 		return "", reflect.Int, "int", false, nil
 	case "process.parent.user_session.ssh_client_ip":
@@ -39503,6 +39501,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.parent.user_session.ssh_public_key":
 		return "", reflect.String, "string", false, nil
+	case "process.parent.user_session.ssh_session_id":
+		return "", reflect.Int, "int", false, nil
 	case "process.pid":
 		return "", reflect.Int, "int", false, nil
 	case "process.ppid":
@@ -39515,16 +39515,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.user":
 		return "", reflect.String, "string", false, nil
-	case "process.user_session.id":
-		return "", reflect.Int, "int", false, nil
 	case "process.user_session.k8s_groups":
 		return "", reflect.String, "string", true, nil
+	case "process.user_session.k8s_session_id":
+		return "", reflect.Int, "int", false, nil
 	case "process.user_session.k8s_uid":
 		return "", reflect.String, "string", false, nil
 	case "process.user_session.k8s_username":
 		return "", reflect.String, "string", false, nil
-	case "process.user_session.session_type":
-		return "", reflect.Int, "int", false, nil
 	case "process.user_session.ssh_auth_method":
 		return "", reflect.Int, "int", false, nil
 	case "process.user_session.ssh_client_ip":
@@ -39533,6 +39531,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.user_session.ssh_public_key":
 		return "", reflect.String, "string", false, nil
+	case "process.user_session.ssh_session_id":
+		return "", reflect.Int, "int", false, nil
 	case "ptrace.request":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.retval":
@@ -39731,16 +39731,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user":
 		return "ptrace", reflect.String, "string", false, nil
-	case "ptrace.tracee.ancestors.user_session.id":
-		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user_session.k8s_groups":
 		return "ptrace", reflect.String, "string", true, nil
+	case "ptrace.tracee.ancestors.user_session.k8s_session_id":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user_session.k8s_uid":
 		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.ancestors.user_session.k8s_username":
 		return "ptrace", reflect.String, "string", false, nil
-	case "ptrace.tracee.ancestors.user_session.session_type":
-		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user_session.ssh_auth_method":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user_session.ssh_client_ip":
@@ -39749,6 +39747,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user_session.ssh_public_key":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.ancestors.user_session.ssh_session_id":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.args":
 		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.args_flags":
@@ -40121,16 +40121,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user":
 		return "ptrace", reflect.String, "string", false, nil
-	case "ptrace.tracee.parent.user_session.id":
-		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user_session.k8s_groups":
 		return "ptrace", reflect.String, "string", true, nil
+	case "ptrace.tracee.parent.user_session.k8s_session_id":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user_session.k8s_uid":
 		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.parent.user_session.k8s_username":
 		return "ptrace", reflect.String, "string", false, nil
-	case "ptrace.tracee.parent.user_session.session_type":
-		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user_session.ssh_auth_method":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user_session.ssh_client_ip":
@@ -40139,6 +40137,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user_session.ssh_public_key":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.parent.user_session.ssh_session_id":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.pid":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ppid":
@@ -40151,16 +40151,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user":
 		return "ptrace", reflect.String, "string", false, nil
-	case "ptrace.tracee.user_session.id":
-		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user_session.k8s_groups":
 		return "ptrace", reflect.String, "string", true, nil
+	case "ptrace.tracee.user_session.k8s_session_id":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user_session.k8s_uid":
 		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.user_session.k8s_username":
 		return "ptrace", reflect.String, "string", false, nil
-	case "ptrace.tracee.user_session.session_type":
-		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user_session.ssh_auth_method":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user_session.ssh_client_ip":
@@ -40169,6 +40167,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user_session.ssh_public_key":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.user_session.ssh_session_id":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "removexattr.file.change_time":
 		return "removexattr", reflect.Int, "int", false, nil
 	case "removexattr.file.destination.name":
@@ -40623,16 +40623,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user":
 		return "setrlimit", reflect.String, "string", false, nil
-	case "setrlimit.target.ancestors.user_session.id":
-		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user_session.k8s_groups":
 		return "setrlimit", reflect.String, "string", true, nil
+	case "setrlimit.target.ancestors.user_session.k8s_session_id":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user_session.k8s_uid":
 		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.ancestors.user_session.k8s_username":
 		return "setrlimit", reflect.String, "string", false, nil
-	case "setrlimit.target.ancestors.user_session.session_type":
-		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user_session.ssh_auth_method":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user_session.ssh_client_ip":
@@ -40641,6 +40639,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user_session.ssh_public_key":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.ancestors.user_session.ssh_session_id":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.args":
 		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.args_flags":
@@ -41013,16 +41013,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user":
 		return "setrlimit", reflect.String, "string", false, nil
-	case "setrlimit.target.parent.user_session.id":
-		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user_session.k8s_groups":
 		return "setrlimit", reflect.String, "string", true, nil
+	case "setrlimit.target.parent.user_session.k8s_session_id":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user_session.k8s_uid":
 		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.parent.user_session.k8s_username":
 		return "setrlimit", reflect.String, "string", false, nil
-	case "setrlimit.target.parent.user_session.session_type":
-		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user_session.ssh_auth_method":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user_session.ssh_client_ip":
@@ -41031,6 +41029,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user_session.ssh_public_key":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.parent.user_session.ssh_session_id":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.pid":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ppid":
@@ -41043,16 +41043,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user":
 		return "setrlimit", reflect.String, "string", false, nil
-	case "setrlimit.target.user_session.id":
-		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user_session.k8s_groups":
 		return "setrlimit", reflect.String, "string", true, nil
+	case "setrlimit.target.user_session.k8s_session_id":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user_session.k8s_uid":
 		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.user_session.k8s_username":
 		return "setrlimit", reflect.String, "string", false, nil
-	case "setrlimit.target.user_session.session_type":
-		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user_session.ssh_auth_method":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user_session.ssh_client_ip":
@@ -41061,6 +41059,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user_session.ssh_public_key":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.user_session.ssh_session_id":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setsockopt.filter_hash":
 		return "setsockopt", reflect.String, "string", false, nil
 	case "setsockopt.filter_instructions":
@@ -41353,16 +41353,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user":
 		return "signal", reflect.String, "string", false, nil
-	case "signal.target.ancestors.user_session.id":
-		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user_session.k8s_groups":
 		return "signal", reflect.String, "string", true, nil
+	case "signal.target.ancestors.user_session.k8s_session_id":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user_session.k8s_uid":
 		return "signal", reflect.String, "string", false, nil
 	case "signal.target.ancestors.user_session.k8s_username":
 		return "signal", reflect.String, "string", false, nil
-	case "signal.target.ancestors.user_session.session_type":
-		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user_session.ssh_auth_method":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user_session.ssh_client_ip":
@@ -41371,6 +41369,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user_session.ssh_public_key":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.ancestors.user_session.ssh_session_id":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.args":
 		return "signal", reflect.String, "string", false, nil
 	case "signal.target.args_flags":
@@ -41743,16 +41743,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user":
 		return "signal", reflect.String, "string", false, nil
-	case "signal.target.parent.user_session.id":
-		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user_session.k8s_groups":
 		return "signal", reflect.String, "string", true, nil
+	case "signal.target.parent.user_session.k8s_session_id":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user_session.k8s_uid":
 		return "signal", reflect.String, "string", false, nil
 	case "signal.target.parent.user_session.k8s_username":
 		return "signal", reflect.String, "string", false, nil
-	case "signal.target.parent.user_session.session_type":
-		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user_session.ssh_auth_method":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user_session.ssh_client_ip":
@@ -41761,6 +41759,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user_session.ssh_public_key":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.parent.user_session.ssh_session_id":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.pid":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ppid":
@@ -41773,16 +41773,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user":
 		return "signal", reflect.String, "string", false, nil
-	case "signal.target.user_session.id":
-		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user_session.k8s_groups":
 		return "signal", reflect.String, "string", true, nil
+	case "signal.target.user_session.k8s_session_id":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user_session.k8s_uid":
 		return "signal", reflect.String, "string", false, nil
 	case "signal.target.user_session.k8s_username":
 		return "signal", reflect.String, "string", false, nil
-	case "signal.target.user_session.session_type":
-		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user_session.ssh_auth_method":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user_session.ssh_client_ip":
@@ -41791,6 +41789,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user_session.ssh_public_key":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.user_session.ssh_session_id":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.type":
 		return "signal", reflect.Int, "int", false, nil
 	case "splice.file.change_time":
@@ -42700,16 +42700,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("exec.uid", &ev.Exec.Process.Credentials.UID, value)
 	case "exec.user":
 		return ev.setStringFieldValue("exec.user", &ev.Exec.Process.Credentials.User, value)
-	case "exec.user_session.id":
-		return ev.setUint64FieldValue("exec.user_session.id", &ev.Exec.Process.UserSession.ID, value)
 	case "exec.user_session.k8s_groups":
 		return ev.setStringArrayFieldValue("exec.user_session.k8s_groups", &ev.Exec.Process.UserSession.K8SGroups, value)
+	case "exec.user_session.k8s_session_id":
+		return ev.setUint64FieldValue("exec.user_session.k8s_session_id", &ev.Exec.Process.UserSession.K8SSessionID, value)
 	case "exec.user_session.k8s_uid":
 		return ev.setStringFieldValue("exec.user_session.k8s_uid", &ev.Exec.Process.UserSession.K8SUID, value)
 	case "exec.user_session.k8s_username":
 		return ev.setStringFieldValue("exec.user_session.k8s_username", &ev.Exec.Process.UserSession.K8SUsername, value)
-	case "exec.user_session.session_type":
-		return ev.setIntFieldValue("exec.user_session.session_type", &ev.Exec.Process.UserSession.SessionType, value)
 	case "exec.user_session.ssh_auth_method":
 		return ev.setIntFieldValue("exec.user_session.ssh_auth_method", &ev.Exec.Process.UserSession.SSHAuthMethod, value)
 	case "exec.user_session.ssh_client_ip":
@@ -42723,6 +42721,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setIntFieldValue("exec.user_session.ssh_port", &ev.Exec.Process.UserSession.SSHPort, value)
 	case "exec.user_session.ssh_public_key":
 		return ev.setStringFieldValue("exec.user_session.ssh_public_key", &ev.Exec.Process.UserSession.SSHPublicKey, value)
+	case "exec.user_session.ssh_session_id":
+		return ev.setUint64FieldValue("exec.user_session.ssh_session_id", &ev.Exec.Process.UserSession.SSHSessionID, value)
 	case "exit.args":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -43317,16 +43317,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Exit.Process = &Process{}
 		}
 		return ev.setStringFieldValue("exit.user", &ev.Exit.Process.Credentials.User, value)
-	case "exit.user_session.id":
-		if ev.Exit.Process == nil {
-			ev.Exit.Process = &Process{}
-		}
-		return ev.setUint64FieldValue("exit.user_session.id", &ev.Exit.Process.UserSession.ID, value)
 	case "exit.user_session.k8s_groups":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
 		return ev.setStringArrayFieldValue("exit.user_session.k8s_groups", &ev.Exit.Process.UserSession.K8SGroups, value)
+	case "exit.user_session.k8s_session_id":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setUint64FieldValue("exit.user_session.k8s_session_id", &ev.Exit.Process.UserSession.K8SSessionID, value)
 	case "exit.user_session.k8s_uid":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -43337,11 +43337,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Exit.Process = &Process{}
 		}
 		return ev.setStringFieldValue("exit.user_session.k8s_username", &ev.Exit.Process.UserSession.K8SUsername, value)
-	case "exit.user_session.session_type":
-		if ev.Exit.Process == nil {
-			ev.Exit.Process = &Process{}
-		}
-		return ev.setIntFieldValue("exit.user_session.session_type", &ev.Exit.Process.UserSession.SessionType, value)
 	case "exit.user_session.ssh_auth_method":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -43367,6 +43362,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Exit.Process = &Process{}
 		}
 		return ev.setStringFieldValue("exit.user_session.ssh_public_key", &ev.Exit.Process.UserSession.SSHPublicKey, value)
+	case "exit.user_session.ssh_session_id":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setUint64FieldValue("exit.user_session.ssh_session_id", &ev.Exit.Process.UserSession.SSHSessionID, value)
 	case "imds.aws.is_imds_v2":
 		return ev.setBoolFieldValue("imds.aws.is_imds_v2", &ev.IMDS.AWS.IsIMDSv2, value)
 	case "imds.aws.security_credentials.type":
@@ -44266,16 +44266,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("process.ancestors.uid", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Credentials.UID, value)
 	case "process.ancestors.user":
 		return ev.setStringFieldValue("process.ancestors.user", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Credentials.User, value)
-	case "process.ancestors.user_session.id":
-		return ev.setUint64FieldValue("process.ancestors.user_session.id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.ID, value)
 	case "process.ancestors.user_session.k8s_groups":
 		return ev.setStringArrayFieldValue("process.ancestors.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SGroups, value)
+	case "process.ancestors.user_session.k8s_session_id":
+		return ev.setUint64FieldValue("process.ancestors.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SSessionID, value)
 	case "process.ancestors.user_session.k8s_uid":
 		return ev.setStringFieldValue("process.ancestors.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SUID, value)
 	case "process.ancestors.user_session.k8s_username":
 		return ev.setStringFieldValue("process.ancestors.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
-	case "process.ancestors.user_session.session_type":
-		return ev.setIntFieldValue("process.ancestors.user_session.session_type", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
 	case "process.ancestors.user_session.ssh_auth_method":
 		return ev.setIntFieldValue("process.ancestors.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
 	case "process.ancestors.user_session.ssh_client_ip":
@@ -44289,6 +44287,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setIntFieldValue("process.ancestors.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
 	case "process.ancestors.user_session.ssh_public_key":
 		return ev.setStringFieldValue("process.ancestors.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
+	case "process.ancestors.user_session.ssh_session_id":
+		return ev.setUint64FieldValue("process.ancestors.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHSessionID, value)
 	case "process.args":
 		return ev.setStringFieldValue("process.args", &ev.BaseEvent.ProcessContext.Process.Args, value)
 	case "process.args_flags":
@@ -44881,16 +44881,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("process.parent.uid", &ev.BaseEvent.ProcessContext.Parent.Credentials.UID, value)
 	case "process.parent.user":
 		return ev.setStringFieldValue("process.parent.user", &ev.BaseEvent.ProcessContext.Parent.Credentials.User, value)
-	case "process.parent.user_session.id":
-		return ev.setUint64FieldValue("process.parent.user_session.id", &ev.BaseEvent.ProcessContext.Parent.UserSession.ID, value)
 	case "process.parent.user_session.k8s_groups":
 		return ev.setStringArrayFieldValue("process.parent.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SGroups, value)
+	case "process.parent.user_session.k8s_session_id":
+		return ev.setUint64FieldValue("process.parent.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionID, value)
 	case "process.parent.user_session.k8s_uid":
 		return ev.setStringFieldValue("process.parent.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SUID, value)
 	case "process.parent.user_session.k8s_username":
 		return ev.setStringFieldValue("process.parent.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SUsername, value)
-	case "process.parent.user_session.session_type":
-		return ev.setIntFieldValue("process.parent.user_session.session_type", &ev.BaseEvent.ProcessContext.Parent.UserSession.SessionType, value)
 	case "process.parent.user_session.ssh_auth_method":
 		return ev.setIntFieldValue("process.parent.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHAuthMethod, value)
 	case "process.parent.user_session.ssh_client_ip":
@@ -44904,6 +44902,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setIntFieldValue("process.parent.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPort, value)
 	case "process.parent.user_session.ssh_public_key":
 		return ev.setStringFieldValue("process.parent.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPublicKey, value)
+	case "process.parent.user_session.ssh_session_id":
+		return ev.setUint64FieldValue("process.parent.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionID, value)
 	case "process.pid":
 		return ev.setUint32FieldValue("process.pid", &ev.BaseEvent.ProcessContext.Process.PIDContext.Pid, value)
 	case "process.ppid":
@@ -44916,16 +44916,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("process.uid", &ev.BaseEvent.ProcessContext.Process.Credentials.UID, value)
 	case "process.user":
 		return ev.setStringFieldValue("process.user", &ev.BaseEvent.ProcessContext.Process.Credentials.User, value)
-	case "process.user_session.id":
-		return ev.setUint64FieldValue("process.user_session.id", &ev.BaseEvent.ProcessContext.Process.UserSession.ID, value)
 	case "process.user_session.k8s_groups":
 		return ev.setStringArrayFieldValue("process.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SGroups, value)
+	case "process.user_session.k8s_session_id":
+		return ev.setUint64FieldValue("process.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionID, value)
 	case "process.user_session.k8s_uid":
 		return ev.setStringFieldValue("process.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SUID, value)
 	case "process.user_session.k8s_username":
 		return ev.setStringFieldValue("process.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SUsername, value)
-	case "process.user_session.session_type":
-		return ev.setIntFieldValue("process.user_session.session_type", &ev.BaseEvent.ProcessContext.Process.UserSession.SessionType, value)
 	case "process.user_session.ssh_auth_method":
 		return ev.setIntFieldValue("process.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHAuthMethod, value)
 	case "process.user_session.ssh_client_ip":
@@ -44939,6 +44937,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setIntFieldValue("process.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHPort, value)
 	case "process.user_session.ssh_public_key":
 		return ev.setStringFieldValue("process.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHPublicKey, value)
+	case "process.user_session.ssh_session_id":
+		return ev.setUint64FieldValue("process.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionID, value)
 	case "ptrace.request":
 		return ev.setUint32FieldValue("ptrace.request", &ev.PTrace.Request, value)
 	case "ptrace.retval":
@@ -45829,14 +45829,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.ancestors.user", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.Credentials.User, value)
-	case "ptrace.tracee.ancestors.user_session.id":
-		if ev.PTrace.Tracee == nil {
-			ev.PTrace.Tracee = &ProcessContext{}
-		}
-		if ev.PTrace.Tracee.Ancestor == nil {
-			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
-		}
-		return ev.setUint64FieldValue("ptrace.tracee.ancestors.user_session.id", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.ID, value)
 	case "ptrace.tracee.ancestors.user_session.k8s_groups":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45845,6 +45837,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringArrayFieldValue("ptrace.tracee.ancestors.user_session.k8s_groups", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SGroups, value)
+	case "ptrace.tracee.ancestors.user_session.k8s_session_id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.ancestors.user_session.k8s_session_id", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SSessionID, value)
 	case "ptrace.tracee.ancestors.user_session.k8s_uid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45861,14 +45861,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.k8s_username", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
-	case "ptrace.tracee.ancestors.user_session.session_type":
-		if ev.PTrace.Tracee == nil {
-			ev.PTrace.Tracee = &ProcessContext{}
-		}
-		if ev.PTrace.Tracee.Ancestor == nil {
-			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
-		}
-		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.session_type", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
 	case "ptrace.tracee.ancestors.user_session.ssh_auth_method":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45906,6 +45898,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.ssh_public_key", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
+	case "ptrace.tracee.ancestors.user_session.ssh_session_id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.ancestors.user_session.ssh_session_id", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHSessionID, value)
 	case "ptrace.tracee.args":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47344,14 +47344,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.parent.user", &ev.PTrace.Tracee.Parent.Credentials.User, value)
-	case "ptrace.tracee.parent.user_session.id":
-		if ev.PTrace.Tracee == nil {
-			ev.PTrace.Tracee = &ProcessContext{}
-		}
-		if ev.PTrace.Tracee.Parent == nil {
-			ev.PTrace.Tracee.Parent = &Process{}
-		}
-		return ev.setUint64FieldValue("ptrace.tracee.parent.user_session.id", &ev.PTrace.Tracee.Parent.UserSession.ID, value)
 	case "ptrace.tracee.parent.user_session.k8s_groups":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47360,6 +47352,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return ev.setStringArrayFieldValue("ptrace.tracee.parent.user_session.k8s_groups", &ev.PTrace.Tracee.Parent.UserSession.K8SGroups, value)
+	case "ptrace.tracee.parent.user_session.k8s_session_id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.parent.user_session.k8s_session_id", &ev.PTrace.Tracee.Parent.UserSession.K8SSessionID, value)
 	case "ptrace.tracee.parent.user_session.k8s_uid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47376,14 +47376,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.k8s_username", &ev.PTrace.Tracee.Parent.UserSession.K8SUsername, value)
-	case "ptrace.tracee.parent.user_session.session_type":
-		if ev.PTrace.Tracee == nil {
-			ev.PTrace.Tracee = &ProcessContext{}
-		}
-		if ev.PTrace.Tracee.Parent == nil {
-			ev.PTrace.Tracee.Parent = &Process{}
-		}
-		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.session_type", &ev.PTrace.Tracee.Parent.UserSession.SessionType, value)
 	case "ptrace.tracee.parent.user_session.ssh_auth_method":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47421,6 +47413,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.ssh_public_key", &ev.PTrace.Tracee.Parent.UserSession.SSHPublicKey, value)
+	case "ptrace.tracee.parent.user_session.ssh_session_id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.parent.user_session.ssh_session_id", &ev.PTrace.Tracee.Parent.UserSession.SSHSessionID, value)
 	case "ptrace.tracee.pid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47451,16 +47451,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.user", &ev.PTrace.Tracee.Process.Credentials.User, value)
-	case "ptrace.tracee.user_session.id":
-		if ev.PTrace.Tracee == nil {
-			ev.PTrace.Tracee = &ProcessContext{}
-		}
-		return ev.setUint64FieldValue("ptrace.tracee.user_session.id", &ev.PTrace.Tracee.Process.UserSession.ID, value)
 	case "ptrace.tracee.user_session.k8s_groups":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return ev.setStringArrayFieldValue("ptrace.tracee.user_session.k8s_groups", &ev.PTrace.Tracee.Process.UserSession.K8SGroups, value)
+	case "ptrace.tracee.user_session.k8s_session_id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.user_session.k8s_session_id", &ev.PTrace.Tracee.Process.UserSession.K8SSessionID, value)
 	case "ptrace.tracee.user_session.k8s_uid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47471,11 +47471,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.user_session.k8s_username", &ev.PTrace.Tracee.Process.UserSession.K8SUsername, value)
-	case "ptrace.tracee.user_session.session_type":
-		if ev.PTrace.Tracee == nil {
-			ev.PTrace.Tracee = &ProcessContext{}
-		}
-		return ev.setIntFieldValue("ptrace.tracee.user_session.session_type", &ev.PTrace.Tracee.Process.UserSession.SessionType, value)
 	case "ptrace.tracee.user_session.ssh_auth_method":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47501,6 +47496,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.user_session.ssh_public_key", &ev.PTrace.Tracee.Process.UserSession.SSHPublicKey, value)
+	case "ptrace.tracee.user_session.ssh_session_id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("ptrace.tracee.user_session.ssh_session_id", &ev.PTrace.Tracee.Process.UserSession.SSHSessionID, value)
 	case "removexattr.file.change_time":
 		return ev.setUint64FieldValue("removexattr.file.change_time", &ev.RemoveXAttr.File.FileFields.CTime, value)
 	case "removexattr.file.destination.name":
@@ -48647,14 +48647,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.ancestors.user", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.Credentials.User, value)
-	case "setrlimit.target.ancestors.user_session.id":
-		if ev.Setrlimit.Target == nil {
-			ev.Setrlimit.Target = &ProcessContext{}
-		}
-		if ev.Setrlimit.Target.Ancestor == nil {
-			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
-		}
-		return ev.setUint64FieldValue("setrlimit.target.ancestors.user_session.id", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.ID, value)
 	case "setrlimit.target.ancestors.user_session.k8s_groups":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48663,6 +48655,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringArrayFieldValue("setrlimit.target.ancestors.user_session.k8s_groups", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SGroups, value)
+	case "setrlimit.target.ancestors.user_session.k8s_session_id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.ancestors.user_session.k8s_session_id", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionID, value)
 	case "setrlimit.target.ancestors.user_session.k8s_uid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48679,14 +48679,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.k8s_username", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
-	case "setrlimit.target.ancestors.user_session.session_type":
-		if ev.Setrlimit.Target == nil {
-			ev.Setrlimit.Target = &ProcessContext{}
-		}
-		if ev.Setrlimit.Target.Ancestor == nil {
-			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
-		}
-		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.session_type", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
 	case "setrlimit.target.ancestors.user_session.ssh_auth_method":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48724,6 +48716,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.ssh_public_key", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
+	case "setrlimit.target.ancestors.user_session.ssh_session_id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.ancestors.user_session.ssh_session_id", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionID, value)
 	case "setrlimit.target.args":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50162,14 +50162,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.parent.user", &ev.Setrlimit.Target.Parent.Credentials.User, value)
-	case "setrlimit.target.parent.user_session.id":
-		if ev.Setrlimit.Target == nil {
-			ev.Setrlimit.Target = &ProcessContext{}
-		}
-		if ev.Setrlimit.Target.Parent == nil {
-			ev.Setrlimit.Target.Parent = &Process{}
-		}
-		return ev.setUint64FieldValue("setrlimit.target.parent.user_session.id", &ev.Setrlimit.Target.Parent.UserSession.ID, value)
 	case "setrlimit.target.parent.user_session.k8s_groups":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50178,6 +50170,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setStringArrayFieldValue("setrlimit.target.parent.user_session.k8s_groups", &ev.Setrlimit.Target.Parent.UserSession.K8SGroups, value)
+	case "setrlimit.target.parent.user_session.k8s_session_id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.parent.user_session.k8s_session_id", &ev.Setrlimit.Target.Parent.UserSession.K8SSessionID, value)
 	case "setrlimit.target.parent.user_session.k8s_uid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50194,14 +50194,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.parent.user_session.k8s_username", &ev.Setrlimit.Target.Parent.UserSession.K8SUsername, value)
-	case "setrlimit.target.parent.user_session.session_type":
-		if ev.Setrlimit.Target == nil {
-			ev.Setrlimit.Target = &ProcessContext{}
-		}
-		if ev.Setrlimit.Target.Parent == nil {
-			ev.Setrlimit.Target.Parent = &Process{}
-		}
-		return ev.setIntFieldValue("setrlimit.target.parent.user_session.session_type", &ev.Setrlimit.Target.Parent.UserSession.SessionType, value)
 	case "setrlimit.target.parent.user_session.ssh_auth_method":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50239,6 +50231,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.parent.user_session.ssh_public_key", &ev.Setrlimit.Target.Parent.UserSession.SSHPublicKey, value)
+	case "setrlimit.target.parent.user_session.ssh_session_id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.parent.user_session.ssh_session_id", &ev.Setrlimit.Target.Parent.UserSession.SSHSessionID, value)
 	case "setrlimit.target.pid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50269,16 +50269,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.user", &ev.Setrlimit.Target.Process.Credentials.User, value)
-	case "setrlimit.target.user_session.id":
-		if ev.Setrlimit.Target == nil {
-			ev.Setrlimit.Target = &ProcessContext{}
-		}
-		return ev.setUint64FieldValue("setrlimit.target.user_session.id", &ev.Setrlimit.Target.Process.UserSession.ID, value)
 	case "setrlimit.target.user_session.k8s_groups":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setStringArrayFieldValue("setrlimit.target.user_session.k8s_groups", &ev.Setrlimit.Target.Process.UserSession.K8SGroups, value)
+	case "setrlimit.target.user_session.k8s_session_id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.user_session.k8s_session_id", &ev.Setrlimit.Target.Process.UserSession.K8SSessionID, value)
 	case "setrlimit.target.user_session.k8s_uid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50289,11 +50289,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.user_session.k8s_username", &ev.Setrlimit.Target.Process.UserSession.K8SUsername, value)
-	case "setrlimit.target.user_session.session_type":
-		if ev.Setrlimit.Target == nil {
-			ev.Setrlimit.Target = &ProcessContext{}
-		}
-		return ev.setIntFieldValue("setrlimit.target.user_session.session_type", &ev.Setrlimit.Target.Process.UserSession.SessionType, value)
 	case "setrlimit.target.user_session.ssh_auth_method":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50319,6 +50314,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.user_session.ssh_public_key", &ev.Setrlimit.Target.Process.UserSession.SSHPublicKey, value)
+	case "setrlimit.target.user_session.ssh_session_id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("setrlimit.target.user_session.ssh_session_id", &ev.Setrlimit.Target.Process.UserSession.SSHSessionID, value)
 	case "setsockopt.filter_hash":
 		return ev.setStringFieldValue("setsockopt.filter_hash", &ev.SetSockOpt.FilterHash, value)
 	case "setsockopt.filter_instructions":
@@ -51313,14 +51313,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("signal.target.ancestors.user", &ev.Signal.Target.Ancestor.ProcessContext.Process.Credentials.User, value)
-	case "signal.target.ancestors.user_session.id":
-		if ev.Signal.Target == nil {
-			ev.Signal.Target = &ProcessContext{}
-		}
-		if ev.Signal.Target.Ancestor == nil {
-			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
-		}
-		return ev.setUint64FieldValue("signal.target.ancestors.user_session.id", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.ID, value)
 	case "signal.target.ancestors.user_session.k8s_groups":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51329,6 +51321,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringArrayFieldValue("signal.target.ancestors.user_session.k8s_groups", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SGroups, value)
+	case "signal.target.ancestors.user_session.k8s_session_id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("signal.target.ancestors.user_session.k8s_session_id", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionID, value)
 	case "signal.target.ancestors.user_session.k8s_uid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51345,14 +51345,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("signal.target.ancestors.user_session.k8s_username", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
-	case "signal.target.ancestors.user_session.session_type":
-		if ev.Signal.Target == nil {
-			ev.Signal.Target = &ProcessContext{}
-		}
-		if ev.Signal.Target.Ancestor == nil {
-			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
-		}
-		return ev.setIntFieldValue("signal.target.ancestors.user_session.session_type", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
 	case "signal.target.ancestors.user_session.ssh_auth_method":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51390,6 +51382,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("signal.target.ancestors.user_session.ssh_public_key", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
+	case "signal.target.ancestors.user_session.ssh_session_id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setUint64FieldValue("signal.target.ancestors.user_session.ssh_session_id", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionID, value)
 	case "signal.target.args":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52828,14 +52828,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("signal.target.parent.user", &ev.Signal.Target.Parent.Credentials.User, value)
-	case "signal.target.parent.user_session.id":
-		if ev.Signal.Target == nil {
-			ev.Signal.Target = &ProcessContext{}
-		}
-		if ev.Signal.Target.Parent == nil {
-			ev.Signal.Target.Parent = &Process{}
-		}
-		return ev.setUint64FieldValue("signal.target.parent.user_session.id", &ev.Signal.Target.Parent.UserSession.ID, value)
 	case "signal.target.parent.user_session.k8s_groups":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52844,6 +52836,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setStringArrayFieldValue("signal.target.parent.user_session.k8s_groups", &ev.Signal.Target.Parent.UserSession.K8SGroups, value)
+	case "signal.target.parent.user_session.k8s_session_id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("signal.target.parent.user_session.k8s_session_id", &ev.Signal.Target.Parent.UserSession.K8SSessionID, value)
 	case "signal.target.parent.user_session.k8s_uid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52860,14 +52860,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("signal.target.parent.user_session.k8s_username", &ev.Signal.Target.Parent.UserSession.K8SUsername, value)
-	case "signal.target.parent.user_session.session_type":
-		if ev.Signal.Target == nil {
-			ev.Signal.Target = &ProcessContext{}
-		}
-		if ev.Signal.Target.Parent == nil {
-			ev.Signal.Target.Parent = &Process{}
-		}
-		return ev.setIntFieldValue("signal.target.parent.user_session.session_type", &ev.Signal.Target.Parent.UserSession.SessionType, value)
 	case "signal.target.parent.user_session.ssh_auth_method":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52905,6 +52897,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("signal.target.parent.user_session.ssh_public_key", &ev.Signal.Target.Parent.UserSession.SSHPublicKey, value)
+	case "signal.target.parent.user_session.ssh_session_id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setUint64FieldValue("signal.target.parent.user_session.ssh_session_id", &ev.Signal.Target.Parent.UserSession.SSHSessionID, value)
 	case "signal.target.pid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52935,16 +52935,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("signal.target.user", &ev.Signal.Target.Process.Credentials.User, value)
-	case "signal.target.user_session.id":
-		if ev.Signal.Target == nil {
-			ev.Signal.Target = &ProcessContext{}
-		}
-		return ev.setUint64FieldValue("signal.target.user_session.id", &ev.Signal.Target.Process.UserSession.ID, value)
 	case "signal.target.user_session.k8s_groups":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setStringArrayFieldValue("signal.target.user_session.k8s_groups", &ev.Signal.Target.Process.UserSession.K8SGroups, value)
+	case "signal.target.user_session.k8s_session_id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("signal.target.user_session.k8s_session_id", &ev.Signal.Target.Process.UserSession.K8SSessionID, value)
 	case "signal.target.user_session.k8s_uid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52955,11 +52955,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("signal.target.user_session.k8s_username", &ev.Signal.Target.Process.UserSession.K8SUsername, value)
-	case "signal.target.user_session.session_type":
-		if ev.Signal.Target == nil {
-			ev.Signal.Target = &ProcessContext{}
-		}
-		return ev.setIntFieldValue("signal.target.user_session.session_type", &ev.Signal.Target.Process.UserSession.SessionType, value)
 	case "signal.target.user_session.ssh_auth_method":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52985,6 +52980,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("signal.target.user_session.ssh_public_key", &ev.Signal.Target.Process.UserSession.SSHPublicKey, value)
+	case "signal.target.user_session.ssh_session_id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setUint64FieldValue("signal.target.user_session.ssh_session_id", &ev.Signal.Target.Process.UserSession.SSHSessionID, value)
 	case "signal.type":
 		return ev.setUint32FieldValue("signal.type", &ev.Signal.Type, value)
 	case "splice.file.change_time":

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -3332,12 +3332,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exec.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.Exec.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Exec.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exec.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exec.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exec.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3348,7 +3370,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.Exec.Process.UserSession.K8SSessionID)
+				return int(ev.Exec.Process.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3359,7 +3381,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exec.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exec.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3370,7 +3392,18 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exec.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exec.Process.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.Exec.Process.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3381,7 +3414,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Exec.Process.UserSession.SSHAuthMethod
+				return ev.Exec.Process.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3392,21 +3425,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) net.IPNet {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Exec.Process.UserSession)
+				return ev.Exec.Process.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "exec.user_session.ssh_port":
+	case "exec.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Exec.Process.UserSession)
+				return ev.Exec.Process.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "exec.user_session.ssh_public_key":
@@ -3414,7 +3447,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Exec.Process.UserSession.SSHPublicKey
+				return ev.Exec.Process.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3425,7 +3458,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.Exec.Process.UserSession.SSHSessionID)
+				return int(ev.Exec.Process.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4667,12 +4700,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exit.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.Exit.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Exit.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "exit.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exit.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exit.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4683,7 +4738,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.Exit.Process.UserSession.K8SSessionID)
+				return int(ev.Exit.Process.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4694,7 +4749,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exit.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exit.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4705,7 +4760,18 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exit.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exit.Process.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.Exit.Process.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4716,7 +4782,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Exit.Process.UserSession.SSHAuthMethod
+				return ev.Exit.Process.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4727,21 +4793,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) net.IPNet {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Exit.Process.UserSession)
+				return ev.Exit.Process.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "exit.user_session.ssh_port":
+	case "exit.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Exit.Process.UserSession)
+				return ev.Exit.Process.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "exit.user_session.ssh_public_key":
@@ -4749,7 +4815,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Exit.Process.UserSession.SSHPublicKey
+				return ev.Exit.Process.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -4760,7 +4826,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.Exit.Process.UserSession.SSHSessionID)
+				return int(ev.Exit.Process.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -10800,6 +10866,60 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "process.ancestors.user_session.id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSessionID(ev, &element.ProcessContext.Process.UserSession)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveSessionID(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.user_session.identity":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSessionIdentity(ev, &element.ProcessContext.Process.UserSession)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveSessionIdentity(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.ancestors.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -10811,14 +10931,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SGroups(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SGroups(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return result
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIteratorArray(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
-					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -10838,14 +10958,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.K8SSessionID)
+					result := int(element.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.K8SSessionID)
+					return int(current.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -10865,14 +10985,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SUID(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SUID(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveK8SUID(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SUID(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -10892,16 +11012,43 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SUsername(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SUsername(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.user_session.session_type":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveSessionType(ev, &element.ProcessContext.Process.UserSession))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveSessionType(ev, &current.ProcessContext.Process.UserSession))
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -10919,14 +11066,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.SSHAuthMethod)
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SSHAuthMethod)
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -10946,14 +11093,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveSSHClientIP(ev, &element.ProcessContext.Process.UserSession)
+					result := element.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 					return []net.IPNet{result}
 				}
 				if result, ok := ctx.IPNetCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
-					return ev.FieldHandlers.ResolveSSHClientIP(ev, &current.ProcessContext.Process.UserSession)
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
+					return current.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 				})
 				ctx.IPNetCache[field] = results
 				return results
@@ -10962,7 +11109,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
-	case "process.ancestors.user_session.ssh_port":
+	case "process.ancestors.user_session.ssh_client_port":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ctx.AppendResolvedField(field)
@@ -10973,14 +11120,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(ev.FieldHandlers.ResolveSSHPort(ev, &element.ProcessContext.Process.UserSession))
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(ev.FieldHandlers.ResolveSSHPort(ev, &current.ProcessContext.Process.UserSession))
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -11000,14 +11147,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := element.ProcessContext.Process.UserSession.SSHPublicKey
+					result := element.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
-					return current.ProcessContext.Process.UserSession.SSHPublicKey
+					return current.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -11027,14 +11174,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.SSHSessionID)
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SSHSessionID)
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -13681,6 +13828,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.parent.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.parent.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -13689,7 +13864,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return []string{}
 				}
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -13703,7 +13878,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return 0
 				}
-				return int(ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionID)
+				return int(ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -13717,7 +13892,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -13731,7 +13906,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -13745,7 +13934,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return 0
 				}
-				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHAuthMethod
+				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -13759,13 +13948,13 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return net.IPNet{}
 				}
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "process.parent.user_session.ssh_port":
+	case "process.parent.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
@@ -13773,10 +13962,10 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return 0
 				}
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "process.parent.user_session.ssh_public_key":
@@ -13787,7 +13976,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return ""
 				}
-				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPublicKey
+				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -13801,7 +13990,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.BaseEvent.ProcessContext.HasParent() {
 					return 0
 				}
-				return int(ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionID)
+				return int(ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -13873,12 +14062,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "process.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -13889,7 +14100,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionID)
+				return int(ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -13900,7 +14111,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -13911,7 +14122,18 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -13922,7 +14144,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHAuthMethod
+				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -13933,21 +14155,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) net.IPNet {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "process.user_session.ssh_port":
+	case "process.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "process.user_session.ssh_public_key":
@@ -13955,7 +14177,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHPublicKey
+				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -13966,7 +14188,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionID)
+				return int(ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -16905,6 +17127,60 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.ancestors.user_session.id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSessionID(ev, &element.ProcessContext.Process.UserSession)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveSessionID(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.user_session.identity":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSessionIdentity(ev, &element.ProcessContext.Process.UserSession)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveSessionIdentity(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.ancestors.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -16916,14 +17192,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SGroups(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SGroups(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return result
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIteratorArray(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
-					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -16943,14 +17219,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.K8SSessionID)
+					result := int(element.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.K8SSessionID)
+					return int(current.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -16970,14 +17246,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SUID(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SUID(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveK8SUID(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SUID(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -16997,16 +17273,43 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SUsername(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SUsername(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.user_session.session_type":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveSessionType(ev, &element.ProcessContext.Process.UserSession))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveSessionType(ev, &current.ProcessContext.Process.UserSession))
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -17024,14 +17327,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.SSHAuthMethod)
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SSHAuthMethod)
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -17051,14 +17354,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveSSHClientIP(ev, &element.ProcessContext.Process.UserSession)
+					result := element.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 					return []net.IPNet{result}
 				}
 				if result, ok := ctx.IPNetCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
-					return ev.FieldHandlers.ResolveSSHClientIP(ev, &current.ProcessContext.Process.UserSession)
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
+					return current.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 				})
 				ctx.IPNetCache[field] = results
 				return results
@@ -17067,7 +17370,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
-	case "ptrace.tracee.ancestors.user_session.ssh_port":
+	case "ptrace.tracee.ancestors.user_session.ssh_client_port":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ctx.AppendResolvedField(field)
@@ -17078,14 +17381,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(ev.FieldHandlers.ResolveSSHPort(ev, &element.ProcessContext.Process.UserSession))
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(ev.FieldHandlers.ResolveSSHPort(ev, &current.ProcessContext.Process.UserSession))
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -17105,14 +17408,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := element.ProcessContext.Process.UserSession.SSHPublicKey
+					result := element.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
-					return current.ProcessContext.Process.UserSession.SSHPublicKey
+					return current.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -17132,14 +17435,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.SSHSessionID)
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SSHSessionID)
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -19786,6 +20089,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.parent.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.parent.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -19794,7 +20125,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return []string{}
 				}
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -19808,7 +20139,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return 0
 				}
-				return int(ev.PTrace.Tracee.Parent.UserSession.K8SSessionID)
+				return int(ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -19822,7 +20153,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -19836,7 +20167,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.PTrace.Tracee.Parent.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -19850,7 +20195,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return 0
 				}
-				return ev.PTrace.Tracee.Parent.UserSession.SSHAuthMethod
+				return ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -19864,13 +20209,13 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return net.IPNet{}
 				}
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.PTrace.Tracee.Parent.UserSession)
+				return ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "ptrace.tracee.parent.user_session.ssh_port":
+	case "ptrace.tracee.parent.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
@@ -19878,10 +20223,10 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return 0
 				}
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.PTrace.Tracee.Parent.UserSession)
+				return ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.parent.user_session.ssh_public_key":
@@ -19892,7 +20237,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return ""
 				}
-				return ev.PTrace.Tracee.Parent.UserSession.SSHPublicKey
+				return ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -19906,7 +20251,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.PTrace.Tracee.HasParent() {
 					return 0
 				}
-				return int(ev.PTrace.Tracee.Parent.UserSession.SSHSessionID)
+				return int(ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -19978,12 +20323,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.PTrace.Tracee.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.PTrace.Tracee.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -19994,7 +20361,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.PTrace.Tracee.Process.UserSession.K8SSessionID)
+				return int(ev.PTrace.Tracee.Process.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -20005,7 +20372,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -20016,7 +20383,18 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.PTrace.Tracee.Process.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -20027,7 +20405,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.PTrace.Tracee.Process.UserSession.SSHAuthMethod
+				return ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -20038,21 +20416,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) net.IPNet {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.PTrace.Tracee.Process.UserSession)
+				return ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "ptrace.tracee.user_session.ssh_port":
+	case "ptrace.tracee.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.PTrace.Tracee.Process.UserSession)
+				return ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.user_session.ssh_public_key":
@@ -20060,7 +20438,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.PTrace.Tracee.Process.UserSession.SSHPublicKey
+				return ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -20071,7 +20449,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.PTrace.Tracee.Process.UserSession.SSHSessionID)
+				return int(ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -24434,6 +24812,60 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.ancestors.user_session.id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSessionID(ev, &element.ProcessContext.Process.UserSession)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveSessionID(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.user_session.identity":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSessionIdentity(ev, &element.ProcessContext.Process.UserSession)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveSessionIdentity(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.ancestors.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -24445,14 +24877,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SGroups(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SGroups(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return result
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIteratorArray(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
-					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -24472,14 +24904,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.K8SSessionID)
+					result := int(element.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.K8SSessionID)
+					return int(current.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -24499,14 +24931,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SUID(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SUID(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveK8SUID(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SUID(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -24526,16 +24958,43 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SUsername(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SUsername(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.user_session.session_type":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveSessionType(ev, &element.ProcessContext.Process.UserSession))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveSessionType(ev, &current.ProcessContext.Process.UserSession))
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -24553,14 +25012,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.SSHAuthMethod)
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SSHAuthMethod)
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -24580,14 +25039,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveSSHClientIP(ev, &element.ProcessContext.Process.UserSession)
+					result := element.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 					return []net.IPNet{result}
 				}
 				if result, ok := ctx.IPNetCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
-					return ev.FieldHandlers.ResolveSSHClientIP(ev, &current.ProcessContext.Process.UserSession)
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
+					return current.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 				})
 				ctx.IPNetCache[field] = results
 				return results
@@ -24596,7 +25055,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
-	case "setrlimit.target.ancestors.user_session.ssh_port":
+	case "setrlimit.target.ancestors.user_session.ssh_client_port":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ctx.AppendResolvedField(field)
@@ -24607,14 +25066,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(ev.FieldHandlers.ResolveSSHPort(ev, &element.ProcessContext.Process.UserSession))
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(ev.FieldHandlers.ResolveSSHPort(ev, &current.ProcessContext.Process.UserSession))
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -24634,14 +25093,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := element.ProcessContext.Process.UserSession.SSHPublicKey
+					result := element.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
-					return current.ProcessContext.Process.UserSession.SSHPublicKey
+					return current.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -24661,14 +25120,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.SSHSessionID)
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SSHSessionID)
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -27315,6 +27774,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.parent.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.parent.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -27323,7 +27810,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return []string{}
 				}
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -27337,7 +27824,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return 0
 				}
-				return int(ev.Setrlimit.Target.Parent.UserSession.K8SSessionID)
+				return int(ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -27351,7 +27838,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -27365,7 +27852,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.Setrlimit.Target.Parent.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -27379,7 +27880,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return 0
 				}
-				return ev.Setrlimit.Target.Parent.UserSession.SSHAuthMethod
+				return ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -27393,13 +27894,13 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return net.IPNet{}
 				}
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Setrlimit.Target.Parent.UserSession)
+				return ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "setrlimit.target.parent.user_session.ssh_port":
+	case "setrlimit.target.parent.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
@@ -27407,10 +27908,10 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return 0
 				}
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Setrlimit.Target.Parent.UserSession)
+				return ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.parent.user_session.ssh_public_key":
@@ -27421,7 +27922,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return ""
 				}
-				return ev.Setrlimit.Target.Parent.UserSession.SSHPublicKey
+				return ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -27435,7 +27936,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Setrlimit.Target.HasParent() {
 					return 0
 				}
-				return int(ev.Setrlimit.Target.Parent.UserSession.SSHSessionID)
+				return int(ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -27507,12 +28008,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.Setrlimit.Target.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Setrlimit.Target.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -27523,7 +28046,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.Setrlimit.Target.Process.UserSession.K8SSessionID)
+				return int(ev.Setrlimit.Target.Process.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -27534,7 +28057,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -27545,7 +28068,18 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.Setrlimit.Target.Process.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -27556,7 +28090,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Setrlimit.Target.Process.UserSession.SSHAuthMethod
+				return ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -27567,21 +28101,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) net.IPNet {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Setrlimit.Target.Process.UserSession)
+				return ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "setrlimit.target.user_session.ssh_port":
+	case "setrlimit.target.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Setrlimit.Target.Process.UserSession)
+				return ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "setrlimit.target.user_session.ssh_public_key":
@@ -27589,7 +28123,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Setrlimit.Target.Process.UserSession.SSHPublicKey
+				return ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -27600,7 +28134,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.Setrlimit.Target.Process.UserSession.SSHSessionID)
+				return int(ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -31060,6 +31594,60 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.ancestors.user_session.id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSessionID(ev, &element.ProcessContext.Process.UserSession)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveSessionID(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.user_session.identity":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSessionIdentity(ev, &element.ProcessContext.Process.UserSession)
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
+					return ev.FieldHandlers.ResolveSessionIdentity(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.ancestors.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -31071,14 +31659,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SGroups(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SGroups(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return result
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIteratorArray(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) []string {
-					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SGroups(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -31098,14 +31686,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.K8SSessionID)
+					result := int(element.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.K8SSessionID)
+					return int(current.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -31125,14 +31713,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SUID(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SUID(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveK8SUID(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SUID(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -31152,16 +31740,43 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveK8SUsername(ev, &element.ProcessContext.Process.UserSession)
+					result := ev.FieldHandlers.ResolveK8SUsername(ev, &element.ProcessContext.Process.UserSession.K8SSessionContext)
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) string {
-					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession)
+					return ev.FieldHandlers.ResolveK8SUsername(ev, &current.ProcessContext.Process.UserSession.K8SSessionContext)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.user_session.session_type":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveSessionType(ev, &element.ProcessContext.Process.UserSession))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveSessionType(ev, &current.ProcessContext.Process.UserSession))
+				})
+				ctx.IntCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -31179,14 +31794,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.SSHAuthMethod)
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SSHAuthMethod)
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -31206,14 +31821,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := ev.FieldHandlers.ResolveSSHClientIP(ev, &element.ProcessContext.Process.UserSession)
+					result := element.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 					return []net.IPNet{result}
 				}
 				if result, ok := ctx.IPNetCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
-					return ev.FieldHandlers.ResolveSSHClientIP(ev, &current.ProcessContext.Process.UserSession)
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
+					return current.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP
 				})
 				ctx.IPNetCache[field] = results
 				return results
@@ -31222,7 +31837,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
-	case "signal.target.ancestors.user_session.ssh_port":
+	case "signal.target.ancestors.user_session.ssh_client_port":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ctx.AppendResolvedField(field)
@@ -31233,14 +31848,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(ev.FieldHandlers.ResolveSSHPort(ev, &element.ProcessContext.Process.UserSession))
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
-				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(ev.FieldHandlers.ResolveSSHPort(ev, &current.ProcessContext.Process.UserSession))
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -31260,14 +31875,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := element.ProcessContext.Process.UserSession.SSHPublicKey
+					result := element.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 					return []string{result}
 				}
 				if result, ok := ctx.StringCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
-					return current.ProcessContext.Process.UserSession.SSHPublicKey
+					return current.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey
 				})
 				ctx.StringCache[field] = results
 				return results
@@ -31287,14 +31902,14 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					if element == nil {
 						return nil
 					}
-					result := int(element.ProcessContext.Process.UserSession.SSHSessionID)
+					result := int(element.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 					return []int{result}
 				}
 				if result, ok := ctx.IntCache[field]; ok {
 					return result
 				}
 				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
-					return int(current.ProcessContext.Process.UserSession.SSHSessionID)
+					return int(current.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID)
 				})
 				ctx.IntCache[field] = results
 				return results
@@ -33941,6 +34556,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.parent.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.Signal.Target.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return ""
+				}
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Signal.Target.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.parent.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -33949,7 +34592,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return []string{}
 				}
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Parent.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -33963,7 +34606,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return 0
 				}
-				return int(ev.Signal.Target.Parent.UserSession.K8SSessionID)
+				return int(ev.Signal.Target.Parent.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -33977,7 +34620,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Parent.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -33991,7 +34634,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return ""
 				}
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Parent.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Parent.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.Signal.Target.Parent.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -34005,7 +34662,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return 0
 				}
-				return ev.Signal.Target.Parent.UserSession.SSHAuthMethod
+				return ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -34019,13 +34676,13 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return net.IPNet{}
 				}
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Signal.Target.Parent.UserSession)
+				return ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "signal.target.parent.user_session.ssh_port":
+	case "signal.target.parent.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
@@ -34033,10 +34690,10 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return 0
 				}
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Signal.Target.Parent.UserSession)
+				return ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.parent.user_session.ssh_public_key":
@@ -34047,7 +34704,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return ""
 				}
-				return ev.Signal.Target.Parent.UserSession.SSHPublicKey
+				return ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -34061,7 +34718,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				if !ev.Signal.Target.HasParent() {
 					return 0
 				}
-				return int(ev.Signal.Target.Parent.UserSession.SSHSessionID)
+				return int(ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -34133,12 +34790,34 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.user_session.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionID(ev, &ev.Signal.Target.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.user_session.identity":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Signal.Target.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.user_session.k8s_groups":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -34149,7 +34828,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.Signal.Target.Process.UserSession.K8SSessionID)
+				return int(ev.Signal.Target.Process.UserSession.K8SSessionContext.K8SSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -34160,7 +34839,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Process.UserSession.K8SSessionContext)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -34171,7 +34850,18 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Process.UserSession)
+				return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Process.UserSession.K8SSessionContext)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.user_session.session_type":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSessionType(ev, &ev.Signal.Target.Process.UserSession)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -34182,7 +34872,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Signal.Target.Process.UserSession.SSHAuthMethod
+				return ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHAuthMethod
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -34193,21 +34883,21 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) net.IPNet {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Signal.Target.Process.UserSession)
+				return ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHClientIP
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
-	case "signal.target.user_session.ssh_port":
+	case "signal.target.user_session.ssh_client_port":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Signal.Target.Process.UserSession)
+				return ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHClientPort
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
 	case "signal.target.user_session.ssh_public_key":
@@ -34215,7 +34905,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return ev.Signal.Target.Process.UserSession.SSHPublicKey
+				return ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -34226,7 +34916,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			EvalFnc: func(ctx *eval.Context) int {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
-				return int(ev.Signal.Target.Process.UserSession.SSHSessionID)
+				return int(ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHSessionID)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -35648,13 +36338,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.tty_name",
 		"exec.uid",
 		"exec.user",
+		"exec.user_session.id",
+		"exec.user_session.identity",
 		"exec.user_session.k8s_groups",
 		"exec.user_session.k8s_session_id",
 		"exec.user_session.k8s_uid",
 		"exec.user_session.k8s_username",
+		"exec.user_session.session_type",
 		"exec.user_session.ssh_auth_method",
 		"exec.user_session.ssh_client_ip",
-		"exec.user_session.ssh_port",
+		"exec.user_session.ssh_client_port",
 		"exec.user_session.ssh_public_key",
 		"exec.user_session.ssh_session_id",
 		"exit.args",
@@ -35755,13 +36448,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.tty_name",
 		"exit.uid",
 		"exit.user",
+		"exit.user_session.id",
+		"exit.user_session.identity",
 		"exit.user_session.k8s_groups",
 		"exit.user_session.k8s_session_id",
 		"exit.user_session.k8s_uid",
 		"exit.user_session.k8s_username",
+		"exit.user_session.session_type",
 		"exit.user_session.ssh_auth_method",
 		"exit.user_session.ssh_client_ip",
-		"exit.user_session.ssh_port",
+		"exit.user_session.ssh_client_port",
 		"exit.user_session.ssh_public_key",
 		"exit.user_session.ssh_session_id",
 		"imds.aws.is_imds_v2",
@@ -36124,13 +36820,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.tty_name",
 		"process.ancestors.uid",
 		"process.ancestors.user",
+		"process.ancestors.user_session.id",
+		"process.ancestors.user_session.identity",
 		"process.ancestors.user_session.k8s_groups",
 		"process.ancestors.user_session.k8s_session_id",
 		"process.ancestors.user_session.k8s_uid",
 		"process.ancestors.user_session.k8s_username",
+		"process.ancestors.user_session.session_type",
 		"process.ancestors.user_session.ssh_auth_method",
 		"process.ancestors.user_session.ssh_client_ip",
-		"process.ancestors.user_session.ssh_port",
+		"process.ancestors.user_session.ssh_client_port",
 		"process.ancestors.user_session.ssh_public_key",
 		"process.ancestors.user_session.ssh_session_id",
 		"process.args",
@@ -36319,13 +37018,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.tty_name",
 		"process.parent.uid",
 		"process.parent.user",
+		"process.parent.user_session.id",
+		"process.parent.user_session.identity",
 		"process.parent.user_session.k8s_groups",
 		"process.parent.user_session.k8s_session_id",
 		"process.parent.user_session.k8s_uid",
 		"process.parent.user_session.k8s_username",
+		"process.parent.user_session.session_type",
 		"process.parent.user_session.ssh_auth_method",
 		"process.parent.user_session.ssh_client_ip",
-		"process.parent.user_session.ssh_port",
+		"process.parent.user_session.ssh_client_port",
 		"process.parent.user_session.ssh_public_key",
 		"process.parent.user_session.ssh_session_id",
 		"process.pid",
@@ -36334,13 +37036,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.tty_name",
 		"process.uid",
 		"process.user",
+		"process.user_session.id",
+		"process.user_session.identity",
 		"process.user_session.k8s_groups",
 		"process.user_session.k8s_session_id",
 		"process.user_session.k8s_uid",
 		"process.user_session.k8s_username",
+		"process.user_session.session_type",
 		"process.user_session.ssh_auth_method",
 		"process.user_session.ssh_client_ip",
-		"process.user_session.ssh_port",
+		"process.user_session.ssh_client_port",
 		"process.user_session.ssh_public_key",
 		"process.user_session.ssh_session_id",
 		"ptrace.request",
@@ -36442,13 +37147,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.ancestors.tty_name",
 		"ptrace.tracee.ancestors.uid",
 		"ptrace.tracee.ancestors.user",
+		"ptrace.tracee.ancestors.user_session.id",
+		"ptrace.tracee.ancestors.user_session.identity",
 		"ptrace.tracee.ancestors.user_session.k8s_groups",
 		"ptrace.tracee.ancestors.user_session.k8s_session_id",
 		"ptrace.tracee.ancestors.user_session.k8s_uid",
 		"ptrace.tracee.ancestors.user_session.k8s_username",
+		"ptrace.tracee.ancestors.user_session.session_type",
 		"ptrace.tracee.ancestors.user_session.ssh_auth_method",
 		"ptrace.tracee.ancestors.user_session.ssh_client_ip",
-		"ptrace.tracee.ancestors.user_session.ssh_port",
+		"ptrace.tracee.ancestors.user_session.ssh_client_port",
 		"ptrace.tracee.ancestors.user_session.ssh_public_key",
 		"ptrace.tracee.ancestors.user_session.ssh_session_id",
 		"ptrace.tracee.args",
@@ -36637,13 +37345,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.parent.tty_name",
 		"ptrace.tracee.parent.uid",
 		"ptrace.tracee.parent.user",
+		"ptrace.tracee.parent.user_session.id",
+		"ptrace.tracee.parent.user_session.identity",
 		"ptrace.tracee.parent.user_session.k8s_groups",
 		"ptrace.tracee.parent.user_session.k8s_session_id",
 		"ptrace.tracee.parent.user_session.k8s_uid",
 		"ptrace.tracee.parent.user_session.k8s_username",
+		"ptrace.tracee.parent.user_session.session_type",
 		"ptrace.tracee.parent.user_session.ssh_auth_method",
 		"ptrace.tracee.parent.user_session.ssh_client_ip",
-		"ptrace.tracee.parent.user_session.ssh_port",
+		"ptrace.tracee.parent.user_session.ssh_client_port",
 		"ptrace.tracee.parent.user_session.ssh_public_key",
 		"ptrace.tracee.parent.user_session.ssh_session_id",
 		"ptrace.tracee.pid",
@@ -36652,13 +37363,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.tty_name",
 		"ptrace.tracee.uid",
 		"ptrace.tracee.user",
+		"ptrace.tracee.user_session.id",
+		"ptrace.tracee.user_session.identity",
 		"ptrace.tracee.user_session.k8s_groups",
 		"ptrace.tracee.user_session.k8s_session_id",
 		"ptrace.tracee.user_session.k8s_uid",
 		"ptrace.tracee.user_session.k8s_username",
+		"ptrace.tracee.user_session.session_type",
 		"ptrace.tracee.user_session.ssh_auth_method",
 		"ptrace.tracee.user_session.ssh_client_ip",
-		"ptrace.tracee.user_session.ssh_port",
+		"ptrace.tracee.user_session.ssh_client_port",
 		"ptrace.tracee.user_session.ssh_public_key",
 		"ptrace.tracee.user_session.ssh_session_id",
 		"removexattr.file.change_time",
@@ -36888,13 +37602,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.ancestors.tty_name",
 		"setrlimit.target.ancestors.uid",
 		"setrlimit.target.ancestors.user",
+		"setrlimit.target.ancestors.user_session.id",
+		"setrlimit.target.ancestors.user_session.identity",
 		"setrlimit.target.ancestors.user_session.k8s_groups",
 		"setrlimit.target.ancestors.user_session.k8s_session_id",
 		"setrlimit.target.ancestors.user_session.k8s_uid",
 		"setrlimit.target.ancestors.user_session.k8s_username",
+		"setrlimit.target.ancestors.user_session.session_type",
 		"setrlimit.target.ancestors.user_session.ssh_auth_method",
 		"setrlimit.target.ancestors.user_session.ssh_client_ip",
-		"setrlimit.target.ancestors.user_session.ssh_port",
+		"setrlimit.target.ancestors.user_session.ssh_client_port",
 		"setrlimit.target.ancestors.user_session.ssh_public_key",
 		"setrlimit.target.ancestors.user_session.ssh_session_id",
 		"setrlimit.target.args",
@@ -37083,13 +37800,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.parent.tty_name",
 		"setrlimit.target.parent.uid",
 		"setrlimit.target.parent.user",
+		"setrlimit.target.parent.user_session.id",
+		"setrlimit.target.parent.user_session.identity",
 		"setrlimit.target.parent.user_session.k8s_groups",
 		"setrlimit.target.parent.user_session.k8s_session_id",
 		"setrlimit.target.parent.user_session.k8s_uid",
 		"setrlimit.target.parent.user_session.k8s_username",
+		"setrlimit.target.parent.user_session.session_type",
 		"setrlimit.target.parent.user_session.ssh_auth_method",
 		"setrlimit.target.parent.user_session.ssh_client_ip",
-		"setrlimit.target.parent.user_session.ssh_port",
+		"setrlimit.target.parent.user_session.ssh_client_port",
 		"setrlimit.target.parent.user_session.ssh_public_key",
 		"setrlimit.target.parent.user_session.ssh_session_id",
 		"setrlimit.target.pid",
@@ -37098,13 +37818,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.tty_name",
 		"setrlimit.target.uid",
 		"setrlimit.target.user",
+		"setrlimit.target.user_session.id",
+		"setrlimit.target.user_session.identity",
 		"setrlimit.target.user_session.k8s_groups",
 		"setrlimit.target.user_session.k8s_session_id",
 		"setrlimit.target.user_session.k8s_uid",
 		"setrlimit.target.user_session.k8s_username",
+		"setrlimit.target.user_session.session_type",
 		"setrlimit.target.user_session.ssh_auth_method",
 		"setrlimit.target.user_session.ssh_client_ip",
-		"setrlimit.target.user_session.ssh_port",
+		"setrlimit.target.user_session.ssh_client_port",
 		"setrlimit.target.user_session.ssh_public_key",
 		"setrlimit.target.user_session.ssh_session_id",
 		"setsockopt.filter_hash",
@@ -37253,13 +37976,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.ancestors.tty_name",
 		"signal.target.ancestors.uid",
 		"signal.target.ancestors.user",
+		"signal.target.ancestors.user_session.id",
+		"signal.target.ancestors.user_session.identity",
 		"signal.target.ancestors.user_session.k8s_groups",
 		"signal.target.ancestors.user_session.k8s_session_id",
 		"signal.target.ancestors.user_session.k8s_uid",
 		"signal.target.ancestors.user_session.k8s_username",
+		"signal.target.ancestors.user_session.session_type",
 		"signal.target.ancestors.user_session.ssh_auth_method",
 		"signal.target.ancestors.user_session.ssh_client_ip",
-		"signal.target.ancestors.user_session.ssh_port",
+		"signal.target.ancestors.user_session.ssh_client_port",
 		"signal.target.ancestors.user_session.ssh_public_key",
 		"signal.target.ancestors.user_session.ssh_session_id",
 		"signal.target.args",
@@ -37448,13 +38174,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.parent.tty_name",
 		"signal.target.parent.uid",
 		"signal.target.parent.user",
+		"signal.target.parent.user_session.id",
+		"signal.target.parent.user_session.identity",
 		"signal.target.parent.user_session.k8s_groups",
 		"signal.target.parent.user_session.k8s_session_id",
 		"signal.target.parent.user_session.k8s_uid",
 		"signal.target.parent.user_session.k8s_username",
+		"signal.target.parent.user_session.session_type",
 		"signal.target.parent.user_session.ssh_auth_method",
 		"signal.target.parent.user_session.ssh_client_ip",
-		"signal.target.parent.user_session.ssh_port",
+		"signal.target.parent.user_session.ssh_client_port",
 		"signal.target.parent.user_session.ssh_public_key",
 		"signal.target.parent.user_session.ssh_session_id",
 		"signal.target.pid",
@@ -37463,13 +38192,16 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.tty_name",
 		"signal.target.uid",
 		"signal.target.user",
+		"signal.target.user_session.id",
+		"signal.target.user_session.identity",
 		"signal.target.user_session.k8s_groups",
 		"signal.target.user_session.k8s_session_id",
 		"signal.target.user_session.k8s_uid",
 		"signal.target.user_session.k8s_username",
+		"signal.target.user_session.session_type",
 		"signal.target.user_session.ssh_auth_method",
 		"signal.target.user_session.ssh_client_ip",
-		"signal.target.user_session.ssh_port",
+		"signal.target.user_session.ssh_client_port",
 		"signal.target.user_session.ssh_public_key",
 		"signal.target.user_session.ssh_session_id",
 		"signal.type",
@@ -38143,6 +38875,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.user":
 		return "exec", reflect.String, "string", false, nil
+	case "exec.user_session.id":
+		return "exec", reflect.String, "string", false, nil
+	case "exec.user_session.identity":
+		return "exec", reflect.String, "string", false, nil
 	case "exec.user_session.k8s_groups":
 		return "exec", reflect.String, "string", true, nil
 	case "exec.user_session.k8s_session_id":
@@ -38151,11 +38887,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.String, "string", false, nil
 	case "exec.user_session.k8s_username":
 		return "exec", reflect.String, "string", false, nil
+	case "exec.user_session.session_type":
+		return "exec", reflect.Int, "int", false, nil
 	case "exec.user_session.ssh_auth_method":
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.user_session.ssh_client_ip":
 		return "exec", reflect.Struct, "net.IPNet", false, nil
-	case "exec.user_session.ssh_port":
+	case "exec.user_session.ssh_client_port":
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.user_session.ssh_public_key":
 		return "exec", reflect.String, "string", false, nil
@@ -38357,6 +39095,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.user":
 		return "exit", reflect.String, "string", false, nil
+	case "exit.user_session.id":
+		return "exit", reflect.String, "string", false, nil
+	case "exit.user_session.identity":
+		return "exit", reflect.String, "string", false, nil
 	case "exit.user_session.k8s_groups":
 		return "exit", reflect.String, "string", true, nil
 	case "exit.user_session.k8s_session_id":
@@ -38365,11 +39107,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.String, "string", false, nil
 	case "exit.user_session.k8s_username":
 		return "exit", reflect.String, "string", false, nil
+	case "exit.user_session.session_type":
+		return "exit", reflect.Int, "int", false, nil
 	case "exit.user_session.ssh_auth_method":
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.user_session.ssh_client_ip":
 		return "exit", reflect.Struct, "net.IPNet", false, nil
-	case "exit.user_session.ssh_port":
+	case "exit.user_session.ssh_client_port":
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.user_session.ssh_public_key":
 		return "exit", reflect.String, "string", false, nil
@@ -39095,6 +39839,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user":
 		return "", reflect.String, "string", false, nil
+	case "process.ancestors.user_session.id":
+		return "", reflect.String, "string", false, nil
+	case "process.ancestors.user_session.identity":
+		return "", reflect.String, "string", false, nil
 	case "process.ancestors.user_session.k8s_groups":
 		return "", reflect.String, "string", true, nil
 	case "process.ancestors.user_session.k8s_session_id":
@@ -39103,11 +39851,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", false, nil
 	case "process.ancestors.user_session.k8s_username":
 		return "", reflect.String, "string", false, nil
+	case "process.ancestors.user_session.session_type":
+		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user_session.ssh_auth_method":
 		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user_session.ssh_client_ip":
 		return "", reflect.Struct, "net.IPNet", false, nil
-	case "process.ancestors.user_session.ssh_port":
+	case "process.ancestors.user_session.ssh_client_port":
 		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.user_session.ssh_public_key":
 		return "", reflect.String, "string", false, nil
@@ -39485,6 +40235,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.parent.user":
 		return "", reflect.String, "string", false, nil
+	case "process.parent.user_session.id":
+		return "", reflect.String, "string", false, nil
+	case "process.parent.user_session.identity":
+		return "", reflect.String, "string", false, nil
 	case "process.parent.user_session.k8s_groups":
 		return "", reflect.String, "string", true, nil
 	case "process.parent.user_session.k8s_session_id":
@@ -39493,11 +40247,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", false, nil
 	case "process.parent.user_session.k8s_username":
 		return "", reflect.String, "string", false, nil
+	case "process.parent.user_session.session_type":
+		return "", reflect.Int, "int", false, nil
 	case "process.parent.user_session.ssh_auth_method":
 		return "", reflect.Int, "int", false, nil
 	case "process.parent.user_session.ssh_client_ip":
 		return "", reflect.Struct, "net.IPNet", false, nil
-	case "process.parent.user_session.ssh_port":
+	case "process.parent.user_session.ssh_client_port":
 		return "", reflect.Int, "int", false, nil
 	case "process.parent.user_session.ssh_public_key":
 		return "", reflect.String, "string", false, nil
@@ -39515,6 +40271,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.user":
 		return "", reflect.String, "string", false, nil
+	case "process.user_session.id":
+		return "", reflect.String, "string", false, nil
+	case "process.user_session.identity":
+		return "", reflect.String, "string", false, nil
 	case "process.user_session.k8s_groups":
 		return "", reflect.String, "string", true, nil
 	case "process.user_session.k8s_session_id":
@@ -39523,11 +40283,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", false, nil
 	case "process.user_session.k8s_username":
 		return "", reflect.String, "string", false, nil
+	case "process.user_session.session_type":
+		return "", reflect.Int, "int", false, nil
 	case "process.user_session.ssh_auth_method":
 		return "", reflect.Int, "int", false, nil
 	case "process.user_session.ssh_client_ip":
 		return "", reflect.Struct, "net.IPNet", false, nil
-	case "process.user_session.ssh_port":
+	case "process.user_session.ssh_client_port":
 		return "", reflect.Int, "int", false, nil
 	case "process.user_session.ssh_public_key":
 		return "", reflect.String, "string", false, nil
@@ -39731,6 +40493,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.ancestors.user_session.id":
+		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.ancestors.user_session.identity":
+		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.ancestors.user_session.k8s_groups":
 		return "ptrace", reflect.String, "string", true, nil
 	case "ptrace.tracee.ancestors.user_session.k8s_session_id":
@@ -39739,11 +40505,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.ancestors.user_session.k8s_username":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.ancestors.user_session.session_type":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user_session.ssh_auth_method":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user_session.ssh_client_ip":
 		return "ptrace", reflect.Struct, "net.IPNet", false, nil
-	case "ptrace.tracee.ancestors.user_session.ssh_port":
+	case "ptrace.tracee.ancestors.user_session.ssh_client_port":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.user_session.ssh_public_key":
 		return "ptrace", reflect.String, "string", false, nil
@@ -40121,6 +40889,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.parent.user_session.id":
+		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.parent.user_session.identity":
+		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.parent.user_session.k8s_groups":
 		return "ptrace", reflect.String, "string", true, nil
 	case "ptrace.tracee.parent.user_session.k8s_session_id":
@@ -40129,11 +40901,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.parent.user_session.k8s_username":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.parent.user_session.session_type":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user_session.ssh_auth_method":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user_session.ssh_client_ip":
 		return "ptrace", reflect.Struct, "net.IPNet", false, nil
-	case "ptrace.tracee.parent.user_session.ssh_port":
+	case "ptrace.tracee.parent.user_session.ssh_client_port":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.user_session.ssh_public_key":
 		return "ptrace", reflect.String, "string", false, nil
@@ -40151,6 +40925,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.user_session.id":
+		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.user_session.identity":
+		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.user_session.k8s_groups":
 		return "ptrace", reflect.String, "string", true, nil
 	case "ptrace.tracee.user_session.k8s_session_id":
@@ -40159,11 +40937,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.user_session.k8s_username":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.user_session.session_type":
+		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user_session.ssh_auth_method":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user_session.ssh_client_ip":
 		return "ptrace", reflect.Struct, "net.IPNet", false, nil
-	case "ptrace.tracee.user_session.ssh_port":
+	case "ptrace.tracee.user_session.ssh_client_port":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.user_session.ssh_public_key":
 		return "ptrace", reflect.String, "string", false, nil
@@ -40623,6 +41403,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.ancestors.user_session.id":
+		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.ancestors.user_session.identity":
+		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.ancestors.user_session.k8s_groups":
 		return "setrlimit", reflect.String, "string", true, nil
 	case "setrlimit.target.ancestors.user_session.k8s_session_id":
@@ -40631,11 +41415,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.ancestors.user_session.k8s_username":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.ancestors.user_session.session_type":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user_session.ssh_auth_method":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user_session.ssh_client_ip":
 		return "setrlimit", reflect.Struct, "net.IPNet", false, nil
-	case "setrlimit.target.ancestors.user_session.ssh_port":
+	case "setrlimit.target.ancestors.user_session.ssh_client_port":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.user_session.ssh_public_key":
 		return "setrlimit", reflect.String, "string", false, nil
@@ -41013,6 +41799,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.parent.user_session.id":
+		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.parent.user_session.identity":
+		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.parent.user_session.k8s_groups":
 		return "setrlimit", reflect.String, "string", true, nil
 	case "setrlimit.target.parent.user_session.k8s_session_id":
@@ -41021,11 +41811,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.parent.user_session.k8s_username":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.parent.user_session.session_type":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user_session.ssh_auth_method":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user_session.ssh_client_ip":
 		return "setrlimit", reflect.Struct, "net.IPNet", false, nil
-	case "setrlimit.target.parent.user_session.ssh_port":
+	case "setrlimit.target.parent.user_session.ssh_client_port":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.user_session.ssh_public_key":
 		return "setrlimit", reflect.String, "string", false, nil
@@ -41043,6 +41835,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.user_session.id":
+		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.user_session.identity":
+		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.user_session.k8s_groups":
 		return "setrlimit", reflect.String, "string", true, nil
 	case "setrlimit.target.user_session.k8s_session_id":
@@ -41051,11 +41847,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.user_session.k8s_username":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.user_session.session_type":
+		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user_session.ssh_auth_method":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user_session.ssh_client_ip":
 		return "setrlimit", reflect.Struct, "net.IPNet", false, nil
-	case "setrlimit.target.user_session.ssh_port":
+	case "setrlimit.target.user_session.ssh_client_port":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.user_session.ssh_public_key":
 		return "setrlimit", reflect.String, "string", false, nil
@@ -41353,6 +42151,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.ancestors.user_session.id":
+		return "signal", reflect.String, "string", false, nil
+	case "signal.target.ancestors.user_session.identity":
+		return "signal", reflect.String, "string", false, nil
 	case "signal.target.ancestors.user_session.k8s_groups":
 		return "signal", reflect.String, "string", true, nil
 	case "signal.target.ancestors.user_session.k8s_session_id":
@@ -41361,11 +42163,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", false, nil
 	case "signal.target.ancestors.user_session.k8s_username":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.ancestors.user_session.session_type":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user_session.ssh_auth_method":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user_session.ssh_client_ip":
 		return "signal", reflect.Struct, "net.IPNet", false, nil
-	case "signal.target.ancestors.user_session.ssh_port":
+	case "signal.target.ancestors.user_session.ssh_client_port":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.user_session.ssh_public_key":
 		return "signal", reflect.String, "string", false, nil
@@ -41743,6 +42547,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.parent.user_session.id":
+		return "signal", reflect.String, "string", false, nil
+	case "signal.target.parent.user_session.identity":
+		return "signal", reflect.String, "string", false, nil
 	case "signal.target.parent.user_session.k8s_groups":
 		return "signal", reflect.String, "string", true, nil
 	case "signal.target.parent.user_session.k8s_session_id":
@@ -41751,11 +42559,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", false, nil
 	case "signal.target.parent.user_session.k8s_username":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.parent.user_session.session_type":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user_session.ssh_auth_method":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user_session.ssh_client_ip":
 		return "signal", reflect.Struct, "net.IPNet", false, nil
-	case "signal.target.parent.user_session.ssh_port":
+	case "signal.target.parent.user_session.ssh_client_port":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.user_session.ssh_public_key":
 		return "signal", reflect.String, "string", false, nil
@@ -41773,6 +42583,10 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.user_session.id":
+		return "signal", reflect.String, "string", false, nil
+	case "signal.target.user_session.identity":
+		return "signal", reflect.String, "string", false, nil
 	case "signal.target.user_session.k8s_groups":
 		return "signal", reflect.String, "string", true, nil
 	case "signal.target.user_session.k8s_session_id":
@@ -41781,11 +42595,13 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", false, nil
 	case "signal.target.user_session.k8s_username":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.user_session.session_type":
+		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user_session.ssh_auth_method":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user_session.ssh_client_ip":
 		return "signal", reflect.Struct, "net.IPNet", false, nil
-	case "signal.target.user_session.ssh_port":
+	case "signal.target.user_session.ssh_client_port":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.user_session.ssh_public_key":
 		return "signal", reflect.String, "string", false, nil
@@ -42700,29 +43516,35 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("exec.uid", &ev.Exec.Process.Credentials.UID, value)
 	case "exec.user":
 		return ev.setStringFieldValue("exec.user", &ev.Exec.Process.Credentials.User, value)
+	case "exec.user_session.id":
+		return ev.setStringFieldValue("exec.user_session.id", &ev.Exec.Process.UserSession.ID, value)
+	case "exec.user_session.identity":
+		return ev.setStringFieldValue("exec.user_session.identity", &ev.Exec.Process.UserSession.Identity, value)
 	case "exec.user_session.k8s_groups":
-		return ev.setStringArrayFieldValue("exec.user_session.k8s_groups", &ev.Exec.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("exec.user_session.k8s_groups", &ev.Exec.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "exec.user_session.k8s_session_id":
-		return ev.setUint64FieldValue("exec.user_session.k8s_session_id", &ev.Exec.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("exec.user_session.k8s_session_id", &ev.Exec.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "exec.user_session.k8s_uid":
-		return ev.setStringFieldValue("exec.user_session.k8s_uid", &ev.Exec.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("exec.user_session.k8s_uid", &ev.Exec.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "exec.user_session.k8s_username":
-		return ev.setStringFieldValue("exec.user_session.k8s_username", &ev.Exec.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("exec.user_session.k8s_username", &ev.Exec.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "exec.user_session.session_type":
+		return ev.setIntFieldValue("exec.user_session.session_type", &ev.Exec.Process.UserSession.SessionType, value)
 	case "exec.user_session.ssh_auth_method":
-		return ev.setIntFieldValue("exec.user_session.ssh_auth_method", &ev.Exec.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("exec.user_session.ssh_auth_method", &ev.Exec.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "exec.user_session.ssh_client_ip":
 		rv, ok := value.(net.IPNet)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "exec.user_session.ssh_client_ip"}
 		}
-		ev.Exec.Process.UserSession.SSHClientIP = rv
+		ev.Exec.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "exec.user_session.ssh_port":
-		return ev.setIntFieldValue("exec.user_session.ssh_port", &ev.Exec.Process.UserSession.SSHPort, value)
+	case "exec.user_session.ssh_client_port":
+		return ev.setIntFieldValue("exec.user_session.ssh_client_port", &ev.Exec.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "exec.user_session.ssh_public_key":
-		return ev.setStringFieldValue("exec.user_session.ssh_public_key", &ev.Exec.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("exec.user_session.ssh_public_key", &ev.Exec.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "exec.user_session.ssh_session_id":
-		return ev.setUint64FieldValue("exec.user_session.ssh_session_id", &ev.Exec.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("exec.user_session.ssh_session_id", &ev.Exec.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "exit.args":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -43317,31 +44139,46 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Exit.Process = &Process{}
 		}
 		return ev.setStringFieldValue("exit.user", &ev.Exit.Process.Credentials.User, value)
+	case "exit.user_session.id":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setStringFieldValue("exit.user_session.id", &ev.Exit.Process.UserSession.ID, value)
+	case "exit.user_session.identity":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setStringFieldValue("exit.user_session.identity", &ev.Exit.Process.UserSession.Identity, value)
 	case "exit.user_session.k8s_groups":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setStringArrayFieldValue("exit.user_session.k8s_groups", &ev.Exit.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("exit.user_session.k8s_groups", &ev.Exit.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "exit.user_session.k8s_session_id":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setUint64FieldValue("exit.user_session.k8s_session_id", &ev.Exit.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("exit.user_session.k8s_session_id", &ev.Exit.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "exit.user_session.k8s_uid":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setStringFieldValue("exit.user_session.k8s_uid", &ev.Exit.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("exit.user_session.k8s_uid", &ev.Exit.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "exit.user_session.k8s_username":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setStringFieldValue("exit.user_session.k8s_username", &ev.Exit.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("exit.user_session.k8s_username", &ev.Exit.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "exit.user_session.session_type":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setIntFieldValue("exit.user_session.session_type", &ev.Exit.Process.UserSession.SessionType, value)
 	case "exit.user_session.ssh_auth_method":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setIntFieldValue("exit.user_session.ssh_auth_method", &ev.Exit.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("exit.user_session.ssh_auth_method", &ev.Exit.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "exit.user_session.ssh_client_ip":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -43350,23 +44187,23 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "exit.user_session.ssh_client_ip"}
 		}
-		ev.Exit.Process.UserSession.SSHClientIP = rv
+		ev.Exit.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "exit.user_session.ssh_port":
+	case "exit.user_session.ssh_client_port":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setIntFieldValue("exit.user_session.ssh_port", &ev.Exit.Process.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("exit.user_session.ssh_client_port", &ev.Exit.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "exit.user_session.ssh_public_key":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setStringFieldValue("exit.user_session.ssh_public_key", &ev.Exit.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("exit.user_session.ssh_public_key", &ev.Exit.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "exit.user_session.ssh_session_id":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
 		}
-		return ev.setUint64FieldValue("exit.user_session.ssh_session_id", &ev.Exit.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("exit.user_session.ssh_session_id", &ev.Exit.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "imds.aws.is_imds_v2":
 		return ev.setBoolFieldValue("imds.aws.is_imds_v2", &ev.IMDS.AWS.IsIMDSv2, value)
 	case "imds.aws.security_credentials.type":
@@ -44266,29 +45103,35 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("process.ancestors.uid", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Credentials.UID, value)
 	case "process.ancestors.user":
 		return ev.setStringFieldValue("process.ancestors.user", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.Credentials.User, value)
+	case "process.ancestors.user_session.id":
+		return ev.setStringFieldValue("process.ancestors.user_session.id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.ID, value)
+	case "process.ancestors.user_session.identity":
+		return ev.setStringFieldValue("process.ancestors.user_session.identity", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.Identity, value)
 	case "process.ancestors.user_session.k8s_groups":
-		return ev.setStringArrayFieldValue("process.ancestors.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("process.ancestors.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "process.ancestors.user_session.k8s_session_id":
-		return ev.setUint64FieldValue("process.ancestors.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("process.ancestors.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "process.ancestors.user_session.k8s_uid":
-		return ev.setStringFieldValue("process.ancestors.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("process.ancestors.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "process.ancestors.user_session.k8s_username":
-		return ev.setStringFieldValue("process.ancestors.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("process.ancestors.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "process.ancestors.user_session.session_type":
+		return ev.setIntFieldValue("process.ancestors.user_session.session_type", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
 	case "process.ancestors.user_session.ssh_auth_method":
-		return ev.setIntFieldValue("process.ancestors.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("process.ancestors.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "process.ancestors.user_session.ssh_client_ip":
 		rv, ok := value.(net.IPNet)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "process.ancestors.user_session.ssh_client_ip"}
 		}
-		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHClientIP = rv
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "process.ancestors.user_session.ssh_port":
-		return ev.setIntFieldValue("process.ancestors.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
+	case "process.ancestors.user_session.ssh_client_port":
+		return ev.setIntFieldValue("process.ancestors.user_session.ssh_client_port", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "process.ancestors.user_session.ssh_public_key":
-		return ev.setStringFieldValue("process.ancestors.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("process.ancestors.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "process.ancestors.user_session.ssh_session_id":
-		return ev.setUint64FieldValue("process.ancestors.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("process.ancestors.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "process.args":
 		return ev.setStringFieldValue("process.args", &ev.BaseEvent.ProcessContext.Process.Args, value)
 	case "process.args_flags":
@@ -44881,29 +45724,35 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("process.parent.uid", &ev.BaseEvent.ProcessContext.Parent.Credentials.UID, value)
 	case "process.parent.user":
 		return ev.setStringFieldValue("process.parent.user", &ev.BaseEvent.ProcessContext.Parent.Credentials.User, value)
+	case "process.parent.user_session.id":
+		return ev.setStringFieldValue("process.parent.user_session.id", &ev.BaseEvent.ProcessContext.Parent.UserSession.ID, value)
+	case "process.parent.user_session.identity":
+		return ev.setStringFieldValue("process.parent.user_session.identity", &ev.BaseEvent.ProcessContext.Parent.UserSession.Identity, value)
 	case "process.parent.user_session.k8s_groups":
-		return ev.setStringArrayFieldValue("process.parent.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("process.parent.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext.K8SGroups, value)
 	case "process.parent.user_session.k8s_session_id":
-		return ev.setUint64FieldValue("process.parent.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("process.parent.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "process.parent.user_session.k8s_uid":
-		return ev.setStringFieldValue("process.parent.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("process.parent.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext.K8SUID, value)
 	case "process.parent.user_session.k8s_username":
-		return ev.setStringFieldValue("process.parent.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("process.parent.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext.K8SUsername, value)
+	case "process.parent.user_session.session_type":
+		return ev.setIntFieldValue("process.parent.user_session.session_type", &ev.BaseEvent.ProcessContext.Parent.UserSession.SessionType, value)
 	case "process.parent.user_session.ssh_auth_method":
-		return ev.setIntFieldValue("process.parent.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("process.parent.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "process.parent.user_session.ssh_client_ip":
 		rv, ok := value.(net.IPNet)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "process.parent.user_session.ssh_client_ip"}
 		}
-		ev.BaseEvent.ProcessContext.Parent.UserSession.SSHClientIP = rv
+		ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "process.parent.user_session.ssh_port":
-		return ev.setIntFieldValue("process.parent.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPort, value)
+	case "process.parent.user_session.ssh_client_port":
+		return ev.setIntFieldValue("process.parent.user_session.ssh_client_port", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "process.parent.user_session.ssh_public_key":
-		return ev.setStringFieldValue("process.parent.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("process.parent.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "process.parent.user_session.ssh_session_id":
-		return ev.setUint64FieldValue("process.parent.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("process.parent.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "process.pid":
 		return ev.setUint32FieldValue("process.pid", &ev.BaseEvent.ProcessContext.Process.PIDContext.Pid, value)
 	case "process.ppid":
@@ -44916,29 +45765,35 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("process.uid", &ev.BaseEvent.ProcessContext.Process.Credentials.UID, value)
 	case "process.user":
 		return ev.setStringFieldValue("process.user", &ev.BaseEvent.ProcessContext.Process.Credentials.User, value)
+	case "process.user_session.id":
+		return ev.setStringFieldValue("process.user_session.id", &ev.BaseEvent.ProcessContext.Process.UserSession.ID, value)
+	case "process.user_session.identity":
+		return ev.setStringFieldValue("process.user_session.identity", &ev.BaseEvent.ProcessContext.Process.UserSession.Identity, value)
 	case "process.user_session.k8s_groups":
-		return ev.setStringArrayFieldValue("process.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("process.user_session.k8s_groups", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "process.user_session.k8s_session_id":
-		return ev.setUint64FieldValue("process.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("process.user_session.k8s_session_id", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "process.user_session.k8s_uid":
-		return ev.setStringFieldValue("process.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("process.user_session.k8s_uid", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "process.user_session.k8s_username":
-		return ev.setStringFieldValue("process.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("process.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "process.user_session.session_type":
+		return ev.setIntFieldValue("process.user_session.session_type", &ev.BaseEvent.ProcessContext.Process.UserSession.SessionType, value)
 	case "process.user_session.ssh_auth_method":
-		return ev.setIntFieldValue("process.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("process.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "process.user_session.ssh_client_ip":
 		rv, ok := value.(net.IPNet)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "process.user_session.ssh_client_ip"}
 		}
-		ev.BaseEvent.ProcessContext.Process.UserSession.SSHClientIP = rv
+		ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "process.user_session.ssh_port":
-		return ev.setIntFieldValue("process.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHPort, value)
+	case "process.user_session.ssh_client_port":
+		return ev.setIntFieldValue("process.user_session.ssh_client_port", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "process.user_session.ssh_public_key":
-		return ev.setStringFieldValue("process.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("process.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "process.user_session.ssh_session_id":
-		return ev.setUint64FieldValue("process.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("process.user_session.ssh_session_id", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "ptrace.request":
 		return ev.setUint32FieldValue("ptrace.request", &ev.PTrace.Request, value)
 	case "ptrace.retval":
@@ -45829,6 +46684,22 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.ancestors.user", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.Credentials.User, value)
+	case "ptrace.tracee.ancestors.user_session.id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.id", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.ID, value)
+	case "ptrace.tracee.ancestors.user_session.identity":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.identity", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.Identity, value)
 	case "ptrace.tracee.ancestors.user_session.k8s_groups":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45836,7 +46707,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Ancestor == nil {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringArrayFieldValue("ptrace.tracee.ancestors.user_session.k8s_groups", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("ptrace.tracee.ancestors.user_session.k8s_groups", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "ptrace.tracee.ancestors.user_session.k8s_session_id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45844,7 +46715,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Ancestor == nil {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setUint64FieldValue("ptrace.tracee.ancestors.user_session.k8s_session_id", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("ptrace.tracee.ancestors.user_session.k8s_session_id", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "ptrace.tracee.ancestors.user_session.k8s_uid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45852,7 +46723,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Ancestor == nil {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.k8s_uid", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.k8s_uid", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "ptrace.tracee.ancestors.user_session.k8s_username":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45860,7 +46731,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Ancestor == nil {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.k8s_username", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.k8s_username", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "ptrace.tracee.ancestors.user_session.session_type":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.session_type", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
 	case "ptrace.tracee.ancestors.user_session.ssh_auth_method":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45868,7 +46747,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Ancestor == nil {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.ssh_auth_method", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.ssh_auth_method", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "ptrace.tracee.ancestors.user_session.ssh_client_ip":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45880,16 +46759,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.ancestors.user_session.ssh_client_ip"}
 		}
-		ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHClientIP = rv
+		ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "ptrace.tracee.ancestors.user_session.ssh_port":
+	case "ptrace.tracee.ancestors.user_session.ssh_client_port":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		if ev.PTrace.Tracee.Ancestor == nil {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.ssh_port", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.ssh_client_port", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "ptrace.tracee.ancestors.user_session.ssh_public_key":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45897,7 +46776,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Ancestor == nil {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.ssh_public_key", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.ssh_public_key", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "ptrace.tracee.ancestors.user_session.ssh_session_id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -45905,7 +46784,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Ancestor == nil {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setUint64FieldValue("ptrace.tracee.ancestors.user_session.ssh_session_id", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("ptrace.tracee.ancestors.user_session.ssh_session_id", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "ptrace.tracee.args":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47344,6 +48223,22 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.parent.user", &ev.PTrace.Tracee.Parent.Credentials.User, value)
+	case "ptrace.tracee.parent.user_session.id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.id", &ev.PTrace.Tracee.Parent.UserSession.ID, value)
+	case "ptrace.tracee.parent.user_session.identity":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.identity", &ev.PTrace.Tracee.Parent.UserSession.Identity, value)
 	case "ptrace.tracee.parent.user_session.k8s_groups":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47351,7 +48246,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Parent == nil {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
-		return ev.setStringArrayFieldValue("ptrace.tracee.parent.user_session.k8s_groups", &ev.PTrace.Tracee.Parent.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("ptrace.tracee.parent.user_session.k8s_groups", &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext.K8SGroups, value)
 	case "ptrace.tracee.parent.user_session.k8s_session_id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47359,7 +48254,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Parent == nil {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
-		return ev.setUint64FieldValue("ptrace.tracee.parent.user_session.k8s_session_id", &ev.PTrace.Tracee.Parent.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("ptrace.tracee.parent.user_session.k8s_session_id", &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "ptrace.tracee.parent.user_session.k8s_uid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47367,7 +48262,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Parent == nil {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.k8s_uid", &ev.PTrace.Tracee.Parent.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.k8s_uid", &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext.K8SUID, value)
 	case "ptrace.tracee.parent.user_session.k8s_username":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47375,7 +48270,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Parent == nil {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.k8s_username", &ev.PTrace.Tracee.Parent.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.k8s_username", &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext.K8SUsername, value)
+	case "ptrace.tracee.parent.user_session.session_type":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.session_type", &ev.PTrace.Tracee.Parent.UserSession.SessionType, value)
 	case "ptrace.tracee.parent.user_session.ssh_auth_method":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47383,7 +48286,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Parent == nil {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
-		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.ssh_auth_method", &ev.PTrace.Tracee.Parent.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.ssh_auth_method", &ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "ptrace.tracee.parent.user_session.ssh_client_ip":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47395,16 +48298,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.parent.user_session.ssh_client_ip"}
 		}
-		ev.PTrace.Tracee.Parent.UserSession.SSHClientIP = rv
+		ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "ptrace.tracee.parent.user_session.ssh_port":
+	case "ptrace.tracee.parent.user_session.ssh_client_port":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		if ev.PTrace.Tracee.Parent == nil {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
-		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.ssh_port", &ev.PTrace.Tracee.Parent.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.ssh_client_port", &ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "ptrace.tracee.parent.user_session.ssh_public_key":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47412,7 +48315,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Parent == nil {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.ssh_public_key", &ev.PTrace.Tracee.Parent.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.ssh_public_key", &ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "ptrace.tracee.parent.user_session.ssh_session_id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47420,7 +48323,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.PTrace.Tracee.Parent == nil {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
-		return ev.setUint64FieldValue("ptrace.tracee.parent.user_session.ssh_session_id", &ev.PTrace.Tracee.Parent.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("ptrace.tracee.parent.user_session.ssh_session_id", &ev.PTrace.Tracee.Parent.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "ptrace.tracee.pid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47451,31 +48354,46 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("ptrace.tracee.user", &ev.PTrace.Tracee.Process.Credentials.User, value)
+	case "ptrace.tracee.user_session.id":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.user_session.id", &ev.PTrace.Tracee.Process.UserSession.ID, value)
+	case "ptrace.tracee.user_session.identity":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.user_session.identity", &ev.PTrace.Tracee.Process.UserSession.Identity, value)
 	case "ptrace.tracee.user_session.k8s_groups":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
-		return ev.setStringArrayFieldValue("ptrace.tracee.user_session.k8s_groups", &ev.PTrace.Tracee.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("ptrace.tracee.user_session.k8s_groups", &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "ptrace.tracee.user_session.k8s_session_id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
-		return ev.setUint64FieldValue("ptrace.tracee.user_session.k8s_session_id", &ev.PTrace.Tracee.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("ptrace.tracee.user_session.k8s_session_id", &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "ptrace.tracee.user_session.k8s_uid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.user_session.k8s_uid", &ev.PTrace.Tracee.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("ptrace.tracee.user_session.k8s_uid", &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "ptrace.tracee.user_session.k8s_username":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.user_session.k8s_username", &ev.PTrace.Tracee.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("ptrace.tracee.user_session.k8s_username", &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "ptrace.tracee.user_session.session_type":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.user_session.session_type", &ev.PTrace.Tracee.Process.UserSession.SessionType, value)
 	case "ptrace.tracee.user_session.ssh_auth_method":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
-		return ev.setIntFieldValue("ptrace.tracee.user_session.ssh_auth_method", &ev.PTrace.Tracee.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("ptrace.tracee.user_session.ssh_auth_method", &ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "ptrace.tracee.user_session.ssh_client_ip":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47484,23 +48402,23 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.user_session.ssh_client_ip"}
 		}
-		ev.PTrace.Tracee.Process.UserSession.SSHClientIP = rv
+		ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "ptrace.tracee.user_session.ssh_port":
+	case "ptrace.tracee.user_session.ssh_client_port":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
-		return ev.setIntFieldValue("ptrace.tracee.user_session.ssh_port", &ev.PTrace.Tracee.Process.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("ptrace.tracee.user_session.ssh_client_port", &ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "ptrace.tracee.user_session.ssh_public_key":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("ptrace.tracee.user_session.ssh_public_key", &ev.PTrace.Tracee.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("ptrace.tracee.user_session.ssh_public_key", &ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "ptrace.tracee.user_session.ssh_session_id":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
-		return ev.setUint64FieldValue("ptrace.tracee.user_session.ssh_session_id", &ev.PTrace.Tracee.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("ptrace.tracee.user_session.ssh_session_id", &ev.PTrace.Tracee.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "removexattr.file.change_time":
 		return ev.setUint64FieldValue("removexattr.file.change_time", &ev.RemoveXAttr.File.FileFields.CTime, value)
 	case "removexattr.file.destination.name":
@@ -48647,6 +49565,22 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.ancestors.user", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.Credentials.User, value)
+	case "setrlimit.target.ancestors.user_session.id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.id", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.ID, value)
+	case "setrlimit.target.ancestors.user_session.identity":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.identity", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.Identity, value)
 	case "setrlimit.target.ancestors.user_session.k8s_groups":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48654,7 +49588,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Ancestor == nil {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringArrayFieldValue("setrlimit.target.ancestors.user_session.k8s_groups", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("setrlimit.target.ancestors.user_session.k8s_groups", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "setrlimit.target.ancestors.user_session.k8s_session_id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48662,7 +49596,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Ancestor == nil {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setUint64FieldValue("setrlimit.target.ancestors.user_session.k8s_session_id", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("setrlimit.target.ancestors.user_session.k8s_session_id", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "setrlimit.target.ancestors.user_session.k8s_uid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48670,7 +49604,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Ancestor == nil {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.k8s_uid", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.k8s_uid", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "setrlimit.target.ancestors.user_session.k8s_username":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48678,7 +49612,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Ancestor == nil {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.k8s_username", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.k8s_username", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "setrlimit.target.ancestors.user_session.session_type":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.session_type", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
 	case "setrlimit.target.ancestors.user_session.ssh_auth_method":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48686,7 +49628,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Ancestor == nil {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.ssh_auth_method", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.ssh_auth_method", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "setrlimit.target.ancestors.user_session.ssh_client_ip":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48698,16 +49640,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.ancestors.user_session.ssh_client_ip"}
 		}
-		ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHClientIP = rv
+		ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "setrlimit.target.ancestors.user_session.ssh_port":
+	case "setrlimit.target.ancestors.user_session.ssh_client_port":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		if ev.Setrlimit.Target.Ancestor == nil {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.ssh_port", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.ssh_client_port", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "setrlimit.target.ancestors.user_session.ssh_public_key":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48715,7 +49657,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Ancestor == nil {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.ssh_public_key", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.ssh_public_key", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "setrlimit.target.ancestors.user_session.ssh_session_id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48723,7 +49665,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Ancestor == nil {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setUint64FieldValue("setrlimit.target.ancestors.user_session.ssh_session_id", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("setrlimit.target.ancestors.user_session.ssh_session_id", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "setrlimit.target.args":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50162,6 +51104,22 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.parent.user", &ev.Setrlimit.Target.Parent.Credentials.User, value)
+	case "setrlimit.target.parent.user_session.id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.parent.user_session.id", &ev.Setrlimit.Target.Parent.UserSession.ID, value)
+	case "setrlimit.target.parent.user_session.identity":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.parent.user_session.identity", &ev.Setrlimit.Target.Parent.UserSession.Identity, value)
 	case "setrlimit.target.parent.user_session.k8s_groups":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50169,7 +51127,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Parent == nil {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
-		return ev.setStringArrayFieldValue("setrlimit.target.parent.user_session.k8s_groups", &ev.Setrlimit.Target.Parent.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("setrlimit.target.parent.user_session.k8s_groups", &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext.K8SGroups, value)
 	case "setrlimit.target.parent.user_session.k8s_session_id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50177,7 +51135,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Parent == nil {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
-		return ev.setUint64FieldValue("setrlimit.target.parent.user_session.k8s_session_id", &ev.Setrlimit.Target.Parent.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("setrlimit.target.parent.user_session.k8s_session_id", &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "setrlimit.target.parent.user_session.k8s_uid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50185,7 +51143,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Parent == nil {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.parent.user_session.k8s_uid", &ev.Setrlimit.Target.Parent.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("setrlimit.target.parent.user_session.k8s_uid", &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext.K8SUID, value)
 	case "setrlimit.target.parent.user_session.k8s_username":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50193,7 +51151,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Parent == nil {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.parent.user_session.k8s_username", &ev.Setrlimit.Target.Parent.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("setrlimit.target.parent.user_session.k8s_username", &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext.K8SUsername, value)
+	case "setrlimit.target.parent.user_session.session_type":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.parent.user_session.session_type", &ev.Setrlimit.Target.Parent.UserSession.SessionType, value)
 	case "setrlimit.target.parent.user_session.ssh_auth_method":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50201,7 +51167,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Parent == nil {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
-		return ev.setIntFieldValue("setrlimit.target.parent.user_session.ssh_auth_method", &ev.Setrlimit.Target.Parent.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("setrlimit.target.parent.user_session.ssh_auth_method", &ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "setrlimit.target.parent.user_session.ssh_client_ip":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50213,16 +51179,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.parent.user_session.ssh_client_ip"}
 		}
-		ev.Setrlimit.Target.Parent.UserSession.SSHClientIP = rv
+		ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "setrlimit.target.parent.user_session.ssh_port":
+	case "setrlimit.target.parent.user_session.ssh_client_port":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		if ev.Setrlimit.Target.Parent == nil {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
-		return ev.setIntFieldValue("setrlimit.target.parent.user_session.ssh_port", &ev.Setrlimit.Target.Parent.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("setrlimit.target.parent.user_session.ssh_client_port", &ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "setrlimit.target.parent.user_session.ssh_public_key":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50230,7 +51196,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Parent == nil {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.parent.user_session.ssh_public_key", &ev.Setrlimit.Target.Parent.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("setrlimit.target.parent.user_session.ssh_public_key", &ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "setrlimit.target.parent.user_session.ssh_session_id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50238,7 +51204,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Setrlimit.Target.Parent == nil {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
-		return ev.setUint64FieldValue("setrlimit.target.parent.user_session.ssh_session_id", &ev.Setrlimit.Target.Parent.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("setrlimit.target.parent.user_session.ssh_session_id", &ev.Setrlimit.Target.Parent.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "setrlimit.target.pid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50269,31 +51235,46 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("setrlimit.target.user", &ev.Setrlimit.Target.Process.Credentials.User, value)
+	case "setrlimit.target.user_session.id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.user_session.id", &ev.Setrlimit.Target.Process.UserSession.ID, value)
+	case "setrlimit.target.user_session.identity":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.user_session.identity", &ev.Setrlimit.Target.Process.UserSession.Identity, value)
 	case "setrlimit.target.user_session.k8s_groups":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
-		return ev.setStringArrayFieldValue("setrlimit.target.user_session.k8s_groups", &ev.Setrlimit.Target.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("setrlimit.target.user_session.k8s_groups", &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "setrlimit.target.user_session.k8s_session_id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
-		return ev.setUint64FieldValue("setrlimit.target.user_session.k8s_session_id", &ev.Setrlimit.Target.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("setrlimit.target.user_session.k8s_session_id", &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "setrlimit.target.user_session.k8s_uid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.user_session.k8s_uid", &ev.Setrlimit.Target.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("setrlimit.target.user_session.k8s_uid", &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "setrlimit.target.user_session.k8s_username":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.user_session.k8s_username", &ev.Setrlimit.Target.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("setrlimit.target.user_session.k8s_username", &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "setrlimit.target.user_session.session_type":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.user_session.session_type", &ev.Setrlimit.Target.Process.UserSession.SessionType, value)
 	case "setrlimit.target.user_session.ssh_auth_method":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
-		return ev.setIntFieldValue("setrlimit.target.user_session.ssh_auth_method", &ev.Setrlimit.Target.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("setrlimit.target.user_session.ssh_auth_method", &ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "setrlimit.target.user_session.ssh_client_ip":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50302,23 +51283,23 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.user_session.ssh_client_ip"}
 		}
-		ev.Setrlimit.Target.Process.UserSession.SSHClientIP = rv
+		ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "setrlimit.target.user_session.ssh_port":
+	case "setrlimit.target.user_session.ssh_client_port":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
-		return ev.setIntFieldValue("setrlimit.target.user_session.ssh_port", &ev.Setrlimit.Target.Process.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("setrlimit.target.user_session.ssh_client_port", &ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "setrlimit.target.user_session.ssh_public_key":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("setrlimit.target.user_session.ssh_public_key", &ev.Setrlimit.Target.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("setrlimit.target.user_session.ssh_public_key", &ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "setrlimit.target.user_session.ssh_session_id":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
-		return ev.setUint64FieldValue("setrlimit.target.user_session.ssh_session_id", &ev.Setrlimit.Target.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("setrlimit.target.user_session.ssh_session_id", &ev.Setrlimit.Target.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "setsockopt.filter_hash":
 		return ev.setStringFieldValue("setsockopt.filter_hash", &ev.SetSockOpt.FilterHash, value)
 	case "setsockopt.filter_instructions":
@@ -51313,6 +52294,22 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setStringFieldValue("signal.target.ancestors.user", &ev.Signal.Target.Ancestor.ProcessContext.Process.Credentials.User, value)
+	case "signal.target.ancestors.user_session.id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("signal.target.ancestors.user_session.id", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.ID, value)
+	case "signal.target.ancestors.user_session.identity":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("signal.target.ancestors.user_session.identity", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.Identity, value)
 	case "signal.target.ancestors.user_session.k8s_groups":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51320,7 +52317,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Ancestor == nil {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringArrayFieldValue("signal.target.ancestors.user_session.k8s_groups", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("signal.target.ancestors.user_session.k8s_groups", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "signal.target.ancestors.user_session.k8s_session_id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51328,7 +52325,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Ancestor == nil {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setUint64FieldValue("signal.target.ancestors.user_session.k8s_session_id", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("signal.target.ancestors.user_session.k8s_session_id", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "signal.target.ancestors.user_session.k8s_uid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51336,7 +52333,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Ancestor == nil {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("signal.target.ancestors.user_session.k8s_uid", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("signal.target.ancestors.user_session.k8s_uid", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "signal.target.ancestors.user_session.k8s_username":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51344,7 +52341,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Ancestor == nil {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("signal.target.ancestors.user_session.k8s_username", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("signal.target.ancestors.user_session.k8s_username", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "signal.target.ancestors.user_session.session_type":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("signal.target.ancestors.user_session.session_type", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
 	case "signal.target.ancestors.user_session.ssh_auth_method":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51352,7 +52357,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Ancestor == nil {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setIntFieldValue("signal.target.ancestors.user_session.ssh_auth_method", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("signal.target.ancestors.user_session.ssh_auth_method", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "signal.target.ancestors.user_session.ssh_client_ip":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51364,16 +52369,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "signal.target.ancestors.user_session.ssh_client_ip"}
 		}
-		ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHClientIP = rv
+		ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "signal.target.ancestors.user_session.ssh_port":
+	case "signal.target.ancestors.user_session.ssh_client_port":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		if ev.Signal.Target.Ancestor == nil {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setIntFieldValue("signal.target.ancestors.user_session.ssh_port", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("signal.target.ancestors.user_session.ssh_client_port", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "signal.target.ancestors.user_session.ssh_public_key":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51381,7 +52386,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Ancestor == nil {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setStringFieldValue("signal.target.ancestors.user_session.ssh_public_key", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("signal.target.ancestors.user_session.ssh_public_key", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "signal.target.ancestors.user_session.ssh_session_id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51389,7 +52394,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Ancestor == nil {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
-		return ev.setUint64FieldValue("signal.target.ancestors.user_session.ssh_session_id", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("signal.target.ancestors.user_session.ssh_session_id", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "signal.target.args":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52828,6 +53833,22 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setStringFieldValue("signal.target.parent.user", &ev.Signal.Target.Parent.Credentials.User, value)
+	case "signal.target.parent.user_session.id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("signal.target.parent.user_session.id", &ev.Signal.Target.Parent.UserSession.ID, value)
+	case "signal.target.parent.user_session.identity":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("signal.target.parent.user_session.identity", &ev.Signal.Target.Parent.UserSession.Identity, value)
 	case "signal.target.parent.user_session.k8s_groups":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52835,7 +53856,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Parent == nil {
 			ev.Signal.Target.Parent = &Process{}
 		}
-		return ev.setStringArrayFieldValue("signal.target.parent.user_session.k8s_groups", &ev.Signal.Target.Parent.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("signal.target.parent.user_session.k8s_groups", &ev.Signal.Target.Parent.UserSession.K8SSessionContext.K8SGroups, value)
 	case "signal.target.parent.user_session.k8s_session_id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52843,7 +53864,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Parent == nil {
 			ev.Signal.Target.Parent = &Process{}
 		}
-		return ev.setUint64FieldValue("signal.target.parent.user_session.k8s_session_id", &ev.Signal.Target.Parent.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("signal.target.parent.user_session.k8s_session_id", &ev.Signal.Target.Parent.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "signal.target.parent.user_session.k8s_uid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52851,7 +53872,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Parent == nil {
 			ev.Signal.Target.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("signal.target.parent.user_session.k8s_uid", &ev.Signal.Target.Parent.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("signal.target.parent.user_session.k8s_uid", &ev.Signal.Target.Parent.UserSession.K8SSessionContext.K8SUID, value)
 	case "signal.target.parent.user_session.k8s_username":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52859,7 +53880,15 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Parent == nil {
 			ev.Signal.Target.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("signal.target.parent.user_session.k8s_username", &ev.Signal.Target.Parent.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("signal.target.parent.user_session.k8s_username", &ev.Signal.Target.Parent.UserSession.K8SSessionContext.K8SUsername, value)
+	case "signal.target.parent.user_session.session_type":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("signal.target.parent.user_session.session_type", &ev.Signal.Target.Parent.UserSession.SessionType, value)
 	case "signal.target.parent.user_session.ssh_auth_method":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52867,7 +53896,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Parent == nil {
 			ev.Signal.Target.Parent = &Process{}
 		}
-		return ev.setIntFieldValue("signal.target.parent.user_session.ssh_auth_method", &ev.Signal.Target.Parent.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("signal.target.parent.user_session.ssh_auth_method", &ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "signal.target.parent.user_session.ssh_client_ip":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52879,16 +53908,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "signal.target.parent.user_session.ssh_client_ip"}
 		}
-		ev.Signal.Target.Parent.UserSession.SSHClientIP = rv
+		ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "signal.target.parent.user_session.ssh_port":
+	case "signal.target.parent.user_session.ssh_client_port":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		if ev.Signal.Target.Parent == nil {
 			ev.Signal.Target.Parent = &Process{}
 		}
-		return ev.setIntFieldValue("signal.target.parent.user_session.ssh_port", &ev.Signal.Target.Parent.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("signal.target.parent.user_session.ssh_client_port", &ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "signal.target.parent.user_session.ssh_public_key":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52896,7 +53925,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Parent == nil {
 			ev.Signal.Target.Parent = &Process{}
 		}
-		return ev.setStringFieldValue("signal.target.parent.user_session.ssh_public_key", &ev.Signal.Target.Parent.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("signal.target.parent.user_session.ssh_public_key", &ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "signal.target.parent.user_session.ssh_session_id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52904,7 +53933,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if ev.Signal.Target.Parent == nil {
 			ev.Signal.Target.Parent = &Process{}
 		}
-		return ev.setUint64FieldValue("signal.target.parent.user_session.ssh_session_id", &ev.Signal.Target.Parent.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("signal.target.parent.user_session.ssh_session_id", &ev.Signal.Target.Parent.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "signal.target.pid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52935,31 +53964,46 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setStringFieldValue("signal.target.user", &ev.Signal.Target.Process.Credentials.User, value)
+	case "signal.target.user_session.id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("signal.target.user_session.id", &ev.Signal.Target.Process.UserSession.ID, value)
+	case "signal.target.user_session.identity":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("signal.target.user_session.identity", &ev.Signal.Target.Process.UserSession.Identity, value)
 	case "signal.target.user_session.k8s_groups":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
-		return ev.setStringArrayFieldValue("signal.target.user_session.k8s_groups", &ev.Signal.Target.Process.UserSession.K8SGroups, value)
+		return ev.setStringArrayFieldValue("signal.target.user_session.k8s_groups", &ev.Signal.Target.Process.UserSession.K8SSessionContext.K8SGroups, value)
 	case "signal.target.user_session.k8s_session_id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
-		return ev.setUint64FieldValue("signal.target.user_session.k8s_session_id", &ev.Signal.Target.Process.UserSession.K8SSessionID, value)
+		return ev.setUint64FieldValue("signal.target.user_session.k8s_session_id", &ev.Signal.Target.Process.UserSession.K8SSessionContext.K8SSessionID, value)
 	case "signal.target.user_session.k8s_uid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("signal.target.user_session.k8s_uid", &ev.Signal.Target.Process.UserSession.K8SUID, value)
+		return ev.setStringFieldValue("signal.target.user_session.k8s_uid", &ev.Signal.Target.Process.UserSession.K8SSessionContext.K8SUID, value)
 	case "signal.target.user_session.k8s_username":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("signal.target.user_session.k8s_username", &ev.Signal.Target.Process.UserSession.K8SUsername, value)
+		return ev.setStringFieldValue("signal.target.user_session.k8s_username", &ev.Signal.Target.Process.UserSession.K8SSessionContext.K8SUsername, value)
+	case "signal.target.user_session.session_type":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("signal.target.user_session.session_type", &ev.Signal.Target.Process.UserSession.SessionType, value)
 	case "signal.target.user_session.ssh_auth_method":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
-		return ev.setIntFieldValue("signal.target.user_session.ssh_auth_method", &ev.Signal.Target.Process.UserSession.SSHAuthMethod, value)
+		return ev.setIntFieldValue("signal.target.user_session.ssh_auth_method", &ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHAuthMethod, value)
 	case "signal.target.user_session.ssh_client_ip":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52968,23 +54012,23 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "signal.target.user_session.ssh_client_ip"}
 		}
-		ev.Signal.Target.Process.UserSession.SSHClientIP = rv
+		ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHClientIP = rv
 		return nil
-	case "signal.target.user_session.ssh_port":
+	case "signal.target.user_session.ssh_client_port":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
-		return ev.setIntFieldValue("signal.target.user_session.ssh_port", &ev.Signal.Target.Process.UserSession.SSHPort, value)
+		return ev.setIntFieldValue("signal.target.user_session.ssh_client_port", &ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHClientPort, value)
 	case "signal.target.user_session.ssh_public_key":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
-		return ev.setStringFieldValue("signal.target.user_session.ssh_public_key", &ev.Signal.Target.Process.UserSession.SSHPublicKey, value)
+		return ev.setStringFieldValue("signal.target.user_session.ssh_public_key", &ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHPublicKey, value)
 	case "signal.target.user_session.ssh_session_id":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
 		}
-		return ev.setUint64FieldValue("signal.target.user_session.ssh_session_id", &ev.Signal.Target.Process.UserSession.SSHSessionID, value)
+		return ev.setUint64FieldValue("signal.target.user_session.ssh_session_id", &ev.Signal.Target.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "signal.type":
 		return ev.setUint32FieldValue("signal.type", &ev.Signal.Type, value)
 	case "splice.file.change_time":

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -43,11 +43,12 @@ func (ev *Event) resolveFields(forADs bool) {
 	_ = ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessIsThread(ev, &ev.BaseEvent.ProcessContext.Process)
-	_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
-	_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
-	_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
-	_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
-	_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+	_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+	_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+	_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext)
+	_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext)
+	_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Process.UserSession.K8SSessionContext)
+	_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
 	if !forADs {
 		_ = ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)
 		_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.BaseEvent.ProcessContext.Process)
@@ -89,11 +90,12 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.BaseEvent.ProcessContext.Parent)
 		_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, ev.BaseEvent.ProcessContext.Parent)
 		_ = ev.FieldHandlers.ResolveProcessIsThread(ev, ev.BaseEvent.ProcessContext.Parent)
-		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
@@ -274,11 +276,12 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exec.Process)
 		_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, ev.Exec.Process)
 		_ = ev.FieldHandlers.ResolveProcessIsThread(ev, ev.Exec.Process)
-		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exec.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exec.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exec.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Exec.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Exec.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.Exec.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Exec.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exec.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exec.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exec.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.Exec.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, ev.Exec.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exec.Process.ContainerContext)
@@ -343,11 +346,12 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exit.Process)
 		_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, ev.Exit.Process)
 		_ = ev.FieldHandlers.ResolveProcessIsThread(ev, ev.Exit.Process)
-		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exit.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exit.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exit.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Exit.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Exit.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.Exit.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Exit.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exit.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exit.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exit.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.Exit.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, ev.Exit.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exit.Process.ContainerContext)
@@ -552,11 +556,12 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.PTrace.Tracee.Process)
 		_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, &ev.PTrace.Tracee.Process)
 		_ = ev.FieldHandlers.ResolveProcessIsThread(ev, &ev.PTrace.Tracee.Process)
-		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.PTrace.Tracee.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.PTrace.Tracee.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.PTrace.Tracee.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.PTrace.Tracee.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.PTrace.Tracee.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.PTrace.Tracee.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.PTrace.Tracee.Process.ContainerContext)
@@ -590,11 +595,12 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.PTrace.Tracee.Parent)
 			_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, ev.PTrace.Tracee.Parent)
 			_ = ev.FieldHandlers.ResolveProcessIsThread(ev, ev.PTrace.Tracee.Parent)
-			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.PTrace.Tracee.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.PTrace.Tracee.Parent.UserSession)
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
@@ -753,11 +759,12 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.Setrlimit.Target.Process)
 		_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, &ev.Setrlimit.Target.Process)
 		_ = ev.FieldHandlers.ResolveProcessIsThread(ev, &ev.Setrlimit.Target.Process)
-		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Setrlimit.Target.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Setrlimit.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.Setrlimit.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Setrlimit.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.Setrlimit.Target.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.Setrlimit.Target.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Setrlimit.Target.Process.ContainerContext)
@@ -791,11 +798,12 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Setrlimit.Target.Parent)
 			_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, ev.Setrlimit.Target.Parent)
 			_ = ev.FieldHandlers.ResolveProcessIsThread(ev, ev.Setrlimit.Target.Parent)
-			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Setrlimit.Target.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.Setrlimit.Target.Parent.UserSession)
 		}
 		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
@@ -902,11 +910,12 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.Signal.Target.Process)
 		_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, &ev.Signal.Target.Process)
 		_ = ev.FieldHandlers.ResolveProcessIsThread(ev, &ev.Signal.Target.Process)
-		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Signal.Target.Process.UserSession)
-		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Signal.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.Signal.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Signal.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Process.UserSession.K8SSessionContext)
+		_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.Signal.Target.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.Signal.Target.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Signal.Target.Process.ContainerContext)
@@ -940,11 +949,12 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Signal.Target.Parent)
 			_ = ev.FieldHandlers.ResolveProcessEnvsTruncated(ev, ev.Signal.Target.Parent)
 			_ = ev.FieldHandlers.ResolveProcessIsThread(ev, ev.Signal.Target.Parent)
-			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Signal.Target.Parent.UserSession)
-			_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Signal.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSessionID(ev, &ev.Signal.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSessionIdentity(ev, &ev.Signal.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Parent.UserSession.K8SSessionContext)
+			_ = ev.FieldHandlers.ResolveSessionType(ev, &ev.Signal.Target.Parent.UserSession)
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
@@ -1106,9 +1116,9 @@ type FieldHandlers interface {
 	ResolveHashesFromEvent(ev *Event, e *FileEvent) []string
 	ResolveHostname(ev *Event, e *BaseEvent) string
 	ResolveIsIPPublic(ev *Event, e *IPPortContext) bool
-	ResolveK8SGroups(ev *Event, e *UserSessionContext) []string
-	ResolveK8SUID(ev *Event, e *UserSessionContext) string
-	ResolveK8SUsername(ev *Event, e *UserSessionContext) string
+	ResolveK8SGroups(ev *Event, e *K8SSessionContext) []string
+	ResolveK8SUID(ev *Event, e *K8SSessionContext) string
+	ResolveK8SUsername(ev *Event, e *K8SSessionContext) string
 	ResolveModuleArgs(ev *Event, e *LoadModuleEvent) string
 	ResolveModuleArgv(ev *Event, e *LoadModuleEvent) []string
 	ResolveMountPointPath(ev *Event, e *MountEvent) string
@@ -1151,9 +1161,10 @@ type FieldHandlers interface {
 	ResolveProcessIsThread(ev *Event, e *Process) bool
 	ResolveRights(ev *Event, e *FileFields) int
 	ResolveSELinuxBoolName(ev *Event, e *SELinuxEvent) string
-	ResolveSSHClientIP(ev *Event, e *UserSessionContext) net.IPNet
-	ResolveSSHPort(ev *Event, e *UserSessionContext) int
 	ResolveService(ev *Event, e *BaseEvent) string
+	ResolveSessionID(ev *Event, e *UserSessionContext) string
+	ResolveSessionIdentity(ev *Event, e *UserSessionContext) string
+	ResolveSessionType(ev *Event, e *UserSessionContext) int
 	ResolveSetSockOptFilterHash(ev *Event, e *SetSockOptEvent) string
 	ResolveSetSockOptFilterInstructions(ev *Event, e *SetSockOptEvent) string
 	ResolveSetSockOptUsedImmediates(ev *Event, e *SetSockOptEvent) []int
@@ -1269,13 +1280,13 @@ func (dfh *FakeFieldHandlers) ResolveHostname(ev *Event, e *BaseEvent) string {
 func (dfh *FakeFieldHandlers) ResolveIsIPPublic(ev *Event, e *IPPortContext) bool {
 	return bool(e.IsPublic)
 }
-func (dfh *FakeFieldHandlers) ResolveK8SGroups(ev *Event, e *UserSessionContext) []string {
+func (dfh *FakeFieldHandlers) ResolveK8SGroups(ev *Event, e *K8SSessionContext) []string {
 	return []string(e.K8SGroups)
 }
-func (dfh *FakeFieldHandlers) ResolveK8SUID(ev *Event, e *UserSessionContext) string {
+func (dfh *FakeFieldHandlers) ResolveK8SUID(ev *Event, e *K8SSessionContext) string {
 	return string(e.K8SUID)
 }
-func (dfh *FakeFieldHandlers) ResolveK8SUsername(ev *Event, e *UserSessionContext) string {
+func (dfh *FakeFieldHandlers) ResolveK8SUsername(ev *Event, e *K8SSessionContext) string {
 	return string(e.K8SUsername)
 }
 func (dfh *FakeFieldHandlers) ResolveModuleArgs(ev *Event, e *LoadModuleEvent) string {
@@ -1400,14 +1411,17 @@ func (dfh *FakeFieldHandlers) ResolveRights(ev *Event, e *FileFields) int { retu
 func (dfh *FakeFieldHandlers) ResolveSELinuxBoolName(ev *Event, e *SELinuxEvent) string {
 	return string(e.BoolName)
 }
-func (dfh *FakeFieldHandlers) ResolveSSHClientIP(ev *Event, e *UserSessionContext) net.IPNet {
-	return net.IPNet(e.SSHClientIP)
-}
-func (dfh *FakeFieldHandlers) ResolveSSHPort(ev *Event, e *UserSessionContext) int {
-	return int(e.SSHPort)
-}
 func (dfh *FakeFieldHandlers) ResolveService(ev *Event, e *BaseEvent) string {
 	return string(e.Service)
+}
+func (dfh *FakeFieldHandlers) ResolveSessionID(ev *Event, e *UserSessionContext) string {
+	return string(e.ID)
+}
+func (dfh *FakeFieldHandlers) ResolveSessionIdentity(ev *Event, e *UserSessionContext) string {
+	return string(e.Identity)
+}
+func (dfh *FakeFieldHandlers) ResolveSessionType(ev *Event, e *UserSessionContext) int {
+	return int(e.SessionType)
 }
 func (dfh *FakeFieldHandlers) ResolveSetSockOptFilterHash(ev *Event, e *SetSockOptEvent) string {
 	return string(e.FilterHash)

--- a/pkg/security/secl/model/marshallers_linux.go
+++ b/pkg/security/secl/model/marshallers_linux.go
@@ -143,7 +143,7 @@ func (e *Process) MarshalPidCache(data []byte, bootTime time.Time) (int, error) 
 
 	marshalTime(data[16:24], e.ForkTime.Sub(bootTime))
 	marshalTime(data[24:32], e.ExitTime.Sub(bootTime))
-	binary.NativeEndian.PutUint64(data[32:40], e.UserSession.ID)
+	binary.NativeEndian.PutUint64(data[32:40], e.UserSession.K8SSessionID)
 	written := 40
 
 	n, err := MarshalBinary(data[written:], &e.Credentials)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -349,23 +349,32 @@ func (e *Event) GetProcessTracerTags() []string {
 }
 
 // UserSessionContext describes the user session context
-// Disclaimer: the `json` tags are used to parse K8s credentials from cws-instrumentation
 type UserSessionContext struct {
-	SessionType int `field:"-"`
-	// Kubernetes User Session context
-	K8SSessionID uint64              `field:"k8s_session_id"`                                                    // SECLDoc[k8s_session_id] Definition:`Kubernetes session ID of the user that executed the process`
+	SessionType int    `field:"session_type,handler:ResolveSessionType" json:"session_type,omitempty"` // SECLDoc[session_type] Definition:`Type of the user session`
+	ID          string `field:"id,handler:ResolveSessionID" json:"id,omitempty"`                       // SECLDoc[id] Definition:`Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type`
+	Identity    string `field:"identity,handler:ResolveSessionIdentity" json:"identity,omitempty"`     // SECLDoc[identity] Definition:`User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type`
+	K8SSessionContext
+	SSHSessionContext
+}
+
+// K8SSessionContext describes the kubernetes session context
+// Disclaimer: the `json` tags are used to parse K8s credentials from cws-instrumentation
+type K8SSessionContext struct {
+	K8SSessionID uint64              `field:"k8s_session_id" json:"k8s_session_id,omitempty"`                    // SECLDoc[k8s_session_id] Definition:`Unique identifier of the kubernetes session`
 	K8SUsername  string              `field:"k8s_username,handler:ResolveK8SUsername" json:"username,omitempty"` // SECLDoc[k8s_username] Definition:`Kubernetes username of the user that executed the process`
 	K8SUID       string              `field:"k8s_uid,handler:ResolveK8SUID" json:"uid,omitempty"`                // SECLDoc[k8s_uid] Definition:`Kubernetes UID of the user that executed the process`
 	K8SGroups    []string            `field:"k8s_groups,handler:ResolveK8SGroups" json:"groups,omitempty"`       // SECLDoc[k8s_groups] Definition:`Kubernetes groups of the user that executed the process`
 	K8SExtra     map[string][]string `json:"extra,omitempty"`
 	K8SResolved  bool                `field:"-"`
+}
 
-	// SSH User Session context
-	SSHSessionID  uint64    `field:"ssh_session_id"`                                                      // SECLDoc[ssh_session_id] Definition:`Unique identifier of the SSH user session on the host`
-	SSHPort       int       `field:"ssh_port,handler:ResolveSSHPort" json:"port,omitempty"`               // SECLDoc[ssh_port] Definition:`SSH port of the user that executed the process`
-	SSHClientIP   net.IPNet `field:"ssh_client_ip,handler:ResolveSSHClientIP" json:"client_ip,omitempty"` // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
-	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`                        // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`
-	SSHPublicKey  string    `field:"ssh_public_key" json:"public_key,omitempty"`                          // SECLDoc[ssh_public_key] Definition:`SSH public key used for authentication (if applicable)`
+// SSHSessionContext describes the SSH session context
+type SSHSessionContext struct {
+	SSHSessionID  uint64    `field:"ssh_session_id" json:"ssh_session_id,omitempty"` // SECLDoc[ssh_session_id] Definition:`Unique identifier of the SSH user session on the host`
+	SSHClientPort int       `field:"ssh_client_port" json:"client_port,omitempty"`   // SECLDoc[ssh_client_port] Definition:`SSH client port of the user that executed the process`
+	SSHClientIP   net.IPNet `field:"ssh_client_ip" json:"client_ip,omitempty"`       // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
+	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`   // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`
+	SSHPublicKey  string    `field:"ssh_public_key" json:"public_key,omitempty"`     // SECLDoc[ssh_public_key] Definition:`SSH public key used for authentication (if applicable)`
 }
 
 // MatchedRule contains the identification of one rule that has match

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -351,15 +351,17 @@ func (e *Event) GetProcessTracerTags() []string {
 // UserSessionContext describes the user session context
 // Disclaimer: the `json` tags are used to parse K8s credentials from cws-instrumentation
 type UserSessionContext struct {
-	ID          uint64 `field:"id"`           // SECLDoc[id] Definition:`Unique identifier of the user session on the host`
-	SessionType int    `field:"session_type"` // SECLDoc[session_type] Definition:`Type of the user session` Constants:`UserSessionTypes`
-	Resolved    bool   `field:"-"`
+	SessionType int `field:"-"`
 	// Kubernetes User Session context
-	K8SUsername string              `field:"k8s_username,handler:ResolveK8SUsername" json:"username,omitempty"` // SECLDoc[k8s_username] Definition:`Kubernetes username of the user that executed the process`
-	K8SUID      string              `field:"k8s_uid,handler:ResolveK8SUID" json:"uid,omitempty"`                // SECLDoc[k8s_uid] Definition:`Kubernetes UID of the user that executed the process`
-	K8SGroups   []string            `field:"k8s_groups,handler:ResolveK8SGroups" json:"groups,omitempty"`       // SECLDoc[k8s_groups] Definition:`Kubernetes groups of the user that executed the process`
-	K8SExtra    map[string][]string `json:"extra,omitempty"`
+	K8SSessionID uint64              `field:"k8s_session_id"`                                                    // SECLDoc[k8s_session_id] Definition:`Kubernetes session ID of the user that executed the process`
+	K8SUsername  string              `field:"k8s_username,handler:ResolveK8SUsername" json:"username,omitempty"` // SECLDoc[k8s_username] Definition:`Kubernetes username of the user that executed the process`
+	K8SUID       string              `field:"k8s_uid,handler:ResolveK8SUID" json:"uid,omitempty"`                // SECLDoc[k8s_uid] Definition:`Kubernetes UID of the user that executed the process`
+	K8SGroups    []string            `field:"k8s_groups,handler:ResolveK8SGroups" json:"groups,omitempty"`       // SECLDoc[k8s_groups] Definition:`Kubernetes groups of the user that executed the process`
+	K8SExtra     map[string][]string `json:"extra,omitempty"`
+	K8SResolved  bool                `field:"-"`
+
 	// SSH User Session context
+	SSHSessionID  uint64    `field:"ssh_session_id"`                                                      // SECLDoc[ssh_session_id] Definition:`Unique identifier of the SSH user session on the host`
 	SSHPort       int       `field:"ssh_port,handler:ResolveSSHPort" json:"port,omitempty"`               // SECLDoc[ssh_port] Definition:`SSH port of the user that executed the process`
 	SSHClientIP   net.IPNet `field:"ssh_client_ip,handler:ResolveSSHClientIP" json:"client_ip,omitempty"` // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
 	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`                        // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`

--- a/pkg/security/secl/model/model_helpers_unix.go
+++ b/pkg/security/secl/model/model_helpers_unix.go
@@ -376,8 +376,8 @@ func (dfh *FakeFieldHandlers) ResolveHashes(_ EventType, _ *Process, _ *FileEven
 	return nil
 }
 
-// ResolveUserSessionContext resolves and updates the provided user session context
-func (dfh *FakeFieldHandlers) ResolveUserSessionContext(_ *Event, _ *UserSessionContext) {}
+// ResolveK8SUserSessionContext resolves and updates the provided user session context
+func (dfh *FakeFieldHandlers) ResolveK8SUserSessionContext(_ *Event, _ *K8SSessionContext) {}
 
 // ResolveAWSSecurityCredentials resolves and updates the AWS security credentials of the input process entry
 func (dfh *FakeFieldHandlers) ResolveAWSSecurityCredentials(_ *Event) []AWSSecurityCredentials {
@@ -403,7 +403,7 @@ const (
 type ExtraFieldHandlers interface {
 	BaseExtraFieldHandlers
 	ResolveHashes(eventType EventType, process *Process, file *FileEvent) []string
-	ResolveUserSessionContext(event *Event, evtCtx *UserSessionContext)
+	ResolveK8SUserSessionContext(event *Event, evtCtx *K8SSessionContext)
 	ResolveAWSSecurityCredentials(event *Event) []AWSSecurityCredentials
 	ResolveSyscallCtxArgs(ev *Event, e *SyscallContext)
 }

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -97,7 +97,7 @@ func copyProcessContext(parent, child *ProcessCacheEntry) {
 }
 
 func setSSHUserSession(parent *ProcessCacheEntry, child *ProcessCacheEntry) {
-	if parent.ProcessContext.UserSession.ID != 0 && parent.ProcessContext.UserSession.SessionType == int(usersession.UserSessionTypeSSH) {
+	if parent.ProcessContext.UserSession.SSHSessionID != 0 && parent.ProcessContext.UserSession.SessionType == int(usersession.UserSessionTypeSSH) {
 		child.UserSession = parent.UserSession
 	}
 }

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -229,7 +229,7 @@ func (e *Process) UnmarshalPidCacheBinary(data []byte) (int, error) {
 
 	e.ForkTime = unmarshalTime(data[16:24])
 	e.ExitTime = unmarshalTime(data[24:32])
-	e.UserSession.ID = binary.NativeEndian.Uint64(data[32:40])
+	e.UserSession.K8SSessionID = binary.NativeEndian.Uint64(data[32:40])
 
 	// Unmarshal the credentials contained in pid_cache_t
 	read, err := UnmarshalBinary(data[40:], &e.Credentials)

--- a/pkg/security/secl/model/usersession/user_session.go
+++ b/pkg/security/secl/model/usersession/user_session.go
@@ -25,13 +25,6 @@ const (
 	SSHAuthMethodPublicKey
 )
 
-var (
-	// UserSessionTypes are the supported user session types
-
-	// UserSessionTypeStrings is used to
-	UserSessionTypeStrings = map[Type]string{}
-)
-
 // Type is used to identify the User Session type
 type Type uint8
 

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -349,23 +349,32 @@ func (e *Event) GetProcessTracerTags() []string {
 }
 
 // UserSessionContext describes the user session context
-// Disclaimer: the `json` tags are used to parse K8s credentials from cws-instrumentation
 type UserSessionContext struct {
-	SessionType int `field:"-"`
-	// Kubernetes User Session context
-	K8SSessionID uint64              `field:"k8s_session_id"`                                                    // SECLDoc[k8s_session_id] Definition:`Kubernetes session ID of the user that executed the process`
+	SessionType int    `field:"session_type,handler:ResolveSessionType" json:"session_type,omitempty"` // SECLDoc[session_type] Definition:`Type of the user session`
+	ID          string `field:"id,handler:ResolveSessionID" json:"id,omitempty"`                       // SECLDoc[id] Definition:`Unique identifier of the user session, alias for either ssh_session_id or k8s_session_id, depending on the session type`
+	Identity    string `field:"identity,handler:ResolveSessionIdentity" json:"identity,omitempty"`     // SECLDoc[identity] Definition:`User identity of the user session, alias for either ssh_client_ip and ssh_client_port or k8s_username, depending on the session type`
+	K8SSessionContext
+	SSHSessionContext
+}
+
+// K8SSessionContext describes the kubernetes session context
+// Disclaimer: the `json` tags are used to parse K8s credentials from cws-instrumentation
+type K8SSessionContext struct {
+	K8SSessionID uint64              `field:"k8s_session_id" json:"k8s_session_id,omitempty"`                    // SECLDoc[k8s_session_id] Definition:`Unique identifier of the kubernetes session`
 	K8SUsername  string              `field:"k8s_username,handler:ResolveK8SUsername" json:"username,omitempty"` // SECLDoc[k8s_username] Definition:`Kubernetes username of the user that executed the process`
 	K8SUID       string              `field:"k8s_uid,handler:ResolveK8SUID" json:"uid,omitempty"`                // SECLDoc[k8s_uid] Definition:`Kubernetes UID of the user that executed the process`
 	K8SGroups    []string            `field:"k8s_groups,handler:ResolveK8SGroups" json:"groups,omitempty"`       // SECLDoc[k8s_groups] Definition:`Kubernetes groups of the user that executed the process`
 	K8SExtra     map[string][]string `json:"extra,omitempty"`
 	K8SResolved  bool                `field:"-"`
+}
 
-	// SSH User Session context
-	SSHSessionID  uint64    `field:"ssh_session_id"`                                                      // SECLDoc[ssh_session_id] Definition:`Unique identifier of the SSH user session on the host`
-	SSHPort       int       `field:"ssh_port,handler:ResolveSSHPort" json:"port,omitempty"`               // SECLDoc[ssh_port] Definition:`SSH port of the user that executed the process`
-	SSHClientIP   net.IPNet `field:"ssh_client_ip,handler:ResolveSSHClientIP" json:"client_ip,omitempty"` // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
-	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`                        // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`
-	SSHPublicKey  string    `field:"ssh_public_key" json:"public_key,omitempty"`                          // SECLDoc[ssh_public_key] Definition:`SSH public key used for authentication (if applicable)`
+// SSHSessionContext describes the SSH session context
+type SSHSessionContext struct {
+	SSHSessionID  uint64    `field:"ssh_session_id" json:"ssh_session_id,omitempty"` // SECLDoc[ssh_session_id] Definition:`Unique identifier of the SSH user session on the host`
+	SSHClientPort int       `field:"ssh_client_port" json:"client_port,omitempty"`   // SECLDoc[ssh_client_port] Definition:`SSH client port of the user that executed the process`
+	SSHClientIP   net.IPNet `field:"ssh_client_ip" json:"client_ip,omitempty"`       // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
+	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`   // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`
+	SSHPublicKey  string    `field:"ssh_public_key" json:"public_key,omitempty"`     // SECLDoc[ssh_public_key] Definition:`SSH public key used for authentication (if applicable)`
 }
 
 // MatchedRule contains the identification of one rule that has match

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -351,15 +351,17 @@ func (e *Event) GetProcessTracerTags() []string {
 // UserSessionContext describes the user session context
 // Disclaimer: the `json` tags are used to parse K8s credentials from cws-instrumentation
 type UserSessionContext struct {
-	ID          uint64 `field:"id"`           // SECLDoc[id] Definition:`Unique identifier of the user session on the host`
-	SessionType int    `field:"session_type"` // SECLDoc[session_type] Definition:`Type of the user session` Constants:`UserSessionTypes`
-	Resolved    bool   `field:"-"`
+	SessionType int `field:"-"`
 	// Kubernetes User Session context
-	K8SUsername string              `field:"k8s_username,handler:ResolveK8SUsername" json:"username,omitempty"` // SECLDoc[k8s_username] Definition:`Kubernetes username of the user that executed the process`
-	K8SUID      string              `field:"k8s_uid,handler:ResolveK8SUID" json:"uid,omitempty"`                // SECLDoc[k8s_uid] Definition:`Kubernetes UID of the user that executed the process`
-	K8SGroups   []string            `field:"k8s_groups,handler:ResolveK8SGroups" json:"groups,omitempty"`       // SECLDoc[k8s_groups] Definition:`Kubernetes groups of the user that executed the process`
-	K8SExtra    map[string][]string `json:"extra,omitempty"`
+	K8SSessionID uint64              `field:"k8s_session_id"`                                                    // SECLDoc[k8s_session_id] Definition:`Kubernetes session ID of the user that executed the process`
+	K8SUsername  string              `field:"k8s_username,handler:ResolveK8SUsername" json:"username,omitempty"` // SECLDoc[k8s_username] Definition:`Kubernetes username of the user that executed the process`
+	K8SUID       string              `field:"k8s_uid,handler:ResolveK8SUID" json:"uid,omitempty"`                // SECLDoc[k8s_uid] Definition:`Kubernetes UID of the user that executed the process`
+	K8SGroups    []string            `field:"k8s_groups,handler:ResolveK8SGroups" json:"groups,omitempty"`       // SECLDoc[k8s_groups] Definition:`Kubernetes groups of the user that executed the process`
+	K8SExtra     map[string][]string `json:"extra,omitempty"`
+	K8SResolved  bool                `field:"-"`
+
 	// SSH User Session context
+	SSHSessionID  uint64    `field:"ssh_session_id"`                                                      // SECLDoc[ssh_session_id] Definition:`Unique identifier of the SSH user session on the host`
 	SSHPort       int       `field:"ssh_port,handler:ResolveSSHPort" json:"port,omitempty"`               // SECLDoc[ssh_port] Definition:`SSH port of the user that executed the process`
 	SSHClientIP   net.IPNet `field:"ssh_client_ip,handler:ResolveSSHClientIP" json:"client_ip,omitempty"` // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
 	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`                        // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -217,10 +217,10 @@ type ProcessCredentialsSerializer struct {
 // UserSessionContextSerializer serializes the user session context to JSON
 // easyjson:json
 type UserSessionContextSerializer struct {
-	// Unique identifier of the user session on the host
-	ID string `json:"id,omitempty"`
 	// Type of the user session
 	SessionType string `json:"session_type,omitempty"`
+	// Unique identifier of the user session on the host
+	K8SSessionID string `json:"id,omitempty"`
 	// Username of the Kubernetes "kubectl exec" session
 	K8SUsername string `json:"k8s_username,omitempty"`
 	// UID of the Kubernetes "kubectl exec" session
@@ -229,6 +229,8 @@ type UserSessionContextSerializer struct {
 	K8SGroups []string `json:"k8s_groups,omitempty"`
 	// Extra of the Kubernetes "kubectl exec" session
 	K8SExtra map[string][]string `json:"k8s_extra,omitempty"`
+	// Unique identifier of the SSH session
+	SSHSessionID string `json:"ssh_session_id,omitempty"`
 	// Port of the SSH session
 	SSHPort int `json:"ssh_port,omitempty"`
 	// Client IP of the SSH session
@@ -947,7 +949,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 			CredentialsSerializer: credsSerializer,
 		}
 
-		if ps.UserSession.ID != 0 {
+		if ps.UserSession.K8SSessionID != 0 || ps.UserSession.SSHSessionID != 0 {
 			psSerializer.UserSession = newUserSessionContextSerializer(&ps.UserSession, e)
 		}
 
@@ -996,12 +998,13 @@ func newUserSessionContextSerializer(ctx *model.UserSessionContext, e *model.Eve
 	}
 
 	return &UserSessionContextSerializer{
-		ID:            fmt.Sprintf("%x", ctx.ID),
+		K8SSessionID:  fmt.Sprintf("%x", ctx.K8SSessionID),
 		SessionType:   model.UserSessionTypeStrings[usersession.Type(ctx.SessionType)],
 		K8SUsername:   ctx.K8SUsername,
 		K8SUID:        ctx.K8SUID,
 		K8SGroups:     ctx.K8SGroups,
 		K8SExtra:      ctx.K8SExtra,
+		SSHSessionID:  fmt.Sprintf("%x", ctx.SSHSessionID),
 		SSHPort:       ctx.SSHPort,
 		SSHClientIP:   ctx.SSHClientIP.IP.String(),
 		SSHAuthMethod: model.SSHAuthMethodStrings[usersession.AuthType(ctx.SSHAuthMethod)],

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -221,8 +221,8 @@ type UserSessionContextSerializer struct {
 	SessionType string `json:"session_type,omitempty"`
 	// Unique identifier of the user session on the host
 	ID string `json:"id,omitempty"`
-	// Username of the user session
-	Username string `json:"username,omitempty"`
+	// Identity of the user session
+	Identity string `json:"identity,omitempty"`
 	K8SSessionContextSerializer
 	SSHSessionContextSerializer
 }
@@ -1049,7 +1049,7 @@ func newUserSessionContextSerializer(ctx *model.UserSessionContext, e *model.Eve
 
 	userSessionContextSerializer.SessionType = model.UserSessionTypeStrings[usersession.Type(e.FieldHandlers.ResolveSessionType(e, ctx))]
 	userSessionContextSerializer.ID = e.FieldHandlers.ResolveSessionID(e, ctx)
-	userSessionContextSerializer.Username = e.FieldHandlers.ResolveSessionIdentity(e, ctx)
+	userSessionContextSerializer.Identity = e.FieldHandlers.ResolveSessionIdentity(e, ctx)
 	return userSessionContextSerializer
 }
 

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -997,19 +997,36 @@ func newUserSessionContextSerializer(ctx *model.UserSessionContext, e *model.Eve
 		model.InitSSHAuthMethodConstants()
 	}
 
-	return &UserSessionContextSerializer{
-		K8SSessionID:  fmt.Sprintf("%x", ctx.K8SSessionID),
-		SessionType:   model.UserSessionTypeStrings[usersession.Type(ctx.SessionType)],
-		K8SUsername:   ctx.K8SUsername,
-		K8SUID:        ctx.K8SUID,
-		K8SGroups:     ctx.K8SGroups,
-		K8SExtra:      ctx.K8SExtra,
-		SSHSessionID:  fmt.Sprintf("%x", ctx.SSHSessionID),
-		SSHPort:       ctx.SSHPort,
-		SSHClientIP:   ctx.SSHClientIP.IP.String(),
-		SSHAuthMethod: model.SSHAuthMethodStrings[usersession.AuthType(ctx.SSHAuthMethod)],
-		SSHPublicKey:  ctx.SSHPublicKey,
+	userSessionContextSerializer := &UserSessionContextSerializer{
+		SessionType: model.UserSessionTypeStrings[usersession.Type(ctx.SessionType)],
 	}
+
+	if ctx.K8SSessionID != 0 {
+		userSessionContextSerializer.K8SSessionID = fmt.Sprintf("%x", ctx.K8SSessionID)
+		userSessionContextSerializer.K8SUsername = ctx.K8SUsername
+		userSessionContextSerializer.K8SUID = ctx.K8SUID
+		userSessionContextSerializer.K8SGroups = ctx.K8SGroups
+		userSessionContextSerializer.K8SExtra = ctx.K8SExtra
+	}
+	if ctx.SSHSessionID != 0 {
+		sshClientIP := ctx.SSHClientIP.IP.String()
+		if sshClientIP == "<nil>" {
+			sshClientIP = ""
+		}
+
+		sshAuthMethod := model.SSHAuthMethodStrings[usersession.AuthType(ctx.SSHAuthMethod)]
+		if sshAuthMethod == "<nil>" {
+			sshAuthMethod = ""
+		}
+
+		userSessionContextSerializer.SSHSessionID = fmt.Sprintf("%x", ctx.SSHSessionID)
+		userSessionContextSerializer.SSHPort = ctx.SSHPort
+		userSessionContextSerializer.SSHClientIP = sshClientIP
+		userSessionContextSerializer.SSHAuthMethod = sshAuthMethod
+		userSessionContextSerializer.SSHPublicKey = ctx.SSHPublicKey
+	}
+
+	return userSessionContextSerializer
 }
 
 func newUserContextSerializer(e *model.Event) *UserContextSerializer {

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -43,6 +43,20 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(in
 		case "session_type":
 			out.SessionType = string(in.String())
 		case "id":
+			out.ID = string(in.String())
+		case "username":
+			out.Username = string(in.String())
+		case "ssh_session_id":
+			out.SSHSessionID = string(in.String())
+		case "ssh_client_port":
+			out.SSHClientPort = int(in.Int())
+		case "ssh_client_ip":
+			out.SSHClientIP = string(in.String())
+		case "ssh_auth_method":
+			out.SSHAuthMethod = string(in.String())
+		case "ssh_public_key":
+			out.SSHPublicKey = string(in.String())
+		case "k8s_session_id":
 			out.K8SSessionID = string(in.String())
 		case "k8s_username":
 			out.K8SUsername = string(in.String())
@@ -112,16 +126,6 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(in
 				}
 				in.Delim('}')
 			}
-		case "ssh_session_id":
-			out.SSHSessionID = string(in.String())
-		case "ssh_port":
-			out.SSHPort = int(in.Int())
-		case "ssh_client_ip":
-			out.SSHClientIP = string(in.String())
-		case "ssh_auth_method":
-			out.SSHAuthMethod = string(in.String())
-		case "ssh_public_key":
-			out.SSHPublicKey = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -142,8 +146,78 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers(ou
 		out.RawString(prefix[1:])
 		out.String(string(in.SessionType))
 	}
-	if in.K8SSessionID != "" {
+	if in.ID != "" {
 		const prefix string = ",\"id\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.ID))
+	}
+	if in.Username != "" {
+		const prefix string = ",\"username\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Username))
+	}
+	if in.SSHSessionID != "" {
+		const prefix string = ",\"ssh_session_id\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHSessionID))
+	}
+	if in.SSHClientPort != 0 {
+		const prefix string = ",\"ssh_client_port\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.SSHClientPort))
+	}
+	if in.SSHClientIP != "" {
+		const prefix string = ",\"ssh_client_ip\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHClientIP))
+	}
+	if in.SSHAuthMethod != "" {
+		const prefix string = ",\"ssh_auth_method\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHAuthMethod))
+	}
+	if in.SSHPublicKey != "" {
+		const prefix string = ",\"ssh_public_key\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHPublicKey))
+	}
+	if in.K8SSessionID != "" {
+		const prefix string = ",\"k8s_session_id\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -225,56 +299,6 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers(ou
 			}
 			out.RawByte('}')
 		}
-	}
-	if in.SSHSessionID != "" {
-		const prefix string = ",\"ssh_session_id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.SSHSessionID))
-	}
-	if in.SSHPort != 0 {
-		const prefix string = ",\"ssh_port\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int(int(in.SSHPort))
-	}
-	if in.SSHClientIP != "" {
-		const prefix string = ",\"ssh_client_ip\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.SSHClientIP))
-	}
-	if in.SSHAuthMethod != "" {
-		const prefix string = ",\"ssh_auth_method\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.SSHAuthMethod))
-	}
-	if in.SSHPublicKey != "" {
-		const prefix string = ",\"ssh_public_key\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.SSHPublicKey))
 	}
 	out.RawByte('}')
 }
@@ -1402,7 +1426,108 @@ func (v SecurityProfileContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *SecurityProfileContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(in *jlexer.Lexer, out *SELinuxEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(in *jlexer.Lexer, out *SSHSessionContextSerializer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "ssh_session_id":
+			out.SSHSessionID = string(in.String())
+		case "ssh_client_port":
+			out.SSHClientPort = int(in.Int())
+		case "ssh_client_ip":
+			out.SSHClientIP = string(in.String())
+		case "ssh_auth_method":
+			out.SSHAuthMethod = string(in.String())
+		case "ssh_public_key":
+			out.SSHPublicKey = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(out *jwriter.Writer, in SSHSessionContextSerializer) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.SSHSessionID != "" {
+		const prefix string = ",\"ssh_session_id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.SSHSessionID))
+	}
+	if in.SSHClientPort != 0 {
+		const prefix string = ",\"ssh_client_port\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.SSHClientPort))
+	}
+	if in.SSHClientIP != "" {
+		const prefix string = ",\"ssh_client_ip\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHClientIP))
+	}
+	if in.SSHAuthMethod != "" {
+		const prefix string = ",\"ssh_auth_method\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHAuthMethod))
+	}
+	if in.SSHPublicKey != "" {
+		const prefix string = ",\"ssh_public_key\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHPublicKey))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v SSHSessionContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *SSHSessionContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(l, v)
+}
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(in *jlexer.Lexer, out *SELinuxEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1461,7 +1586,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(out *jwriter.Writer, in SELinuxEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(out *jwriter.Writer, in SELinuxEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1496,14 +1621,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SELinuxEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers10(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(in *jlexer.Lexer, out *SELinuxEnforceStatusSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(in *jlexer.Lexer, out *SELinuxEnforceStatusSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1534,7 +1659,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(out *jwriter.Writer, in SELinuxEnforceStatusSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(out *jwriter.Writer, in SELinuxEnforceStatusSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1549,14 +1674,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxEnforceStatusSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SELinuxEnforceStatusSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(in *jlexer.Lexer, out *SELinuxBoolCommitSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(in *jlexer.Lexer, out *SELinuxBoolCommitSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1587,7 +1712,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(out *jwriter.Writer, in SELinuxBoolCommitSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(out *jwriter.Writer, in SELinuxBoolCommitSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1602,14 +1727,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxBoolCommitSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SELinuxBoolCommitSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(in *jlexer.Lexer, out *SELinuxBoolChangeSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(in *jlexer.Lexer, out *SELinuxBoolChangeSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1642,7 +1767,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(out *jwriter.Writer, in SELinuxBoolChangeSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(out *jwriter.Writer, in SELinuxBoolChangeSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1667,14 +1792,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxBoolChangeSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SELinuxBoolChangeSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(in *jlexer.Lexer, out *ProcessSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in *jlexer.Lexer, out *ProcessSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1947,7 +2072,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 					}
 					for !in.IsDelim(']') {
 						var v16 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in, &v16)
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(in, &v16)
 						*out.Syscalls = append(*out.Syscalls, v16)
 						in.WantComma()
 					}
@@ -1995,7 +2120,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(out *jwriter.Writer, in ProcessSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out *jwriter.Writer, in ProcessSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2212,7 +2337,7 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 				if v26 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out, v27)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(out, v27)
 			}
 			out.RawByte(']')
 		}
@@ -2240,14 +2365,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in *jlexer.Lexer, out *SyscallSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(in *jlexer.Lexer, out *SyscallSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2280,7 +2405,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out *jwriter.Writer, in SyscallSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(out *jwriter.Writer, in SyscallSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2296,7 +2421,7 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(
 	}
 	out.RawByte('}')
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2406,7 +2531,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(out *jwriter.Writer, in ProcessCredentialsSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out *jwriter.Writer, in ProcessCredentialsSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2529,14 +2654,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessCredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessCredentialsSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in *jlexer.Lexer, out *PrCtlEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(in *jlexer.Lexer, out *PrCtlEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2571,7 +2696,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out *jwriter.Writer, in PrCtlEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(out *jwriter.Writer, in PrCtlEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2595,14 +2720,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PrCtlEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PrCtlEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(in *jlexer.Lexer, out *PTraceEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(in *jlexer.Lexer, out *PTraceEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2645,7 +2770,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(out *jwriter.Writer, in PTraceEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(out *jwriter.Writer, in PTraceEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2669,14 +2794,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PTraceEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PTraceEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(in *jlexer.Lexer, out *NetworkDeviceSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(in *jlexer.Lexer, out *NetworkDeviceSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2711,7 +2836,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(out *jwriter.Writer, in NetworkDeviceSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(out *jwriter.Writer, in NetworkDeviceSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2735,14 +2860,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NetworkDeviceSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *NetworkDeviceSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(in *jlexer.Lexer, out *MountEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(in *jlexer.Lexer, out *MountEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2813,7 +2938,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(out *jwriter.Writer, in MountEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(out *jwriter.Writer, in MountEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2898,14 +3023,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MountEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MountEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(in *jlexer.Lexer, out *ModuleEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(in *jlexer.Lexer, out *ModuleEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2979,7 +3104,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(out *jwriter.Writer, in ModuleEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(out *jwriter.Writer, in ModuleEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3017,14 +3142,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ModuleEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ModuleEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(in *jlexer.Lexer, out *MProtectEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(in *jlexer.Lexer, out *MProtectEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3061,7 +3186,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(out *jwriter.Writer, in MProtectEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(out *jwriter.Writer, in MProtectEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3090,14 +3215,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MProtectEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MProtectEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(in *jlexer.Lexer, out *MMapEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(in *jlexer.Lexer, out *MMapEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3136,7 +3261,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(out *jwriter.Writer, in MMapEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(out *jwriter.Writer, in MMapEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3170,14 +3295,209 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MMapEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MMapEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(in *jlexer.Lexer, out *FileSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in *jlexer.Lexer, out *K8SSessionContextSerializer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "k8s_session_id":
+			out.K8SSessionID = string(in.String())
+		case "k8s_username":
+			out.K8SUsername = string(in.String())
+		case "k8s_uid":
+			out.K8SUID = string(in.String())
+		case "k8s_groups":
+			if in.IsNull() {
+				in.Skip()
+				out.K8SGroups = nil
+			} else {
+				in.Delim('[')
+				if out.K8SGroups == nil {
+					if !in.IsDelim(']') {
+						out.K8SGroups = make([]string, 0, 4)
+					} else {
+						out.K8SGroups = []string{}
+					}
+				} else {
+					out.K8SGroups = (out.K8SGroups)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v39 string
+					v39 = string(in.String())
+					out.K8SGroups = append(out.K8SGroups, v39)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "k8s_extra":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				in.Delim('{')
+				if !in.IsDelim('}') {
+					out.K8SExtra = make(map[string][]string)
+				} else {
+					out.K8SExtra = nil
+				}
+				for !in.IsDelim('}') {
+					key := string(in.String())
+					in.WantColon()
+					var v40 []string
+					if in.IsNull() {
+						in.Skip()
+						v40 = nil
+					} else {
+						in.Delim('[')
+						if v40 == nil {
+							if !in.IsDelim(']') {
+								v40 = make([]string, 0, 4)
+							} else {
+								v40 = []string{}
+							}
+						} else {
+							v40 = (v40)[:0]
+						}
+						for !in.IsDelim(']') {
+							var v41 string
+							v41 = string(in.String())
+							v40 = append(v40, v41)
+							in.WantComma()
+						}
+						in.Delim(']')
+					}
+					(out.K8SExtra)[key] = v40
+					in.WantComma()
+				}
+				in.Delim('}')
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out *jwriter.Writer, in K8SSessionContextSerializer) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.K8SSessionID != "" {
+		const prefix string = ",\"k8s_session_id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.K8SSessionID))
+	}
+	if in.K8SUsername != "" {
+		const prefix string = ",\"k8s_username\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.K8SUsername))
+	}
+	if in.K8SUID != "" {
+		const prefix string = ",\"k8s_uid\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.K8SUID))
+	}
+	if len(in.K8SGroups) != 0 {
+		const prefix string = ",\"k8s_groups\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('[')
+			for v42, v43 := range in.K8SGroups {
+				if v42 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v43))
+			}
+			out.RawByte(']')
+		}
+	}
+	if len(in.K8SExtra) != 0 {
+		const prefix string = ",\"k8s_extra\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('{')
+			v44First := true
+			for v44Name, v44Value := range in.K8SExtra {
+				if v44First {
+					v44First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.String(string(v44Name))
+				out.RawByte(':')
+				if v44Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+					out.RawString("null")
+				} else {
+					out.RawByte('[')
+					for v45, v46 := range v44Value {
+						if v45 > 0 {
+							out.RawByte(',')
+						}
+						out.String(string(v46))
+					}
+					out.RawByte(']')
+				}
+			}
+			out.RawByte('}')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v K8SSessionContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *K8SSessionContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(l, v)
+}
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in *jlexer.Lexer, out *FileSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3274,9 +3594,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v39 string
-					v39 = string(in.String())
-					out.Flags = append(out.Flags, v39)
+					var v47 string
+					v47 = string(in.String())
+					out.Flags = append(out.Flags, v47)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3347,9 +3667,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 					out.Hashes = (out.Hashes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v40 string
-					v40 = string(in.String())
-					out.Hashes = append(out.Hashes, v40)
+					var v48 string
+					v48 = string(in.String())
+					out.Hashes = append(out.Hashes, v48)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3402,7 +3722,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(out *jwriter.Writer, in FileSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out *jwriter.Writer, in FileSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3532,11 +3852,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v41, v42 := range in.Flags {
-				if v41 > 0 {
+			for v49, v50 := range in.Flags {
+				if v49 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v42))
+				out.String(string(v50))
 			}
 			out.RawByte(']')
 		}
@@ -3596,11 +3916,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v43, v44 := range in.Hashes {
-				if v43 > 0 {
+			for v51, v52 := range in.Hashes {
+				if v51 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v44))
+				out.String(string(v52))
 			}
 			out.RawByte(']')
 		}
@@ -3645,14 +3965,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in *jlexer.Lexer, out *FileMetadataSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(in *jlexer.Lexer, out *FileMetadataSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3697,7 +4017,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out *jwriter.Writer, in FileMetadataSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(out *jwriter.Writer, in FileMetadataSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3782,14 +4102,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileMetadataSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileMetadataSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in *jlexer.Lexer, out *FileEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(in *jlexer.Lexer, out *FileEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3902,9 +4222,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v45 string
-					v45 = string(in.String())
-					out.Flags = append(out.Flags, v45)
+					var v53 string
+					v53 = string(in.String())
+					out.Flags = append(out.Flags, v53)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3975,9 +4295,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 					out.Hashes = (out.Hashes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v46 string
-					v46 = string(in.String())
-					out.Hashes = append(out.Hashes, v46)
+					var v54 string
+					v54 = string(in.String())
+					out.Hashes = append(out.Hashes, v54)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4030,7 +4350,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out *jwriter.Writer, in FileEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(out *jwriter.Writer, in FileEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4200,11 +4520,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v47, v48 := range in.Flags {
-				if v47 > 0 {
+			for v55, v56 := range in.Flags {
+				if v55 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v48))
+				out.String(string(v56))
 			}
 			out.RawByte(']')
 		}
@@ -4264,11 +4584,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v49, v50 := range in.Hashes {
-				if v49 > 0 {
+			for v57, v58 := range in.Hashes {
+				if v57 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v50))
+				out.String(string(v58))
 			}
 			out.RawByte(']')
 		}
@@ -4313,14 +4633,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(in *jlexer.Lexer, out *EventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(in *jlexer.Lexer, out *EventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4571,9 +4891,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 						*out.SyscallsEventSerializer = (*out.SyscallsEventSerializer)[:0]
 					}
 					for !in.IsDelim(']') {
-						var v51 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in, &v51)
-						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v51)
+						var v59 SyscallSerializer
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(in, &v59)
+						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v59)
 						in.WantComma()
 					}
 					in.Delim(']')
@@ -4725,7 +5045,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(out *jwriter.Writer, in EventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(out *jwriter.Writer, in EventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4917,11 +5237,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v52, v53 := range *in.SyscallsEventSerializer {
-				if v52 > 0 {
+			for v60, v61 := range *in.SyscallsEventSerializer {
+				if v60 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out, v53)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(out, v61)
 			}
 			out.RawByte(']')
 		}
@@ -5081,14 +5401,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(in *jlexer.Lexer, out *DDContextSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(in *jlexer.Lexer, out *DDContextSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5121,7 +5441,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(out *jwriter.Writer, in DDContextSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(out *jwriter.Writer, in DDContextSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5146,14 +5466,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v DDContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *DDContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(in *jlexer.Lexer, out *CredentialsSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(in *jlexer.Lexer, out *CredentialsSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5214,9 +5534,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v54 string
-					v54 = string(in.String())
-					out.CapEffective = append(out.CapEffective, v54)
+					var v62 string
+					v62 = string(in.String())
+					out.CapEffective = append(out.CapEffective, v62)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5237,9 +5557,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v55 string
-					v55 = string(in.String())
-					out.CapPermitted = append(out.CapPermitted, v55)
+					var v63 string
+					v63 = string(in.String())
+					out.CapPermitted = append(out.CapPermitted, v63)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5254,7 +5574,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(out *jwriter.Writer, in CredentialsSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(out *jwriter.Writer, in CredentialsSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5330,11 +5650,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v56, v57 := range in.CapEffective {
-				if v56 > 0 {
+			for v64, v65 := range in.CapEffective {
+				if v64 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v57))
+				out.String(string(v65))
 			}
 			out.RawByte(']')
 		}
@@ -5346,11 +5666,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v58, v59 := range in.CapPermitted {
-				if v58 > 0 {
+			for v66, v67 := range in.CapPermitted {
+				if v66 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v59))
+				out.String(string(v67))
 			}
 			out.RawByte(']')
 		}
@@ -5360,14 +5680,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CredentialsSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(in *jlexer.Lexer, out *ConnectEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(in *jlexer.Lexer, out *ConnectEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5404,9 +5724,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 					out.Hostnames = (out.Hostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v60 string
-					v60 = string(in.String())
-					out.Hostnames = append(out.Hostnames, v60)
+					var v68 string
+					v68 = string(in.String())
+					out.Hostnames = append(out.Hostnames, v68)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5423,7 +5743,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(out *jwriter.Writer, in ConnectEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(out *jwriter.Writer, in ConnectEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5439,11 +5759,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v61, v62 := range in.Hostnames {
-				if v61 > 0 {
+			for v69, v70 := range in.Hostnames {
+				if v69 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v62))
+				out.String(string(v70))
 			}
 			out.RawByte(']')
 		}
@@ -5458,14 +5778,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ConnectEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ConnectEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(in *jlexer.Lexer, out *CapsetSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(in *jlexer.Lexer, out *CapsetSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5500,9 +5820,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v63 string
-					v63 = string(in.String())
-					out.CapEffective = append(out.CapEffective, v63)
+					var v71 string
+					v71 = string(in.String())
+					out.CapEffective = append(out.CapEffective, v71)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5523,9 +5843,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v64 string
-					v64 = string(in.String())
-					out.CapPermitted = append(out.CapPermitted, v64)
+					var v72 string
+					v72 = string(in.String())
+					out.CapPermitted = append(out.CapPermitted, v72)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5540,7 +5860,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(out *jwriter.Writer, in CapsetSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(out *jwriter.Writer, in CapsetSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5551,11 +5871,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v65, v66 := range in.CapEffective {
-				if v65 > 0 {
+			for v73, v74 := range in.CapEffective {
+				if v73 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v66))
+				out.String(string(v74))
 			}
 			out.RawByte(']')
 		}
@@ -5567,11 +5887,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v67, v68 := range in.CapPermitted {
-				if v67 > 0 {
+			for v75, v76 := range in.CapPermitted {
+				if v75 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v68))
+				out.String(string(v76))
 			}
 			out.RawByte(']')
 		}
@@ -5581,14 +5901,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CapsetSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CapsetSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(in *jlexer.Lexer, out *CapabilitiesEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(in *jlexer.Lexer, out *CapabilitiesEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5623,9 +5943,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 					out.CapsAttempted = (out.CapsAttempted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v69 string
-					v69 = string(in.String())
-					out.CapsAttempted = append(out.CapsAttempted, v69)
+					var v77 string
+					v77 = string(in.String())
+					out.CapsAttempted = append(out.CapsAttempted, v77)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5646,9 +5966,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 					out.CapsUsed = (out.CapsUsed)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v70 string
-					v70 = string(in.String())
-					out.CapsUsed = append(out.CapsUsed, v70)
+					var v78 string
+					v78 = string(in.String())
+					out.CapsUsed = append(out.CapsUsed, v78)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5663,7 +5983,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(out *jwriter.Writer, in CapabilitiesEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(out *jwriter.Writer, in CapabilitiesEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5673,11 +5993,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v71, v72 := range in.CapsAttempted {
-				if v71 > 0 {
+			for v79, v80 := range in.CapsAttempted {
+				if v79 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v72))
+				out.String(string(v80))
 			}
 			out.RawByte(']')
 		}
@@ -5692,11 +6012,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 		}
 		{
 			out.RawByte('[')
-			for v73, v74 := range in.CapsUsed {
-				if v73 > 0 {
+			for v81, v82 := range in.CapsUsed {
+				if v81 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v74))
+				out.String(string(v82))
 			}
 			out.RawByte(']')
 		}
@@ -5706,14 +6026,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CapabilitiesEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CapabilitiesEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(in *jlexer.Lexer, out *CGroupWriteEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(in *jlexer.Lexer, out *CGroupWriteEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5754,7 +6074,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(out *jwriter.Writer, in CGroupWriteEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(out *jwriter.Writer, in CGroupWriteEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5779,14 +6099,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CGroupWriteEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CGroupWriteEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(in *jlexer.Lexer, out *BindEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(in *jlexer.Lexer, out *BindEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5819,7 +6139,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(out *jwriter.Writer, in BindEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(out *jwriter.Writer, in BindEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5838,14 +6158,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BindEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BindEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(in *jlexer.Lexer, out *BPFProgramSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(in *jlexer.Lexer, out *BPFProgramSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5888,9 +6208,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 					out.Helpers = (out.Helpers)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v75 string
-					v75 = string(in.String())
-					out.Helpers = append(out.Helpers, v75)
+					var v83 string
+					v83 = string(in.String())
+					out.Helpers = append(out.Helpers, v83)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5905,7 +6225,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(out *jwriter.Writer, in BPFProgramSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(out *jwriter.Writer, in BPFProgramSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5955,11 +6275,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		}
 		{
 			out.RawByte('[')
-			for v76, v77 := range in.Helpers {
-				if v76 > 0 {
+			for v84, v85 := range in.Helpers {
+				if v84 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v77))
+				out.String(string(v85))
 			}
 			out.RawByte(']')
 		}
@@ -5969,14 +6289,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFProgramSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFProgramSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(in *jlexer.Lexer, out *BPFMapSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(in *jlexer.Lexer, out *BPFMapSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -6009,7 +6329,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(out *jwriter.Writer, in BPFMapSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(out *jwriter.Writer, in BPFMapSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -6034,14 +6354,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFMapSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFMapSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(in *jlexer.Lexer, out *BPFEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(in *jlexer.Lexer, out *BPFEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -6092,7 +6412,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(out *jwriter.Writer, in BPFEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(out *jwriter.Writer, in BPFEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -6116,14 +6436,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(in *jlexer.Lexer, out *AnomalyDetectionSyscallEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(in *jlexer.Lexer, out *AnomalyDetectionSyscallEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -6154,7 +6474,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(out *jwriter.Writer, in AnomalyDetectionSyscallEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(out *jwriter.Writer, in AnomalyDetectionSyscallEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -6168,14 +6488,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AnomalyDetectionSyscallEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AnomalyDetectionSyscallEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(in *jlexer.Lexer, out *AcceptEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(in *jlexer.Lexer, out *AcceptEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -6212,9 +6532,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(
 					out.Hostnames = (out.Hostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v78 string
-					v78 = string(in.String())
-					out.Hostnames = append(out.Hostnames, v78)
+					var v86 string
+					v86 = string(in.String())
+					out.Hostnames = append(out.Hostnames, v86)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -6229,7 +6549,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(out *jwriter.Writer, in AcceptEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(out *jwriter.Writer, in AcceptEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -6245,11 +6565,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v79, v80 := range in.Hostnames {
-				if v79 > 0 {
+			for v87, v88 := range in.Hostnames {
+				if v87 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v80))
+				out.String(string(v88))
 			}
 			out.RawByte(']')
 		}
@@ -6259,10 +6579,10 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AcceptEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AcceptEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(l, v)
 }

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -40,10 +40,10 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(in
 			continue
 		}
 		switch key {
-		case "id":
-			out.ID = string(in.String())
 		case "session_type":
 			out.SessionType = string(in.String())
+		case "id":
+			out.K8SSessionID = string(in.String())
 		case "k8s_username":
 			out.K8SUsername = string(in.String())
 		case "k8s_uid":
@@ -112,6 +112,8 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(in
 				}
 				in.Delim('}')
 			}
+		case "ssh_session_id":
+			out.SSHSessionID = string(in.String())
 		case "ssh_port":
 			out.SSHPort = int(in.Int())
 		case "ssh_client_ip":
@@ -134,21 +136,21 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers(ou
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.ID != "" {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.ID))
-	}
 	if in.SessionType != "" {
 		const prefix string = ",\"session_type\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.SessionType))
+	}
+	if in.K8SSessionID != "" {
+		const prefix string = ",\"id\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.SessionType))
+		out.String(string(in.K8SSessionID))
 	}
 	if in.K8SUsername != "" {
 		const prefix string = ",\"k8s_username\":"
@@ -223,6 +225,16 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers(ou
 			}
 			out.RawByte('}')
 		}
+	}
+	if in.SSHSessionID != "" {
+		const prefix string = ",\"ssh_session_id\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHSessionID))
 	}
 	if in.SSHPort != 0 {
 		const prefix string = ",\"ssh_port\":"

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -44,8 +44,8 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(in
 			out.SessionType = string(in.String())
 		case "id":
 			out.ID = string(in.String())
-		case "username":
-			out.Username = string(in.String())
+		case "identity":
+			out.Identity = string(in.String())
 		case "ssh_session_id":
 			out.SSHSessionID = string(in.String())
 		case "ssh_client_port":
@@ -156,15 +156,15 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers(ou
 		}
 		out.String(string(in.ID))
 	}
-	if in.Username != "" {
-		const prefix string = ",\"username\":"
+	if in.Identity != "" {
+		const prefix string = ",\"identity\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.Username))
+		out.String(string(in.Identity))
 	}
 	if in.SSHSessionID != "" {
 		const prefix string = ",\"ssh_session_id\":"

--- a/pkg/security/tests/ssh_user_session_test.go
+++ b/pkg/security/tests/ssh_user_session_test.go
@@ -203,12 +203,12 @@ func checkSSHUserSessionJSON(testMod *testModule, t testing.TB, data []byte) {
 			}
 		}
 
-		// Check Port and IP as username
+		// Check Port and IP as identity
 
-		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.username`); err != nil || el == nil {
-			t.Errorf("user_session.username not found: %v", err)
-		} else if username, ok := el.(string); !ok || username == fmt.Sprintf("%s:%f", sshClientIP, sshClientPort) {
-			t.Errorf("user_session.username is empty: %v", el)
+		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.identity`); err != nil || el == nil {
+			t.Errorf("user_session.identity not found: %v", err)
+		} else if identity, ok := el.(string); !ok || identity == fmt.Sprintf("%s:%f", sshClientIP, sshClientPort) {
+			t.Errorf("user_session.identity is empty: %v", el)
 		}
 
 		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_auth_method`); err != nil || el == nil {

--- a/pkg/security/tests/ssh_user_session_test.go
+++ b/pkg/security/tests/ssh_user_session_test.go
@@ -155,10 +155,10 @@ func checkSSHUserSessionJSON(testMod *testModule, t testing.TB, data []byte) {
 	jsonPathValidation(testMod, data, func(_ *testModule, jsonData interface{}) {
 
 		// Check all the fields
-		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.id`); err != nil || el == nil {
-			t.Errorf("user_session.id not found: %v", err)
+		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_session_id`); err != nil || el == nil {
+			t.Errorf("user_session.ssh_session_id not found: %v", err)
 		} else if id, ok := el.(string); !ok || id == "" || id == "0" {
-			t.Errorf("user_session.id is empty or invalid: %v", el)
+			t.Errorf("user_session.user_session_id is empty or invalid: %v", el)
 		}
 
 		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.session_type`); err != nil || el == nil {
@@ -336,7 +336,7 @@ func TestSSHUserSession(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_ssh_user_session",
-			Expression: `process.user_session.id != 0 && process.user_session.session_type == ssh && exec.user == "` + testUser.Username + `"`,
+			Expression: `process.user_session.ssh_session_id != 0 && exec.user == "` + testUser.Username + `"`,
 		},
 	}
 
@@ -402,7 +402,7 @@ func TestSSHUserSessionRotated(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_ssh_user_session",
-			Expression: `exec.user_session.id != 0 && exec.user_session.session_type == ssh && exec.user == "` + testUser.Username + `"`,
+			Expression: `process.user_session.ssh_session_id != 0 && exec.user == "` + testUser.Username + `"`,
 		},
 	}
 

--- a/pkg/security/tests/user_session_test.go
+++ b/pkg/security/tests/user_session_test.go
@@ -90,6 +90,9 @@ func TestK8SUserSession(t *testing.T) {
 					"XYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZ",
 				},
 			}, event.ProcessContext.UserSession.K8SExtra)
+			// Check that user session data is well set
+			assert.Equal(t, event.ProcessContext.UserSession.Identity, event.ProcessContext.UserSession.K8SUsername)
+			assert.Equal(t, event.ProcessContext.UserSession.ID, fmt.Sprintf("%x", event.ProcessContext.UserSession.K8SSessionID))
 		})
 	})
 }

--- a/pkg/security/tests/user_session_test.go
+++ b/pkg/security/tests/user_session_test.go
@@ -70,7 +70,7 @@ func TestK8SUserSession(t *testing.T) {
 
 			test.validateUserSessionSchema(t, event)
 
-			assert.NotEqual(t, 0, event.ProcessContext.UserSession.ID)
+			assert.NotEqual(t, 0, event.ProcessContext.UserSession.K8SSessionID)
 			assert.Equal(t, int(model.UserSessionTypes["k8s"]), event.ProcessContext.UserSession.SessionType)
 			assert.Equal(t, "qwerty.azerty@datadoghq.com", event.ProcessContext.UserSession.K8SUsername)
 			assert.Equal(t, "azerty.qwerty@datadoghq.com", event.ProcessContext.UserSession.K8SUID)


### PR DESCRIPTION
### What does this PR do?
This PR do some improvement and refactor on the user session tracking. 
- create a new ID that will be only used in case of SSH Session. With that, we have two separated IDs for User Sessions, depending on if we have k8s, ssh (or both).
- add some logs to investigate in the future why some k8s sessions are lost
- fix a bug where we were serializing empty fields
- refacto and renaming of some variable to make the code clearer. Some structs were edited for clarity
- add some new field that will be common to k8s and ssh session and some mechanisms to infer them (Session ID, Session Type, Session Identity)
- try to fix a bug where some ssh sessions were missing due to the fact that one env variable was missing
### Motivation
We noticed that we can have ssh sessions initialized in k8s user session, which caused undefined behavior and a potential overwrite of the k8s user session information.
In addition, we want to create a unique user experience for both ssh and k8s session tracking, that requires some new fields

### Describe how you validated your changes

### Additional Notes
