### PR TITLE
Add more details on bazel module lock file check failures

### DIFF
--- a/.gitlab/bazel/lint.yaml
+++ b/.gitlab/bazel/lint.yaml
@@ -1,12 +1,15 @@
 bazel:mod-deps:
+  allow_failure: true  #incident-46079
   extends: [ .bazel:defs, .bazel:runner:linux-amd64 ]
   stage: lint
   script:
-    - bazel mod deps --lockfile_mode=error || true
+    - bazel mod deps --lockfile_mode=error
   after_script:
     - |-
       if [ $CI_JOB_STATUS = failed ]; then
         echo >&2 "💡 bazel mod deps"
+        bazel mod deps
+        git diff
       fi
 
 bazel:run-buildifier-test:


### PR DESCRIPTION
### What does this PR do?
This reverts commit b8940b38128c5d96e0f1872421490697d01e24ee (#43344) and instead add more details when the bazel module file check fails.

### Motivation
Seeing the diff is no luxury to tackle the issue.

### Additional Notes
`allow_failure: true`: the job is marked as allowed to fail until we figure out the cause.