### PR TITLE
[CWS] Add support for policy `type` field 

### DIFF
--- a/pkg/security/clihelpers/eval_test.go
+++ b/pkg/security/clihelpers/eval_test.go
@@ -22,9 +22,9 @@ type fakeProvider struct {
 
 func (p *fakeProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFilters []rules.RuleFilter) ([]*rules.Policy, *multierror.Error) {
 	pInfo := &rules.PolicyInfo{
-		Name:   "default.policy",
-		Source: "fake",
-		Type:   "fake",
+		Name:         "default.policy",
+		Source:       "fake",
+		InternalType: "fake",
 	}
 
 	var (

--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -211,10 +211,10 @@ func (t *SelfTester) LoadPolicies(_ []rules.MacroFilter, _ []rules.RuleFilter) (
 	}
 
 	pInfo := &rules.PolicyInfo{
-		Name:       policyName,
-		Source:     policySource,
-		Type:       rules.SelftestPolicy,
-		IsInternal: true,
+		Name:         policyName,
+		Source:       policySource,
+		InternalType: rules.SelftestPolicyType,
+		IsInternal:   true,
 	}
 
 	policy, err := rules.LoadPolicyFromDefinition(pInfo, policyDef, nil, nil)

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -162,7 +162,7 @@ func (r *RCPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFi
 	r.RLock()
 	defer r.RUnlock()
 
-	load := func(policyType rules.PolicyType, id string, cfg []byte) error {
+	load := func(internalType rules.InternalPolicyType, id string, cfg []byte) error {
 		if r.dumpPolicies {
 			name, err := writePolicy(id, cfg)
 			if err != nil {
@@ -173,9 +173,9 @@ func (r *RCPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFi
 		}
 
 		pInfo := &rules.PolicyInfo{
-			Name:   normalizePolicyName(id),
-			Source: rules.PolicyProviderTypeRC,
-			Type:   policyType,
+			Name:         normalizePolicyName(id),
+			Source:       rules.PolicyProviderTypeRC,
+			InternalType: internalType,
 		}
 		reader := bytes.NewReader(cfg)
 		policy, err := rules.LoadPolicy(pInfo, reader, macroFilters, ruleFilters)

--- a/pkg/security/rules/bundled/bundled_policy_provider.go
+++ b/pkg/security/rules/bundled/bundled_policy_provider.go
@@ -34,10 +34,10 @@ func (p *PolicyProvider) LoadPolicies([]rules.MacroFilter, []rules.RuleFilter) (
 	}
 
 	pInfo := &rules.PolicyInfo{
-		Name:       "bundled_policy",
-		Source:     "bundled",
-		Type:       rules.InternalPolicyType,
-		IsInternal: true,
+		Name:         "bundled_policy",
+		Source:       "bundled",
+		InternalType: rules.BundledPolicyType,
+		IsInternal:   true,
 	}
 
 	policy, err := rules.LoadPolicyFromDefinition(pInfo, policyDef, nil, nil)

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -155,6 +155,8 @@ type PolicyMetadata struct {
 	Name string `json:"name"`
 	// Version is the version of the policy
 	Version string `json:"version,omitempty"`
+	// ContentType is the type of content served by the policy (e.g. "policy", "detection_pack" or empty)
+	ContentType string `json:"type,omitempty"`
 	// Source is the source of the policy
 	Source string `json:"source"`
 	// ReplacePolicyID is the ID that this policy should replace
@@ -297,19 +299,20 @@ func (e HeartbeatEvent) ToJSON() ([]byte, error) {
 }
 
 // NewPolicyMetadata returns a new policy metadata object
-func NewPolicyMetadata(name, source, version, replacePolicyID string) *PolicyMetadata {
+func NewPolicyMetadata(name, source, version, contentType, replacePolicyID string) *PolicyMetadata {
 	return &PolicyMetadata{
 		Name:            name,
 		Version:         version,
+		ContentType:     contentType,
 		Source:          source,
 		ReplacePolicyID: replacePolicyID,
 	}
 }
 
 // NewPolicyState returns a policy state based on the policy info
-func NewPolicyState(name, source, version, replacePolicyID string, status PolicyStatus, message string) *PolicyState {
+func NewPolicyState(name, source, version, contentType, replacePolicyID string, status PolicyStatus, message string) *PolicyState {
 	return &PolicyState{
-		PolicyMetadata: *NewPolicyMetadata(name, source, version, replacePolicyID),
+		PolicyMetadata: *NewPolicyMetadata(name, source, version, contentType, replacePolicyID),
 		Status:         status,
 		Message:        message,
 	}
@@ -385,7 +388,7 @@ func RuleStateFromRule(rule *rules.PolicyRule, policy *rules.PolicyInfo, status 
 		if policy.Equals(&pInfo) {
 			continue
 		}
-		ruleState.ModifiedBy = append(ruleState.ModifiedBy, NewPolicyMetadata(pInfo.Name, pInfo.Source, pInfo.Version, pInfo.ReplacePolicyID))
+		ruleState.ModifiedBy = append(ruleState.ModifiedBy, NewPolicyMetadata(pInfo.Name, pInfo.Source, pInfo.Version, pInfo.ContentType, pInfo.ReplacePolicyID))
 	}
 
 	if !rule.Accepted {
@@ -413,7 +416,7 @@ func NewPoliciesState(rs *rules.RuleSet, filteredRules []*rules.PolicyRule, err 
 	for _, rule := range rs.GetRules() {
 		for pInfo := range rule.Policies(includeInternalPolicies) {
 			if policyState, exists = mp[pInfo.Name]; !exists {
-				policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, pInfo.ReplacePolicyID, PolicyStatusLoaded, "")
+				policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, pInfo.ContentType, pInfo.ReplacePolicyID, PolicyStatusLoaded, "")
 				mp[pInfo.Name] = policyState
 			}
 			policyState.Rules = append(policyState.Rules, RuleStateFromRule(rule.PolicyRule, pInfo, "loaded", ""))
@@ -428,7 +431,7 @@ func NewPoliciesState(rs *rules.RuleSet, filteredRules []*rules.PolicyRule, err 
 					policyName := pInfo.Name
 					if policyState, exists = mp[policyName]; !exists {
 						// if the policy is not in the map, this means that no rule from this policy was loaded successfully
-						policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, pInfo.ReplacePolicyID, PolicyStatusFullyRejected, "")
+						policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, pInfo.ContentType, pInfo.ReplacePolicyID, PolicyStatusFullyRejected, "")
 						mp[policyName] = policyState
 					} else if policyState.Status == PolicyStatusLoaded {
 						policyState.Status = PolicyStatusPartiallyLoaded
@@ -438,7 +441,7 @@ func NewPoliciesState(rs *rules.RuleSet, filteredRules []*rules.PolicyRule, err 
 			} else if pErr, ok := err.(*rules.ErrPolicyLoad); ok {
 				policyName := pErr.Name
 				if policyState, exists = mp[policyName]; !exists {
-					mp[policyName] = NewPolicyState(pErr.Name, pErr.Source, pErr.Version, "", PolicyStatusError, pErr.Err.Error())
+					mp[policyName] = NewPolicyState(pErr.Name, pErr.Source, pErr.Version, pErr.ContentType, "", PolicyStatusError, pErr.Err.Error())
 				} else { // this case shouldn't happen, but just in case it does let's update the policy status
 					policyState.Status = PolicyStatusError
 					if policyState.Message == "" {
@@ -454,7 +457,7 @@ func NewPoliciesState(rs *rules.RuleSet, filteredRules []*rules.PolicyRule, err 
 			policyName := pInfo.Name
 			if policyState, exists = mp[policyName]; !exists {
 				// if the policy is not in the map, this means that no rule from this policy was loaded successfully
-				policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, pInfo.ReplacePolicyID, PolicyStatusFullyFiltered, "")
+				policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, pInfo.ContentType, pInfo.ReplacePolicyID, PolicyStatusFullyFiltered, "")
 				mp[policyName] = policyState
 			} else if policyState.Status == PolicyStatusLoaded {
 				policyState.Status = PolicyStatusPartiallyFiltered

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -1241,6 +1241,8 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor2(
 			out.Name = string(in.String())
 		case "version":
 			out.Version = string(in.String())
+		case "type":
+			out.Type = string(in.String())
 		case "source":
 			out.Source = string(in.String())
 		case "replace_policy_id":
@@ -1268,6 +1270,11 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor2(
 		const prefix string = ",\"version\":"
 		out.RawString(prefix)
 		out.String(string(in.Version))
+	}
+	if in.Type != "" {
+		const prefix string = ",\"type\":"
+		out.RawString(prefix)
+		out.String(string(in.Type))
 	}
 	{
 		const prefix string = ",\"source\":"
@@ -1782,6 +1789,8 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor6(
 			out.Name = string(in.String())
 		case "version":
 			out.Version = string(in.String())
+		case "type":
+			out.Type = string(in.String())
 		case "source":
 			out.Source = string(in.String())
 		case "replace_policy_id":
@@ -1837,6 +1846,11 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor6(
 		const prefix string = ",\"version\":"
 		out.RawString(prefix)
 		out.String(string(in.Version))
+	}
+	if in.Type != "" {
+		const prefix string = ",\"type\":"
+		out.RawString(prefix)
+		out.String(string(in.Type))
 	}
 	{
 		const prefix string = ",\"source\":"

--- a/pkg/security/secl/rules/bucket.go
+++ b/pkg/security/secl/rules/bucket.go
@@ -40,8 +40,8 @@ func (rb *RuleBucket) AddRule(rule *Rule) error {
 	// sort by policy, execution context, then by priority
 	sort.SliceStable(rb.rules, func(i, j int) bool {
 		// sort by policy type
-		if rb.rules[i].Policy.Type != rb.rules[j].Policy.Type {
-			return rb.rules[i].Policy.Type == DefaultPolicyType
+		if rb.rules[i].Policy.InternalType != rb.rules[j].Policy.InternalType {
+			return rb.rules[i].Policy.InternalType == DefaultPolicyType
 		}
 
 		// sort by execution context

--- a/pkg/security/secl/rules/bucket_test.go
+++ b/pkg/security/secl/rules/bucket_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // newTestRuleWithExecContextTag creates a *Rule with the given id and tag value
-func newOrderTestRule(t *testing.T, id string, policyType PolicyType, execContextTag string, priority int) *Rule {
+func newOrderTestRule(t *testing.T, id string, internalPolicyType InternalPolicyType, execContextTag string, priority int) *Rule {
 	expression := `open.file.path == "/tmp/test"`
 	pc := ast.NewParsingContext(false)
 	evalRule, err := eval.NewRule(id, expression, pc, &eval.Opts{})
@@ -36,7 +36,7 @@ func newOrderTestRule(t *testing.T, id string, policyType PolicyType, execContex
 				Priority:   priority,
 			},
 			Policy: PolicyInfo{
-				Type: policyType,
+				InternalType: internalPolicyType,
 			},
 		},
 		Rule: evalRule,

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -59,10 +59,11 @@ func (e ErrNoEventTypeBucket) Error() string {
 
 // ErrPolicyLoad is returned on policy file error
 type ErrPolicyLoad struct {
-	Name    string
-	Version string
-	Source  string
-	Err     error
+	Name        string
+	Version     string
+	ContentType string
+	Source      string
+	Err         error
 }
 
 func (e *ErrPolicyLoad) Error() string {

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -59,11 +59,11 @@ func (e ErrNoEventTypeBucket) Error() string {
 
 // ErrPolicyLoad is returned on policy file error
 type ErrPolicyLoad struct {
-	Name        string
-	Version     string
-	ContentType string
-	Source      string
-	Err         error
+	Name    string
+	Version string
+	Type    string
+	Source  string
+	Err     error
 }
 
 func (e *ErrPolicyLoad) Error() string {

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -417,8 +417,9 @@ type HookPointArg struct {
 
 // PolicyDef represents a policy file definition
 type PolicyDef struct {
-	Version         string             `yaml:"version,omitempty" json:"version"`
-	ContentType     string             `yaml:"type,omitempty" json:"type,omitempty"`
+	Version string `yaml:"version,omitempty" json:"version"`
+	// Type is the type of content served by the policy (e.g. "policy" for a default policy, "detection_pack" or empty for others)
+	Type            string             `yaml:"type,omitempty" json:"type,omitempty"`
 	ReplacePolicyID string             `yaml:"replace_policy_id,omitempty" json:"replace_policy_id,omitempty"`
 	Macros          []*MacroDefinition `yaml:"macros,omitempty" json:"macros,omitempty"`
 	Rules           []*RuleDefinition  `yaml:"rules" json:"rules"`

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -418,6 +418,7 @@ type HookPointArg struct {
 // PolicyDef represents a policy file definition
 type PolicyDef struct {
 	Version         string             `yaml:"version,omitempty" json:"version"`
+	ContentType     string             `yaml:"type,omitempty" json:"type,omitempty"`
 	ReplacePolicyID string             `yaml:"replace_policy_id,omitempty" json:"replace_policy_id,omitempty"`
 	Macros          []*MacroDefinition `yaml:"macros,omitempty" json:"macros,omitempty"`
 	Rules           []*RuleDefinition  `yaml:"rules" json:"rules"`

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -102,7 +102,7 @@ func applyOverride(rd1, rd2 *PolicyRule) {
 
 	wasOverridden := false
 	// for backward compatibility, by default only the expression is copied if no options
-	if slices.Contains(rd2.Def.OverrideOptions.Fields, OverrideAllFields) && rd1.Policy.Type == DefaultPolicyType {
+	if slices.Contains(rd2.Def.OverrideOptions.Fields, OverrideAllFields) && rd1.Policy.InternalType == DefaultPolicyType {
 		tmpExpression := rd1.Def.Expression
 		*rd1.Def = *rd2.Def
 		rd1.Def.Expression = tmpExpression
@@ -172,7 +172,7 @@ func (r *PolicyRule) MergeWith(r2 *PolicyRule) {
 		r.Def.Disabled = r2.Def.Disabled
 		r.Policy = r2.Policy
 	} else {
-		if r.Policy.Type == DefaultPolicyType && r2.Policy.Type == CustomPolicyType {
+		if r.Policy.InternalType == DefaultPolicyType && r2.Policy.InternalType == CustomPolicyType {
 			if !r2.Def.Disabled || (r2.Def.Disabled && r.EnableCount < 0) {
 				r.Def.Disabled = r2.Def.Disabled
 				r.Policy = r2.Policy
@@ -183,18 +183,18 @@ func (r *PolicyRule) MergeWith(r2 *PolicyRule) {
 	r.ModifiedBy = append(r.ModifiedBy, r2.Policy)
 }
 
-// PolicyType represents the type of a policy
-type PolicyType string
+// InternalPolicyType represents the internal type of a policy
+type InternalPolicyType string
 
 const (
 	// DefaultPolicyType is the default policy type
-	DefaultPolicyType PolicyType = "default"
+	DefaultPolicyType InternalPolicyType = "default"
 	// CustomPolicyType is the custom policy type
-	CustomPolicyType PolicyType = "custom"
-	// InternalPolicyType is the policy for internal use (bundled_policy_provider)
-	InternalPolicyType PolicyType = "internal"
-	// SelftestPolicy is the policy for self tests
-	SelftestPolicy PolicyType = "selftest"
+	CustomPolicyType InternalPolicyType = "custom"
+	// BundledPolicyType is the policy for internal use (bundled_policy_provider)
+	BundledPolicyType InternalPolicyType = "internal"
+	// SelftestPolicyType is the policy for self tests
+	SelftestPolicyType InternalPolicyType = "selftest"
 )
 
 // PolicyInfo contains information about a policy that aren't part of the policy definition
@@ -203,10 +203,10 @@ type PolicyInfo struct {
 	Name string
 	// Source is the source of the policy
 	Source string
-	// Type is the type of the policy
-	Type PolicyType
-	// ContentType is the type of content served by the policy (e.g. "policy", "detection_pack" or empty)
-	ContentType string
+	// InternalType is the internal type of the policy
+	InternalType InternalPolicyType
+	// Type is the type of content served by the policy (e.g. "policy" for a default policy, "detection_pack" or empty for others)
+	Type string
 	// Version is the version of the policy, this field is copied from the policy definition
 	Version string
 	// ReplacePolicyID is the ID that this policy should replace
@@ -370,9 +370,16 @@ RULES:
 
 // LoadPolicyFromDefinition load a policy from a definition
 func LoadPolicyFromDefinition(info *PolicyInfo, def *PolicyDef, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
-	if def != nil && def.Version != "" {
-		info.Version = def.Version
-		info.ReplacePolicyID = def.ReplacePolicyID
+	if def != nil {
+		if def.Version != "" {
+			info.Version = def.Version
+		}
+		if def.ReplacePolicyID != "" {
+			info.ReplacePolicyID = def.ReplacePolicyID
+		}
+		if def.Type != "" {
+			info.Type = def.Type
+		}
 	}
 
 	p := &Policy{
@@ -390,7 +397,7 @@ func LoadPolicy(info *PolicyInfo, reader io.Reader, macroFilters []MacroFilter, 
 	def := PolicyDef{}
 	decoder := yaml.NewDecoder(reader)
 	if err := decoder.Decode(&def); err != nil {
-		return nil, &ErrPolicyLoad{Name: info.Name, Source: info.Source, ContentType: info.ContentType, Err: err}
+		return nil, &ErrPolicyLoad{Name: info.Name, Source: info.Source, Type: info.Type, Err: err}
 	}
 
 	return LoadPolicyFromDefinition(info, &def, macroFilters, ruleFilters)

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -205,6 +205,8 @@ type PolicyInfo struct {
 	Source string
 	// Type is the type of the policy
 	Type PolicyType
+	// ContentType is the type of content served by the policy (e.g. "policy", "detection_pack" or empty)
+	ContentType string
 	// Version is the version of the policy, this field is copied from the policy definition
 	Version string
 	// ReplacePolicyID is the ID that this policy should replace
@@ -388,7 +390,7 @@ func LoadPolicy(info *PolicyInfo, reader io.Reader, macroFilters []MacroFilter, 
 	def := PolicyDef{}
 	decoder := yaml.NewDecoder(reader)
 	if err := decoder.Decode(&def); err != nil {
-		return nil, &ErrPolicyLoad{Name: info.Name, Source: info.Source, Err: err}
+		return nil, &ErrPolicyLoad{Name: info.Name, Source: info.Source, ContentType: info.ContentType, Err: err}
 	}
 
 	return LoadPolicyFromDefinition(info, &def, macroFilters, ruleFilters)

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -35,22 +35,22 @@ func (p *PoliciesDirProvider) Start() {}
 func (p *PoliciesDirProvider) loadPolicy(filename string, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, &ErrPolicyLoad{Name: filename, Source: PolicyProviderTypeDir, ContentType: "", Err: err}
+		return nil, &ErrPolicyLoad{Name: filename, Source: PolicyProviderTypeDir, Type: "", Err: err}
 	}
 	defer f.Close()
 
 	name := filepath.Base(filename)
-	var policyType PolicyType
+	var internalPolicyType InternalPolicyType
 	if name == DefaultPolicyName {
-		policyType = DefaultPolicyType
+		internalPolicyType = DefaultPolicyType
 	} else {
-		policyType = CustomPolicyType
+		internalPolicyType = CustomPolicyType
 	}
 
 	pInfo := &PolicyInfo{
-		Name:   name,
-		Source: PolicyProviderTypeDir,
-		Type:   policyType,
+		Name:         name,
+		Source:       PolicyProviderTypeDir,
+		InternalType: internalPolicyType,
 	}
 
 	return LoadPolicy(pInfo, f, macroFilters, ruleFilters)

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -35,7 +35,7 @@ func (p *PoliciesDirProvider) Start() {}
 func (p *PoliciesDirProvider) loadPolicy(filename string, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, &ErrPolicyLoad{Name: filename, Source: PolicyProviderTypeDir, Err: err}
+		return nil, &ErrPolicyLoad{Name: filename, Source: PolicyProviderTypeDir, ContentType: "", Err: err}
 	}
 	defer f.Close()
 

--- a/pkg/security/secl/rules/policy_loader.go
+++ b/pkg/security/secl/rules/policy_loader.go
@@ -92,13 +92,13 @@ func removeReplacedPolicies(policies []*Policy) []*Policy {
 	policyIDsToRemove := make([]string, 0)
 
 	for _, policy := range policies {
-		if policy.Info.Source == PolicyProviderTypeRC && policy.Info.Type == CustomPolicyType && policy.Def.ReplacePolicyID != "" {
+		if policy.Info.Source == PolicyProviderTypeRC && policy.Info.InternalType == CustomPolicyType && policy.Def.ReplacePolicyID != "" {
 			policyIDsToRemove = append(policyIDsToRemove, policy.Def.ReplacePolicyID)
 		}
 	}
 
 	policies = slices.DeleteFunc(policies, func(p *Policy) bool {
-		return p.Info.Source == PolicyProviderTypeRC && p.Info.Type == DefaultPolicyType && slices.Contains(policyIDsToRemove, p.Info.Name)
+		return p.Info.Source == PolicyProviderTypeRC && p.Info.InternalType == DefaultPolicyType && slices.Contains(policyIDsToRemove, p.Info.Name)
 	})
 
 	return policies

--- a/pkg/security/secl/rules/policy_loader_test.go
+++ b/pkg/security/secl/rules/policy_loader_test.go
@@ -130,9 +130,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				expectedLoadedPolicies := []*Policy{
 					{
 						Info: PolicyInfo{
-							Name:   DefaultPolicyName,
-							Source: PolicyProviderTypeRC,
-							Type:   DefaultPolicyType,
+							Name:         DefaultPolicyName,
+							Source:       PolicyProviderTypeRC,
+							InternalType: DefaultPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -143,9 +143,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/rc-default/foo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   DefaultPolicyName,
-										Source: PolicyProviderTypeRC,
-										Type:   DefaultPolicyType,
+										Name:         DefaultPolicyName,
+										Source:       PolicyProviderTypeRC,
+										InternalType: DefaultPolicyType,
 									},
 									Accepted: true,
 								},
@@ -157,9 +157,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/rc-default/bravo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   DefaultPolicyName,
-										Source: PolicyProviderTypeRC,
-										Type:   DefaultPolicyType,
+										Name:         DefaultPolicyName,
+										Source:       PolicyProviderTypeRC,
+										InternalType: DefaultPolicyType,
 									},
 									Accepted: true,
 								},
@@ -168,9 +168,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					},
 					{
 						Info: PolicyInfo{
-							Name:   "myRC.policy",
-							Source: PolicyProviderTypeRC,
-							Type:   CustomPolicyType,
+							Name:         "myRC.policy",
+							Source:       PolicyProviderTypeRC,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -181,9 +181,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/rc-custom/foo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myRC.policy",
-										Source: PolicyProviderTypeRC,
-										Type:   CustomPolicyType,
+										Name:         "myRC.policy",
+										Source:       PolicyProviderTypeRC,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -195,9 +195,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/rc-custom/alpha\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myRC.policy",
-										Source: PolicyProviderTypeRC,
-										Type:   CustomPolicyType,
+										Name:         "myRC.policy",
+										Source:       PolicyProviderTypeRC,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -206,9 +206,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					},
 					{
 						Info: PolicyInfo{
-							Name:   "myLocal.policy",
-							Source: PolicyProviderTypeDir,
-							Type:   CustomPolicyType,
+							Name:         "myLocal.policy",
+							Source:       PolicyProviderTypeDir,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -219,9 +219,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -233,9 +233,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -316,9 +316,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				expectedLoadedPolicies := []*Policy{
 					{
 						Info: PolicyInfo{
-							Name:   "myRC.policy",
-							Source: PolicyProviderTypeRC,
-							Type:   CustomPolicyType,
+							Name:         "myRC.policy",
+							Source:       PolicyProviderTypeRC,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -329,9 +329,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/rc-custom/foo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myRC.policy",
-										Source: PolicyProviderTypeRC,
-										Type:   CustomPolicyType,
+										Name:         "myRC.policy",
+										Source:       PolicyProviderTypeRC,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -343,9 +343,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/rc-custom/bar\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myRC.policy",
-										Source: PolicyProviderTypeRC,
-										Type:   CustomPolicyType,
+										Name:         "myRC.policy",
+										Source:       PolicyProviderTypeRC,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -354,9 +354,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					},
 					{
 						Info: PolicyInfo{
-							Name:   "myLocal.policy",
-							Source: PolicyProviderTypeDir,
-							Type:   CustomPolicyType,
+							Name:         "myLocal.policy",
+							Source:       PolicyProviderTypeDir,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -367,9 +367,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -381,9 +381,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -448,9 +448,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				expectedLoadedPolicies := []*Policy{
 					{
 						Info: PolicyInfo{
-							Name:   "myLocal.policy",
-							Source: PolicyProviderTypeDir,
-							Type:   CustomPolicyType,
+							Name:         "myLocal.policy",
+							Source:       PolicyProviderTypeDir,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -461,9 +461,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -475,9 +475,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -544,9 +544,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				expectedLoadedPolicies := []*Policy{
 					{
 						Info: PolicyInfo{
-							Name:   "myLocal.policy",
-							Source: PolicyProviderTypeDir,
-							Type:   CustomPolicyType,
+							Name:         "myLocal.policy",
+							Source:       PolicyProviderTypeDir,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -557,9 +557,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -571,9 +571,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -645,18 +645,18 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				expectedLoadedPolicies := []*Policy{
 					{
 						Info: PolicyInfo{
-							Name:   "myRC.policy",
-							Source: PolicyProviderTypeRC,
-							Type:   CustomPolicyType,
+							Name:         "myRC.policy",
+							Source:       PolicyProviderTypeRC,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules:  map[string][]*PolicyRule{},
 					},
 					{
 						Info: PolicyInfo{
-							Name:   "myLocal.policy",
-							Source: PolicyProviderTypeDir,
-							Type:   CustomPolicyType,
+							Name:         "myLocal.policy",
+							Source:       PolicyProviderTypeDir,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -667,9 +667,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -681,9 +681,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "myLocal.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "myLocal.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -757,9 +757,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
 							Policy: PolicyInfo{
-								Name:   DefaultPolicyName,
-								Source: PolicyProviderTypeRC,
-								Type:   DefaultPolicyType,
+								Name:         DefaultPolicyName,
+								Source:       PolicyProviderTypeRC,
+								InternalType: DefaultPolicyType,
 							},
 							Accepted: true,
 						},
@@ -812,9 +812,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
 							Policy: PolicyInfo{
-								Name:   DefaultPolicyName,
-								Source: PolicyProviderTypeRC,
-								Type:   DefaultPolicyType,
+								Name:         DefaultPolicyName,
+								Source:       PolicyProviderTypeRC,
+								InternalType: DefaultPolicyType,
 							},
 							Accepted: true,
 						},
@@ -868,9 +868,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   DefaultPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: DefaultPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1072,9 +1072,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
 							Policy: PolicyInfo{
-								Name:   "P0.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   DefaultPolicyType,
+								Name:         "P0.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: DefaultPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1083,9 +1083,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_2", Expression: "exec.file.path == \"/etc/default/bar\""},
 							Policy: PolicyInfo{
-								Name:   "P0.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   DefaultPolicyType,
+								Name:         "P0.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: DefaultPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1171,9 +1171,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_2", Expression: "exec.file.path == \"/etc/default/bar\""},
 							Policy: PolicyInfo{
-								Name:   "P0.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   DefaultPolicyType,
+								Name:         "P0.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: DefaultPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1242,9 +1242,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
 							Policy: PolicyInfo{
-								Name:   "P2.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P2.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1340,9 +1340,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/custom/foo\""},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1395,9 +1395,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
 							Policy: PolicyInfo{
-								Name:   DefaultPolicyName,
-								Source: PolicyProviderTypeRC,
-								Type:   DefaultPolicyType,
+								Name:         DefaultPolicyName,
+								Source:       PolicyProviderTypeRC,
+								InternalType: DefaultPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1451,9 +1451,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/custom/foo\""},
 							Policy: PolicyInfo{
-								Name:   "P0.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P0.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1507,9 +1507,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/custom/foo\""},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1562,9 +1562,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/custom/foo\""},
 							Policy: PolicyInfo{
-								Name:   "P0.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P0.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1682,9 +1682,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 								},
 							},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   DefaultPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: DefaultPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1777,9 +1777,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 								},
 							},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1859,9 +1859,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 								},
 							},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -1941,9 +1941,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 								},
 							},
 							Policy: PolicyInfo{
-								Name:   "P0.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P0.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -2020,9 +2020,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 								ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\"",
 							},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -2128,9 +2128,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 								Combine: OverridePolicy,
 							},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -2222,9 +2222,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 								},
 							},
 							Policy: PolicyInfo{
-								Name:   "P1.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "P1.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -2304,9 +2304,10 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				expectedPolicies := []*Policy{
 					{
 						Info: PolicyInfo{
-							Name:   "rc-custom.policy",
-							Source: PolicyProviderTypeRC,
-							Type:   CustomPolicyType,
+							Name:            "rc-custom.policy",
+							Source:          PolicyProviderTypeRC,
+							InternalType:    CustomPolicyType,
+							ReplacePolicyID: "rc-default.policy",
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -2317,9 +2318,10 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/rc-custom/rule3\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "rc-custom.policy",
-										Source: PolicyProviderTypeRC,
-										Type:   CustomPolicyType,
+										Name:            "rc-custom.policy",
+										Source:          PolicyProviderTypeRC,
+										InternalType:    CustomPolicyType,
+										ReplacePolicyID: "rc-default.policy",
 									},
 									Accepted: true,
 								},
@@ -2328,9 +2330,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					},
 					{
 						Info: PolicyInfo{
-							Name:   "local-custom.policy",
-							Source: PolicyProviderTypeDir,
-							Type:   CustomPolicyType,
+							Name:         "local-custom.policy",
+							Source:       PolicyProviderTypeDir,
+							InternalType: CustomPolicyType,
 						},
 						Macros: map[string][]*PolicyMacro{},
 						Rules: map[string][]*PolicyRule{
@@ -2341,9 +2343,9 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										Expression: "open.file.path == \"/etc/local/rule1\"",
 									},
 									Policy: PolicyInfo{
-										Name:   "local-custom.policy",
-										Source: PolicyProviderTypeDir,
-										Type:   CustomPolicyType,
+										Name:         "local-custom.policy",
+										Source:       PolicyProviderTypeDir,
+										InternalType: CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -2807,14 +2809,14 @@ type testPolicyDef struct {
 	def        PolicyDef
 	name       string
 	source     string
-	policyType PolicyType
+	policyType InternalPolicyType
 }
 
 func testPolicyToPolicy(testPolicy *testPolicyDef) (*Policy, *multierror.Error) {
 	info := &PolicyInfo{
-		Name:   testPolicy.name,
-		Source: testPolicy.source,
-		Type:   testPolicy.policyType,
+		Name:         testPolicy.name,
+		Source:       testPolicy.source,
+		InternalType: testPolicy.policyType,
 	}
 	policy, err := LoadPolicyFromDefinition(info, &testPolicy.def, nil, nil)
 	if err != nil {
@@ -2848,7 +2850,7 @@ func checkOverrideResult(t assert.TestingT, expected map[eval.RuleID]*Rule, got 
 			assert.Equal(t, r.PolicyRule.Def, got[ruleID].PolicyRule.Def) &&
 			assert.Equal(t, r.PolicyRule.Policy.Name, got[ruleID].Policy.Name) &&
 			assert.Equal(t, r.PolicyRule.Policy.Source, got[ruleID].Policy.Source) &&
-			assert.Equal(t, r.PolicyRule.Policy.Type, got[ruleID].Policy.Type) &&
+			assert.Equal(t, r.PolicyRule.Policy.InternalType, got[ruleID].Policy.InternalType) &&
 			assert.Equal(t, r.PolicyRule.Accepted, got[ruleID].PolicyRule.Accepted)
 		if !res {
 			return res

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -2419,7 +2419,7 @@ func TestActionSetVariableLength(t *testing.T) {
 func TestLoadPolicy(t *testing.T) {
 	type args struct {
 		name         string
-		policyType   PolicyType
+		policyType   InternalPolicyType
 		source       string
 		fileContent  string
 		macroFilters []MacroFilter
@@ -2476,9 +2476,9 @@ rules:
 			},
 			want: &Policy{
 				Info: PolicyInfo{
-					Name:   "myLocal.policy",
-					Source: PolicyProviderTypeRC,
-					Type:   CustomPolicyType,
+					Name:         "myLocal.policy",
+					Source:       PolicyProviderTypeRC,
+					InternalType: CustomPolicyType,
 				},
 				Rules:  map[string][]*PolicyRule{},
 				Macros: map[string][]*PolicyMacro{},
@@ -2517,9 +2517,9 @@ broken
 			},
 			want: &Policy{
 				Info: PolicyInfo{
-					Name:   "myLocal.policy",
-					Source: PolicyProviderTypeRC,
-					Type:   CustomPolicyType,
+					Name:         "myLocal.policy",
+					Source:       PolicyProviderTypeRC,
+					InternalType: CustomPolicyType,
 				},
 				Rules: map[string][]*PolicyRule{
 					"rule_test": {
@@ -2530,9 +2530,9 @@ broken
 								Disabled:   true,
 							},
 							Policy: PolicyInfo{
-								Name:   "myLocal.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "myLocal.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -2558,9 +2558,9 @@ broken
 			},
 			want: &Policy{
 				Info: PolicyInfo{
-					Name:   "myLocal.policy",
-					Source: PolicyProviderTypeRC,
-					Type:   CustomPolicyType,
+					Name:         "myLocal.policy",
+					Source:       PolicyProviderTypeRC,
+					InternalType: CustomPolicyType,
 				},
 				Rules: map[string][]*PolicyRule{
 					"rule_test": {
@@ -2571,9 +2571,9 @@ broken
 								Combine:    OverridePolicy,
 							},
 							Policy: PolicyInfo{
-								Name:   "myLocal.policy",
-								Source: PolicyProviderTypeRC,
-								Type:   CustomPolicyType,
+								Name:         "myLocal.policy",
+								Source:       PolicyProviderTypeRC,
+								InternalType: CustomPolicyType,
 							},
 							Accepted: true,
 						},
@@ -2589,9 +2589,9 @@ broken
 			r := strings.NewReader(tt.args.fileContent)
 
 			info := &PolicyInfo{
-				Name:   tt.args.name,
-				Source: tt.args.source,
-				Type:   tt.args.policyType,
+				Name:         tt.args.name,
+				Source:       tt.args.source,
+				InternalType: tt.args.policyType,
 			}
 
 			got, err := LoadPolicy(info, r, tt.args.macroFilters, tt.args.ruleFilters)

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1121,10 +1121,11 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) ([]
 	for _, policy := range policies {
 		if len(policy.Macros) == 0 && len(policy.Rules) == 0 && (policy.Info.Name != DefaultPolicyName && !policy.Info.IsInternal) {
 			errs = multierror.Append(errs, &ErrPolicyLoad{
-				Name:    policy.Info.Name,
-				Version: policy.Info.Version,
-				Source:  policy.Info.Source,
-				Err:     ErrPolicyIsEmpty,
+				Name:        policy.Info.Name,
+				ContentType: policy.Info.ContentType,
+				Version:     policy.Info.Version,
+				Source:      policy.Info.Source,
+				Err:         ErrPolicyIsEmpty,
 			})
 			continue
 		}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1121,11 +1121,11 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) ([]
 	for _, policy := range policies {
 		if len(policy.Macros) == 0 && len(policy.Rules) == 0 && (policy.Info.Name != DefaultPolicyName && !policy.Info.IsInternal) {
 			errs = multierror.Append(errs, &ErrPolicyLoad{
-				Name:        policy.Info.Name,
-				ContentType: policy.Info.ContentType,
-				Version:     policy.Info.Version,
-				Source:      policy.Info.Source,
-				Err:         ErrPolicyIsEmpty,
+				Name:    policy.Info.Name,
+				Type:    policy.Info.Type,
+				Version: policy.Info.Version,
+				Source:  policy.Info.Source,
+				Err:     ErrPolicyIsEmpty,
 			})
 			continue
 		}

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -453,6 +453,9 @@
     "version": {
       "type": "string"
     },
+    "type": {
+      "type": "string"
+    },
     "replace_policy_id": {
       "type": "string"
     },

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -454,7 +454,8 @@
       "type": "string"
     },
     "type": {
-      "type": "string"
+      "type": "string",
+      "description": "Type is the type of content served by the policy (e.g. \"policy\" for a default policy, \"detection_pack\" or empty for others)"
     },
     "replace_policy_id": {
       "type": "string"

--- a/pkg/security/secl/schemas/ruleset_loaded.schema.json
+++ b/pkg/security/secl/schemas/ruleset_loaded.schema.json
@@ -43,6 +43,9 @@
                 "version": {
                     "type": "string"
                 },
+                "type": {
+                    "type": "string"
+                },
                 "status": {
                     "type": "string",
                     "enum": [


### PR DESCRIPTION
### What does this PR do?

- Rename existing `Type` field to `InternalType`
- `Type` field now matches the data read from a policy
- Report the field in `ruleset_loaded` events

### Motivation

### Describe how you validated your changes

### Additional Notes
