### PR TITLE
Store attr in S3 bucket

### DIFF
--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -144,7 +144,10 @@ http_archive(
     },
     sha256 = "db448a626f9313a1a970d636767316a8da32aede70518b8050fa0de7947adc32",
     strip_prefix = "attr-2.5.1",
-    url = "https://download.savannah.nongnu.org/releases/attr/attr-2.5.1.tar.xz",
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/attr-attr-2.5.1.tar.xz",
+        "https://download.savannah.nongnu.org/releases/attr/attr-2.5.1.tar.xz",
+    ],
 )
 
 http_archive(


### PR DESCRIPTION
### What does this PR do?
Adds attr package to our S3 bucket to ensure resilience in case original source is unavailable. The order in `urls` attribute in `http_archive` is important, so S3 URL should always come first (if we assume our bucket is more reliable).

### Motivation
The original source of attr is currently unavailable and it breaks our builds.
