### PR TITLE
[CWS] remove regexp cache in eval state

### DIFF
--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -36,16 +36,14 @@ const (
 // BoolEvalFnc describe a eval function return a boolean
 type BoolEvalFnc = func(ctx *Context) bool
 
-func extractField(field string, state *State) (Field, Field, RegisterID, error) {
-	if state.regexpCache.arraySubscriptFindRE == nil {
-		state.regexpCache.arraySubscriptFindRE = regexp.MustCompile(`\[([^\]]*)\]`)
-	}
-	if state.regexpCache.arraySubscriptReplaceRE == nil {
-		state.regexpCache.arraySubscriptReplaceRE = regexp.MustCompile(`(.+)\[[^\]]+\](.*)`)
-	}
+var (
+	arraySubscriptFindRE    = regexp.MustCompile(`\[([^\]]*)\]`)
+	arraySubscriptReplaceRE = regexp.MustCompile(`(.+)\[[^\]]+\](.*)`)
+)
 
+func extractField(field string) (Field, Field, RegisterID, error) {
 	var regID RegisterID
-	ids := state.regexpCache.arraySubscriptFindRE.FindStringSubmatch(field)
+	ids := arraySubscriptFindRE.FindStringSubmatch(field)
 
 	switch len(ids) {
 	case 0:
@@ -56,8 +54,8 @@ func extractField(field string, state *State) (Field, Field, RegisterID, error) 
 		return "", "", "", fmt.Errorf("wrong register format for fields: %s", field)
 	}
 
-	resField := state.regexpCache.arraySubscriptReplaceRE.ReplaceAllString(field, `$1$2`)
-	itField := state.regexpCache.arraySubscriptReplaceRE.ReplaceAllString(field, `$1`)
+	resField := arraySubscriptReplaceRE.ReplaceAllString(field, `$1$2`)
+	itField := arraySubscriptReplaceRE.ReplaceAllString(field, `$1`)
 
 	return resField, itField, regID, nil
 }
@@ -78,7 +76,7 @@ func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.
 		}
 	}
 
-	field, itField, regID, err := extractField(*obj.Ident, state)
+	field, itField, regID, err := extractField(*obj.Ident)
 	if err != nil {
 		return nil, obj.Pos, err
 	}

--- a/pkg/security/secl/compiler/eval/state.go
+++ b/pkg/security/secl/compiler/eval/state.go
@@ -6,23 +6,12 @@
 // Package eval holds eval related files
 package eval
 
-import (
-	"regexp"
-)
-
-// StateRegexpCache is used to cache regexps used in the rule compilation process
-type StateRegexpCache struct {
-	arraySubscriptFindRE    *regexp.Regexp
-	arraySubscriptReplaceRE *regexp.Regexp
-}
-
 // State defines the current state of the rule compilation
 type State struct {
 	model       Model
 	field       Field
 	fieldValues map[Field][]FieldValue
 	macros      MacroEvaluatorGetter
-	regexpCache StateRegexpCache
 	registers   []Register
 }
 


### PR DESCRIPTION
to make sure we compile the regexp once per program (and not once per expression or even per eval cycle)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
