### PR TITLE
dyninst: use a fake test dir for the tombstones

### DIFF
--- a/pkg/dyninst/circuit_breaker_test.go
+++ b/pkg/dyninst/circuit_breaker_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/module"
@@ -22,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCircuitBreaker(t *testing.T) {
@@ -60,6 +61,7 @@ func testCircuitBreaker(
 		AllProbesCPULimit: 0.5,
 		InterruptOverhead: 5 * time.Microsecond,
 	}
+	cfg.ProbeTombstoneFilePath = filepath.Join(tempDir, "tombstone.json")
 	var sendUpdate fakeProcessSubscriber
 	cfg.TestingKnobs.ProcessSubscriberOverride = func(
 		real module.ProcessSubscriber,

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -155,6 +155,7 @@ func testDyninst(
 	cfg.TestingKnobs.IRGeneratorOverride = func(g module.IRGenerator) module.IRGenerator {
 		return &outputSavingIRGenerator{irGenerator: g, t: t, output: irDump}
 	}
+	cfg.ProbeTombstoneFilePath = filepath.Join(tempDir, "tombstone.json")
 	m, err := module.NewModule(cfg, nil)
 	require.NoError(t, err)
 	t.Cleanup(m.Close)

--- a/pkg/dyninst/module/tombstone/tombstone.go
+++ b/pkg/dyninst/module/tombstone/tombstone.go
@@ -166,7 +166,7 @@ func WaitOutTombstone(ctx context.Context, tombstoneFilePath string, knobs ...Wa
 	}
 
 	if remainingWait > 0 {
-		log.Warnf("tombstone file detected (previous errors: %d), waiting %s before installing probes", contents.ErrorNumber, remainingWait)
+		log.Warnf("tombstone file detected (previous errors: %d), waiting %s before installing probes: %s", contents.ErrorNumber, remainingWait, tombstoneFilePath)
 		if onSleep != nil {
 			onSleep()
 		}
@@ -177,7 +177,7 @@ func WaitOutTombstone(ctx context.Context, tombstoneFilePath string, knobs ...Wa
 			return
 		}
 	} else {
-		log.Infof("tombstone file detected (previous errors: %d), backoff period already elapsed", contents.ErrorNumber)
+		log.Infof("tombstone file detected (previous errors: %d), backoff period already elapsed: %s", contents.ErrorNumber, tombstoneFilePath)
 	}
 
 	// Increment error number and update timestamp. If we crash again, we'll


### PR DESCRIPTION
### What does this PR do?

Uses a per-test tombstone file instead of just a raw one in tempdir. Also logs the path of the tombstone when waiting.

### Motivation
I was seeing some waiting in some tests when run with a count of more than 1.

### Describe how you validated your changes
Didn't see it.

