### PR TITLE
`tests_macos_gitlab_amd64`: fix rare `TestConfigRetriverAutoscalingSettingsReconcile` flakiness

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/config_retriever_settings_test.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_settings_test.go
@@ -532,6 +532,8 @@ func TestConfigRetriverAutoscalingSettingsReconcile(t *testing.T) {
 	// Become leader, should reconcile. Unfortunately, as it's another goroutine running the reconcile,
 	// we need to wait for the reconcile to happen.
 	isLeader = true
+	// Wait for the ticker to be registered before stepping the clock to avoid race conditions
+	require.Eventually(t, testClock.HasWaiters, 5*time.Second, 10*time.Millisecond, "ticker should be registered")
 	testClock.Step(settingsReconcileInterval)
 	require.Eventually(t, func() bool {
 		return store.Count() == 1


### PR DESCRIPTION
### What does this PR do?
Fixes a flaky test that was failing very intermittently on macOS GitLab runners with a "Condition never satisfied" error after 60 seconds timeout:
```go
=== FAIL: pkg/clusteragent/autoscaling/workload TestConfigRetriverAutoscalingSettingsReconcile (60.00s)
[Debug] Created new workload scaling config retriever
[Debug] Processing config key: foo1, product: CONTAINER_AUTOSCALING_SETTINGS, id: , name: , version: 1, leader: false
    config_retriever_settings_test.go:536:
        	Error Trace:	/Users/ec2-user/builds/t3_C7z16h/0/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/config_retriever_settings_test.go:536
        	Error:      	Condition never satisfied
        	Test:       	TestConfigRetriverAutoscalingSettingsReconcile
```
(https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1249557956#L1909)

### Motivation
The test `TestConfigRetriverAutoscalingSettingsReconcile` had a race condition with `k8s.io/utils/clock` FakeClock: `testClock.Step()` was being called before the reconciliation goroutine had registered its ticker with the FakeClock, causing the ticker to never fire.

This is a known issue with FakeClock timers documented in Kubernetes issue kubernetes/kubernetes#125581, which describes how "if FakeClock.Step is called after a timer calculation begins but before the timer is created, the timer fires at the wrong time."

### Describe how you validated your changes
- addded synchronization using `testClock.HasWaiters()` to wait for the ticker to be registered before calling `Step()`,
- validated with 1000 stress test runs with race detector enabled.

### Additional Notes
The `HasWaiters()` method exists specifically "so you can write race-free tests" according to the official documentation:
- https://pkg.go.dev/k8s.io/utils/clock/testing#FakeClock.HasWaiters