### PR TITLE
[CWS] do not pragma unroll more loops in fentry mode

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/network/parser.h
+++ b/pkg/security/ebpf/c/include/helpers/network/parser.h
@@ -168,7 +168,9 @@ __attribute__((always_inline)) struct packet_t * parse_packet(struct __sk_buff *
     pkt->translated_ns_flow = pkt->ns_flow;
 
 // lookup flow in conntrack table
+#ifndef USE_FENTRY
 #pragma unroll
+#endif
     for (int i = 0; i < 10; i++) {
         struct namespaced_flow_t *translated_ns_flow = bpf_map_lookup_elem(&conntrack, &tmp_ns_flow);
         if (translated_ns_flow == NULL) {

--- a/pkg/security/ebpf/c/include/helpers/network/stats.h
+++ b/pkg/security/ebpf/c/include/helpers/network/stats.h
@@ -65,7 +65,9 @@ __attribute__((always_inline)) int flush_network_stats(u32 pid, struct active_fl
 
     evt->flows_count = 0;
 
+#ifndef USE_FENTRY
 #pragma unroll
+#endif
     for (int i = 0; i < ACTIVE_FLOWS_MAX_SIZE; i++) {
         if (i >= entry->cursor) {
             break;

--- a/pkg/security/ebpf/c/include/helpers/utils.h
+++ b/pkg/security/ebpf/c/include/helpers/utils.h
@@ -49,7 +49,9 @@ int __attribute__((always_inline)) parse_buf_to_bool(const char *buf) {
         return -1;
     }
 
+#ifndef USE_FENTRY
 #pragma unroll
+#endif
     for (size_t i = 0; i < SELINUX_WRITE_BUFFER_LEN; i++) {
         char curr = copy->buffer[i];
         if (curr == 0) {

--- a/pkg/security/ebpf/c/include/hooks/network/dns.h
+++ b/pkg/security/ebpf/c/include/hooks/network/dns.h
@@ -13,7 +13,9 @@ __attribute__((always_inline)) int parse_dns_request(struct __sk_buff *skb, stru
     u8 end_of_name = 0;
 
 // Handle DNS request
+#ifndef USE_FENTRY
 #pragma unroll
+#endif
     for (int i = 0; i < DNS_MAX_LENGTH; i++) {
         if (end_of_name) {
             evt->name[i] = 0;


### PR DESCRIPTION
### What does this PR do?

Kernels supporting fentry, support bounded loops as well, removing the `#pragma unroll` on those kernels allows a nice reduction of the size of the final eBPF objects.

### Motivation

### Describe how you validated your changes

### Additional Notes
