### PR TITLE
usm: native-tls: Fix a leak

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -361,14 +361,10 @@ int BPF_BYPASSABLE_UPROBE(uprobe__SSL_shutdown, void *ssl_ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/SSL_shutdown: pid_tgid=%llx ctx=%p", pid_tgid, ssl_ctx);
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_ctx, pid_tgid);
-    if (t == NULL) {
-        return 0;
-    }
-
-    // tls_finish can launch a tail call, thus cleanup should be done before.
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_ctx);
-    tls_finish(ctx, t, false);
-
+    if (t != NULL) {
+        tls_finish(ctx, t, false);
+    }
     return 0;
 }
 
@@ -526,13 +522,11 @@ static __always_inline void gnutls_goodbye(struct pt_regs *ctx, void *ssl_sessio
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("gnutls_goodbye: pid=%llu ctx=%p", pid_tgid, ssl_session);
     conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
-    if (t == NULL) {
-        return;
-    }
-
     // tls_finish can launch a tail call, thus cleanup should be done before.
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_session);
-    tls_finish(ctx, t, false);
+    if (t != NULL) {
+        tls_finish(ctx, t, false);
+    }
 }
 
 // int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)


### PR DESCRIPTION
### What does this PR do?

Fixes a memory leak in the native-TLS eBPF code by moving the map cleanup to happen before the null check of the connection tuple.

### Motivation

Previously, when `tup_from_ssl_ctx` returned NULL, we would return early without cleaning up the `ssl_sock_by_ctx` map entry. This caused a leak where the SSL context entries would remain in the map even though they were no longer needed.

By moving the `bpf_map_delete_elem` call before the null check, we ensure the map entry is always cleaned up regardless of whether the tuple lookup succeeds.

### Describe how you validated your changes


### Additional Notes
