### PR TITLE
Support Kafka actions via remote config with one-shot check execution

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -613,8 +613,10 @@ func startAgent(
 	if configUtils.IsRemoteConfigEnabled(cfg) {
 		// Subscribe to `AGENT_TASK` product
 		rcclient.SubscribeAgentTask()
-		controller := datastreams.NewController(ac, rcclient)
-		ac.AddConfigProvider(controller, false, 0)
+		liveMessagesController := datastreams.NewController(ac, rcclient)
+		ac.AddConfigProvider(liveMessagesController, false, 0)
+		actionsController := datastreams.NewActionsController(ac, rcclient)
+		ac.AddConfigProvider(actionsController, false, 0)
 
 		if pkgconfigsetup.Datadog().GetBool("remote_configuration.agent_integrations.enabled") {
 			// Spin up the config provider to schedule integrations through remote-config

--- a/comp/collector/collector/collectorimpl/collector_demux_test.go
+++ b/comp/collector/collector/collectorimpl/collector_demux_test.go
@@ -256,6 +256,7 @@ type cancelledCheck struct {
 	demux demultiplexer.FakeSamplerMock
 }
 
+func (c *cancelledCheck) RunOnce() bool { return false }
 func (c *cancelledCheck) Run() error {
 	c.flip <- struct{}{}
 

--- a/comp/collector/collector/collectorimpl/collector_test.go
+++ b/comp/collector/collector/collectorimpl/collector_test.go
@@ -48,6 +48,7 @@ func (c *TestCheck) Stop()                   { c.stop <- true }
 func (c *TestCheck) Cancel()                 { c.Called() }
 func (c *TestCheck) Interval() time.Duration { return 1 * time.Minute }
 func (c *TestCheck) Run() error              { <-c.stop; return nil }
+func (c *TestCheck) RunOnce() bool           { return false }
 func (c *TestCheck) ID() checkid.ID {
 	if c.uniqueID != "" {
 		return c.uniqueID

--- a/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go
+++ b/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go
@@ -160,3 +160,8 @@ func (c *CheckWrapper) GetDiagnoses() ([]diagnose.Diagnosis, error) {
 func (c *CheckWrapper) IsHASupported() bool {
 	return c.inner.IsHASupported()
 }
+
+// RunOnce returns true if the inner check should run only once
+func (c *CheckWrapper) RunOnce() bool {
+	return c.inner.RunOnce()
+}

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
@@ -86,7 +86,7 @@ func (c *actionsController) manageSubscriptionToRC() {
 		}
 		c.closeMutex.RUnlock()
 		if isConnectedToKafka(c.ac) {
-			c.rcclient.Subscribe(data.ProductDebug, c.update)
+			c.rcclient.Subscribe(data.ProductDataStreamsKafkaActions, c.update)
 			return
 		}
 	}

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
@@ -1,0 +1,297 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2020-present Datadog, Inc.
+
+// Package datastreams contains logic to configure actions for Kafka via remote configuration
+package datastreams
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil/normalize"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	kafkaConsumerIntegrationName = "kafka_consumer"
+	kafkaActionsIntegrationName  = "kafka_actions"
+)
+
+// isConnectedToKafka checks if any kafka_consumer integration is configured
+func isConnectedToKafka(ac autodiscovery.Component) bool {
+	for _, config := range ac.GetUnresolvedConfigs() {
+		if config.Name == kafkaConsumerIntegrationName {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeBootstrapServers(servers string) string {
+	if servers == "" {
+		return ""
+	}
+	return normalize.NormalizeTagValue(servers)
+}
+
+type kafkaActionsConfig struct {
+	Actions          json.RawMessage `json:"actions"`
+	BootstrapServers string          `json:"bootstrap_servers"`
+}
+
+// actionsController listens to remote configuration updates for Kafka actions
+// and schedules one-off kafka_actions checks.
+type actionsController struct {
+	ac            autodiscovery.Component
+	rcclient      rcclient.Component
+	configChanges chan integration.ConfigChanges
+	closeMutex    sync.RWMutex
+	closed        bool
+}
+
+// String returns the name of the provider. All Config instances produced
+// by this provider will have this value in their Provider field.
+func (c *actionsController) String() string {
+	return names.DataStreamsLiveMessages
+}
+
+// GetConfigErrors returns a map of errors that occurred on the last Collect
+// call, indexed by a description of the resource that generated the error.
+// The result is displayed in diagnostic tools such as `agent status`.
+func (c *actionsController) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return map[string]types.ErrorMsgSet{}
+}
+
+func (c *actionsController) manageSubscriptionToRC() {
+	ticker := time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
+	for range ticker.C {
+		c.closeMutex.RLock()
+		if c.closed {
+			c.closeMutex.RUnlock()
+			return
+		}
+		c.closeMutex.RUnlock()
+		if isConnectedToKafka(c.ac) {
+			c.rcclient.Subscribe(data.ProductDebug, c.update)
+			return
+		}
+	}
+}
+
+// NewActionsController creates a new Kafka actions controller instance
+func NewActionsController(ac autodiscovery.Component, rcclient rcclient.Component) types.ConfigProvider {
+	c := &actionsController{
+		ac:            ac,
+		rcclient:      rcclient,
+		configChanges: make(chan integration.ConfigChanges, 10),
+	}
+	c.configChanges <- integration.ConfigChanges{}
+	go c.manageSubscriptionToRC()
+	return c
+}
+
+// Stream starts sending configuration updates for the kafka_actions integration to the output channel.
+func (c *actionsController) Stream(ctx context.Context) <-chan integration.ConfigChanges {
+	go func() {
+		<-ctx.Done()
+		c.closeMutex.Lock()
+		defer c.closeMutex.Unlock()
+		if c.closed {
+			return
+		}
+		c.closed = true
+		close(c.configChanges)
+	}()
+	return c.configChanges
+}
+
+func (c *actionsController) update(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	remoteConfigs := parseActionsConfig(updates, applyStateCallback)
+	if len(remoteConfigs) == 0 {
+		return
+	}
+	cfgs := c.ac.GetUnresolvedConfigs()
+	changes := integration.ConfigChanges{}
+	for _, parsed := range remoteConfigs {
+		auth, base, err := extractKafkaAuthFromInstance(cfgs, parsed.bootstrapServers)
+		if err != nil {
+			log.Errorf("Failed to extract Kafka auth for config %s: %v", parsed.path, err)
+			applyStateCallback(parsed.path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			continue
+		}
+
+		newCfg := integration.Config{
+			Name:       kafkaActionsIntegrationName,
+			Source:     c.String(),
+			Instances:  []integration.Data{},
+			InitConfig: nil,
+			LogsConfig: nil,
+			Provider:   base.Provider,
+			NodeName:   base.NodeName,
+		}
+
+		var actionsMap map[string]any
+		if err := json.Unmarshal(parsed.actionsJSON, &actionsMap); err != nil {
+			log.Errorf("Failed to unmarshal actions JSON for config %s: %v", parsed.path, err)
+			applyStateCallback(parsed.path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			continue
+		}
+
+		actionsMap["run_once"] = true
+		for k, v := range auth {
+			actionsMap[k] = v
+		}
+
+		payload, err := yaml.Marshal(actionsMap)
+		if err != nil {
+			log.Errorf("Failed to marshal instance config for %s: %v", parsed.path, err)
+			applyStateCallback(parsed.path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			continue
+		}
+
+		newCfg.Instances = []integration.Data{integration.Data(payload)}
+		changes.Schedule = append(changes.Schedule, newCfg)
+		applyStateCallback(parsed.path, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+	}
+	if len(changes.Schedule) == 0 {
+		return
+	}
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+	if c.closed {
+		return
+	}
+	c.configChanges <- changes
+}
+
+type parsedActionsConfig struct {
+	path             string
+	bootstrapServers string
+	actionsJSON      json.RawMessage
+}
+
+func parseActionsConfig(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) []parsedActionsConfig {
+	var configs []parsedActionsConfig
+	for path, rawConfig := range updates {
+		var cfg kafkaActionsConfig
+		err := json.Unmarshal(rawConfig.Config, &cfg)
+		if err != nil {
+			log.Errorf("Can't decode kafka actions configuration from remote-config: %v", err)
+			applyStateCallback(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			continue
+		}
+		if len(cfg.Actions) == 0 {
+			applyStateCallback(path, state.ApplyStatus{State: state.ApplyStateError, Error: "missing actions"})
+			continue
+		}
+
+		bootstrapServers := normalizeBootstrapServers(cfg.BootstrapServers)
+
+		configs = append(configs, parsedActionsConfig{
+			path:             path,
+			bootstrapServers: bootstrapServers,
+			actionsJSON:      cfg.Actions,
+		})
+	}
+	return configs
+}
+
+func extractKafkaAuthFromInstance(cfgs []integration.Config, bootstrapServers string) (map[string]any, *integration.Config, error) {
+	out := make(map[string]any)
+
+	for cfgIdx := range cfgs {
+		cfg := cfgs[cfgIdx]
+		if cfg.Name != kafkaConsumerIntegrationName {
+			continue
+		}
+
+		// This is a special case, to be deleted if matching by bootstrap_servers works perfectly.
+		// It is a fallback in case matching by bootstrap_servers fails in some cases.
+		if bootstrapServers == "" {
+			if len(cfg.Instances) > 0 {
+				auth := extractAuthFromInstanceData(cfg.Instances[0])
+				return auth, &cfg, nil
+			}
+			continue
+		}
+
+		for _, instanceData := range cfg.Instances {
+			var instanceMap map[string]any
+			if err := yaml.Unmarshal(instanceData, &instanceMap); err != nil {
+				continue
+			}
+
+			connectStr, ok := instanceMap["kafka_connect_str"].(string)
+			if !ok || connectStr == "" {
+				continue
+			}
+
+			if normalizeBootstrapServers(connectStr) == bootstrapServers {
+				auth := extractAuthFromInstanceData(instanceData)
+				return auth, &cfg, nil
+			}
+		}
+	}
+
+	if bootstrapServers == "" {
+		return out, nil, fmt.Errorf("kafka_consumer integration not found on this node")
+	}
+	return out, nil, fmt.Errorf("kafka_consumer integration with bootstrap_servers=%s not found", bootstrapServers)
+}
+
+func extractAuthFromInstanceData(instanceData integration.Data) map[string]any {
+	out := make(map[string]any)
+	raw := map[string]interface{}{}
+	if err := yaml.Unmarshal(instanceData, &raw); err != nil {
+		return out
+	}
+
+	allowList := []string{
+		"kafka_connect_str",
+		"security_protocol",
+		"sasl_mechanism",
+		"sasl_plain_username",
+		"sasl_plain_password",
+		"sasl_kerberos_keytab",
+		"sasl_kerberos_principal",
+		"sasl_kerberos_service_name",
+		"sasl_kerberos_domain_name",
+		"tls_verify",
+		"tls_ca_cert",
+		"tls_cert",
+		"tls_private_key",
+		"tls_private_key_password",
+		"tls_validate_hostname",
+		"tls_ciphers",
+		"tls_crlfile",
+		"sasl_oauth_token_provider",
+	}
+	for _, k := range allowList {
+		if v, ok := raw[k]; ok {
+			if m, okm := v.(map[interface{}]interface{}); okm {
+				strMap := make(map[string]interface{}, len(m))
+				for kk, vv := range m {
+					strMap[fmt.Sprint(kk)] = vv
+				}
+				out[k] = strMap
+			} else {
+				out[k] = v
+			}
+		}
+	}
+	return out
+}

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
@@ -1,0 +1,220 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2020-present Datadog, Inc.
+
+package datastreams
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	noopautoconfig "github.com/DataDog/datadog-agent/comp/core/autodiscovery/noopimpl"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+type mockedAutodiscoveryActions struct {
+	autodiscovery.Component
+	configs []integration.Config
+}
+
+func getMockedAutodiscoveryActions(t *testing.T, configs []integration.Config) autodiscovery.Component {
+	return &mockedAutodiscoveryActions{
+		Component: fxutil.Test[autodiscovery.Component](
+			t,
+			noopautoconfig.Module(),
+		),
+		configs: configs,
+	}
+}
+
+func (m *mockedAutodiscoveryActions) GetUnresolvedConfigs() []integration.Config {
+	return m.configs
+}
+
+func (m *mockedAutodiscoveryActions) GetAllConfigs() []integration.Config {
+	return m.configs
+}
+
+const kafkaConsumerConfig = `
+kafka_connect_str: localhost:9092
+consumer_groups:
+  - test-group
+topics:
+  - test-topic
+sasl_mechanism: PLAIN
+sasl_plain_username: user
+sasl_plain_password: pass
+security_protocol: SASL_SSL
+`
+
+func TestActionsController(t *testing.T) {
+	kafkaConsumerCfg := integration.Config{
+		Name:       kafkaConsumerIntegrationName,
+		Instances:  []integration.Data{integration.Data(kafkaConsumerConfig)},
+		InitConfig: integration.Data{},
+	}
+
+	c := &actionsController{
+		ac:            getMockedAutodiscoveryActions(t, []integration.Config{kafkaConsumerCfg}),
+		rcclient:      &mockedRcClient{},
+		configChanges: make(chan integration.ConfigChanges, 10),
+	}
+
+	// Create a kafka actions config
+	actions := map[string]any{
+		"read_messages": map[string]any{
+			"topic":      "test-topic",
+			"partition":  0,
+			"offset":     100,
+			"n_messages": 10,
+		},
+	}
+	actionsJSON, err := json.Marshal(actions)
+	require.NoError(t, err)
+
+	kafkaActionsConfig := kafkaActionsConfig{
+		Actions:          actionsJSON,
+		BootstrapServers: "localhost:9092",
+	}
+	serializedConfig, err := json.Marshal(kafkaActionsConfig)
+	require.NoError(t, err)
+
+	rcUpdate := map[string]state.RawConfig{
+		"config_1": {Config: []byte("invalid")},
+		"config_2": {Config: serializedConfig},
+	}
+
+	updateStatus := make(map[string]state.ApplyStatus)
+	callback := func(path string, status state.ApplyStatus) {
+		updateStatus[path] = status
+	}
+
+	c.update(rcUpdate, callback)
+
+	// Verify error handling for invalid config
+	assert.Equal(t, state.ApplyStateError, updateStatus["config_1"].State)
+	assert.Contains(t, updateStatus["config_1"].Error, "invalid character")
+
+	// Verify successful config
+	assert.Equal(t, state.ApplyStateAcknowledged, updateStatus["config_2"].State)
+
+	// Check the scheduled config
+	updates := c.Stream(context.Background())
+	cfg := <-updates
+
+	require.Len(t, cfg.Schedule, 1)
+	assert.Empty(t, cfg.Unschedule)
+
+	scheduledCfg := cfg.Schedule[0]
+	assert.Equal(t, kafkaActionsIntegrationName, scheduledCfg.Name)
+	require.Len(t, scheduledCfg.Instances, 1)
+
+	// Verify the instance has auth merged in
+	var instance map[string]any
+	err = yaml.Unmarshal(scheduledCfg.Instances[0], &instance)
+	require.NoError(t, err)
+
+	// Check that auth fields are present
+	assert.Equal(t, "localhost:9092", instance["kafka_connect_str"])
+	assert.Equal(t, "PLAIN", instance["sasl_mechanism"])
+	assert.Equal(t, "user", instance["sasl_plain_username"])
+	assert.Equal(t, "pass", instance["sasl_plain_password"])
+	assert.Equal(t, "SASL_SSL", instance["security_protocol"])
+
+	// Check that run_once was injected
+	assert.Equal(t, true, instance["run_once"])
+
+	// Check that actions are present
+	assert.NotNil(t, instance["read_messages"])
+}
+
+func TestActionsControllerNoBootstrapServers(t *testing.T) {
+	kafkaConsumerCfg := integration.Config{
+		Name:       kafkaConsumerIntegrationName,
+		Instances:  []integration.Data{integration.Data(kafkaConsumerConfig)},
+		InitConfig: integration.Data{},
+	}
+
+	c := &actionsController{
+		ac:            getMockedAutodiscoveryActions(t, []integration.Config{kafkaConsumerCfg}),
+		rcclient:      &mockedRcClient{},
+		configChanges: make(chan integration.ConfigChanges, 10),
+	}
+
+	// Create config without bootstrap_servers - should match first kafka_consumer
+	actions := map[string]any{
+		"read_messages": map[string]any{
+			"topic": "test-topic",
+		},
+	}
+	actionsJSON, err := json.Marshal(actions)
+	require.NoError(t, err)
+
+	kafkaActionsConfig := kafkaActionsConfig{
+		Actions: actionsJSON,
+		// No BootstrapServers specified
+	}
+	serializedConfig, err := json.Marshal(kafkaActionsConfig)
+	require.NoError(t, err)
+
+	rcUpdate := map[string]state.RawConfig{
+		"config_1": {Config: serializedConfig},
+	}
+
+	updateStatus := make(map[string]state.ApplyStatus)
+	callback := func(path string, status state.ApplyStatus) {
+		updateStatus[path] = status
+	}
+
+	c.update(rcUpdate, callback)
+
+	// Should succeed by matching first kafka_consumer
+	assert.Equal(t, state.ApplyStateAcknowledged, updateStatus["config_1"].State)
+}
+
+func TestActionsControllerNoMatchingKafkaConsumer(t *testing.T) {
+	c := &actionsController{
+		ac:            getMockedAutodiscoveryActions(t, []integration.Config{}),
+		rcclient:      &mockedRcClient{},
+		configChanges: make(chan integration.ConfigChanges, 10),
+	}
+
+	actions := map[string]any{
+		"read_messages": map[string]any{
+			"topic": "test-topic",
+		},
+	}
+	actionsJSON, err := json.Marshal(actions)
+	require.NoError(t, err)
+
+	kafkaActionsConfig := kafkaActionsConfig{
+		Actions:          actionsJSON,
+		BootstrapServers: "localhost:9092",
+	}
+	serializedConfig, err := json.Marshal(kafkaActionsConfig)
+	require.NoError(t, err)
+
+	rcUpdate := map[string]state.RawConfig{
+		"config_1": {Config: serializedConfig},
+	}
+
+	updateStatus := make(map[string]state.ApplyStatus)
+	callback := func(path string, status state.ApplyStatus) {
+		updateStatus[path] = status
+	}
+
+	c.update(rcUpdate, callback)
+
+	// Should fail with error
+	assert.Equal(t, state.ApplyStateError, updateStatus["config_1"].State)
+	assert.Contains(t, updateStatus["config_1"].Error, "kafka_consumer integration")
+}

--- a/comp/core/autodiscovery/providers/datastreams/kafka_messages.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_messages.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	kafkaConsumerIntegrationName = "kafka_consumer"
-	logsConfig                   = `logs:
+	logsConfig = `logs:
   - type: integration
     service: kafka_consumer
     source: kafka_consumer`
@@ -88,15 +87,6 @@ func (c *controller) manageSubscriptionToRC() {
 			return
 		}
 	}
-}
-
-func isConnectedToKafka(ac autodiscovery.Component) bool {
-	for _, config := range ac.GetUnresolvedConfigs() {
-		if config.Name == kafkaConsumerIntegrationName {
-			return true
-		}
-	}
-	return false
 }
 
 // NewController creates a new controller instance

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -56,6 +56,8 @@ type Check interface {
 	GetDiagnoses() ([]diagnose.Diagnosis, error)
 	// IsHASupported returns if the check is compatible with High Availability
 	IsHASupported() bool
+	// RunOnce returns true if the check should be descheduled after its first run
+	RunOnce() bool
 }
 
 // Info is an interface to pull information from types capable to run checks. This is a subsection from the Check

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -291,3 +291,8 @@ func (c *CheckBase) GetDiagnoses() ([]diagnose.Diagnosis, error) {
 func (c *CheckBase) IsHASupported() bool {
 	return false
 }
+
+// RunOnce returns false by default (checks run repeatedly)
+func (c *CheckBase) RunOnce() bool {
+	return false
+}

--- a/pkg/collector/corechecks/embed/apm/apm.go
+++ b/pkg/collector/corechecks/embed/apm/apm.go
@@ -259,6 +259,11 @@ func (c *APMCheck) IsHASupported() bool {
 	return false
 }
 
+// RunOnce returns false
+func (c *APMCheck) RunOnce() bool {
+	return false
+}
+
 // Factory creates a new check factory
 func Factory() option.Option[func() check.Check] {
 	return option.New(newCheck)

--- a/pkg/collector/corechecks/embed/process/process_agent.go
+++ b/pkg/collector/corechecks/embed/process/process_agent.go
@@ -253,6 +253,11 @@ func (c *ProcessAgentCheck) IsHASupported() bool {
 	return false
 }
 
+// RunOnce returns false
+func (c *ProcessAgentCheck) RunOnce() bool {
+	return false
+}
+
 // Factory creates a new check factory
 func Factory() option.Option[func() check.Check] {
 	return option.New(newCheck)

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -23,6 +23,8 @@ type TestCheck struct {
 	stub.StubCheck
 }
 
+func (c *TestCheck) RunOnce() bool { return false }
+
 func (c *TestCheck) Configure(_ sender.SenderManager, _ uint64, data integration.Data, _ integration.Data, _ string) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")

--- a/pkg/collector/corechecks/longrunning_test.go
+++ b/pkg/collector/corechecks/longrunning_test.go
@@ -31,6 +31,8 @@ type mockLongRunningCheck struct {
 	runningCh chan struct{}
 }
 
+func (m *mockLongRunningCheck) RunOnce() bool { return false }
+
 func (m *mockLongRunningCheck) Stop() {
 	m.Called()
 }

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -65,6 +65,7 @@ type PythonCheck struct {
 	instanceConfig string
 	haSupported    bool
 	cancelled      bool
+	runOnce        bool
 }
 
 // NewPythonCheck conveniently creates a PythonCheck instance
@@ -271,6 +272,15 @@ func (c *PythonCheck) Configure(_senderManager sender.SenderManager, integration
 		return err
 	}
 
+	var rawInst integration.RawMap
+	if err := yaml.Unmarshal(data, &rawInst); err == nil {
+		if v, ok := rawInst["run_once"]; ok {
+			if b, okb := v.(bool); okb && b {
+				c.runOnce = true
+			}
+		}
+	}
+
 	// See if a collection interval was specified
 	if commonOptions.MinCollectionInterval > 0 {
 		c.interval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
@@ -375,6 +385,11 @@ func (c *PythonCheck) Interval() time.Duration {
 // ID returns the ID of the check
 func (c *PythonCheck) ID() checkid.ID {
 	return c.id
+}
+
+// RunOnce returns true if this check should run only once
+func (c *PythonCheck) RunOnce() bool {
+	return c.runOnce
 }
 
 // GetDiagnoses returns the diagnoses cached in last run or diagnose explicitly

--- a/pkg/collector/runner/expvars/expvars_test.go
+++ b/pkg/collector/runner/expvars/expvars_test.go
@@ -128,6 +128,7 @@ type testCheck struct {
 }
 
 func (c *testCheck) ID() checkid.ID { return checkid.ID(c.id) }
+func (c *testCheck) RunOnce() bool  { return false }
 func (c *testCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 
 func newTestCheck(id string) *testCheck {

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -51,6 +51,7 @@ type testCheck struct {
 func (c *testCheck) ID() checkid.ID { return checkid.ID(c.id) }
 func (c *testCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 func (c *testCheck) RunCount() int  { return int(c.runCount.Load()) }
+func (c *testCheck) RunOnce() bool  { return false }
 func (c *testCheck) Stop() {
 	c.StopLock.Lock()
 	defer c.StopLock.Unlock()

--- a/pkg/collector/runner/tracker/tracker_test.go
+++ b/pkg/collector/runner/tracker/tracker_test.go
@@ -24,6 +24,7 @@ type testCheck struct {
 }
 
 func (c *testCheck) ID() checkid.ID { return checkid.ID(c.id) }
+func (c *testCheck) RunOnce() bool  { return false }
 func (c *testCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 
 func newTestCheck(id string) *testCheck {

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -210,6 +210,10 @@ func (jq *jobQueue) process(s *Scheduler) bool {
 				return false
 			}
 
+			if check.RunOnce() {
+				_ = jq.removeJob(check.ID())
+			}
+
 			select {
 			// we were able to schedule a check so we're not stuck, therefore poll the health chan
 			case <-jq.health.C:

--- a/pkg/collector/worker/check_logger_test.go
+++ b/pkg/collector/worker/check_logger_test.go
@@ -27,6 +27,7 @@ type stubCheck struct {
 }
 
 func (c *stubCheck) ID() checkid.ID { return checkid.ID(c.id) }
+func (c *stubCheck) RunOnce() bool  { return false }
 func (c *stubCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 
 func newTestCheck(id string) *stubCheck {

--- a/pkg/collector/worker/worker_test.go
+++ b/pkg/collector/worker/worker_test.go
@@ -48,6 +48,7 @@ type testCheck struct {
 func (c *testCheck) ID() checkid.ID { return checkid.ID(c.id) }
 func (c *testCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 func (c *testCheck) RunCount() int  { return int(c.runCount.Load()) }
+func (c *testCheck) RunOnce() bool  { return false }
 
 func (c *testCheck) Interval() time.Duration {
 	if c.longRunning {

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -38,8 +38,8 @@ const (
 	ProductContainerAutoscalingValues = "CONTAINER_AUTOSCALING_VALUES"
 	// ProductDataStreamsLiveMessages is to capture messages from Kafka
 	ProductDataStreamsLiveMessages = "DSM_LIVE_MESSAGES"
-	// ProductDebug is for debugging and testing remote configuration
-	ProductDebug = "DEBUG"
+	// ProductDataStreamsKafkaActions is to execute Kafka actions remotely
+	ProductDataStreamsKafkaActions = "DSM_KAFKA_ACTIONS"
 )
 
 // ProductListToString converts a product list to string list

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -38,6 +38,8 @@ const (
 	ProductContainerAutoscalingValues = "CONTAINER_AUTOSCALING_VALUES"
 	// ProductDataStreamsLiveMessages is to capture messages from Kafka
 	ProductDataStreamsLiveMessages = "DSM_LIVE_MESSAGES"
+	// ProductDebug is for debugging and testing remote configuration
+	ProductDebug = "DEBUG"
 )
 
 // ProductListToString converts a product list to string list

--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -43,6 +43,7 @@ var validProducts = map[string]struct{}{
 	ProductSyntheticsTest:               {},
 	ProductBTFDD:                        {},
 	ProductFFEFlags:                     {},
+	ProductDebug:                        {},
 }
 
 const (
@@ -121,4 +122,6 @@ const (
 	ProductApmPolicies = "APM_POLICIES"
 	// ProductFFEFlags is used for feature flagging experiments remote updates
 	ProductFFEFlags = "FFE_FLAGS"
+	// ProductDebug is for debugging and testing remote configuration
+	ProductDebug = "DEBUG"
 )

--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -37,13 +37,13 @@ var validProducts = map[string]struct{}{
 	ProductNDMDeviceProfilesCustom:      {},
 	ProductMetricControl:                {},
 	ProductDataStreamsLiveMessages:      {},
+	ProductDataStreamsKafkaActions:      {},
 	ProductLiveDebuggingSymbolDB:        {},
 	ProductGradualRollout:               {},
 	ProductApmPolicies:                  {},
 	ProductSyntheticsTest:               {},
 	ProductBTFDD:                        {},
 	ProductFFEFlags:                     {},
-	ProductDebug:                        {},
 }
 
 const (
@@ -114,6 +114,8 @@ const (
 	ProductMetricControl = "METRIC_CONTROL"
 	// ProductDataStreamsLiveMessages is used for capturing messages from Kafka
 	ProductDataStreamsLiveMessages = "DSM_LIVE_MESSAGES"
+	// ProductDataStreamsKafkaActions is used for executing Kafka actions remotely
+	ProductDataStreamsKafkaActions = "DSM_KAFKA_ACTIONS"
 	// ProductGradualRollout tracks the latest stable release versions for K8s gradual rollout.
 	ProductGradualRollout = "K8S_INJECTION_DD"
 	// ProductBTFDD accesses a BTF catalog used when the kernel is newer than the system-probe has bundled support for
@@ -122,6 +124,4 @@ const (
 	ProductApmPolicies = "APM_POLICIES"
 	// ProductFFEFlags is used for feature flagging experiments remote updates
 	ProductFFEFlags = "FFE_FLAGS"
-	// ProductDebug is for debugging and testing remote configuration
-	ProductDebug = "DEBUG"
 )

--- a/releasenotes/notes/data-streams-actions-39bfd4c97d878c29.yaml
+++ b/releasenotes/notes/data-streams-actions-39bfd4c97d878c29.yaml
@@ -1,0 +1,4 @@
+features:
+  - Checks can be scheduled only once with run_once configuration
+  - Data Streams Kafka actions perform actions on Kafka clusters
+


### PR DESCRIPTION
### What does this PR do?

Adds support for one-shot Kafka actions via remote configuration and introduces the `RunOnce()` interface for checks that should be descheduled after their first execution.

**Key changes:**
- New `kafka_actions` check scheduled via remote config (DSM_KAFKA_ACTIONS product) for one-off Kafka operations
- `RunOnce()` method added to `check.Check` interface to support one-shot check execution
- Scheduler automatically removes checks that return `true` from `RunOnce()` after first run
- `kafka_messages` controller retained for backwards compatibility

### Motivation

The existing `kafka_messages` feature mutates `kafka_consumer` configs to add live message collection. This approach has limitations, as it modifies the existing kafka_consumer integration with a config that is only used once (it for example makes the kafka_consumer integration drop its cache, since the integration digest changes).

`kafka_actions` replaces this with a more flexible approach: it schedules dedicated one-shot checks that execute a single action and are automatically removed from the scheduler. The check receives authentication details by matching `bootstrap_servers` from existing `kafka_consumer` integrations, ensuring correct cluster targeting.

We keep `kafka_messages` until the frontend switches to `kafka_actions`.

### Describe how you validated your changes

- Added comprehensive tests for `kafka_actions` controller (matching, auth extraction, config parsing)
- Added scheduler tests for `RunOnce()` behavior
- Verified checks are removed from job queue after first execution
- Ran locally using the DEBUG remote configuration product, and verified that the kafka_actions check is scheduled, and runs only once

### Additional Notes

The `RunOnce()` interface is generic and can be used by any check needing one-shot execution semantics (e.g., migration tasks, one-time configuration changes, etc.).
