### PR TITLE
Increase Bazel HTTP download timeouts for slow mirrors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,7 @@ startup --max_idle_secs=28800 # Keep the server alive for at most 8 hours of ina
 # Common options -------------------------------------------------------------------------------------------------------
 common --@rules_python//python/config_settings:bootstrap_impl=script # https://github.com/bazel-contrib/rules_python/blob/main/BZLMOD_SUPPORT.md
 common --enable_platform_specific_config # Supported OS identifiers are linux, macos, windows, freebsd, and openbsd
+common --http_timeout_scaling=3.0 # At least one attempt reaches 30s (3,6,12,24,30,30,30,30) instead of only 10s (1,2,4,8,10,10,10,10)
 common --incompatible_strict_action_env # Do not leak local environment variables into the build context
 common --verbose_failures
 


### PR DESCRIPTION
### What does this PR do?
Add `--http_timeout_scaling=3.0` to `.bazelrc` to increase HTTP download connection timeouts for Bazel's `http_archive` operations.

### Motivation
Mitigation to #incident-46077, in addition to #43339. CI builds occasionally fail when downloading dependencies from slow or overloaded upstream mirrors (e.g., `download.savannah.nongnu.org`).

The default Bazel timeout progression (1s, 2s, 4s, 8s, 10s, 10s, 10s, 10s) maxes out at **10 seconds** per attempt, which is not enough to survive the HTTP server backlog queue. With `--http_timeout_scaling=3.0`, the timeout progression becomes: 3s, 6s, 12s, 24s, 30s, 30s, 30s, 30s. This ensures at least one retry attempt gets **30 seconds** to connect, improving resilience against slow upstream mirrors while maintaining reasonable overall timeout bounds.

### Additional Notes
Reference: Bazel implements exponential backoff with `connectTimeout = Math.min(connectTimeout * 2, scale(MAX_CONNECT_TIMEOUT_MS))` where `MAX_CONNECT_TIMEOUT_MS = 10000ms` scaled by `--http_timeout_scaling`:
- https://github.com/bazelbuild/bazel/blob/f8c7609024345029ab650d94c60669580a1797bb/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java#L123-L240