### PR TITLE
[OTAGENT-649] Add dd-otel-metric-config header to host profiler

### DIFF
--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -20,6 +20,7 @@ exporters:
     profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     headers:
       dd-api-key: ${env:DD_API_KEY}
+      dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
 service:
   extensions: [hpflare/default]
   pipelines:


### PR DESCRIPTION
### What does this PR do?

Adds the `dd-otel-metric-config` header with `resource_attributes_as_tags: true` to the host profiler configuration file.

### Motivation

Enable resource attributes to be exported as tags in the host profiler's OTLP metrics export, allowing better correlation and filtering of profiling data based on resource attributes.

### Describe how you validated your changes

Tested locally with the host profiler to verify the header is correctly included in requests to the profiles endpoint.

### Additional Notes

This change is internal to the host profiler configuration and does not impact customer-facing functionality.