### PR TITLE
`new-e2e-npm-eks`: reduce `Test00FakeIntakeNPM` variability

### DIFF
--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -436,6 +436,7 @@ func (fi *Server) handleDatadogPostRequest(w http.ResponseWriter, req *http.Requ
 		writeHTTPResponse(w, response)
 		return nil
 	}
+	collectTime := fi.clock.Now().UTC() // record before I/O to cut down on variability
 	payload, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Printf("Error reading body: %v", err.Error())
@@ -456,7 +457,7 @@ func (fi *Server) handleDatadogPostRequest(w http.ResponseWriter, req *http.Requ
 	contentType := req.Header.Get("Content-Type")
 
 	apiKey := fi.extractDatadogAPIKey(req)
-	err = fi.store.AppendPayload(req.URL.Path, apiKey, payload, encoding, contentType, fi.clock.Now().UTC())
+	err = fi.store.AppendPayload(req.URL.Path, apiKey, payload, encoding, contentType, collectTime)
 	if err != nil {
 		log.Printf("Error adding payload to store: %v", err)
 		response := buildErrorResponse(err)


### PR DESCRIPTION
### What does this PR do?
Moves determination of collection timestamp in fakeintake to before `io.ReadAll` in an attempt to reduce collection interval variability.

### Motivation
The `Test00FakeIntakeNPM` test intermittently fails ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1251598009)) when checking that NPM connection payloads arrive at ~30 second intervals:
```
    common_1host.go:99: hostname+networkID diff time 32.276405 seconds
    common_1host.go:102:
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/npm/common_1host.go:102
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e/suite.go:234
        	            				/usr/local/go/src/runtime/asm_amd64.s:1700
        	Error:      	"1" is not greater than "2.2764053120000014"
        	Test:       	TestEKSVMSuite/Test00FakeIntakeNPM
        	Messages:   	delta between collection is higher than 1s
```

The collection timestamp was determined after I/O operations:
- `io.ReadAll(req.Body)`: reads entire HTTP body, duration varies with payload size, network conditions, TCP buffering,
- `forwardRequestToDDDev`: makes another HTTP request with, when enabled, even more uncertainty.

While these operations are unlikely to be the only culprit for the test failure, they are a contributing factor to the variability in collection intervals.
By determining the collection timestamp before these operations, the change aims at reducing the variability on a best-effort basis.