### PR TITLE
`new-e2e-otel-eks`: explicitly set cluster name (`EKS` provisioner)

### DIFF
--- a/test/new-e2e/pkg/provisioners/aws/kubernetes/eks.go
+++ b/test/new-e2e/pkg/provisioners/aws/kubernetes/eks.go
@@ -146,6 +146,9 @@ func EKSRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Provi
 			params.agentOptions = append(params.agentOptions, kubernetesagentparams.WithDeployWindows())
 		}
 
+		// Explicitly set cluster name to avoid autodiscovery race conditions
+		newOpts := []kubernetesagentparams.Option{kubernetesagentparams.WithClusterName(cluster.ClusterName)}
+		params.agentOptions = append(newOpts, params.agentOptions...)
 		kubernetesAgent, err = helm.NewKubernetesAgent(&awsEnv, "eks", cluster.KubeProvider, params.agentOptions...)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What does this PR do?
Adds explicit cluster name configuration to the `EKS` provisioner's agent deployment, matching the pattern established in #30546 (5dc2ddb15d1258f51a3f34ce400390deaac587c6) for the `Kind` provisioner.

### Motivation
The `new-e2e-otel-eks` job fails at times when the Cluster Agent can't discover the cluster name, causing it to crash with:
```
Error: Failed to start: autoscaling is enabled but no cluster name detected, exiting
```
(https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1252786735)

This leads to:
- `cluster-agent` pods entering `CrashLoopBackOff`s,
- helm release `dda-linux` timing out after 300+ seconds,
- test suite failures during environment provisioning.

The Cluster Agent attempts to auto-discover the cluster name from EC2 instance tags (specifically `kubernetes.io/cluster/<name>`). However, this auto-discovery can fail due to timing issues where:
- EC2 metadata service isn't immediately available,
- instance tags haven't propagated yet,
- transient network connectivity issues during cluster initialization.

### Additional Notes
The `Kind` provisioner already solves this by explicitly passing the cluster name via `kubernetesagentparams.WithClusterName` since #30546.
This change therefore consists in applying it to the `EKS` provisioner.