### PR TITLE
CONTINT-4886 CONTINT-4899 Add CRD to kubeapiserver collector

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -369,15 +369,16 @@ func start(log log.Component,
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "datadog-cluster-agent"})
 
 	ctx := controllers.ControllerContext{
-		InformerFactory:        apiCl.InformerFactory,
-		DynamicClient:          apiCl.DynamicInformerCl,
-		DynamicInformerFactory: apiCl.DynamicInformerFactory,
-		Client:                 apiCl.InformerCl,
-		IsLeaderFunc:           le.IsLeader,
-		EventRecorder:          eventRecorder,
-		WorkloadMeta:           wmeta,
-		StopCh:                 stopCh,
-		DatadogClient:          dc,
+		InformerFactory:             apiCl.InformerFactory,
+		APIExentionsInformerFactory: apiCl.APIExentionsInformerFactory,
+		DynamicClient:               apiCl.DynamicInformerCl,
+		DynamicInformerFactory:      apiCl.DynamicInformerFactory,
+		Client:                      apiCl.InformerCl,
+		IsLeaderFunc:                le.IsLeader,
+		EventRecorder:               eventRecorder,
+		WorkloadMeta:                wmeta,
+		StopCh:                      stopCh,
+		DatadogClient:               dc,
 	}
 
 	if aggErr := controllers.StartControllers(&ctx); aggErr != nil {

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -168,6 +168,8 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 				tagInfos = append(tagInfos, c.handleKubeDeployment(ev)...)
 			case workloadmeta.KindGPU:
 				tagInfos = append(tagInfos, c.handleGPU(ev)...)
+			case workloadmeta.KindCRD:
+				tagInfos = append(tagInfos, c.handleCRD(ev)...)
 			default:
 				log.Errorf("cannot handle event for entity %q with kind %q", entityID.ID, entityID.Kind)
 			}
@@ -756,6 +758,33 @@ func (c *WorkloadMetaCollector) extractGPUTags(gpu *workloadmeta.GPU, tagList *t
 	tagList.AddLow(tags.GPUDriverVersion, gpu.DriverVersion)
 	tagList.AddLow(tags.GPUVirtualizationMode, gpu.VirtualizationMode)
 	tagList.AddLow(tags.GPUArchitecture, strings.ToLower(gpu.Architecture))
+}
+
+func (c *WorkloadMetaCollector) handleCRD(ev workloadmeta.Event) []*types.TagInfo {
+	crd := ev.Entity.(*workloadmeta.CRD)
+
+	tagList := taglist.NewTagList()
+
+	tagList.AddLow("crd_group", crd.Group)
+	tagList.AddLow("crd_kind", crd.Kind)
+	tagList.AddLow("crd_version", crd.Version)
+	tagList.AddLow("crd_name", crd.Name)
+	tagList.AddLow("crd_namespace", crd.Namespace)
+
+	low, orch, high, standard := tagList.Compute()
+
+	tagInfos := []*types.TagInfo{
+		{
+			Source:               crdSource,
+			EntityID:             common.BuildTaggerEntityID(crd.EntityID),
+			HighCardTags:         high,
+			OrchestratorCardTags: orch,
+			LowCardTags:          low,
+			StandardTags:         standard,
+		},
+	}
+
+	return tagInfos
 }
 
 func (c *WorkloadMetaCollector) extractTagsFromPodLabels(pod *workloadmeta.KubernetesPod, tagList *taglist.TagList) {

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -39,6 +39,7 @@ const (
 	kubeMetadataSource   = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesMetadata)
 	deploymentSource     = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesDeployment)
 	gpuSource            = workloadmetaCollectorName + "-" + string(workloadmeta.KindGPU)
+	crdSource            = workloadmetaCollectorName + "-" + string(workloadmeta.KindCRD)
 
 	clusterTagNamePrefix = tags.KubeClusterName
 )

--- a/comp/core/tagger/common/entity_id_builder.go
+++ b/comp/core/tagger/common/entity_id_builder.go
@@ -33,6 +33,8 @@ func BuildTaggerEntityID(entityID workloadmeta.EntityID) types.EntityID {
 		return types.NewEntityID(types.GPU, entityID.ID)
 	case workloadmeta.KindKubelet:
 		return types.NewEntityID(types.Kubelet, entityID.ID)
+	case workloadmeta.KindCRD:
+		return types.NewEntityID(types.Crd, entityID.ID)
 	default:
 		log.Errorf("can't recognize entity %q with kind %q; trying %s://%s as tagger entity",
 			entityID.ID, entityID.Kind, entityID.ID, entityID.Kind)

--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -83,6 +83,8 @@ const (
 	GPU EntityIDPrefix = "gpu"
 	// Kubelet is the prefix `kubelet`
 	Kubelet EntityIDPrefix = "kubelet"
+	// Crd is the prefix `crd`
+	Crd EntityIDPrefix = "crd"
 )
 
 // AllPrefixesSet returns a set of all possible entity id prefixes that can be used in the tagger
@@ -99,6 +101,7 @@ func AllPrefixesSet() map[EntityIDPrefix]struct{} {
 		InternalID:             {},
 		GPU:                    {},
 		Kubelet:                {},
+		Crd:                    {},
 	}
 }
 

