### PR TITLE
dyninst/module: reorder shutdown a tad

### DIFF
--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -165,12 +165,6 @@ func (c *realDependencies) asDependencies() dependencies {
 }
 
 func (c *realDependencies) shutdown() {
-	if c.logUploader != nil {
-		c.logUploader.Stop()
-	}
-	if c.diagsUploader != nil {
-		c.diagsUploader.Stop()
-	}
 	if c.actuator != nil {
 		if err := c.actuator.Shutdown(); err != nil {
 			log.Warnf("error shutting down actuator: %v", err)
@@ -183,6 +177,12 @@ func (c *realDependencies) shutdown() {
 	}
 	if c.loader != nil {
 		c.loader.Close()
+	}
+	if c.logUploader != nil {
+		c.logUploader.Stop()
+	}
+	if c.diagsUploader != nil {
+		c.diagsUploader.Stop()
 	}
 	if c.symdbManager != nil {
 		c.symdbManager.stop()


### PR DESCRIPTION
### What does this PR do?

Shuts down the uploaders after we stop using them.

### Motivation

I didn't like seeing:

```
w 04:16:41.279027655 @/git/datadog-agent/pkg/dyninst/uploader/logs.go:155| closing a tagged uploader (logs:1) that is not in the factory: metadata={tags: "", entityID: "", containerID: ""}
```

Perhaps a better change would be to, well, notice that the factory is shut down and not emit such a warning, but it doesn't quite seem worth it.

### Describe how you validated your changes

Noticed improvements in the test output.
