### PR TITLE
[kubernetes/kubelet] Disable pod list cache by default

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -21,6 +21,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
@@ -429,9 +430,11 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 	// Cache never expires because the unit tests below are not covering the case
 	// of cache miss. They are only testing parsePods behaves correctly depending
 	// on the cluster agent version and the agent configuration.
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("kubelet_cache_pods_duration", 5) // Cache is disabled by default. Enable it.
 	cache.Cache.Set("KubeletPodListCacheKey", podsCache, -1)
 
-	kubeUtilFake := &kubelet.KubeUtil{}
+	kubeUtilFake := kubelet.NewKubeUtil()
 
 	type fields struct {
 		kubeUtil                    *kubelet.KubeUtil

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3713,11 +3713,11 @@ api_key:
 #
 # kubelet_client_key: <CLIENT_KEY_FILE_PATH>
 
-## @param kubelet_cache_pods_duration - integer - optional - default: 5
-## @env DD_KUBELET_CACHE_PODS_DURATION - integer - optional - default: 5
+## @param kubelet_cache_pods_duration - integer - optional - default: 0
+## @env DD_KUBELET_CACHE_PODS_DURATION - integer - optional - default: 0
 ## Polling frequency in seconds of the Agent to the kubelet "/pods" endpoint.
 #
-# kubelet_cache_pods_duration: 5
+# kubelet_cache_pods_duration: 0
 
 ## @param kubernetes_pod_expiration_duration - integer - optional - default: 900
 ## @env DD_KUBERNETES_POD_EXPIRATION_DURATION - integer - optional - default: 900

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2013,7 +2013,10 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubelet_client_key", "")
 
 	config.BindEnvAndSetDefault("kubernetes_pod_expiration_duration", 15*60) // in seconds, default 15 minutes
-	config.BindEnvAndSetDefault("kubelet_cache_pods_duration", 5)            // Polling frequency in seconds of the agent to the kubelet "/pods" endpoint
+	// Cache TTL for pod lists in the kubelet client. Set to 0 because it's only
+	// used by workloadmeta that already defines its own pull frequency and has
+	// its own storage, so no need for an extra cache.
+	config.BindEnvAndSetDefault("kubelet_cache_pods_duration", 0)
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_use_endpoint_slices", false)
 	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -414,6 +414,7 @@ func (suite *KubeletTestSuite) TestPodlistCache() {
 	mockConfig.SetWithoutSource("kubernetes_kubelet_host", "localhost")
 	mockConfig.SetWithoutSource("kubernetes_http_kubelet_port", kubeletPort)
 	mockConfig.SetWithoutSource("kubernetes_https_kubelet_port", -1)
+	mockConfig.SetWithoutSource("kubelet_cache_pods_duration", 5) // Default is 0. Need to set to > 0 to test cache
 
 	kubeutil := suite.getCustomKubeUtil()
 	kubelet.dropRequests() // Throwing away first GETs

--- a/releasenotes/notes/kubelet-disablet-pod-list-cache-by-default-9c4d9911bc2b01b2.yaml
+++ b/releasenotes/notes/kubelet-disablet-pod-list-cache-by-default-9c4d9911bc2b01b2.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The kubelet pod list cache is now disabled by default to reduce staleness.
+    The Agent lists pods from the kubelet every 5s. Users who explicitly set
+    ``kubelet_cache_pods_duration`` retain their existing behavior (the Agent
+    lists pods approximately every 5 + cache duration seconds).


### PR DESCRIPTION
### What does this PR do?

This PR disables the pod list cache in the Kubelet client by default.

The only part of the code that lists pods from the kubelet is workloadmeta, and it already has its own storage. The frequency at which workloadmeta pulls from the kubelet isn’t just set by its own pull interval, we also have to consider the cache TTL, which was set to 5s by default.

In short, keeping another cache in the Kubelet client duplicates data, makes debugging harder, and adds delay. Disabling it may increase the pull frequency, but the impact should be minimal, and having more up to date data is probably worth it.

For backwards compatibility, this PR keeps the `kubelet_cache_pods_duration` config option for users who still want to set it to reduce pulls from the kubelet.

### Describe how you validated your changes

CI
