### PR TITLE
Enable `FF_USE_WINDOWS_JOB_OBJECT` for proper 🪟 process cleanup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -234,6 +234,7 @@ variables:
   FF_KUBERNETES_HONOR_ENTRYPOINT: true # Honor the entrypoint in the Docker image when running Kubernetes jobs
   FF_TIMESTAMPS: true
   FF_USE_FASTZIP: true
+  FF_USE_WINDOWS_JOB_OBJECT: true # Prevent orphaned processes from holding file handles, see https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4525
   CACHE_COMPRESSION_LEVEL: slowest
   # Force python to print to stdout immediately, otherwise gitlab sections might not be displayed properly and we can miss some logs
   PYTHONUNBUFFERED: 1


### PR DESCRIPTION
### What does this PR do?
Enable the `FF_USE_WINDOWS_JOB_OBJECT` GitLab Runner feature flag to ensure proper process cleanup on Windows CI runners.

### Motivation
We've been experiencing recurring issues with file handles remaining locked on Windows runners, preventing subsequent CI runs from succeeding:
- `cannot access the file 'test_output.json' because it is being used by another process` (eg, https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1250481964)
- `com.google.devtools.build.lib.vfs.FileAccessException: c:[...] (Permission denied)` (eg, https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1251781553)
- `failed to remove test_output.json: Invalid argument` (eg, https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1250481964)
- `remove C:/ProgramData/Datadog/logs/agent.log: permission denied` (eg, https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1245592301)
- `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process` (eg, https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1233096474)

These errors strongly suggest that background processes from previous CI runs are not being properly terminated, leaving file handles open and preventing new jobs from accessing those files.

### Additional Notes
With `FF_USE_WINDOWS_JOB_OBJECT: true`, all child processes created during a CI job are tracked by a job-scoped collector, and when the CI job completes (successfully or not), the entire process tree is terminated atomically.

This feature is available in GitLab Runner 16.9 and later, and seems even [advised](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/3121#note_1746342459):
> We believe this will reliably cause spawned processes to be killed.
> If people find that this change improves the situation and doesn't cause other problems, it could become the default in a future release.

Issue: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/3121
Fix: https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4525