### PR TITLE
Reduce the default sample size in each dogstatsd server worker

### DIFF
--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -18,7 +18,7 @@ var (
 	// defaultSampleSize is the default allocation size used to store
 	// samples when a message contains multiple values. This will
 	// automatically be extended if needed when we append to it.
-	defaultSampleSize = 1024
+	defaultSampleSize = 128
 )
 
 type worker struct {


### PR DESCRIPTION
### What does this PR do?

Each server worker allocates a growable space in which to parse
    packets. This was introduced to accommodate multi-value metrics,
    avoiding GC churn when multi-value metrics cause a single packet to
    expand into many MetricSamples. However in practice the use of
    multi-value metrics does not reach the provisioned space reserved
    here, consuming ~0.25MiB per worker.

Expectation is that this will save ~1MiB from the quality_gate_idle workload.

### Motivation

See https://app.datadoghq.com/notebook/13499986/brian-nov-21-2025-15-25

