### PR TITLE
[CXP-2853] fix missing fargate status field container bug

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/sidecar_parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/sidecar_parser.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -118,13 +119,5 @@ func (c *collector) parseClusterName(value string) string {
 
 // parseStatus converts ECS container status strings to workloadmeta ContainerStatus enum.
 func (c *collector) parseStatus(status string) workloadmeta.ContainerStatus {
-	switch status {
-	case "RUNNING":
-		return workloadmeta.ContainerStatusRunning
-	case "STOPPED":
-		return workloadmeta.ContainerStatusStopped
-	case "PULLED", "CREATED", "RESOURCES_PROVISIONED":
-		return workloadmeta.ContainerStatusCreated
-	}
-	return workloadmeta.ContainerStatusUnknown
+	return util.ContainerStatusFromKnownStatus(status)
 }

--- a/comp/core/workloadmeta/collectors/internal/ecs/v4parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v4parser_test.go
@@ -90,6 +90,7 @@ func verifyV4ParserResults(t *testing.T, store *fakeWorkloadmetaStore, checkTags
 			}
 		case *workloadmeta.Container:
 			require.Equal(t, "RUNNING", entity.KnownStatus)
+			require.Equal(t, workloadmeta.ContainerStatusRunning, entity.State.Status)
 			require.Equal(t, "HEALTHY", entity.Health.Status)
 			if entity.Image.Name == "datadog/datadog-agent" {
 				require.Equal(t, "7.50.0", entity.Image.Tag)

--- a/comp/core/workloadmeta/collectors/util/ecs_util.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util.go
@@ -152,6 +152,7 @@ func ParseV4TaskContainers(
 			},
 			State: workloadmeta.ContainerState{
 				Running:  container.KnownStatus == "RUNNING",
+				Status:   ContainerStatusFromKnownStatus(container.KnownStatus),
 				ExitCode: container.ExitCode,
 			},
 			Owner: &workloadmeta.EntityID{
@@ -250,6 +251,20 @@ func ParseV4TaskContainers(
 	}
 
 	return taskContainers, events
+}
+
+// ContainerStatusFromKnownStatus converts the ECS known status string into a workloadmeta.ContainerStatus.
+func ContainerStatusFromKnownStatus(status string) workloadmeta.ContainerStatus {
+	switch status {
+	case "RUNNING":
+		return workloadmeta.ContainerStatusRunning
+	case "STOPPED":
+		return workloadmeta.ContainerStatusStopped
+	case "PULLED", "CREATED", "RESOURCES_PROVISIONED":
+		return workloadmeta.ContainerStatusCreated
+	default:
+		return workloadmeta.ContainerStatusUnknown
+	}
 }
 
 func parseTime(fieldOwner, fieldName, fieldValue string) *time.Time {

--- a/go.work
+++ b/go.work
@@ -6,6 +6,7 @@ go 1.24.10
 godebug tlsmlkem=0
 
 use (
+
 	.
 	comp/api/api/def
 	comp/core/agenttelemetry/def

--- a/go.work
+++ b/go.work
@@ -6,7 +6,6 @@ go 1.24.10
 godebug tlsmlkem=0
 
 use (
-
 	.
 	comp/api/api/def
 	comp/core/agenttelemetry/def

--- a/releasenotes/notes/ecs-fargate-container-check-missing-status-bugfix-228ffc291bd493d4.yaml
+++ b/releasenotes/notes/ecs-fargate-container-check-missing-status-bugfix-228ffc291bd493d4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a bug on ecs fargate where the container check on the core agent was not reporting the status of the container

--- a/test/new-e2e/tests/process/fargate_test.go
+++ b/test/new-e2e/tests/process/fargate_test.go
@@ -15,16 +15,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
-
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/cpustress"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
-
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 
 	fakeintakeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
 	ecsComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/ecs"

--- a/test/new-e2e/tests/process/fargate_test.go
+++ b/test/new-e2e/tests/process/fargate_test.go
@@ -10,20 +10,28 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/cpustress"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/cpustress"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 
 	fakeintakeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
 	ecsComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/ecs"
 	scenecs "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ecs"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/ecs"
@@ -71,6 +79,9 @@ func (s *ECSFargateSuite) TestProcessCheck() {
 		assertProcessCollectedNew(c, payloads, false, "stress-ng-cpu [run]")
 		assertProcessCollectedNew(c, payloads, false, "process-agent")
 		assertContainersCollectedNew(c, payloads, []string{"stress-ng"})
+		assertContainerStates(c, payloads, map[string]agentmodel.ContainerState{
+			"stress-ng": agentmodel.ContainerState_running,
+		})
 		assertFargateHostname(t, payloads)
 	}, 5*time.Minute, 10*time.Second)
 }
@@ -104,6 +115,9 @@ func (s *ECSFargateCoreAgentSuite) TestProcessCheckInCoreAgent() {
 		assertProcessCollectedNew(c, payloads, false, "stress-ng-cpu [run]")
 		requireProcessNotCollected(c, payloads, "process-agent")
 		assertContainersCollectedNew(c, payloads, []string{"stress-ng"})
+		assertContainerStates(c, payloads, map[string]agentmodel.ContainerState{
+			"stress-ng": agentmodel.ContainerState_running,
+		})
 		assertFargateHostname(t, payloads)
 	}, 5*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/tests/process/fargate_test.go
+++ b/test/new-e2e/tests/process/fargate_test.go
@@ -16,19 +16,16 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/cpustress"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
-
 	fakeintakeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
 	ecsComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/ecs"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
 	scenecs "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ecs"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
-
-	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
-
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/ecs"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 )
 
 type ECSFargateSuite struct {

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -179,6 +179,17 @@ func assertContainersCollectedNew(t assert.TestingT, payloads []*aggregator.Proc
 	}
 }
 
+// assertContainerStates asserts that the matched containers have the expected states
+func assertContainerStates(t require.TestingT, payloads []*aggregator.ProcessPayload, expected map[string]agentmodel.ContainerState) {
+	for name, state := range expected {
+		containers := collectContainersByName(payloads, name)
+		require.NotEmpty(t, containers, "%s container not found in payloads: %+v", name, payloads)
+		for _, container := range containers {
+			assert.Equalf(t, state, container.State, "%s container has unexpected state", name)
+		}
+	}
+}
+
 // requireProcessNotCollected asserts that the given process is NOT collected by the process check
 func requireProcessNotCollected(t require.TestingT, payloads []*aggregator.ProcessPayload, process string) {
 	for _, payload := range payloads {
@@ -332,13 +343,38 @@ func assertContainersNotCollected(t *testing.T, payloads []*aggregator.ProcessPa
 // findContainer returns whether the container with the given name exists in the given list of
 // containers and whether it has the expected data populated
 func findContainer(name string, containers []*agentmodel.Container) bool {
+	for _, container := range containers {
+		if matchContainerName(container, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func collectContainersByName(payloads []*aggregator.ProcessPayload, name string) []*agentmodel.Container {
+	var matched []*agentmodel.Container
+	for _, payload := range payloads {
+		matched = append(matched, filterContainersByName(name, payload.Containers)...)
+	}
+	return matched
+}
+
+func filterContainersByName(name string, containers []*agentmodel.Container) []*agentmodel.Container {
+	var matched []*agentmodel.Container
+	for _, container := range containers {
+		if matchContainerName(container, name) {
+			matched = append(matched, container)
+		}
+	}
+	return matched
+}
+
+func matchContainerName(container *agentmodel.Container, name string) bool {
 	// check if there is a tag for the container. The tag could be `container_name:*` or `short_image:*`
 	containerNameTag := ":" + name
-	for _, container := range containers {
-		for _, tag := range container.Tags {
-			if strings.HasSuffix(tag, containerNameTag) {
-				return true
-			}
+	for _, tag := range container.Tags {
+		if strings.HasSuffix(tag, containerNameTag) {
+			return true
 		}
 	}
 	return false

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -183,7 +183,7 @@ func assertContainersCollectedNew(t assert.TestingT, payloads []*aggregator.Proc
 func assertContainerStates(t require.TestingT, payloads []*aggregator.ProcessPayload, expected map[string]agentmodel.ContainerState) {
 	for name, state := range expected {
 		containers := collectContainersByName(payloads, name)
-		require.NotEmpty(t, containers, "%s container not found in payloads: %+v", name, payloads)
+		assert.NotEmptyf(t, containers, "%s container not found in payloads: %+v", name, payloads)
 		for _, container := range containers {
 			assert.Equalf(t, state, container.State, "%s container has unexpected state", name)
 		}


### PR DESCRIPTION
### What does this PR do?
- fixes a missing `status` field for containers on ecs fargate when the process check runs on the core agent
    - this used to work before agent 7.65 since we used the process agent to do container collection whereas the container collecton on the core agent is missing this status field
    
### Motivation
- fargate containers show an unknown status for all agent versions after and including 7.65 (https://github.com/DataDog/datadog-agent/releases/tag/7.65.0) as 7.65 was when we defaulted to the core agent for process checks
    - the core agent missed assigning the status field for fargate containers which did not have tests prior to 7.65 being released. As a result, all fargate containers collected on the core agent show an unknown status field:
    
Specifically, the previous collector on the process agent would use the `v2` metadata endpoint on the collector based on this check here 

[source](https://github.com/DataDog/datadog-agent/blob/678f5186ac193cf0404473baa4b499fa0ee2d6ef/comp/core/workloadmeta/collectors/util/ecs_util.go#L31-L33)
```
func IsTaskCollectionEnabled(cfg config.Component) bool {
	return cfg.GetBool("ecs_task_collection_enabled") && (flavor.GetFlavor() == flavor.DefaultAgent)
}
```

and then checked here:

[source](https://github.com/DataDog/datadog-agent/blob/678f5186ac193cf0404473baa4b499fa0ee2d6ef/comp/core/workloadmeta/collectors/internal/ecs/sidecar_parser.go#L58-L75)
```
func (c *collector) setTaskCollectionParserForSidecar() {
	if !c.taskCollectionEnabled {
		log.Infof("detailed task collection disabled, using metadata v2 endpoint")
		c.taskCollectionParser = c.parseTaskFromV2Endpoint
		return
	}

	var err error
	c.metaV4, err = ecsmeta.V4FromCurrentTask()
	if err != nil {
		log.Warnf("failed to initialize metadata v4 client, using metadata v2: %v", err)
		c.taskCollectionParser = c.parseTaskFromV2Endpoint
		return
	}

	log.Infof("detailed task collection enabled, using metadata v4 endpoint")
	c.taskCollectionParser = c.parseTaskFromV4EndpointSidecar
}
```
where the v2 parser correctly sets the status field:

[source](https://github.com/DataDog/datadog-agent/blob/678f5186ac193cf0404473baa4b499fa0ee2d6ef/comp/core/workloadmeta/collectors/util/ecs_util.go#L31-L33)
```
// parseV2TaskContainers extracts containers from a v2 task
func (c *collector) parseV2TaskContainers(
	task *v2.Task,
	seen map[workloadmeta.EntityID]struct{},
) ([]workloadmeta.OrchestratorContainer, []workloadmeta.CollectorEvent) {
       ...
		events = append(events, workloadmeta.CollectorEvent{
                                  ...,
				State: workloadmeta.ContainerState{
					StartedAt: startedAt,
					CreatedAt: createdAt,
					Running:   container.KnownStatus == "RUNNING",
					Status:    c.parseStatus(container.KnownStatus),
				},
			},
		})
	}

	...
}

```

and the v4 parser does not:

[source](https://github.com/DataDog/datadog-agent/blob/308d9aca8eebdd779154c86599c83020306c2fe6/comp/core/workloadmeta/collectors/util/ecs_util.go#L153-L156)
```
State: workloadmeta.ContainerState{
				Running:  container.KnownStatus == "RUNNING",
				ExitCode: container.ExitCode,
			},
```

this has now been fixed as so:

```
			State: workloadmeta.ContainerState{
				Running:  container.KnownStatus == "RUNNING",
				Status:   ContainerStatusFromKnownStatus(container.KnownStatus),
				ExitCode: container.ExitCode,
			},
```


you can see that agents running the latest version all have containers that have an unknown status
<img width="1508" height="825" alt="image" src="https://github.com/user-attachments/assets/c303cd06-a2ee-4523-beab-de0f11b62fd3" />


### Describe how you validated your changes
- updated e2e tests and ran manual e2e tests 

1. setup AMD devcontainer using the following devcontainer and running `devcontainer up --workspace-folder .`

```
{
  "name": "Datadog-Agent-DevEnv-amd",
  "image": "registry.ddbuild.io/ci/datadog-agent-devenv:1-amd64",
  "runArgs": [
    "--cap-add=SYS_PTRACE",
    "--security-opt",
    "seccomp=unconfined",
    "-w",
    "/workspaces/datadog-agent",
    "--name",
    "datadog_agent_devcontainer_amd",
    "--hostname",
    "matthew.geng-devcontainer-amd"
  ],
  "features": {},
  "remoteUser": "datadog",
  "mounts": [
    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached",
    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
  ],
  "customizations": {
    "vscode": {
      "settings": {
        "go.toolsManagement.checkForUpdates": "local",
        "go.useLanguageServer": true,
        "go.gopath": "/home/datadog/go",
        "go.goroot": "/usr/local/go",
        "go.buildTags": "no_dynamic_plugins,otlp,trivy,zstd,kubeapiserver,podman,orchestrator,consul,kubelet,python,oracle,datadog.no_waf,bundle_installer,etcd,zlib,zk,containerd,cri,ec2,jetson,nvml,trivy_no_javadb,crio,docker,jmx,netcgo,systemd,test",
        "go.testTags": "no_dynamic_plugins,otlp,trivy,zstd,kubeapiserver,podman,orchestrator,consul,kubelet,python,oracle,datadog.no_waf,bundle_installer,etcd,zlib,zk,containerd,cri,ec2,jetson,nvml,trivy_no_javadb,crio,docker,jmx,netcgo,systemd,test",
        "go.lintTool": "golangci-lint",
        "go.lintOnSave": "package",
        "go.lintFlags": [
          "--build-tags",
          "no_dynamic_plugins,otlp,trivy,zstd,kubeapiserver,podman,orchestrator,consul,kubelet,python,oracle,datadog.no_waf,bundle_installer,etcd,zlib,zk,containerd,cri,ec2,jetson,nvml,trivy_no_javadb,crio,docker,jmx,netcgo,systemd,test"
        ],
        "[go]": {
          "editor.formatOnSave": true
        },
        "gopls": {
          "formatting.local": "github.com/DataDog/datadog-agent"
        }
      },
      "extensions": [
        "golang.Go",
        "ms-python.python",
        "redhat.vscode-yaml"
      ]
    }
  },
  "containerEnv": {
    "GITLAB_TOKEN": "${localEnv:GITLAB_TOKEN}",
    "DOCKERHUB_USER": "${localEnv:DOCKERHUB_USER}"
  },
  "onCreateCommand": {
    "setup": "git config --global --add safe.directory /workspaces/datadog-agent && dda inv -- -e install-tools && dda inv -- -e deps && DD_API_KEY=<API_KEY> bash -c \"$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)\""
  }
}

```

2. exec into the docker container `docker exec -it datadog_agent_devcontainer_amd bash`

3. build image in devcontainer
```
export DOCKER_DEFAULT_PLATFORM=linux/amd64 && dda inv agent.hacky-dev-image-build --target-image 376334461865.dkr.ecr.us-east-1.amazonaws.com/agent-e2e-tests:matthewgeng --push
```

4. pushed image to sandbox repo `docker push 376334461865.dkr.ecr.us-east-1.amazonaws.com/agent-e2e-tests:matthewgeng` since the previous command didn't when I think it should?

5. Ran the e2e test 
```
E2E_DEV_MODE=true E2E_STACK_NAME_SUFFIX=_bruh \
     dda inv new-e2e-tests.run --targets=./tests/process --run=TestECSFargateCoreAgentTestSuite --agent-image 376334461865.dkr.ecr.us-east-1.amazonaws.com/agent-e2e-tests:matthewgeng --configparams ddagent:ecsDeploymentMode=sidecar,ddagent:ecsLaunchType=fargate,ddagent:extraEnvVars=DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED=true,DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED=true
```

```
=== RUN   TestECSFargateCoreAgentTestSuite/TestProcessCheckInCoreAgent
    suite.go:383: No change in provisioners, skipping environment update
--- PASS: TestECSFargateCoreAgentTestSuite (121.83s)
    --- PASS: TestECSFargateCoreAgentTestSuite/TestProcessCheckInCoreAgent (20.02s)
PASS
ok      github.com/DataDog/datadog-agent/test/new-e2e/tests/process     124.078s

DONE 2 tests in 124.077s
All tests passed
```


# Testing 2 

created my own dev cluster since I couldn't see containers via the e2e test ^ I'm probably missing some sort of configuration

1. created test-matthewgeng dev cluster in dddev
2. used the following task def to create a task

```
{
    "pidMode": "task",
    "containerDefinitions": [
        {
            "name": "nginx",
            "image": "nginx:latest",
            "cpu": 256,
            "memory": 256,
            "portMappings": [
                {
                    "containerPort": 80,
                    "hostPort": 80,
                    "protocol": "tcp"
                }
            ],
            "essential": true,
            "environment": [],
            "mountPoints": [],
            "volumesFrom": [],
            "logConfiguration": {
                "logDriver": "awslogs",
                "options": {
                    "awslogs-group": "/ecs/test-matthewgeng",
                    "mode": "non-blocking",
                    "awslogs-create-group": "true",
                    "max-buffer-size": "25m",
                    "awslogs-region": "us-east-1",
                    "awslogs-stream-prefix": "ecs"
                }
            },
            "systemControls": []
        },
        {
            "name": "agent",
            "image": "376334461865.dkr.ecr.us-east-1.amazonaws.com/agent-e2e-tests:matthewgeng",
            "cpu": 0,
            "portMappings": [],
            "essential": true,
            "environment": [
                {
                    "name": "ECS_FARGATE",
                    "value": "true"
                },
                {
                    "name": "DD_API_KEY",
                    "value": "<API_KEY>"
                },
                {
                    "name": "DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED",
                    "value": "true"
                },
                {
                    "name": "DD_ECS_TASK_COLLECTION_ENABLED",
                    "value": "true"
                },
                {
                    "name": "DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED",
                    "value": "true"
                }
            ],
            "mountPoints": [],
            "volumesFrom": [],
            "logConfiguration": {
                "logDriver": "awslogs",
                "options": {
                    "awslogs-group": "/ecs/test-matthewgeng",
                    "mode": "non-blocking",
                    "awslogs-create-group": "true",
                    "max-buffer-size": "25m",
                    "awslogs-region": "us-east-1",
                    "awslogs-stream-prefix": "ecs"
                }
            },
            "systemControls": []
        }
    ],
    "family": "test-matthewgeng",
    "taskRoleArn": "arn:aws:iam::376334461865:role/ecsTaskRole",
    "executionRoleArn": "arn:aws:iam::376334461865:role/ecsTaskExecutionRole",
    "networkMode": "awsvpc",
    "volumes": [],
    "placementConstraints": [],
    "requiresCompatibilities": [
        "FARGATE"
    ],
    "cpu": "1024",
    "memory": "3072",
    "runtimePlatform": {
        "cpuArchitecture": "X86_64",
        "operatingSystemFamily": "LINUX"
    },
    "enableFaultInjection": false,
    "tags": [
        {
            "key": "team",
            "value": "container-experiences"
        },
        {
            "key": "username",
            "value": "matthew.geng"
        }
    ]
}
```

and ran 
```
aws-vault exec sso-agent-sandbox-account-admin --  aws ecs register-task-definition --cli-input-json file://<PATH_TO_FILE>
```

3. started task via command like:

```
aws-vault exec sso-agent-sandbox-account-admin --  aws ecs run-task --cluster dev-matthewgeng --task-definition test-matthewgeng:14 --network-configuration awsvpcConfiguration="{subnets=[subnet-091570395d476e9ce],securityGroups=[sg-038231b976eb13d44],assignPublicIp=ENABLED}" --enable-execute-command --launch-type FARGATE
```


4. Shows up in dddev

<img width="1335" height="814" alt="image" src="https://github.com/user-attachments/assets/23382c56-f608-40a7-b90c-12384e94e844" />

shows in main containers page with up status now

<img width="1481" height="790" alt="image" src="https://github.com/user-attachments/assets/0100bf57-6d0b-41e1-84a5-89e4245ed103" />


### Additional Notes
