### PR TITLE
[USMON-1491] Add pid_tgid to ssl_sock_by_ctx map key

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/types.h
+++ b/pkg/network/ebpf/c/protocols/http/types.h
@@ -57,6 +57,12 @@ typedef struct {
 } http_event_t;
 
 // OpenSSL types
+
+typedef struct {
+    __u64 pid_tgid;
+    void *ctx;
+} ssl_ctx_pid_tgid_t;
+
 typedef struct {
     void *ctx;
     void *buf;

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -65,24 +65,24 @@ update_stack:
 
 /*
  * Processes decrypted TLS traffic and dispatches it to appropriate protocol handlers.
- * 
+ *
  * This function is called by various TLS hookpoints (OpenSSL, GnuTLS, GoTLS, JavaTLS)
  * to process decrypted TLS payloads. It manages the protocol stack for each connection,
  * classifies the decrypted payload if the application protocol is not yet known, and
  * dispatches the traffic to the appropriate protocol handler via tail calls.
- * 
+ *
  * The function first creates or retrieves a protocol stack for the connection. If the
  * application protocol is unknown, it attempts to classify the payload. For Kafka traffic,
  * an additional classification step may be performed via a tail call if Kafka monitoring
  * is enabled.
- * 
+ *
  * For each supported protocol, the function performs a tail call to a dedicated handler:
  * - HTTP: PROG_HTTP
  * - HTTP2: PROG_HTTP2_HANDLE_FIRST_FRAME
  * - Kafka: PROG_KAFKA
  * - PostgreSQL: PROG_POSTGRES
  * - Redis: PROG_REDIS
- * 
+ *
  * The function takes the BPF program context, connection metadata (tuple), a pointer to
  * the decrypted payload and its length, and connection metadata tags as input.
  */
@@ -269,7 +269,11 @@ static __always_inline void tls_finish(struct pt_regs *ctx, conn_tuple_t *t, boo
 }
 
 static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgid) {
-    ssl_sock_t *ssl_sock = bpf_map_lookup_elem(&ssl_sock_by_ctx, &ssl_ctx);
+    ssl_ctx_pid_tgid_t key = {
+        .pid_tgid = pid_tgid,
+        .ctx = ssl_ctx,
+    };
+    ssl_sock_t *ssl_sock = bpf_map_lookup_elem(&ssl_sock_by_ctx, &key);
     if (ssl_sock == NULL) {
         // Best-effort fallback mechanism to guess the socket address without
         // intercepting the SSL socket initialization. This improves the the quality
@@ -306,9 +310,15 @@ static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgi
 }
 
 static __always_inline void init_ssl_sock(void *ssl_ctx, u32 socket_fd) {
-    ssl_sock_t ssl_sock = { 0 };
-    ssl_sock.fd = socket_fd;
-    bpf_map_update_with_telemetry(ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
+    ssl_sock_t ssl_sock = {
+        .fd = socket_fd,
+    };
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    ssl_ctx_pid_tgid_t key = {
+        .pid_tgid = pid_tgid,
+        .ctx = ssl_ctx,
+    };
+    bpf_map_update_with_telemetry(ssl_sock_by_ctx, &key, &ssl_sock, BPF_ANY);
 }
 
 static __always_inline void map_ssl_ctx_to_sock(struct sock *skp) {
@@ -326,7 +336,11 @@ static __always_inline void map_ssl_ctx_to_sock(struct sock *skp) {
 
     // copy map value to stack. required for older kernels
     void *ssl_ctx = *ssl_ctx_map_val;
-    bpf_map_update_with_telemetry(ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
+    ssl_ctx_pid_tgid_t key = {
+        .pid_tgid = pid_tgid,
+        .ctx = ssl_ctx,
+    };
+    bpf_map_update_with_telemetry(ssl_sock_by_ctx, &key, &ssl_sock, BPF_ANY);
     bpf_map_update_with_telemetry(ssl_ctx_by_tuple, &ssl_sock.tup, &ssl_ctx, BPF_ANY);
 }
 

--- a/pkg/network/ebpf/c/protocols/tls/native-tls-maps.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls-maps.h
@@ -3,7 +3,7 @@
 
 #include "map-defs.h"
 
-BPF_HASH_MAP(ssl_sock_by_ctx, void *, ssl_sock_t, 1)
+BPF_HASH_MAP(ssl_sock_by_ctx, ssl_ctx_pid_tgid_t, ssl_sock_t, 1)
 
 BPF_HASH_MAP(ssl_ctx_by_tuple, conn_tuple_t, void *, 1)
 

--- a/pkg/network/protocols/http/types.go
+++ b/pkg/network/protocols/http/types.go
@@ -14,6 +14,7 @@ package http
 import "C"
 
 type ConnTuple = C.conn_tuple_t
+type SSLCtxPidTGID C.ssl_ctx_pid_tgid_t
 type SslSock C.ssl_sock_t
 type SslReadArgs C.ssl_read_args_t
 type SslReadExArgs C.ssl_read_ex_args_t

--- a/pkg/network/protocols/http/types_linux.go
+++ b/pkg/network/protocols/http/types_linux.go
@@ -14,6 +14,10 @@ type ConnTuple = struct {
 	Pid      uint32
 	Metadata uint32
 }
+type SSLCtxPidTGID struct {
+	Tgid uint64
+	Ctx  uint64
+}
 type SslSock struct {
 	Tup       ConnTuple
 	Fd        uint32

--- a/pkg/network/protocols/http/types_linux_test.go
+++ b/pkg/network/protocols/http/types_linux_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 )
 
+func TestCgoAlignment_SSLCtxPidTGID(t *testing.T) {
+	ebpftest.TestCgoAlignment[SSLCtxPidTGID](t)
+}
+
 func TestCgoAlignment_SslSock(t *testing.T) {
 	ebpftest.TestCgoAlignment[SslSock](t)
 }


### PR DESCRIPTION
### What does this PR do?

Modifies the `ssl_sock_by_ctx` eBPF map to use a composite key containing both `pid_tgid` and SSL context pointer, instead of just the context pointer. This prevents key conflicts in multi-process scenarios where different processes might reuse the same SSL context pointer addresses.

### Motivation

When multiple processes use native TLS libraries (OpenSSL/GnuTLS), the same virtual address can be used for SSL context pointers across different processes. Using only the context pointer as the map key causes collisions where one process's connection data overwrites another's, leading to:
- Incorrect connection tracking
- Memory leaks in cleanup paths
- Connection tuple mismatches

By including `pid_tgid` in the key, each process's SSL contexts are properly isolated.

### Describe how you validated your changes

- Updated all eBPF map operations (lookup, insert, delete) to use the new `ssl_ctx_pid_tgid_t` composite key structure
- Added C struct type definition and corresponding Go type with alignment test
- Adjusted cleanup logic in `tcp_close`, `SSL_shutdown`, and `gnutls_goodbye` to use the new key format
- Fixed cleanup ordering in shutdown paths to prevent tail call issues before map cleanup
- Verified map dumping code uses the correct key type

### Additional Notes

This change also addresses a cleanup ordering issue where `tls_finish` could perform tail calls before map cleanup completed, potentially causing cleanup operations to be skipped.