### PR TITLE
add CNM direct send config

### DIFF
--- a/cmd/system-probe/modules/network_tracer_windows.go
+++ b/cmd/system-probe/modules/network_tracer_windows.go
@@ -9,6 +9,7 @@ package modules
 
 import (
 	"time"
+	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"

--- a/cmd/system-probe/modules/network_tracer_windows.go
+++ b/cmd/system-probe/modules/network_tracer_windows.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/messagestrings"
 )
@@ -25,6 +26,14 @@ var NetworkTracer = &module.Factory{
 	Fn:               createNetworkTracerModule,
 }
 
-func inactivityEventLog(duration time.Duration) {
-	winutil.LogEventViewer(config.ServiceName, messagestrings.MSG_SYSPROBE_RESTART_INACTIVITY, duration.String())
+func (nt *networkTracer) platformRegister(httpMux *module.Router) error {
+	if !nt.cfg.DirectSend {
+		nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
+			log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)
+			winutil.LogEventViewer(config.ServiceName, messagestrings.MSG_SYSPROBE_RESTART_INACTIVITY, inactivityRestartDuration.String())
+			nt.Close()
+			os.Exit(1)
+		})
+	}
+	return nil
 }

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -404,6 +404,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 
 	initCWSSystemProbeConfig(cfg)
 	initUSMSystemProbeConfig(cfg)
+
+	cfg.BindEnvAndSetDefault(join(netNS, "direct_send"), false)
 }
 
 func join(pieces ...string) string {

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -206,6 +206,10 @@ type Config struct {
 
 	// CertCollectionMapCleanerInterval is the interval between eBPF map cleaning for TLS cert collection
 	CertCollectionMapCleanerInterval time.Duration
+
+	// DirectSend controls whether we send payloads directly from system-probe or they are queried from process-agent.
+	// Not supported on Windows
+	DirectSend bool
 }
 
 // New creates a config for the network tracer
@@ -287,6 +291,8 @@ func New() *Config {
 
 		EnableCertCollection:             cfg.GetBool(sysconfig.FullKeyPath(netNS, "enable_cert_collection")),
 		CertCollectionMapCleanerInterval: cfg.GetDuration(sysconfig.FullKeyPath(netNS, "cert_collection_map_cleaner_interval")),
+
+		DirectSend: cfg.GetBool(sysconfig.FullKeyPath(netNS, "direct_send")),
 	}
 
 	if !c.CollectTCPv4Conns {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -39,7 +39,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel/headers"
 	netnsutil "github.com/DataDog/datadog-agent/pkg/util/kernel/netns"
@@ -883,20 +882,6 @@ func newUSMMonitor(c *config.Config, tracer connection.Tracer, statsd statsd.Cli
 	}
 
 	return monitor
-}
-
-// GetNetworkID retrieves the vpc_id (network_id) from IMDS
-func (t *Tracer) GetNetworkID(context context.Context) (string, error) {
-	id := ""
-	err := netnsutil.WithRootNS(kernel.ProcFSRoot(), func() error {
-		var err error
-		id, err = ec2.GetNetworkID(context)
-		return err
-	})
-	if err != nil {
-		return "", err
-	}
-	return id, nil
 }
 
 const connProtoTTL = 3 * time.Minute

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -325,11 +325,6 @@ func (t *Tracer) DebugDumpProcessCache(_ context.Context) (interface{}, error) {
 	return nil, ebpf.ErrNotImplemented
 }
 
-// GetNetworkID is not implemented on this OS for Tracer
-func (t *Tracer) GetNetworkID(_ context.Context) (string, error) {
-	return "", ebpf.ErrNotImplemented
-}
-
 func newUSMMonitor(c *config.Config, dh driver.Handle) usm.Monitor {
 	if !c.EnableHTTPMonitoring && !c.EnableNativeTLSMonitoring {
 		return nil

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -6,7 +6,6 @@
 package checks
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -27,13 +26,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
 	netEncoding "github.com/DataDog/datadog-agent/pkg/network/encoding/unmarshal"
 	"github.com/DataDog/datadog-agent/pkg/process/metadata/parser"
-	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/process/net/resolver"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
-	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	hostinfoutils "github.com/DataDog/datadog-agent/pkg/util/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -620,21 +617,4 @@ func retryGetNetworkID(sysProbeClient *http.Client) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("failed to get network ID after %d attempts: %w", maxRetries, err)
-}
-
-// getNetworkID fetches network_id from the current netNS or from the system probe if necessary, where the root netNS is used
-func getNetworkID(sysProbeClient *http.Client) (string, error) {
-	networkID, err := network.GetNetworkID(context.Background())
-	if err != nil {
-		if sysProbeClient == nil {
-			return "", fmt.Errorf("no network ID detected and system-probe client not available: %w", err)
-		}
-		log.Debugf("no network ID detected. retrying via system-probe: %s", err)
-		networkID, err = net.GetNetworkID(sysProbeClient)
-		if err != nil {
-			log.Debugf("failed to get network ID from system-probe: %s", err)
-			return "", fmt.Errorf("failed to get network ID from system-probe: %w", err)
-		}
-	}
-	return networkID, err
 }

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -142,7 +142,7 @@ func (c *ConnectionsCheck) IsEnabled() bool {
 	}
 
 	_, npmModuleEnabled := c.syscfg.EnabledModules[sysconfig.NetworkTracerModule]
-	return npmModuleEnabled && c.syscfg.Enabled
+	return npmModuleEnabled && c.syscfg.Enabled && !c.sysprobeYamlConfig.GetBool("network_config.direct_send")
 }
 
 // SupportsRunOptions returns true if the check supports RunOptions

--- a/pkg/process/checks/net_linux.go
+++ b/pkg/process/checks/net_linux.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package checks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/process/net"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// getNetworkID fetches network_id from the current netNS or from the system probe if necessary, where the root netNS is used
+func getNetworkID(sysProbeClient *http.Client) (string, error) {
+	networkID, err := network.GetNetworkID(context.Background())
+	if err != nil {
+		if sysProbeClient == nil {
+			return "", fmt.Errorf("no network ID detected and system-probe client not available: %w", err)
+		}
+		log.Debugf("no network ID detected. retrying via system-probe: %s", err)
+		networkID, err = net.GetNetworkID(sysProbeClient)
+		if err != nil {
+			log.Debugf("failed to get network ID from system-probe: %s", err)
+			return "", fmt.Errorf("failed to get network ID from system-probe: %w", err)
+		}
+	}
+	return networkID, err
+}

--- a/pkg/process/checks/net_unsupported.go
+++ b/pkg/process/checks/net_unsupported.go
@@ -9,7 +9,7 @@ package checks
 
 import (
 	"errors"
-	"http"
+	"net/http"
 )
 
 // getNetworkID fetches network_id

--- a/pkg/process/checks/net_unsupported.go
+++ b/pkg/process/checks/net_unsupported.go
@@ -3,11 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package net
+//go:build !linux && !windows
 
-import "net/http"
+package checks
 
-// GetNetworkID is not implemented on windows
-func GetNetworkID(_ *http.Client) (string, error) {
-	return "", nil
+import (
+	"errors"
+	"http"
+)
+
+// getNetworkID fetches network_id
+func getNetworkID(_ *http.Client) (string, error) {
+	return "", errors.New("unsupported on this platform")
 }

--- a/pkg/process/checks/net_windows.go
+++ b/pkg/process/checks/net_windows.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package checks
+
+import (
+	"context"
+	"http"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
+)
+
+// getNetworkID fetches network_id
+func getNetworkID(_ *http.Client) (string, error) {
+	return network.GetNetworkID(context.Background())
+}

--- a/pkg/process/checks/net_windows.go
+++ b/pkg/process/checks/net_windows.go
@@ -7,7 +7,7 @@ package checks
 
 import (
 	"context"
-	"http"
+	"net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 )

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -63,30 +63,3 @@ func GetProcStats(client *http.Client, pids []int32) (*model.ProcStatsWithPermBy
 
 	return results, nil
 }
-
-// GetNetworkID fetches the network_id (vpc_id) from system-probe
-func GetNetworkID(client *http.Client) (string, error) {
-	url := sysprobeclient.ModuleURL(sysconfig.NetworkTracerModule, "/network_id")
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Accept", "text/plain")
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("network ID request failed: url: %s, status code: %d", req.URL, resp.StatusCode)
-	}
-
-	body, err := sysprobeclient.ReadAllResponseBody(resp)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	return string(body), nil
-}

--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package net
+
+import (
+	"fmt"
+	"net/http"
+
+	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
+	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
+)
+
+// GetNetworkID fetches the network_id (vpc_id) from system-probe
+func GetNetworkID(client *http.Client) (string, error) {
+	url := sysprobeclient.ModuleURL(sysconfig.NetworkTracerModule, "/network_id")
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "text/plain")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("network ID request failed: url: %s, status code: %d", req.URL, resp.StatusCode)
+	}
+
+	body, err := sysprobeclient.ReadAllResponseBody(resp)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return string(body), nil
+}

