### PR TITLE
DSMON-1152: Partially revert RunOnce implementation

### DIFF
--- a/comp/collector/collector/collectorimpl/collector_demux_test.go
+++ b/comp/collector/collector/collectorimpl/collector_demux_test.go
@@ -256,7 +256,6 @@ type cancelledCheck struct {
 	demux demultiplexer.FakeSamplerMock
 }
 
-func (c *cancelledCheck) RunOnce() bool { return false }
 func (c *cancelledCheck) Run() error {
 	c.flip <- struct{}{}
 

--- a/comp/collector/collector/collectorimpl/collector_test.go
+++ b/comp/collector/collector/collectorimpl/collector_test.go
@@ -48,7 +48,6 @@ func (c *TestCheck) Stop()                   { c.stop <- true }
 func (c *TestCheck) Cancel()                 { c.Called() }
 func (c *TestCheck) Interval() time.Duration { return 1 * time.Minute }
 func (c *TestCheck) Run() error              { <-c.stop; return nil }
-func (c *TestCheck) RunOnce() bool           { return false }
 func (c *TestCheck) ID() checkid.ID {
 	if c.uniqueID != "" {
 		return c.uniqueID

--- a/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go
+++ b/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go
@@ -160,8 +160,3 @@ func (c *CheckWrapper) GetDiagnoses() ([]diagnose.Diagnosis, error) {
 func (c *CheckWrapper) IsHASupported() bool {
 	return c.inner.IsHASupported()
 }
-
-// RunOnce returns true if the inner check should run only once
-func (c *CheckWrapper) RunOnce() bool {
-	return c.inner.RunOnce()
-}

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
@@ -7,6 +7,7 @@
 package datastreams
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -145,17 +146,20 @@ func (c *actionsController) update(updates map[string]state.RawConfig, applyStat
 		}
 
 		var actionsMap map[string]any
-		if err := json.Unmarshal(parsed.actionsJSON, &actionsMap); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(parsed.actionsJSON))
+		decoder.UseNumber()
+		if err := decoder.Decode(&actionsMap); err != nil {
 			log.Errorf("Failed to unmarshal actions JSON for config %s: %v", parsed.path, err)
 			applyStateCallback(parsed.path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
 			continue
 		}
 
-		actionsMap["run_once"] = true
-		actionsMap["remote_config_id"] = parsed.remoteConfigID
+		// Copy auth fields first
 		for k, v := range auth {
 			actionsMap[k] = v
 		}
+		actionsMap["run_once"] = true
+		actionsMap["remote_config_id"] = parsed.remoteConfigID
 
 		payload, err := yaml.Marshal(actionsMap)
 		if err != nil {

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
@@ -130,7 +130,6 @@ func TestActionsController(t *testing.T) {
 	assert.Equal(t, "pass", instance["sasl_plain_password"])
 	assert.Equal(t, "SASL_SSL", instance["security_protocol"])
 
-	// Check that run_once was injected
 	assert.Equal(t, true, instance["run_once"])
 
 	// Check that remote_config_id was injected

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -56,8 +56,6 @@ type Check interface {
 	GetDiagnoses() ([]diagnose.Diagnosis, error)
 	// IsHASupported returns if the check is compatible with High Availability
 	IsHASupported() bool
-	// RunOnce returns true if the check should be descheduled after its first run
-	RunOnce() bool
 }
 
 // Info is an interface to pull information from types capable to run checks. This is a subsection from the Check

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -291,8 +291,3 @@ func (c *CheckBase) GetDiagnoses() ([]diagnose.Diagnosis, error) {
 func (c *CheckBase) IsHASupported() bool {
 	return false
 }
-
-// RunOnce returns false by default (checks run repeatedly)
-func (c *CheckBase) RunOnce() bool {
-	return false
-}

--- a/pkg/collector/corechecks/embed/apm/apm.go
+++ b/pkg/collector/corechecks/embed/apm/apm.go
@@ -259,11 +259,6 @@ func (c *APMCheck) IsHASupported() bool {
 	return false
 }
 
-// RunOnce returns false
-func (c *APMCheck) RunOnce() bool {
-	return false
-}
-
 // Factory creates a new check factory
 func Factory() option.Option[func() check.Check] {
 	return option.New(newCheck)

--- a/pkg/collector/corechecks/embed/process/process_agent.go
+++ b/pkg/collector/corechecks/embed/process/process_agent.go
@@ -253,11 +253,6 @@ func (c *ProcessAgentCheck) IsHASupported() bool {
 	return false
 }
 
-// RunOnce returns false
-func (c *ProcessAgentCheck) RunOnce() bool {
-	return false
-}
-
 // Factory creates a new check factory
 func Factory() option.Option[func() check.Check] {
 	return option.New(newCheck)

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -23,8 +23,6 @@ type TestCheck struct {
 	stub.StubCheck
 }
 
-func (c *TestCheck) RunOnce() bool { return false }
-
 func (c *TestCheck) Configure(_ sender.SenderManager, _ uint64, data integration.Data, _ integration.Data, _ string) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")

--- a/pkg/collector/corechecks/longrunning_test.go
+++ b/pkg/collector/corechecks/longrunning_test.go
@@ -31,8 +31,6 @@ type mockLongRunningCheck struct {
 	runningCh chan struct{}
 }
 
-func (m *mockLongRunningCheck) RunOnce() bool { return false }
-
 func (m *mockLongRunningCheck) Stop() {
 	m.Called()
 }

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -65,7 +65,6 @@ type PythonCheck struct {
 	instanceConfig string
 	haSupported    bool
 	cancelled      bool
-	runOnce        bool
 }
 
 // NewPythonCheck conveniently creates a PythonCheck instance
@@ -272,17 +271,21 @@ func (c *PythonCheck) Configure(_senderManager sender.SenderManager, integration
 		return err
 	}
 
+	var runOnce bool
 	var rawInst integration.RawMap
 	if err := yaml.Unmarshal(data, &rawInst); err == nil {
 		if v, ok := rawInst["run_once"]; ok {
 			if b, okb := v.(bool); okb && b {
-				c.runOnce = true
+				runOnce = true
 			}
 		}
 	}
 
 	// See if a collection interval was specified
-	if commonOptions.MinCollectionInterval > 0 {
+	if runOnce {
+		// Set interval to 0 for immediate one-shot execution
+		c.interval = 0
+	} else if commonOptions.MinCollectionInterval > 0 {
 		c.interval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
 	}
 
@@ -385,11 +388,6 @@ func (c *PythonCheck) Interval() time.Duration {
 // ID returns the ID of the check
 func (c *PythonCheck) ID() checkid.ID {
 	return c.id
-}
-
-// RunOnce returns true if this check should run only once
-func (c *PythonCheck) RunOnce() bool {
-	return c.runOnce
 }
 
 // GetDiagnoses returns the diagnoses cached in last run or diagnose explicitly

--- a/pkg/collector/runner/expvars/expvars_test.go
+++ b/pkg/collector/runner/expvars/expvars_test.go
@@ -128,7 +128,6 @@ type testCheck struct {
 }
 
 func (c *testCheck) ID() checkid.ID { return checkid.ID(c.id) }
-func (c *testCheck) RunOnce() bool  { return false }
 func (c *testCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 
 func newTestCheck(id string) *testCheck {

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -51,7 +51,6 @@ type testCheck struct {
 func (c *testCheck) ID() checkid.ID { return checkid.ID(c.id) }
 func (c *testCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 func (c *testCheck) RunCount() int  { return int(c.runCount.Load()) }
-func (c *testCheck) RunOnce() bool  { return false }
 func (c *testCheck) Stop() {
 	c.StopLock.Lock()
 	defer c.StopLock.Unlock()

--- a/pkg/collector/runner/tracker/tracker_test.go
+++ b/pkg/collector/runner/tracker/tracker_test.go
@@ -24,7 +24,6 @@ type testCheck struct {
 }
 
 func (c *testCheck) ID() checkid.ID { return checkid.ID(c.id) }
-func (c *testCheck) RunOnce() bool  { return false }
 func (c *testCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 
 func newTestCheck(id string) *testCheck {

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -210,10 +210,6 @@ func (jq *jobQueue) process(s *Scheduler) bool {
 				return false
 			}
 
-			if check.RunOnce() {
-				_ = jq.removeJob(check.ID())
-			}
-
 			select {
 			// we were able to schedule a check so we're not stuck, therefore poll the health chan
 			case <-jq.health.C:

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -6,15 +6,12 @@
 package scheduler
 
 import (
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/stub"
 )
 
@@ -25,8 +22,6 @@ type TestCheck struct {
 }
 
 func (c *TestCheck) Interval() time.Duration { return c.intl }
-
-func (c *TestCheck) RunOnce() bool { return false }
 
 var initialMinAllowedInterval = minAllowedInterval
 
@@ -202,170 +197,4 @@ func TestStopOneTimeSchedule(t *testing.T) {
 	close(s.checksPipe)
 	// sleep to make the runtime schedule the hanging goroutines, if there are any
 	time.Sleep(time.Millisecond)
-}
-
-// RunOnceTestCheck is a test check that can be configured as run-once or regular
-type RunOnceTestCheck struct {
-	stub.StubCheck
-	mu         sync.RWMutex
-	id         string
-	runOnce    bool
-	intl       time.Duration
-	runCounter int
-}
-
-func (c *RunOnceTestCheck) ID() checkid.ID { return checkid.ID(c.id) }
-func (c *RunOnceTestCheck) RunOnce() bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.runOnce
-}
-func (c *RunOnceTestCheck) Interval() time.Duration { return c.intl }
-func (c *RunOnceTestCheck) Run() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.runCounter++
-	return nil
-}
-func (c *RunOnceTestCheck) GetRunCounter() int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.runCounter
-}
-
-func TestRunOnceCheckDescheduling(t *testing.T) {
-	checkChan := make(chan check.Check, 100)
-	stop := make(chan bool)
-
-	// Track what checks are scheduled
-	scheduledChecks := make(map[checkid.ID]int)
-	var mu sync.RWMutex
-	go func() {
-		for {
-			select {
-			case chk := <-checkChan:
-				mu.Lock()
-				scheduledChecks[chk.ID()]++
-				mu.Unlock()
-			case <-stop:
-				return
-			}
-		}
-	}()
-	defer func() {
-		stop <- true
-	}()
-
-	// Helper to wait for a condition
-	waitForCondition := func(condition func() bool, timeout time.Duration, msg string) {
-		deadline := time.Now().Add(timeout)
-		for time.Now().Before(deadline) {
-			if condition() {
-				return
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-		t.Fatalf("Timeout waiting for: %s", msg)
-	}
-
-	// Helper to get scheduled count for a check
-	getScheduledCount := func(id checkid.ID) int {
-		mu.RLock()
-		defer mu.RUnlock()
-		return scheduledChecks[id]
-	}
-
-	s := NewScheduler(checkChan)
-
-	// Create a run-once check and a regular check
-	runOnceCheck := &RunOnceTestCheck{
-		id:      "run-once-check",
-		runOnce: true,
-		intl:    1 * time.Second,
-	}
-
-	regularCheck := &RunOnceTestCheck{
-		id:      "regular-check",
-		runOnce: false,
-		intl:    1 * time.Second,
-	}
-
-	// Manually create a job queue for 1 second interval and replace its ticker
-	// This must be done BEFORE calling Enter to avoid race conditions
-	jq := newJobQueue(1 * time.Second)
-	tickerChan := make(chan time.Time, 10)
-	jq.bucketTicker.Stop()
-	jq.bucketTicker = &time.Ticker{C: tickerChan}
-	s.jobQueues[1*time.Second] = jq
-
-	// Schedule both checks
-	err := s.Enter(runOnceCheck)
-	require.NoError(t, err)
-	err = s.Enter(regularCheck)
-	require.NoError(t, err)
-
-	// Start the scheduler
-	s.Run()
-
-	// Manually trigger the first tick - both checks should run
-	tickerChan <- time.Now()
-	waitForCondition(func() bool {
-		return getScheduledCount("run-once-check") == 1 && getScheduledCount("regular-check") == 1
-	}, 1*time.Second, "both checks to be scheduled once")
-
-	// Verify both checks were scheduled once
-	require.Equal(t, 1, getScheduledCount("run-once-check"), "run-once check should run exactly once")
-	require.Equal(t, 1, getScheduledCount("regular-check"), "regular check should run once so far")
-
-	// Verify run-once check was removed from the queue
-	waitForCondition(func() bool {
-		totalRunOnceJobs := 0
-		for _, bucket := range jq.buckets {
-			bucket.mu.RLock()
-			for _, job := range bucket.jobs {
-				if job.ID() == "run-once-check" {
-					totalRunOnceJobs++
-				}
-			}
-			bucket.mu.RUnlock()
-		}
-		return totalRunOnceJobs == 0
-	}, 1*time.Second, "run-once check to be removed from queue")
-
-	totalRunOnceJobs := 0
-	totalRegularJobs := 0
-	for _, bucket := range jq.buckets {
-		bucket.mu.RLock()
-		for _, job := range bucket.jobs {
-			if job.ID() == "run-once-check" {
-				totalRunOnceJobs++
-			}
-			if job.ID() == "regular-check" {
-				totalRegularJobs++
-			}
-		}
-		bucket.mu.RUnlock()
-	}
-	require.Equal(t, 0, totalRunOnceJobs, "run-once check should be removed from the queue")
-	require.Equal(t, 1, totalRegularJobs, "regular check should remain in the queue")
-
-	// Trigger another tick - only regular check should run
-	tickerChan <- time.Now()
-	waitForCondition(func() bool {
-		return getScheduledCount("regular-check") == 2
-	}, 1*time.Second, "regular check to run twice")
-
-	require.Equal(t, 1, getScheduledCount("run-once-check"), "run-once check should still be 1")
-	require.Equal(t, 2, getScheduledCount("regular-check"), "regular check should run twice")
-
-	// Trigger one more tick to be sure
-	tickerChan <- time.Now()
-	waitForCondition(func() bool {
-		return getScheduledCount("regular-check") == 3
-	}, 1*time.Second, "regular check to run three times")
-
-	require.Equal(t, 1, getScheduledCount("run-once-check"), "run-once check should still be 1")
-	require.Equal(t, 3, getScheduledCount("regular-check"), "regular check should run three times")
-
-	s.Stop()
 }

--- a/pkg/collector/worker/check_logger_test.go
+++ b/pkg/collector/worker/check_logger_test.go
@@ -27,7 +27,6 @@ type stubCheck struct {
 }
 
 func (c *stubCheck) ID() checkid.ID { return checkid.ID(c.id) }
-func (c *stubCheck) RunOnce() bool  { return false }
 func (c *stubCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 
 func newTestCheck(id string) *stubCheck {

--- a/pkg/collector/worker/worker_test.go
+++ b/pkg/collector/worker/worker_test.go
@@ -48,7 +48,6 @@ type testCheck struct {
 func (c *testCheck) ID() checkid.ID { return checkid.ID(c.id) }
 func (c *testCheck) String() string { return checkid.IDToCheckName(c.ID()) }
 func (c *testCheck) RunCount() int  { return int(c.runCount.Load()) }
-func (c *testCheck) RunOnce() bool  { return false }
 
 func (c *testCheck) Interval() time.Duration {
 	if c.longRunning {

--- a/releasenotes/notes/revert-run-once-4ede42433c566de3.yaml
+++ b/releasenotes/notes/revert-run-once-4ede42433c566de3.yaml
@@ -1,0 +1,1 @@
+other: Reverts RunOnce added in https://github.com/DataDog/datadog-agent/pull/43325 (not released)


### PR DESCRIPTION
### What does this PR do?

Refactors the `kafka_actions` one-shot check implementation to use `run_once: true` + `Interval() == 0` instead of the `RunOnce()` interface, and removes all `RunOnce()` infrastructure that was added in #43325.

**Key changes:**
* Removed `RunOnce()` method from `check.Check` interface and all implementations
* Python checks now support `run_once: true` in instance config, which sets `Interval()` to `0`
* Checks with `Interval() == 0` use existing `enqueueOnce()` for immediate execution
* Removed scheduler logic for de-scheduling `RunOnce()` checks
* Fixed numeric precision issue: use `json.Decoder.UseNumber()` to prevent scientific notation (e.g., `1e+06`) in YAML

### Motivation

After implementing #43325, I realized that the agent already had a mechanism for one-shot check execution: `Interval() == 0` triggers `enqueueOnce()` for immediate, single-run execution. The `RunOnce()` interface I added was:

1. **Redundant** - duplicated existing functionality
2. **Slower** - caused up to a 15-second delays due to bucket scheduling (checks were added to job queues instead of running immediately)
3. **More complex** - required interface changes across ~15 files

### Describe how you validated your changes

* Manually tested with local agent - verified check executes immediately and only once (no more 15-second delay)
