### PR TITLE
[K9VULN-9538] [CSPM] dbbenchs: collect mongod process arguments to complete our benchmarks

### DIFF
--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -160,6 +160,16 @@ func LoadMongoDBConfig(ctx context.Context, hostroot string, proc *process.Proce
 			break
 		}
 	}
+	result.ProcessFlags = make(map[string]string)
+	foreachFlags(cmdline, func(k, v string) {
+		if strings.HasPrefix(k, "--") {
+			if _, redacted := mongoDBRedactedFlags[k]; redacted || strings.Contains(strings.ToLower(k), "password") {
+				result.ProcessFlags[k] = "<redacted>"
+			} else {
+				result.ProcessFlags[k] = v
+			}
+		}
+	})
 
 	configPath := filepath.Join(hostroot, configLocalPath)
 	fi, err := os.Stat(configPath)
@@ -481,4 +491,37 @@ func isIdentifierChar(c uint8) bool {
 		c == '-' ||
 		c == '_' ||
 		c == '.'
+}
+
+func foreachFlags(cmdline []string, f func(k, v string)) {
+	if len(cmdline) <= 1 {
+		return
+	}
+	cmdline = cmdline[1:]
+	pendingFlagValue := false
+	for i, arg := range cmdline {
+		if strings.HasPrefix(arg, "--") && len(arg) > 2 {
+			if pendingFlagValue {
+				f(cmdline[i-1], "true")
+			}
+			pendingFlagValue = false
+			parts := strings.SplitN(arg, "=", 2)
+			if len(parts) == 2 {
+				f(parts[0], parts[1])
+			} else {
+				f(parts[0], "")
+				pendingFlagValue = true
+			}
+		} else {
+			if pendingFlagValue {
+				pendingFlagValue = false
+				f(cmdline[i-1], arg)
+			} else {
+				f(arg, "")
+			}
+		}
+	}
+	if pendingFlagValue {
+		f(cmdline[len(cmdline)-1], "true")
+	}
 }

--- a/pkg/compliance/dbconfig/types.go
+++ b/pkg/compliance/dbconfig/types.go
@@ -18,13 +18,25 @@ type DBResource struct {
 // DBConfig represents a database application configuration metadata that we
 // were able to scan.
 type DBConfig struct {
-	ProcessName     string      `json:"process_name,omitempty"`
-	ProcessUser     string      `json:"process_user,omitempty"`
-	ConfigFilePath  string      `json:"config_file_path"`
-	ConfigFileUser  string      `json:"config_file_user"`
-	ConfigFileGroup string      `json:"config_file_group"`
-	ConfigFileMode  uint32      `json:"config_file_mode"`
-	ConfigData      interface{} `json:"config_data"`
+	ProcessName     string            `json:"process_name,omitempty"`
+	ProcessUser     string            `json:"process_user,omitempty"`
+	ProcessFlags    map[string]string `json:"process_flags,omitempty"`
+	ConfigFilePath  string            `json:"config_file_path"`
+	ConfigFileUser  string            `json:"config_file_user"`
+	ConfigFileGroup string            `json:"config_file_group"`
+	ConfigFileMode  uint32            `json:"config_file_mode"`
+	ConfigData      interface{}       `json:"config_data"`
+}
+
+var mongoDBRedactedFlags = map[string]struct{}{
+	"--auditEncryptionKeyUID":         {},
+	"--kmipClientCertificatePassword": {},
+	"--kmipKeyIdentifier":             {},
+	"--ldapQueryPassword":             {},
+	"--ldapQueryUser":                 {},
+	"--setParameter":                  {},
+	"--tlsCertificateKeyFilePassword": {},
+	"--tlsClusterPassword":            {},
 }
 
 type mongoDBConfig struct {


### PR DESCRIPTION
### What does this PR do?

Processing of the mongod process arguments/flags.

### Motivation

Avoiding bad rule evaluation on our Mongo DB benchmark when parameters are not passed via a configuration file, but via the CLI arguments.
