### PR TITLE
Shrink context map when possible

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -67,6 +67,7 @@ var _ size.HasSizeInBytes = &Context{}
 type contextResolver struct {
 	id               string
 	contextsByKey    map[ckey.ContextKey]resolverEntry
+	contextsCap      int
 	seendByMtype     []bool
 	countsByMtype    []uint64
 	bytesByMtype     []uint64
@@ -87,6 +88,7 @@ func newContextResolver(tagger tagger.Component, cache *tags.Store, id string) *
 	return &contextResolver{
 		id:               id,
 		contextsByKey:    make(map[ckey.ContextKey]resolverEntry),
+		contextsCap:      0,
 		seendByMtype:     make([]bool, metrics.NumMetricTypes),
 		countsByMtype:    make([]uint64, metrics.NumMetricTypes),
 		bytesByMtype:     make([]uint64, metrics.NumMetricTypes),
@@ -122,6 +124,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 			lastSeen: timestamp,
 			context:  context,
 		}
+		cr.contextsCap++
 
 		cr.seendByMtype[mtype] = true
 		cr.countsByMtype[mtype]++
@@ -179,6 +182,22 @@ func (cr *contextResolver) updateMetrics(countsByMTypeGauge telemetry.Gauge, byt
 func (cr *contextResolver) release() {
 	for _, c := range cr.contextsByKey {
 		c.context.release()
+	}
+}
+
+// shrink reduces the map capacity if it has dropped significantly below
+// the peak capacity, similar to tags.Store.Shrink(). This reclaims memory
+// after contexts expire.
+func (cr *contextResolver) shrink() {
+	currentSize := len(cr.contextsByKey)
+	// If the map has shrunk to less than half its capacity, reallocate with the current size
+	if currentSize < cr.contextsCap/2 && cr.contextsCap > 0 {
+		newMap := make(map[ckey.ContextKey]resolverEntry, currentSize)
+		for k, v := range cr.contextsByKey {
+			newMap[k] = v
+		}
+		cr.contextsByKey = newMap
+		cr.contextsCap = currentSize
 	}
 }
 
@@ -259,6 +278,8 @@ func (cr *timestampContextResolver) expireContexts(timestamp int64) {
 			cr.resolver.remove(ck)
 		}
 	}
+	// Shrink the map if it has dropped significantly below peak capacity
+	cr.resolver.shrink()
 }
 
 func (cr *timestampContextResolver) sendOriginTelemetry(timestamp float64, series metrics.SerieSink, hostname string, tags []string) {
@@ -320,6 +341,8 @@ func (cr *countBasedContextResolver) expireContexts() []ckey.ContextKey {
 		}
 	}
 	cr.expireCount++
+	// Shrink the map if it has dropped significantly below peak capacity
+	cr.resolver.shrink()
 	return keys
 }
 


### PR DESCRIPTION
### What does this PR do?

This commit is a part of response to #incident-45849. I'm tinkering to
    reduce -idle memory consumption.

I've added a 'shrink' to contextResolver which cuts the size of the
    interior map in half when contexts expire if the map contents is
    smaller than half its capacity. This will penalize setups where
    context counts vary rapidly and benefit setups where context counts
    are roughly stable over time. A similar tactic is taken for tags
    store.

### Motivation

### Describe how you validated your changes

### Additional Notes