--- a/comp/core/tagger/types/filter_builder_test.go
+++ b/comp/core/tagger/types/filter_builder_test.go
@@ -61,6 +61,7 @@ func TestFilterBuilderOps(t *testing.T) {
 					InternalID:             {},
 					GPU:                    {},
 					Kubelet:                {},
+					Crd:                    {},
 				},
 				cardinality: HighCardinality,
 			},

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/crd.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/crd.go
@@ -1,0 +1,118 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeapiserver
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/client-go/tools/cache"
+
+	kubernetesresourceparsers "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type crdEventHandler struct {
+	wlm    workloadmeta.Component
+	parser kubernetesresourceparsers.ObjectParser
+}
+
+// setupCRDInformer sets up event handlers for the shared CRD informer
+func setupCRDInformer(wlm workloadmeta.Component, informerFactory externalversions.SharedInformerFactory) (cache.ResourceEventHandlerRegistration, error) {
+	informer := informerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer()
+	crdHandler := &crdEventHandler{
+		wlm:    wlm,
+		parser: kubernetesresourceparsers.NewCRDParser(),
+	}
+
+	handlerRegistration, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    crdHandler.OnAdd,
+		UpdateFunc: crdHandler.OnUpdate,
+		DeleteFunc: crdHandler.OnDelete,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return handlerRegistration, nil
+}
+
+func (c *crdEventHandler) OnAdd(obj interface{}) {
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		log.Errorf("expected CustomResourceDefinition but got %T", obj)
+		return
+	}
+
+	entity := c.parser.Parse(crd)
+	event := workloadmeta.Event{
+		Type:   workloadmeta.EventTypeSet,
+		Entity: entity,
+	}
+
+	c.wlm.Notify([]workloadmeta.CollectorEvent{
+		{
+			Type:   event.Type,
+			Source: workloadmeta.SourceKubeAPIServer,
+			Entity: event.Entity,
+		},
+	})
+}
+
+func (c *crdEventHandler) OnUpdate(_, newObj interface{}) {
+	newCRD, ok := newObj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		log.Errorf("expected CustomResourceDefinition but got %T", newObj)
+		return
+	}
+
+	entity := c.parser.Parse(newCRD)
+	event := workloadmeta.Event{
+		Type:   workloadmeta.EventTypeSet,
+		Entity: entity,
+	}
+
+	c.wlm.Notify([]workloadmeta.CollectorEvent{
+		{
+			Type:   event.Type,
+			Source: workloadmeta.SourceKubeAPIServer,
+			Entity: event.Entity,
+		},
+	})
+}
+
+func (c *crdEventHandler) OnDelete(obj interface{}) {
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		// Handle DeletedFinalStateUnknown
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			log.Errorf("expected CustomResourceDefinition or DeletedFinalStateUnknown but got %T", obj)
+			return
+		}
+		crd, ok = deletedState.Obj.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			log.Errorf("DeletedFinalStateUnknown contained unexpected object: %T", deletedState.Obj)
+			return
+		}
+	}
+
+	entity := c.parser.Parse(crd)
+	event := workloadmeta.Event{
+		Type:   workloadmeta.EventTypeUnset,
+		Entity: entity,
+	}
+
+	c.wlm.Notify([]workloadmeta.CollectorEvent{
+		{
+			Type:   event.Type,
+			Source: workloadmeta.SourceKubeAPIServer,
+			Entity: event.Entity,
+		},
+	})
+}

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/crd.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/crd.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubernetesresourceparsers
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+type crdParser struct{}
+
+// NewCRDParser initialises and returns a CRD parser
+func NewCRDParser() ObjectParser {
+	return crdParser{}
+}
+
+func (p crdParser) Parse(obj interface{}) workloadmeta.Entity {
+	crd := obj.(*apiextensionsv1.CustomResourceDefinition)
+
+	// Use the first version as the primary version
+	// CRDs can have multiple versions, but we'll track the stored version
+	var version string
+	for _, v := range crd.Spec.Versions {
+		if v.Storage {
+			version = v.Name
+			break
+		}
+	}
+	// Fallback to first version if no storage version is found
+	if version == "" && len(crd.Spec.Versions) > 0 {
+		version = crd.Spec.Versions[0].Name
+	}
+
+	return &workloadmeta.CRD{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindCRD,
+			ID:   crd.Name, // CRD names are unique cluster-wide
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:        crd.Name,
+			Labels:      crd.Labels,
+			Namespace:   crd.Namespace,
+			Annotations: crd.Annotations,
+			UID:         string(crd.UID),
+		},
+		Group:   crd.Spec.Group,
+		Kind:    crd.Spec.Names.Kind,
+		Version: version,
+	}
+}

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/crd_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/crd_test.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubernetesresourceparsers
+
+import (
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/require"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func TestNewCRDParser(t *testing.T) {
+	tests := []struct {
+		name     string
+		crd      *apiextensionsv1.CustomResourceDefinition
+		expected *workloadmeta.CRD
+	}{
+		{
+			name: "single_version_with_storage",
+			crd: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "datadogagents.datadoghq.com",
+					Namespace:   "datadog",
+					Labels:      map[string]string{"app": "datadog", "app.kubernetes.io/name": "datadogCRDs"},
+					Annotations: map[string]string{"annotation-key": "annotation-value"},
+					UID:         "12345",
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "datadoghq.com",
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Kind: "DatadogAgent",
+					},
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v2alpha1",
+							Storage: true,
+						},
+					},
+				},
+			},
+			expected: &workloadmeta.CRD{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindCRD,
+					ID:   "datadogagents.datadoghq.com",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:        "datadogagents.datadoghq.com",
+					Namespace:   "datadog",
+					Labels:      map[string]string{"app": "datadog", "app.kubernetes.io/name": "datadogCRDs"},
+					Annotations: map[string]string{"annotation-key": "annotation-value"},
+					UID:         "12345",
+				},
+				Group:   "datadoghq.com",
+				Kind:    "DatadogAgent",
+				Version: "v2alpha1",
+			},
+		},
+		{
+			name: "multiple_versions_with_storage",
+			crd: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "datadogagents.datadoghq.com",
+					Namespace:   "datadog",
+					Labels:      map[string]string{"app": "datadog", "app.kubernetes.io/name": "datadogCRDs"},
+					Annotations: map[string]string{"annotation-key": "annotation-value"},
+					UID:         "12345",
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "datadoghq.com",
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Kind: "DatadogAgent",
+					},
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Storage: false,
+						},
+						{
+							Name:    "v1",
+							Storage: true,
+						},
+					},
+				},
+			},
+			expected: &workloadmeta.CRD{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindCRD,
+					ID:   "datadogagents.datadoghq.com",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:        "datadogagents.datadoghq.com",
+					Namespace:   "datadog",
+					Labels:      map[string]string{"app": "datadog", "app.kubernetes.io/name": "datadogCRDs"},
+					Annotations: map[string]string{"annotation-key": "annotation-value"},
+					UID:         "12345",
+				},
+				Group:   "datadoghq.com",
+				Kind:    "DatadogAgent",
+				Version: "v1",
+			},
+		},
+		{
+			name: "multiple_versions_without_storage",
+			crd: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "datadogagents.datadoghq.com",
+					Namespace:   "datadog",
+					Labels:      map[string]string{"app": "datadog", "app.kubernetes.io/name": "datadogCRDs"},
+					Annotations: map[string]string{"annotation-key": "annotation-value"},
+					UID:         "12345",
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "datadoghq.com",
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Kind: "DatadogAgent",
+					},
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Storage: false,
+						},
+						{
+							Name:    "v1",
+							Storage: false,
+						},
+					},
+				},
+			},
+			expected: &workloadmeta.CRD{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindCRD,
+					ID:   "datadogagents.datadoghq.com",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:        "datadogagents.datadoghq.com",
+					Namespace:   "datadog",
+					Labels:      map[string]string{"app": "datadog", "app.kubernetes.io/name": "datadogCRDs"},
+					Annotations: map[string]string{"annotation-key": "annotation-value"},
+					UID:         "12345",
+				},
+				Group:   "datadoghq.com",
+				Kind:    "DatadogAgent",
+				Version: "v1alpha1",
+			},
+		},
+	}
+
+	parser := NewCRDParser()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity := parser.Parse(tt.crd)
+
+			crdEntity, ok := entity.(*workloadmeta.CRD)
+			require.True(t, ok, "expected entity to be of type *workloadmeta.CRD but got %T", entity)
+
+			require.Equal(t, tt.expected, crdEntity, "parsed CRD does not match expected")
+		})
+	}
+}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -52,6 +52,7 @@ const (
 	KindProcess                Kind = "process"
 	KindGPU                    Kind = "gpu"
 	KindKubelet                Kind = "kubelet"
+	KindCRD                    Kind = "crd"
 )
 
 // Source is the source name of an entity.
