### PR TITLE
`new-e2e-containers-eks`: fix `nil` pointer dereference during cleanup

### DIFF
--- a/test/new-e2e/pkg/environments/kubernetes.go
+++ b/test/new-e2e/pkg/environments/kubernetes.go
@@ -230,10 +230,11 @@ func (e *Kubernetes) Coverage(outputDir string) (string, error) {
 	outStr := []string{"===== Coverage ====="}
 
 	// Process Linux pods
-	linuxPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+	if e.Agent.LinuxNodeAgent.LabelSelectors == nil {
+		outStr = append(outStr, "LinuxNodeAgent not initialized, skipping Linux pod coverage")
+	} else if linuxPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", e.Agent.LinuxNodeAgent.LabelSelectors["app"]).String(),
-	})
-	if err != nil {
+	}); err != nil {
 		outStr = append(outStr, fmt.Sprintf("Failed to list linux pods: %s", err.Error()))
 	} else {
 		if len(linuxPods.Items) >= 1 {
@@ -250,10 +251,11 @@ func (e *Kubernetes) Coverage(outputDir string) (string, error) {
 	}
 
 	// Process Windows pods
-	windowsPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+	if e.Agent.WindowsNodeAgent.LabelSelectors == nil {
+		outStr = append(outStr, "WindowsNodeAgent not initialized, skipping Windows pod coverage")
+	} else if windowsPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", e.Agent.WindowsNodeAgent.LabelSelectors["app"]).String(),
-	})
-	if err != nil {
+	}); err != nil {
 		outStr = append(outStr, fmt.Sprintf("Failed to list windows pods: %s", err.Error()))
 	} else {
 		if len(windowsPods.Items) >= 1 {
@@ -269,10 +271,11 @@ func (e *Kubernetes) Coverage(outputDir string) (string, error) {
 	}
 
 	// Process Cluster Agent pods
-	clusterAgentPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+	if e.Agent.LinuxClusterAgent.LabelSelectors == nil {
+		outStr = append(outStr, "LinuxClusterAgent not initialized, skipping Cluster Agent pod coverage")
+	} else if clusterAgentPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", e.Agent.LinuxClusterAgent.LabelSelectors["app"]).String(),
-	})
-	if err != nil {
+	}); err != nil {
 		outStr = append(outStr, fmt.Sprintf("Failed to list cluster agent pods: %s", err.Error()))
 	} else {
 		if len(clusterAgentPods.Items) >= 1 {


### PR DESCRIPTION
### What does this PR do?
Adds defensive `nil` checks for `LinuxNodeAgent`, `WindowsNodeAgent`, and `LinuxClusterAgent` before accessing their fields in the `Coverage` method, allowing each section to proceed independently.

### Motivation
The E2E test `TestEKSSuite` panicked during cleanup when environment provisioning failed:
```
runtime error: invalid memory address or nil pointer dereference
at test/new-e2e/pkg/environments/kubernetes.go:218
```
(https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1252786670#L2363)

When the test environment fails to provision (e.g., etcd deployment failure), the `Coverage` method is called during `TearDownSuite`. The existing `nil` checks covered `KubernetesCluster` and `Agent`, but not their nested components. When the code tried to access fields like `e.Agent.LinuxNodeAgent.LabelSelectors`, it dereferenced a `nil` pointer.

### Additional Notes
The fix wraps each pod type processing section (Linux, Windows, Cluster Agent) in its own `nil` check, allowing coverage collection to proceed for available components while gracefully skipping unavailable ones.

Cleanup code will gracefully skip coverage for uninitialized components while still collecting coverage from initialized ones.