### PR TITLE
omnibus: bzip2: ensure the destination folder exists

### DIFF
--- a/omnibus/config/software/bzip2.rb
+++ b/omnibus/config/software/bzip2.rb
@@ -36,6 +36,9 @@ build do
 
   # The version of bzip2 we use doesn't create a pkgconfig file,
   # we add it here manually (needed at least by the Python build)
+  block do
+    FileUtils.mkdir_p "#{install_dir}/embedded/lib/pkgconfig/"
+  end
   erb source: "bzip2.pc.erb",
       dest: "#{install_dir}/embedded/lib/pkgconfig/bzip2.pc",
       vars: {


### PR DESCRIPTION
### What does this PR do?

Ensures the pkgconfig destination folder exists before attempting to write to it

### Motivation

Fixing build failures when it doesn't

### Describe how you validated your changes

Without the change: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1250462709
With the change: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1250597665
### Additional Notes

This started occurring because the branch migrating python to bazel dropped libffi which was creating the destination folder indirectly, causing `bzip2` to be built before any other software that would attempt to create a `.pc` file.