@@ -2095,3 +2096,53 @@ const (
 	// CollectorsInitialized means workloadmeta collectors have been at least pulled once
 	CollectorsInitialized
 )
+
+// CRD struct exposes known CRD group/kind/versions
+type CRD struct {
+	EntityID
+	EntityMeta
+	Group   string
+	Kind    string
+	Version string
+}
+
+var _ Entity = &CRD{}
+
+// GetID returns the CRD entity ID
+func (crd CRD) GetID() EntityID {
+	return crd.EntityID
+}
+
+// Merge allows the merge of 2 CRD entities
+func (crd *CRD) Merge(e Entity) error {
+	otherCrd, ok := e.(*CRD)
+	if !ok {
+		return fmt.Errorf("cannot merge CRD type with other type: %T", e)
+	}
+
+	return merge(crd, otherCrd)
+}
+
+// DeepCopy returns a deep copy of the given CRD entity
+func (crd CRD) DeepCopy() Entity {
+	copyCrd := deepcopy.Copy(crd).(*CRD)
+	return copyCrd
+}
+
+// String return the string representation of the given CRD entity.
+// set verbose to true to increase verbosity.
+func (crd CRD) String(verbose bool) string {
+	var sb strings.Builder
+
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprintln(&sb, crd.EntityID.String(verbose))
+
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprintln(&sb, crd.EntityMeta.String(verbose))
+
+	_, _ = fmt.Fprintln(&sb, "Group:", crd.Group)
+	_, _ = fmt.Fprintln(&sb, "Kind:", crd.Kind)
+	_, _ = fmt.Fprintln(&sb, "Version:", crd.Version)
+
+	return sb.String()
+}

--- a/comp/core/workloadmeta/impl/dump.go
+++ b/comp/core/workloadmeta/impl/dump.go
@@ -39,6 +39,8 @@ func (w *workloadmeta) Dump(verbose bool) wmdef.WorkloadDumpResponse {
 			info = e.String(verbose)
 		case *wmdef.Kubelet:
 			info = e.String(verbose)
+		case *wmdef.CRD:
+			info = e.String(verbose)
 		default:
 			return "", fmt.Errorf("unsupported type %T", e)
 		}

--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -83,6 +83,17 @@ func ProtobufEventFromWorkloadmetaEvent(event workloadmeta.Event) (*pb.Workloadm
 			Type:    protoEventType,
 			Process: protoProcess,
 		}, nil
+	case workloadmeta.KindCRD:
+		crd := entity.(*workloadmeta.CRD)
+		protoCrd, err := protoCRDFromWorkloadmetaCRD(crd)
+		if err != nil {
+			return nil, err
+		}
+
+		return &pb.WorkloadmetaEvent{
+			Type: protoEventType,
+			Crd:  protoCrd,
+		}, nil
 	}
 
 	// We have not defined a conversion for the workloadmeta type included in
@@ -230,6 +241,8 @@ func toProtoKind(kind workloadmeta.Kind) (pb.WorkloadmetaKind, error) {
 		return pb.WorkloadmetaKind_ECS_TASK, nil
 	case workloadmeta.KindProcess:
 		return pb.WorkloadmetaKind_PROCESS, nil
+	case workloadmeta.KindCRD:
+		return pb.WorkloadmetaKind_CRD, nil
 	}
 
 	return pb.WorkloadmetaKind_CONTAINER, fmt.Errorf("unknown kind: %s", kind)
@@ -555,6 +568,34 @@ func protoProcessFromWorkloadmetaProcess(process *workloadmeta.Process) (*pb.Pro
 	}, nil
 }
 
