### PR TITLE
introduce lazyregexp package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -576,6 +576,7 @@
 /pkg/util/testutil/patternscanner.go    @DataDog/universal-service-monitoring @DataDog/ebpf-platform
 /pkg/util/testutil/docker               @DataDog/universal-service-monitoring @DataDog/ebpf-platform
 /pkg/util/trie                          @DataDog/container-integrations
+/pkg/util/lazyregexp                    @DataDog/agent-security
 /pkg/languagedetection                  @DataDog/container-experiences @DataDog/agent-discovery
 /pkg/linters/                           @DataDog/agent-devx
 /pkg/linters/components/                @DataDog/agent-runtimes

--- a/pkg/util/lazyregexp/re.go
+++ b/pkg/util/lazyregexp/re.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package lazyregexp holds lazy initliazed regexp code
+package lazyregexp
+
+import (
+	"regexp"
+	"sync"
+)
+
+var inTest bool
+
+// LazyRegexp is a lazy initialized regexp
+type LazyRegexp struct {
+	expression string
+	once       sync.Once
+	compiled   *regexp.Regexp
+}
+
+// New returns a new LazyRegexp
+func New(expression string) *LazyRegexp {
+	lr := &LazyRegexp{
+		expression: expression,
+	}
+
+	// in test code, we force the regexp to be compiled at creation time
+	// to make sure the pattern is valid
+	if inTest {
+		_ = lr.re()
+	}
+
+	return lr
+}
+
+func (lr *LazyRegexp) re() *regexp.Regexp {
+	lr.once.Do(func() {
+		lr.compiled = regexp.MustCompile(lr.expression)
+	})
+	return lr.compiled
+}
+
+// Match see regexp.Match
+func (lr *LazyRegexp) Match(b []byte) bool {
+	return lr.re().Match(b)
+}
+
+// MatchString see regexp.MatchString
+func (lr *LazyRegexp) MatchString(s string) bool {
+	return lr.re().MatchString(s)
+}
+
+// FindStringSubmatch see regexp.FindStringSubmatch
+func (lr *LazyRegexp) FindStringSubmatch(s string) []string {
+	return lr.re().FindStringSubmatch(s)
+}
+
+// ReplaceAllString see regexp.ReplaceAllString
+func (lr *LazyRegexp) ReplaceAllString(src, repl string) string {
+	return lr.re().ReplaceAllString(src, repl)
+}
+
+// FindSubmatch see regexp.FindSubmatch
+func (lr *LazyRegexp) FindSubmatch(s []byte) [][]byte {
+	return lr.re().FindSubmatch(s)
+}
+
+// FindAllStringSubmatch see regexp.FindAllStringSubmatch
+func (lr *LazyRegexp) FindAllStringSubmatch(s string, n int) [][]string {
+	return lr.re().FindAllStringSubmatch(s, n)
+}
+
+// FindAllStringSubmatchIndex see regexp.FindAllStringSubmatchIndex
+func (lr *LazyRegexp) FindAllStringSubmatchIndex(s string, n int) [][]int {
+	return lr.re().FindAllStringSubmatchIndex(s, n)
+}
+
+// FindIndex see regexp.FindIndex
+func (lr *LazyRegexp) FindIndex(b []byte) []int {
+	return lr.re().FindIndex(b)
+}
+
+// FindAll see regexp.FindAll
+func (lr *LazyRegexp) FindAll(b []byte, n int) [][]byte {
+	return lr.re().FindAll(b, n)
+}
+
+// FindString see regexp.FindString
+func (lr *LazyRegexp) FindString(s string) string {
+	return lr.re().FindString(s)
+}

--- a/pkg/util/lazyregexp/testutil.go
+++ b/pkg/util/lazyregexp/testutil.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+// Package lazyregexp holds lazy initliazed regexp code
+package lazyregexp
+
+func init() {
+	inTest = true
+}


### PR DESCRIPTION
### What does this PR do?

This package introduces a lazyregexp package. The goal of this, is to solve the following problem:
- regexp compilation is slow so you often want to extract this and do it only once, which often ends up as putting it as a global variable
- putting it as a global variable slows down the start of the agent, and incurs the cost in all configurations even if the regexp is not used

The idea behind a lazyregexp is that it can be used as a global, and will only be compiled during first use.
As a special case, in tests the regexp is compiled during construction ensuring we don't lose the pattern validation behavior we have today.

The package is currently not defining all methods from the upstream regexp package, only a subset, the rest can be added when needed following the same pattern as others. 

No user for now, those will come in later PRs.

### Motivation

### Describe how you validated your changes

### Additional Notes
