### PR TITLE
Enable retry on rate limit errors in `datadog-api-client` calls

### DIFF
--- a/tasks/libs/common/datadog_api.py
+++ b/tasks/libs/common/datadog_api.py
@@ -56,8 +56,7 @@ def send_metrics(series):
     from datadog_api_client.v2.api.metrics_api import MetricsApi
     from datadog_api_client.v2.model.metric_payload import MetricPayload
 
-    configuration = Configuration()
-    with ApiClient(configuration) as api_client:
+    with ApiClient(Configuration(enable_retry=True)) as api_client:
         api_instance = MetricsApi(api_client)
         response = api_instance.submit_metrics(body=MetricPayload(series=series))
 
@@ -85,8 +84,7 @@ def send_event(title: str, text: str, tags: list[str] = None):
         tags=tags or [],
     )
 
-    configuration = Configuration()
-    with ApiClient(configuration) as api_client:
+    with ApiClient(Configuration(enable_retry=True)) as api_client:
         api_instance = EventsApi(api_client)
         try:
             response = api_instance.create_event(body=body)
@@ -110,8 +108,7 @@ def get_ci_pipeline_events(query, days):
     from datadog_api_client import ApiClient, Configuration
     from datadog_api_client.v2.api.ci_visibility_pipelines_api import CIVisibilityPipelinesApi
 
-    configuration = Configuration()
-    with ApiClient(configuration) as api_client:
+    with ApiClient(Configuration(enable_retry=True)) as api_client:
         api_instance = CIVisibilityPipelinesApi(api_client)
         response = api_instance.list_ci_app_pipeline_events(
             filter_query=query,
@@ -130,11 +127,10 @@ def get_ci_test_events(query, days):
     from datadog_api_client import ApiClient, Configuration
     from datadog_api_client.v2.api.ci_visibility_tests_api import CIVisibilityTestsApi
 
-    configuration = Configuration()
     all_events = []
     page_cursor = None
 
-    with ApiClient(configuration) as api_client:
+    with ApiClient(Configuration(enable_retry=True)) as api_client:
         api = CIVisibilityTestsApi(api_client)
 
         while True:

--- a/tasks/libs/notify/jira_failing_tests.py
+++ b/tasks/libs/notify/jira_failing_tests.py
@@ -69,8 +69,7 @@ def get_failing_tests_names() -> set[str]:
         ),
     )
 
-    configuration = Configuration()
-    with ApiClient(configuration) as api_client:
+    with ApiClient(Configuration(enable_retry=True)) as api_client:
         api_instance = CIVisibilityTestsApi(api_client)
         response = api_instance.aggregate_ci_app_test_events(body=body)
         result = response['data']['buckets']

--- a/tasks/macos.py
+++ b/tasks/macos.py
@@ -49,8 +49,7 @@ def list_ci_active_versions(_, lang, n_days=30):
     from datadog_api_client import ApiClient, Configuration
     from datadog_api_client.v1.api.metrics_api import MetricsApi
 
-    configuration = Configuration()
-    with ApiClient(configuration) as api_client:
+    with ApiClient(Configuration(enable_retry=True)) as api_client:
         api_instance = MetricsApi(api_client)
         response = api_instance.query_metrics(
             _from=int((datetime.now() + timedelta(days=-n_days)).timestamp()),


### PR DESCRIPTION
### What does this PR do?
Adds `enable_retry=True` to all `Configuration` instances used with the Datadog API client to enable automatic retry handling for HTTP 429 (rate limit) and 5xx backend errors.

### Motivation
The `dynamic_test-evaluate-e2e` job and likely others have been intermittently failing with "Too Many Requests" errors when calling the Datadog CI Visibility API, for instance:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1248067205
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1247686220

The `datadog-api-client` library has built-in retry support that automatically respects the `Retry-After` header on HTTP 429 responses and uses exponential backoff with sensible defaults (`factor=2`, `max_retries=3`) for other failures.

### Describe how you validated your changes
- verified that `Configuration(enable_retry=True)` enables automatic retry with `Retry-After` header handling for HTTP 429 responses,
- applied consistently across all Datadog API client usage in the codebase.

### Additional Notes
Also inlined `Configuration` construction for single-use cases following idiomatic Python style.