### PR TITLE
`new-e2e-containers-eks`: wait for DNS before deploying `etcd` (`Kind` provisioner)

### DIFF
--- a/test/new-e2e/pkg/provisioners/aws/kubernetes/kind.go
+++ b/test/new-e2e/pkg/provisioners/aws/kubernetes/kind.go
@@ -16,6 +16,7 @@ import (
 	csidriver "github.com/DataDog/test-infra-definitions/components/datadog/csi-driver"
 	"github.com/DataDog/test-infra-definitions/components/kubernetes/argorollouts"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/DataDog/test-infra-definitions/common/utils"
@@ -283,7 +284,12 @@ func KindRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Prov
 			return err
 		}
 
-		if _, err := etcd.K8sAppDefinition(&awsEnv, kubeProvider); err != nil {
+		// Get CoreDNS Deployment to use as dependency for etcd which needs DNS
+		coreDNS, err := appsv1.GetDeployment(ctx, "coredns", pulumi.ID("kube-system/coredns"), nil, pulumi.Provider(kubeProvider))
+		if err != nil {
+			return err
+		}
+		if _, err := etcd.K8sAppDefinition(&awsEnv, kubeProvider, utils.PulumiDependsOn(coreDNS)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
### What does this PR do?
Transpose #43060 (c3576f5cbfcd53ddf92f81bcb78b9ca1b6309d5f, that applied to the `EKS` provisioner) by also adding a CoreDNS dependency to `etcd` deployment for the `Kind` provisioner.

### Motivation
The E2E job `new-e2e-containers-eks` [failed again](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1252786670) during environment provisioning when etcd started before CoreDNS was fully ready, causing two DNS failures:
1. init container: `etcd-config` container failed to download Alpine packages from dl-cdn.alpinelinux.org with "temporary error (try again later)" <= _external_ DNS resolution not working yet,
2. main container: `etcd` failed to resolve its own service name "etcd:2380" after 30 seconds <= _internal_ DNS resolution not working yet.

### Additional Notes
The `Kind` provisioner deployed `etcd` without explicit dependencies, creating a race condition with CoreDNS startup. The `EKS` provisioner was addressed in #43060, and this change therefore transposes it to the `Kind` one.