--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -18,8 +18,3 @@ import (
 func GetProcStats(_ *http.Client, _ []int32) (*model.ProcStatsWithPermByPID, error) {
 	return nil, errors.New("unsupported platform")
 }
-
-// GetNetworkID fetches the network_id (vpc_id) from system-probe
-func GetNetworkID(_ *http.Client) (string, error) {
-	return "", errors.New("unsupported platform")
-}

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package net
+
+import "net/http"
+
+func GetNetworkID(_ *http.Client) (string, error) {
+	return "", nil
+}

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -7,6 +7,7 @@ package net
 
 import "net/http"
 
+// GetNetworkID is not implemented on windows
 func GetNetworkID(_ *http.Client) (string, error) {
 	return "", nil
 }

--- a/pkg/system-probe/config/adjust_npm.go
+++ b/pkg/system-probe/config/adjust_npm.go
@@ -53,6 +53,11 @@ func adjustNetwork(cfg model.Config) {
 			}
 			return nil
 		})
+
+		if cfg.GetBool(netNS("direct_send")) {
+			log.Warn("disabling direct send because this feature is not supported on windows")
+			cfg.Set(netNS("direct_send"), false, model.SourceAgentRuntime)
+		}
 	}
 
 	validateInt64(cfg, spNS("max_tracked_connections"), defaultMaxTrackedConnections, func(v int64) error {


### PR DESCRIPTION
### What does this PR do?

Adds a config key `network_config.direct_send` that controls if CNM/USM in system-probe will try and send data directly to the backend. It defaults to `false` and the `true` value currently doesn't function.

### Motivation

Adding scaffolding in support of work to support system-probe direct send.

### Describe how you validated your changes

Existing tests.

### Additional Notes