+func toProtoEntityMetaFromCrd(crd *workloadmeta.CRD) *pb.EntityMeta {
+	if crd == nil {
+		return nil
+	}
+
+	return &pb.EntityMeta{
+		Name:        crd.EntityMeta.Name,
+		Namespace:   crd.EntityMeta.Namespace,
+		Annotations: crd.EntityMeta.Annotations,
+		Labels:      crd.EntityMeta.Labels,
+	}
+}
+
+func protoCRDFromWorkloadmetaCRD(crd *workloadmeta.CRD) (*pb.Crd, error) {
+	protoEntityID, err := toProtoEntityID(&crd.EntityID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.Crd{
+		EnityId:    protoEntityID,
+		EntityMeta: toProtoEntityMetaFromCrd(crd),
+		Group:      crd.Group,
+		Kind:       crd.Kind,
+		Version:    crd.Version,
+	}, nil
+}
+
 func toProtoEntityID(entityID *workloadmeta.EntityID) (*pb.WorkloadmetaEntityId, error) {
 	if entityID == nil {
 		return nil, nil
@@ -720,6 +761,15 @@ func WorkloadmetaEventFromProtoEvent(protoEvent *pb.WorkloadmetaEvent) (workload
 			Type:   eventType,
 			Entity: process,
 		}, nil
+	} else if protoEvent.Crd != nil {
+		crd, err := toWorkloadmetaCrd(protoEvent.Crd)
+		if err != nil {
+			return workloadmeta.Event{}, err
+		}
+		return workloadmeta.Event{
+			Type:   eventType,
+			Entity: crd,
+		}, nil
 	}
 
 	return workloadmeta.Event{}, errors.New("unknown entity")
@@ -735,6 +785,8 @@ func toWorkloadmetaKind(protoKind pb.WorkloadmetaKind) (workloadmeta.Kind, error
 		return workloadmeta.KindECSTask, nil
 	case pb.WorkloadmetaKind_PROCESS:
 		return workloadmeta.KindProcess, nil
+	case pb.WorkloadmetaKind_CRD:
+		return workloadmeta.KindCRD, nil
 	}
 
 	return workloadmeta.KindContainer, fmt.Errorf("unknown kind: %s", protoKind)
@@ -1109,6 +1161,21 @@ func toWorkloadmetaProcess(protoProcess *pb.Process) (*workloadmeta.Process, err
 		Owner:          owner,
 		Service:        toWorkloadmetaService(protoProcess.Service),
 		InjectionState: workloadmeta.InjectionState(protoProcess.InjectionState),
+	}, nil
+}
+
+func toWorkloadmetaCrd(protoCrd *pb.Crd) (*workloadmeta.CRD, error) {
+	entityID, err := toWorkloadmetaEntityID(protoCrd.EnityId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workloadmeta.CRD{
+		EntityID:   entityID,
+		EntityMeta: toWorkloadmetaEntityMeta(protoCrd.EntityMeta),
+		Group:      protoCrd.Group,
+		Kind:       protoCrd.Kind,
+		Version:    protoCrd.Version,
 	}, nil
 }
 

--- a/comp/core/workloadmeta/proto/proto_test.go
+++ b/comp/core/workloadmeta/proto/proto_test.go
@@ -670,6 +670,46 @@ func TestConversions(t *testing.T) {
 			expectsError: false,
 		},
 		{
+			name: "event with valid crd",
+			workloadmetaEvent: workloadmeta.Event{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.CRD{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindCRD,
+						ID:   "crd://datadogagents.datadoghq.com",
+					},
+					EntityMeta: workloadmeta.EntityMeta{
+						Name:        "datadogagents.datadoghq.com",
+						Namespace:   "",
+						Annotations: map[string]string{"meta.helm.sh/release-name": "datadog-operator"},
+						Labels:      map[string]string{"pp.kubernetes.io/managed-by": "Helm"},
+					},
+					Group:   "datadoghq.com",
+					Kind:    "DatadogAgent",
+					Version: "v2alpha1e",
+				},
+			},
+			protoWorkloadmetaEvent: &pb.WorkloadmetaEvent{
+				Type: pb.WorkloadmetaEventType_EVENT_TYPE_SET,
+				Crd: &pb.Crd{
+					EnityId: &pb.WorkloadmetaEntityId{
+						Kind: pb.WorkloadmetaKind_CRD,
+						Id:   "crd://datadogagents.datadoghq.com",
+					},
+					EntityMeta: &pb.EntityMeta{
+						Name:        "datadogagents.datadoghq.com",
+						Namespace:   "",
+						Annotations: map[string]string{"meta.helm.sh/release-name": "datadog-operator"},
+						Labels:      map[string]string{"pp.kubernetes.io/managed-by": "Helm"},
+					},
+					Group:   "datadoghq.com",
+					Kind:    "DatadogAgent",
+					Version: "v2alpha1e",
+				},
+			},
+			expectsError: false,
+		},
+		{
 			name: "invalid event",
 			workloadmetaEvent: workloadmeta.Event{
 				Type:   -1, // invalid

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -820,6 +820,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks_from_dispatching", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_period", 10*time.Minute)
 	config.BindEnvAndSetDefault("cluster_checks.ksm_sharding_enabled", false) // KSM resource sharding: splits KSM check by resource type (pods, nodes, others)
+	config.BindEnvAndSetDefault("cluster_checks.crd_collection", false)
 
 	// Cluster check runner
 	config.BindEnvAndSetDefault("clc_runner_enabled", false)

--- a/pkg/proto/datadog/workloadmeta/workloadmeta.proto
+++ b/pkg/proto/datadog/workloadmeta/workloadmeta.proto
@@ -9,6 +9,7 @@ enum WorkloadmetaKind {
   KUBERNETES_POD = 1;
   ECS_TASK = 2;
   PROCESS = 3;
+  CRD = 4;
 }
 
 enum WorkloadmetaSource {
@@ -229,12 +230,21 @@ message Process {
   InjectionState injectionState = 17;
 }
 
+message Crd {
+  WorkloadmetaEntityId enity_id = 1;
+  EntityMeta entity_meta = 2;
+  string group = 3;
+  string kind = 4;
+  string version = 5;
+}
+
 message WorkloadmetaEvent {
   WorkloadmetaEventType type = 1;
   Container container = 2;
   KubernetesPod kubernetesPod = 3;
   ECSTask ecsTask = 4;
   Process process = 5;
+  Crd crd = 6;
 }
 
 message WorkloadmetaStreamResponse {

--- a/pkg/proto/pbgo/core/workloadmeta.pb.go
+++ b/pkg/proto/pbgo/core/workloadmeta.pb.go
@@ -28,6 +28,7 @@ const (
 	WorkloadmetaKind_KUBERNETES_POD WorkloadmetaKind = 1
 	WorkloadmetaKind_ECS_TASK       WorkloadmetaKind = 2
 	WorkloadmetaKind_PROCESS        WorkloadmetaKind = 3
+	WorkloadmetaKind_CRD            WorkloadmetaKind = 4
 )
 
 // Enum value maps for WorkloadmetaKind.
@@ -37,12 +38,14 @@ var (
 		1: "KUBERNETES_POD",
 		2: "ECS_TASK",
 		3: "PROCESS",
+		4: "CRD",
 	}
 	WorkloadmetaKind_value = map[string]int32{
 		"CONTAINER":      0,
 		"KUBERNETES_POD": 1,
 		"ECS_TASK":       2,
 		"PROCESS":        3,
+		"CRD":            4,
 	}
 )
 
@@ -2017,6 +2020,82 @@ func (x *Process) GetInjectionState() InjectionState {
 	return InjectionState_INJECTION_UNKNOWN
 }
 
+type Crd struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EnityId       *WorkloadmetaEntityId  `protobuf:"bytes,1,opt,name=enity_id,json=enityId,proto3" json:"enity_id,omitempty"`
+	EntityMeta    *EntityMeta            `protobuf:"bytes,2,opt,name=entity_meta,json=entityMeta,proto3" json:"entity_meta,omitempty"`
+	Group         string                 `protobuf:"bytes,3,opt,name=group,proto3" json:"group,omitempty"`
+	Kind          string                 `protobuf:"bytes,4,opt,name=kind,proto3" json:"kind,omitempty"`
+	Version       string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Crd) Reset() {
+	*x = Crd{}
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Crd) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Crd) ProtoMessage() {}
+
+func (x *Crd) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Crd.ProtoReflect.Descriptor instead.
+func (*Crd) Descriptor() ([]byte, []int) {
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *Crd) GetEnityId() *WorkloadmetaEntityId {
+	if x != nil {
+		return x.EnityId
+	}
+	return nil
+}
+
+func (x *Crd) GetEntityMeta() *EntityMeta {
+	if x != nil {
+		return x.EntityMeta
+	}
+	return nil
+}
+
+func (x *Crd) GetGroup() string {
+	if x != nil {
+		return x.Group
+	}
+	return ""
+}
+
+func (x *Crd) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *Crd) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 type WorkloadmetaEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Type          WorkloadmetaEventType  `protobuf:"varint,1,opt,name=type,proto3,enum=datadog.workloadmeta.WorkloadmetaEventType" json:"type,omitempty"`
@@ -2024,13 +2103,14 @@ type WorkloadmetaEvent struct {
 	KubernetesPod *KubernetesPod         `protobuf:"bytes,3,opt,name=kubernetesPod,proto3" json:"kubernetesPod,omitempty"`
 	EcsTask       *ECSTask               `protobuf:"bytes,4,opt,name=ecsTask,proto3" json:"ecsTask,omitempty"`
 	Process       *Process               `protobuf:"bytes,5,opt,name=process,proto3" json:"process,omitempty"`
+	Crd           *Crd                   `protobuf:"bytes,6,opt,name=crd,proto3" json:"crd,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *WorkloadmetaEvent) Reset() {
 	*x = WorkloadmetaEvent{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[19]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2042,7 +2122,7 @@ func (x *WorkloadmetaEvent) String() string {
 func (*WorkloadmetaEvent) ProtoMessage() {}
 
 func (x *WorkloadmetaEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[19]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2055,7 +2135,7 @@ func (x *WorkloadmetaEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadmetaEvent.ProtoReflect.Descriptor instead.
 func (*WorkloadmetaEvent) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{19}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *WorkloadmetaEvent) GetType() WorkloadmetaEventType {
@@ -2093,6 +2173,13 @@ func (x *WorkloadmetaEvent) GetProcess() *Process {
 	return nil
 }
 
+func (x *WorkloadmetaEvent) GetCrd() *Crd {
+	if x != nil {
+		return x.Crd
+	}
+	return nil
+}
+
 type WorkloadmetaStreamResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Events        []*WorkloadmetaEvent   `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
@@ -2102,7 +2189,7 @@ type WorkloadmetaStreamResponse struct {
 
 func (x *WorkloadmetaStreamResponse) Reset() {
 	*x = WorkloadmetaStreamResponse{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[20]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2114,7 +2201,7 @@ func (x *WorkloadmetaStreamResponse) String() string {
 func (*WorkloadmetaStreamResponse) ProtoMessage() {}
 
 func (x *WorkloadmetaStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[20]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2127,7 +2214,7 @@ func (x *WorkloadmetaStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadmetaStreamResponse.ProtoReflect.Descriptor instead.
 func (*WorkloadmetaStreamResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{20}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *WorkloadmetaStreamResponse) GetEvents() []*WorkloadmetaEvent {
@@ -2323,20 +2410,29 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"\blanguage\x18\x0e \x01(\v2\x1e.datadog.workloadmeta.LanguageR\blanguage\x12@\n" +
 	"\x05owner\x18\x0f \x01(\v2*.datadog.workloadmeta.WorkloadmetaEntityIdR\x05owner\x127\n" +
 	"\aservice\x18\x10 \x01(\v2\x1d.datadog.workloadmeta.ServiceR\aservice\x12L\n" +
-	"\x0einjectionState\x18\x11 \x01(\x0e2$.datadog.workloadmeta.InjectionStateR\x0einjectionState\"\xd0\x02\n" +
+	"\x0einjectionState\x18\x11 \x01(\x0e2$.datadog.workloadmeta.InjectionStateR\x0einjectionState\"\xd3\x01\n" +
+	"\x03Crd\x12E\n" +
+	"\benity_id\x18\x01 \x01(\v2*.datadog.workloadmeta.WorkloadmetaEntityIdR\aenityId\x12A\n" +
+	"\ventity_meta\x18\x02 \x01(\v2 .datadog.workloadmeta.EntityMetaR\n" +
+	"entityMeta\x12\x14\n" +
+	"\x05group\x18\x03 \x01(\tR\x05group\x12\x12\n" +
+	"\x04kind\x18\x04 \x01(\tR\x04kind\x12\x18\n" +
+	"\aversion\x18\x05 \x01(\tR\aversion\"\xfd\x02\n" +
 	"\x11WorkloadmetaEvent\x12?\n" +
 	"\x04type\x18\x01 \x01(\x0e2+.datadog.workloadmeta.WorkloadmetaEventTypeR\x04type\x12=\n" +
 	"\tcontainer\x18\x02 \x01(\v2\x1f.datadog.workloadmeta.ContainerR\tcontainer\x12I\n" +
 	"\rkubernetesPod\x18\x03 \x01(\v2#.datadog.workloadmeta.KubernetesPodR\rkubernetesPod\x127\n" +
 	"\aecsTask\x18\x04 \x01(\v2\x1d.datadog.workloadmeta.ECSTaskR\aecsTask\x127\n" +
-	"\aprocess\x18\x05 \x01(\v2\x1d.datadog.workloadmeta.ProcessR\aprocess\"]\n" +
+	"\aprocess\x18\x05 \x01(\v2\x1d.datadog.workloadmeta.ProcessR\aprocess\x12+\n" +
+	"\x03crd\x18\x06 \x01(\v2\x19.datadog.workloadmeta.CrdR\x03crd\"]\n" +
 	"\x1aWorkloadmetaStreamResponse\x12?\n" +
-	"\x06events\x18\x01 \x03(\v2'.datadog.workloadmeta.WorkloadmetaEventR\x06events*P\n" +
+	"\x06events\x18\x01 \x03(\v2'.datadog.workloadmeta.WorkloadmetaEventR\x06events*Y\n" +
 	"\x10WorkloadmetaKind\x12\r\n" +
 	"\tCONTAINER\x10\x00\x12\x12\n" +
 	"\x0eKUBERNETES_POD\x10\x01\x12\f\n" +
 	"\bECS_TASK\x10\x02\x12\v\n" +
-	"\aPROCESS\x10\x03*[\n" +
+	"\aPROCESS\x10\x03\x12\a\n" +
+	"\x03CRD\x10\x04*[\n" +
 	"\x12WorkloadmetaSource\x12\a\n" +
 	"\x03ALL\x10\x00\x12\v\n" +
 	"\aRUNTIME\x10\x01\x12\x15\n" +
@@ -2390,7 +2486,7 @@ func file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_workloadmeta_workloadmeta_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_datadog_workloadmeta_workloadmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_datadog_workloadmeta_workloadmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_datadog_workloadmeta_workloadmeta_proto_goTypes = []any{
 	(WorkloadmetaKind)(0),              // 0: datadog.workloadmeta.WorkloadmetaKind
 	(WorkloadmetaSource)(0),            // 1: datadog.workloadmeta.WorkloadmetaSource
@@ -2419,15 +2515,16 @@ var file_datadog_workloadmeta_workloadmeta_proto_goTypes = []any{
 	(*Service)(nil),                    // 24: datadog.workloadmeta.Service
 	(*Language)(nil),                   // 25: datadog.workloadmeta.Language
 	(*Process)(nil),                    // 26: datadog.workloadmeta.Process
-	(*WorkloadmetaEvent)(nil),          // 27: datadog.workloadmeta.WorkloadmetaEvent
-	(*WorkloadmetaStreamResponse)(nil), // 28: datadog.workloadmeta.WorkloadmetaStreamResponse
-	nil,                                // 29: datadog.workloadmeta.EntityMeta.AnnotationsEntry
-	nil,                                // 30: datadog.workloadmeta.EntityMeta.LabelsEntry
-	nil,                                // 31: datadog.workloadmeta.Container.EnvVarsEntry
-	nil,                                // 32: datadog.workloadmeta.Container.NetworkIpsEntry
-	nil,                                // 33: datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
-	nil,                                // 34: datadog.workloadmeta.ECSTask.TagsEntry
-	nil,                                // 35: datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
+	(*Crd)(nil),                        // 27: datadog.workloadmeta.Crd
+	(*WorkloadmetaEvent)(nil),          // 28: datadog.workloadmeta.WorkloadmetaEvent
+	(*WorkloadmetaStreamResponse)(nil), // 29: datadog.workloadmeta.WorkloadmetaStreamResponse
+	nil,                                // 30: datadog.workloadmeta.EntityMeta.AnnotationsEntry
+	nil,                                // 31: datadog.workloadmeta.EntityMeta.LabelsEntry
+	nil,                                // 32: datadog.workloadmeta.Container.EnvVarsEntry
+	nil,                                // 33: datadog.workloadmeta.Container.NetworkIpsEntry
+	nil,                                // 34: datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
+	nil,                                // 35: datadog.workloadmeta.ECSTask.TagsEntry
+	nil,                                // 36: datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
 }
 var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	0,  // 0: datadog.workloadmeta.WorkloadmetaFilter.kinds:type_name -> datadog.workloadmeta.WorkloadmetaKind
@@ -2435,15 +2532,15 @@ var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	2,  // 2: datadog.workloadmeta.WorkloadmetaFilter.eventType:type_name -> datadog.workloadmeta.WorkloadmetaEventType
 	8,  // 3: datadog.workloadmeta.WorkloadmetaStreamRequest.filter:type_name -> datadog.workloadmeta.WorkloadmetaFilter
 	0,  // 4: datadog.workloadmeta.WorkloadmetaEntityId.kind:type_name -> datadog.workloadmeta.WorkloadmetaKind
-	29, // 5: datadog.workloadmeta.EntityMeta.annotations:type_name -> datadog.workloadmeta.EntityMeta.AnnotationsEntry
-	30, // 6: datadog.workloadmeta.EntityMeta.labels:type_name -> datadog.workloadmeta.EntityMeta.LabelsEntry
+	30, // 5: datadog.workloadmeta.EntityMeta.annotations:type_name -> datadog.workloadmeta.EntityMeta.AnnotationsEntry
+	31, // 6: datadog.workloadmeta.EntityMeta.labels:type_name -> datadog.workloadmeta.EntityMeta.LabelsEntry
 	4,  // 7: datadog.workloadmeta.ContainerState.status:type_name -> datadog.workloadmeta.ContainerStatus
 	5,  // 8: datadog.workloadmeta.ContainerState.health:type_name -> datadog.workloadmeta.ContainerHealth
 	10, // 9: datadog.workloadmeta.Container.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
 	11, // 10: datadog.workloadmeta.Container.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
-	31, // 11: datadog.workloadmeta.Container.envVars:type_name -> datadog.workloadmeta.Container.EnvVarsEntry
+	32, // 11: datadog.workloadmeta.Container.envVars:type_name -> datadog.workloadmeta.Container.EnvVarsEntry
 	12, // 12: datadog.workloadmeta.Container.image:type_name -> datadog.workloadmeta.ContainerImage
-	32, // 13: datadog.workloadmeta.Container.networkIps:type_name -> datadog.workloadmeta.Container.NetworkIpsEntry
+	33, // 13: datadog.workloadmeta.Container.networkIps:type_name -> datadog.workloadmeta.Container.NetworkIpsEntry
 	13, // 14: datadog.workloadmeta.Container.ports:type_name -> datadog.workloadmeta.ContainerPort
 	3,  // 15: datadog.workloadmeta.Container.runtime:type_name -> datadog.workloadmeta.Runtime
 	14, // 16: datadog.workloadmeta.Container.state:type_name -> datadog.workloadmeta.ContainerState
@@ -2455,13 +2552,13 @@ var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	11, // 22: datadog.workloadmeta.KubernetesPod.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
 	18, // 23: datadog.workloadmeta.KubernetesPod.owners:type_name -> datadog.workloadmeta.KubernetesPodOwner
 	19, // 24: datadog.workloadmeta.KubernetesPod.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	33, // 25: datadog.workloadmeta.KubernetesPod.namespaceLabels:type_name -> datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
+	34, // 25: datadog.workloadmeta.KubernetesPod.namespaceLabels:type_name -> datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
 	19, // 26: datadog.workloadmeta.KubernetesPod.InitContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
 	19, // 27: datadog.workloadmeta.KubernetesPod.ephemeralContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
 	10, // 28: datadog.workloadmeta.ECSTask.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
 	11, // 29: datadog.workloadmeta.ECSTask.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
-	34, // 30: datadog.workloadmeta.ECSTask.tags:type_name -> datadog.workloadmeta.ECSTask.TagsEntry
-	35, // 31: datadog.workloadmeta.ECSTask.containerInstanceTags:type_name -> datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
+	35, // 30: datadog.workloadmeta.ECSTask.tags:type_name -> datadog.workloadmeta.ECSTask.TagsEntry
+	36, // 31: datadog.workloadmeta.ECSTask.containerInstanceTags:type_name -> datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
 	6,  // 32: datadog.workloadmeta.ECSTask.launchType:type_name -> datadog.workloadmeta.ECSLaunchType
 	19, // 33: datadog.workloadmeta.ECSTask.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
 	22, // 34: datadog.workloadmeta.Service.tracerMetadata:type_name -> datadog.workloadmeta.TracerMetadata
@@ -2471,17 +2568,20 @@ var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	10, // 38: datadog.workloadmeta.Process.owner:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
 	24, // 39: datadog.workloadmeta.Process.service:type_name -> datadog.workloadmeta.Service
 	7,  // 40: datadog.workloadmeta.Process.injectionState:type_name -> datadog.workloadmeta.InjectionState
-	2,  // 41: datadog.workloadmeta.WorkloadmetaEvent.type:type_name -> datadog.workloadmeta.WorkloadmetaEventType
-	17, // 42: datadog.workloadmeta.WorkloadmetaEvent.container:type_name -> datadog.workloadmeta.Container
-	20, // 43: datadog.workloadmeta.WorkloadmetaEvent.kubernetesPod:type_name -> datadog.workloadmeta.KubernetesPod
-	21, // 44: datadog.workloadmeta.WorkloadmetaEvent.ecsTask:type_name -> datadog.workloadmeta.ECSTask
-	26, // 45: datadog.workloadmeta.WorkloadmetaEvent.process:type_name -> datadog.workloadmeta.Process
-	27, // 46: datadog.workloadmeta.WorkloadmetaStreamResponse.events:type_name -> datadog.workloadmeta.WorkloadmetaEvent
-	47, // [47:47] is the sub-list for method output_type
-	47, // [47:47] is the sub-list for method input_type
-	47, // [47:47] is the sub-list for extension type_name
-	47, // [47:47] is the sub-list for extension extendee
-	0,  // [0:47] is the sub-list for field type_name
+	10, // 41: datadog.workloadmeta.Crd.enity_id:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
+	11, // 42: datadog.workloadmeta.Crd.entity_meta:type_name -> datadog.workloadmeta.EntityMeta
+	2,  // 43: datadog.workloadmeta.WorkloadmetaEvent.type:type_name -> datadog.workloadmeta.WorkloadmetaEventType
+	17, // 44: datadog.workloadmeta.WorkloadmetaEvent.container:type_name -> datadog.workloadmeta.Container
+	20, // 45: datadog.workloadmeta.WorkloadmetaEvent.kubernetesPod:type_name -> datadog.workloadmeta.KubernetesPod
+	21, // 46: datadog.workloadmeta.WorkloadmetaEvent.ecsTask:type_name -> datadog.workloadmeta.ECSTask
+	26, // 47: datadog.workloadmeta.WorkloadmetaEvent.process:type_name -> datadog.workloadmeta.Process
+	27, // 48: datadog.workloadmeta.WorkloadmetaEvent.crd:type_name -> datadog.workloadmeta.Crd
+	28, // 49: datadog.workloadmeta.WorkloadmetaStreamResponse.events:type_name -> datadog.workloadmeta.WorkloadmetaEvent
+	50, // [50:50] is the sub-list for method output_type
+	50, // [50:50] is the sub-list for method input_type
+	50, // [50:50] is the sub-list for extension type_name
+	50, // [50:50] is the sub-list for extension extendee
+	0,  // [0:50] is the sub-list for field type_name
 }
 
 func init() { file_datadog_workloadmeta_workloadmeta_proto_init() }
@@ -2496,7 +2596,7 @@ func file_datadog_workloadmeta_workloadmeta_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_workloadmeta_workloadmeta_proto_rawDesc), len(file_datadog_workloadmeta_workloadmeta_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   28,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/util/kubernetes/apiserver/controllers/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers/controllers.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
+	apiextentionsinformer "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+
 	datadogclient "github.com/DataDog/datadog-agent/comp/autoscaling/datadogclient/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -59,21 +61,28 @@ var controllerCatalog = map[controllerName]controllerFuncs{
 		func() bool { return pkgconfigsetup.Datadog().GetBool("cluster_checks.enabled") },
 		registerEndpointsInformer,
 	},
+	crdControllerName: {
+		func() bool {
+			return pkgconfigsetup.Datadog().GetBool("cluster_checks.enabled") && pkgconfigsetup.Datadog().GetBool("cluster_checks.crd_collection")
+		},
+		registerCRDInformer,
+	},
 }
 
 // ControllerContext holds all the attributes needed by the controllers
 type ControllerContext struct {
-	informers              map[apiserver.InformerName]cache.SharedInformer
-	informersMutex         sync.Mutex
-	InformerFactory        informers.SharedInformerFactory
-	DynamicClient          dynamic.Interface
-	DynamicInformerFactory dynamicinformer.DynamicSharedInformerFactory
-	Client                 kubernetes.Interface
-	IsLeaderFunc           func() bool
-	EventRecorder          record.EventRecorder
-	WorkloadMeta           workloadmeta.Component
-	DatadogClient          option.Option[datadogclient.Component]
-	StopCh                 chan struct{}
+	informers                   map[apiserver.InformerName]cache.SharedInformer
+	informersMutex              sync.Mutex
+	InformerFactory             informers.SharedInformerFactory
+	APIExentionsInformerFactory apiextentionsinformer.SharedInformerFactory
+	DynamicClient               dynamic.Interface
+	DynamicInformerFactory      dynamicinformer.DynamicSharedInformerFactory
+	Client                      kubernetes.Interface
+	IsLeaderFunc                func() bool
+	EventRecorder               record.EventRecorder
+	WorkloadMeta                workloadmeta.Component
+	DatadogClient               option.Option[datadogclient.Component]
+	StopCh                      chan struct{}
 }
 
 // StartControllers runs the enabled Kubernetes controllers for the Datadog Cluster Agent. This is
@@ -115,6 +124,9 @@ func StartControllers(ctx *ControllerContext) k8serrors.Aggregate {
 	// FIXME: We may want to initialize each of these controllers separately via their respective
 	// `<informer>.Run()`
 	ctx.InformerFactory.Start(ctx.StopCh)
+
+	// same goes for the apiextension informer factory
+	ctx.APIExentionsInformerFactory.Start(ctx.StopCh)
 
 	// Wait for the cache to sync
 	if err := apiserver.SyncInformers(ctx.informers, 0); err != nil {
@@ -182,5 +194,14 @@ func registerEndpointsInformer(ctx *ControllerContext, _ chan error) {
 
 	ctx.informersMutex.Lock()
 	ctx.informers[endpointsInformer] = informer
+	ctx.informersMutex.Unlock()
+}
+
+// registerCRDInformer registers the CRD informer.
+func registerCRDInformer(ctx *ControllerContext, _ chan error) {
+	informer := ctx.APIExentionsInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer()
+
+	ctx.informersMutex.Lock()
+	ctx.informers[crdInformer] = informer
 	ctx.informersMutex.Unlock()
 }

--- a/pkg/util/kubernetes/apiserver/controllers/names.go
+++ b/pkg/util/kubernetes/apiserver/controllers/names.go
@@ -16,9 +16,11 @@ const (
 	autoscalersControllerName controllerName = "autoscalers"
 	servicesControllerName    controllerName = "services"
 	endpointsControllerName   controllerName = "endpoints"
+	crdControllerName         controllerName = "crd"
 )
 
 const (
 	endpointsInformer apiserver.InformerName = "v1/endpoints"
 	servicesInformer  apiserver.InformerName = "v1/services"
+	crdInformer       apiserver.InformerName = "v1/crd"
 )

--- a/releasenotes/notes/add-crd-collector-4768e80f2c0a1593.yaml
+++ b/releasenotes/notes/add-crd-collector-4768e80f2c0a1593.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add a new collector that will collect all CustomResourceDefinitions on the cluster.
+other:
+  - |
+    This feature is currently in development and is protected under the feature flag:
+      `cluster_checks.crd_collection`

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -514,6 +514,12 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 				},
 			},
 			"env": pulumi.StringMapArray{
+				// These options are disabled by default and not exposed in the
+				// Helm chart yet, so we need to set the env.
+				pulumi.StringMap{
+					"name":  pulumi.String("DD_CLUSTER_CHECKS_CRD_COLLECTION"),
+					"value": pulumi.String("true"),
+				},
 				pulumi.StringMap{
 					"name":  pulumi.String("DD_EC2_METADATA_TIMEOUT"),
 					"value": pulumi.String("5000"), // Unit is ms

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -16,8 +16,9 @@ import (
 
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	"github.com/DataDog/agent-payload/v5/sbom"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps"
 	"gopkg.in/zorkian/go-datadog-api.v2"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
@@ -535,6 +536,14 @@ func (suite *k8sSuite) testClusterAgentCLI() {
 			suite.T().Logf("Found %d workload metric entries in local store", validEntryCount)
 			assert.GreaterOrEqual(c, validEntryCount, 10, "Should have at least 10 workload entries in local store, but got %d", validEntryCount)
 		}, 3*time.Minute, 10*time.Second, "Failed to get workload metrics from local store")
+	})
+
+	suite.Run("cluster-agent CRD collector", func() {
+		stdout, stderr, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", leaderDcaPodName, "cluster-agent", []string{"agent", "workload-list"})
+		suite.Require().NoError(err)
+		suite.Empty(stderr, "Standard error of `agent workload-list` should be empty")
+		suite.Contains(stdout, "=== Entity crd sources(merged):[kubeapiserver] id: datadogmetrics.datadoghq.com ===")
+
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Add a new CRD Entity type.

Watch for all CRDs on the cluster.

Add them to WorkloadMeta when found with their latest used version.

This will be useful later for autodisovery to trigger KSM checks based on the CRD type we find.

In WorkloadMeta it will be available to any other future components that need it.

co-author: Mathew Estafanous <mathew.estafanous@datadoghq.com>

### Motivation

CONTINT-4886 + CONTINT-4899

### Describe how you validated your changes

deployed agent, enabled feature flag and listed workloadmeta entries

```sh
k exec datadog-cluster-agent-7cc5c5dcf7-khdtc -- agent workload-list
```

result:

```
=== Entity crd sources(merged):[kubeapiserver] id: datadogagents.datadoghq.com ===
----------- Entity ID -----------
Kind: crd ID: datadogagents.datadoghq.com

----------- Entity Meta -----------
Name: datadogagents.datadoghq.com
Namespace:

Group: datadoghq.com
Kind: DatadogAgent
Version: v2alpha1
===

=== Entity crd sources(merged):[kubeapiserver] id: datadogmetrics.datadoghq.com ===
----------- Entity ID -----------
Kind: crd ID: datadogmetrics.datadoghq.com

----------- Entity Meta -----------
Name: datadogmetrics.datadoghq.com
Namespace:

Group: datadoghq.com
Kind: DatadogMetric
Version: v1alpha1
===
```

### Additional Notes

This is behind a feature flag for safety and even when enabled should has no impact on the agent. 
