### PR TITLE
[workloadmeta/collectors/kubeapiserver] Use minimal pod representation

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -97,8 +97,9 @@ func TestStoreGenerators(t *testing.T) {
 
 func collectResultStoreGenerator(funcs []storeGenerator, config config.Reader) []*reflectorStore {
 	var stores []*reflectorStore
+	client := fakeclientset.NewClientset()
 	for _, f := range funcs {
-		_, s := f(nil, nil, config, nil)
+		_, s := f(nil, nil, config, client)
 		stores = append(stores, s)
 	}
 	return stores

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -9,10 +9,17 @@ package kubeapiserver
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
 
+	jsoniter "github.com/json-iterator/go"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/framer"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -20,10 +27,375 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	kubernetesresourceparsers "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/gpu"
+	kubeutil "github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// This reflector uses a MinimalPod struct that contains only the fields we
+// actually use from the Kubernetes pod. This is for memory optimization.
+//
+// The reflector uses the MinimalPod struct with the Kubernetes REST client
+// instead of the typed client.
+//
+// The typed client always unmarshalls the whole pod object. This includes many
+// fields that we don't use. During startup, in large clusters, this reflector
+// can sync lots of pods causing a large memory spike.
+//
+// This approach of using a minimal pod allows us unmarshal directly into
+// MinimalPod, avoiding allocations of unused fields.
+//
+// We can only use this approach when protobuf is disabled. When protobuf is
+// enabled, we fall back to the typed client approach.
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+// MinimalPod contains only the fields we actually use from a Pod. This is used
+// to reduce memory allocations during JSON unmarshalling by avoiding allocation
+// of unused fields.
+type MinimalPod struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   MinimalPodSpec   `json:"spec,omitempty"`
+	Status MinimalPodStatus `json:"status,omitempty"`
+}
+
+// MinimalPodSpec contains only the pod spec fields we need
+type MinimalPodSpec struct {
+	Containers        []MinimalContainer `json:"containers"`
+	Volumes           []MinimalVolume    `json:"volumes,omitempty"`
+	RuntimeClassName  *string            `json:"runtimeClassName,omitempty"`
+	PriorityClassName string             `json:"priorityClassName,omitempty"`
+}
+
+// MinimalContainer contains only the container fields we need
+type MinimalContainer struct {
+	Name      string                      `json:"name"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+}
+
+// MinimalVolume contains only the volume fields we need
+type MinimalVolume struct {
+	PersistentVolumeClaim *corev1.PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
+}
+
+// MinimalPodStatus contains only the pod status fields we need
+type MinimalPodStatus struct {
+	Phase      corev1.PodPhase       `json:"phase,omitempty"`
+	Conditions []corev1.PodCondition `json:"conditions,omitempty"`
+	PodIP      string                `json:"podIP,omitempty"`
+	QOSClass   corev1.PodQOSClass    `json:"qosClass,omitempty"`
+}
+
+// DeepCopyObject deep copies (required to implement kubernetes runtime.Object
+// interface)
+// Note: we can't use the deepcopy library like we're using in some parts of
+// workloadmeta because it doesn't copy unexported fields. This means it doesn't
+// work with corev1.ResourceRequirements.
+func (p *MinimalPod) DeepCopyObject() runtime.Object {
+	if p == nil {
+		return nil
+	}
+
+	out := &MinimalPod{}
+
+	// TypeMeta
+	out.TypeMeta = p.TypeMeta
+
+	// ObjectMeta
+	p.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+
+	// Spec
+	if p.Spec.Containers != nil {
+		out.Spec.Containers = make([]MinimalContainer, len(p.Spec.Containers))
+		for i := range p.Spec.Containers {
+			out.Spec.Containers[i].Name = p.Spec.Containers[i].Name
+
+			resIn := &p.Spec.Containers[i].Resources
+			resOut := &out.Spec.Containers[i].Resources
+
+			if resIn.Limits != nil {
+				resOut.Limits = make(corev1.ResourceList, len(resIn.Limits))
+				for k, v := range resIn.Limits {
+					resOut.Limits[k] = v.DeepCopy()
+				}
+			}
+			if resIn.Requests != nil {
+				resOut.Requests = make(corev1.ResourceList, len(resIn.Requests))
+				for k, v := range resIn.Requests {
+					resOut.Requests[k] = v.DeepCopy()
+				}
+			}
+			if resIn.Claims != nil {
+				resOut.Claims = make([]corev1.ResourceClaim, len(resIn.Claims))
+				for j := range resIn.Claims {
+					resIn.Claims[j].DeepCopyInto(&resOut.Claims[j])
+				}
+			}
+		}
+	}
+
+	if p.Spec.Volumes != nil {
+		out.Spec.Volumes = make([]MinimalVolume, len(p.Spec.Volumes))
+		for i := range p.Spec.Volumes {
+			if p.Spec.Volumes[i].PersistentVolumeClaim != nil {
+				out.Spec.Volumes[i].PersistentVolumeClaim =
+					p.Spec.Volumes[i].PersistentVolumeClaim.DeepCopy()
+			}
+		}
+	}
+
+	out.Spec.PriorityClassName = p.Spec.PriorityClassName
+
+	if p.Spec.RuntimeClassName != nil {
+		out.Spec.RuntimeClassName = new(string)
+		*out.Spec.RuntimeClassName = *p.Spec.RuntimeClassName
+	}
+
+	// Status
+	out.Status.Phase = p.Status.Phase
+
+	if p.Status.Conditions != nil {
+		out.Status.Conditions = make([]corev1.PodCondition, len(p.Status.Conditions))
+		for i := range p.Status.Conditions {
+			p.Status.Conditions[i].DeepCopyInto(&out.Status.Conditions[i])
+		}
+	}
+
+	out.Status.PodIP = p.Status.PodIP
+	out.Status.QOSClass = p.Status.QOSClass
+
+	return out
+}
+
+// MinimalPodList is a list of MinimalPods
+type MinimalPodList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []MinimalPod `json:"items"`
+}
+
+// DeepCopyObject deep copies (required to implement kubernetes runtime.Object interface)
+func (p *MinimalPodList) DeepCopyObject() runtime.Object {
+	if p == nil {
+		return nil
+	}
+
+	out := &MinimalPodList{}
+	out.TypeMeta = p.TypeMeta
+	p.ListMeta.DeepCopyInto(&out.ListMeta)
+
+	if p.Items != nil {
+		out.Items = make([]MinimalPod, len(p.Items))
+		for i := range p.Items {
+			out.Items[i] = *p.Items[i].DeepCopyObject().(*MinimalPod)
+		}
+	}
+
+	return out
+}
+
+type minimalPodDecoder struct {
+	reader  io.ReadCloser
+	decoder *jsoniter.Decoder
+}
+
+func newMinimalPodDecoder(body io.ReadCloser) *minimalPodDecoder {
+	return &minimalPodDecoder{
+		reader:  body,
+		decoder: json.NewDecoder(body),
+	}
+}
+
+// Decode implements watch.Decoder interface
+func (d *minimalPodDecoder) Decode() (watch.EventType, runtime.Object, error) {
+	var event metav1.WatchEvent
+	if err := d.decoder.Decode(&event); err != nil {
+		return "", nil, err
+	}
+
+	eventType := watch.EventType(event.Type)
+
+	switch eventType {
+	case watch.Added, watch.Modified, watch.Deleted, watch.Error, watch.Bookmark:
+	default:
+		return "", nil, fmt.Errorf("got invalid watch event type: %v", event.Type)
+	}
+
+	if eventType == watch.Error {
+		var status metav1.Status
+		if err := json.Unmarshal(event.Object.Raw, &status); err != nil {
+			return "", nil, fmt.Errorf("unable to decode watch event status: %v", err)
+		}
+		return eventType, &status, nil
+	}
+
+	var pod MinimalPod
+	if err := json.Unmarshal(event.Object.Raw, &pod); err != nil {
+		return "", nil, fmt.Errorf("unable to decode pod in watch event: %v", err)
+	}
+
+	return eventType, &pod, nil
+}
+
+// Close closes the underlying reader
+func (d *minimalPodDecoder) Close() {
+	d.reader.Close()
+}
+
+type minimalPodParser struct {
+	annotationsFilter []*regexp.Regexp
+}
+
+// Parse parses a MinimalPod object into a workloadmeta Pod
+// This is basically a copy of the full pod parser defined in the
+// kubernetesresourceparsers package
+func (p minimalPodParser) Parse(obj interface{}) workloadmeta.Entity {
+	pod := obj.(*MinimalPod)
+	owners := make([]workloadmeta.KubernetesPodOwner, 0, len(pod.OwnerReferences))
+	for _, o := range pod.OwnerReferences {
+		owners = append(owners, workloadmeta.KubernetesPodOwner{
+			Kind: o.Kind,
+			Name: o.Name,
+			ID:   string(o.UID),
+		})
+	}
+
+	var ready bool
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			if condition.Status == corev1.ConditionTrue {
+				ready = true
+			}
+			break
+		}
+	}
+
+	var pvcNames []string
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			pvcNames = append(pvcNames, volume.PersistentVolumeClaim.ClaimName)
+		}
+	}
+
+	var rtcName string
+	if pod.Spec.RuntimeClassName != nil {
+		rtcName = *pod.Spec.RuntimeClassName
+	}
+
+	var gpuVendorList []string
+	uniqueGPUVendor := make(map[string]struct{})
+	for _, container := range pod.Spec.Containers {
+		for resourceName := range container.Resources.Limits {
+			gpuName, found := gpu.ExtractSimpleGPUName(gpu.ResourceGPU(resourceName))
+			if found {
+				uniqueGPUVendor[gpuName] = struct{}{}
+			}
+		}
+	}
+	for gpuVendor := range uniqueGPUVendor {
+		gpuVendorList = append(gpuVendorList, gpuVendor)
+	}
+
+	containersList := make([]workloadmeta.OrchestratorContainer, 0, len(pod.Spec.Containers))
+	for _, container := range pod.Spec.Containers {
+		c := workloadmeta.OrchestratorContainer{
+			Name: container.Name,
+		}
+		if cpuReq, found := container.Resources.Requests[corev1.ResourceCPU]; found {
+			c.Resources.CPURequest = kubeutil.FormatCPURequests(cpuReq)
+		}
+		if memoryReq, found := container.Resources.Requests[corev1.ResourceMemory]; found {
+			c.Resources.MemoryRequest = kubeutil.FormatMemoryRequests(memoryReq)
+		}
+		containersList = append(containersList, c)
+	}
+
+	return &workloadmeta.KubernetesPod{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   string(pod.UID),
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:        pod.Name,
+			Namespace:   pod.Namespace,
+			Annotations: kubernetesresourceparsers.FilterMapStringKey(pod.Annotations, p.annotationsFilter),
+			Labels:      pod.Labels,
+		},
+		Phase:                      string(pod.Status.Phase),
+		Owners:                     owners,
+		PersistentVolumeClaimNames: pvcNames,
+		Ready:                      ready,
+		IP:                         pod.Status.PodIP,
+		PriorityClass:              pod.Spec.PriorityClassName,
+		QOSClass:                   string(pod.Status.QOSClass),
+		RuntimeClass:               rtcName,
+		GPUVendorList:              gpuVendorList,
+		Containers:                 containersList,
+	}
+}
+
 func newPodStore(ctx context.Context, wlm workloadmeta.Component, config config.Reader, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
+	// The REST client approach doesn't work with protobuf, so fallback to typed
+	// client.
+	if config.GetBool("kubernetes_apiserver_use_protobuf") {
+		return newPodStoreWithTypedClient(ctx, wlm, config, client)
+	}
+	return newPodStoreWithRestClient(wlm, config, client)
+}
+
+func newPodStoreWithRestClient(wlm workloadmeta.Component, config config.Reader, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
+	restClient := client.CoreV1().RESTClient()
+
+	listFunc := func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+		var podList MinimalPodList
+		err := restClient.Get().
+			Namespace(metav1.NamespaceAll).
+			Resource("pods").
+			VersionedParams(&options, metav1.ParameterCodec).
+			Do(ctx).
+			Into(&podList)
+		return &podList, err
+	}
+
+	watchFunc := func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+		options.Watch = true
+
+		resp, err := restClient.Get().
+			Namespace(metav1.NamespaceAll).
+			Resource("pods").
+			VersionedParams(&options, metav1.ParameterCodec).
+			Stream(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		framedReader := framer.NewJSONFramedReader(resp) // Needed to decode individual objects
+		decoder := newMinimalPodDecoder(framedReader)
+		errorReporter := errors.NewClientErrorReporter(http.StatusInternalServerError, "GET", "PodWatchDecoding")
+
+		return watch.NewStreamWatcher(decoder, errorReporter), nil
+	}
+
+	podListerWatcher := &cache.ListWatch{
+		ListWithContextFunc:  listFunc,
+		WatchFuncWithContext: watchFunc,
+	}
+
+	podStore := newPodReflectorStoreWithMinimalPodParser(wlm, config)
+	podReflector := cache.NewNamedReflector(
+		componentName,
+		podListerWatcher,
+		&MinimalPod{},
+		podStore,
+		noResync,
+	)
+	log.Debug("pod reflector enabled")
+	return podReflector, podStore
+}
+
+func newPodStoreWithTypedClient(ctx context.Context, wlm workloadmeta.Component, config config.Reader, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
 	podListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, options)
@@ -33,7 +405,7 @@ func newPodStore(ctx context.Context, wlm workloadmeta.Component, config config.
 		},
 	}
 
-	podStore := newPodReflectorStore(wlm, config)
+	podStore := newPodReflectorStoreWithFullPodParser(wlm, config)
 	podReflector := cache.NewNamedReflector(
 		componentName,
 		podListerWatcher,
@@ -45,7 +417,21 @@ func newPodStore(ctx context.Context, wlm workloadmeta.Component, config config.
 	return podReflector, podStore
 }
 
-func newPodReflectorStore(wlmetaStore workloadmeta.Component, config config.Reader) *reflectorStore {
+func newPodReflectorStoreWithMinimalPodParser(wlmetaStore workloadmeta.Component, config config.Reader) *reflectorStore {
+	annotationsExclude := config.GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")
+	filters, err := kubernetesresourceparsers.ParseFilters(annotationsExclude)
+	if err != nil {
+		log.Errorf("unable to parse all pod_annotations_exclude: %v", err)
+	}
+
+	return &reflectorStore{
+		wlmetaStore: wlmetaStore,
+		seen:        make(map[string]workloadmeta.EntityID),
+		parser:      minimalPodParser{annotationsFilter: filters},
+	}
+}
+
+func newPodReflectorStoreWithFullPodParser(wlmetaStore workloadmeta.Component, config config.Reader) *reflectorStore {
 	annotationsExclude := config.GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")
 	parser, err := kubernetesresourceparsers.NewPodParser(annotationsExclude)
 	if err != nil {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod_test.go
@@ -10,16 +10,27 @@ package kubeapiserver
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func Test_PodsFakeKubernetesClient(t *testing.T) {
+func Test_CollectEventsWithFullPod(t *testing.T) {
 	t.Parallel()
 	objectMeta := metav1.ObjectMeta{
 		Name:   "test-pod",
@@ -36,7 +47,7 @@ func Test_PodsFakeKubernetesClient(t *testing.T) {
 			{
 				Type: workloadmeta.EventTypeSet,
 				Entity: &workloadmeta.KubernetesPod{
-					Containers: ([]workloadmeta.OrchestratorContainer{}),
+					Containers: []workloadmeta.OrchestratorContainer{},
 					EntityID: workloadmeta.EntityID{
 						ID:   string(objectMeta.UID),
 						Kind: workloadmeta.KindKubernetesPod,
@@ -50,5 +61,191 @@ func Test_PodsFakeKubernetesClient(t *testing.T) {
 			},
 		},
 	}
-	testCollectEvent(t, createResource, newPodStore, expected)
+
+	testCollectEvent(t, createResource, newPodStoreWithTypedClient, expected)
+}
+
+func Test_CollectEventsWithMinimalPod(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{
+		Name:   "test-pod",
+		Labels: map[string]string{"test-label": "test-value"},
+		UID:    types.UID("test-pod-uid"),
+	}
+
+	overrides := map[string]interface{}{
+		"cluster_agent.collect_kubernetes_tags": true,
+	}
+
+	wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() config.Component {
+			return config.NewMockWithOverrides(t, overrides)
+		}),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	store := newPodReflectorStoreWithMinimalPodParser(wmeta, wmeta.GetConfig())
+
+	ch := wmeta.Subscribe(dummySubscriber, workloadmeta.NormalPriority, nil)
+	defer wmeta.Unsubscribe(ch)
+
+	bundleCh := make(chan workloadmeta.EventBundle, 1)
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+
+	go func() {
+		for {
+			select {
+			case bundle := <-ch:
+				bundle.Acknowledge()
+				if len(bundle.Events) > 0 {
+					bundleCh <- bundle
+					return
+				}
+			case <-doneCh:
+				return
+			}
+		}
+	}()
+
+	pod := &MinimalPod{
+		ObjectMeta: objectMeta,
+		Spec:       MinimalPodSpec{Containers: []MinimalContainer{}},
+	}
+	err := store.Add(pod)
+	require.NoError(t, err)
+
+	var bundle workloadmeta.EventBundle
+	select {
+	case bundle = <-bundleCh:
+		// Received bundle. Continue.
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+
+	expected := workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.KubernetesPod{
+					Containers: []workloadmeta.OrchestratorContainer{},
+					EntityID: workloadmeta.EntityID{
+						ID:   string(objectMeta.UID),
+						Kind: workloadmeta.KindKubernetesPod,
+					},
+					EntityMeta: workloadmeta.EntityMeta{
+						Name:      objectMeta.Name,
+						Namespace: objectMeta.Namespace,
+						Labels:    objectMeta.Labels,
+					},
+					Owners: []workloadmeta.KubernetesPodOwner{},
+				},
+			},
+		},
+	}
+
+	bundle.Ch = nil // to avoid comparing the channel
+	assert.Equal(t, expected, bundle)
+}
+
+func Test_MinimalPodDeepCopy(t *testing.T) {
+	runtimeClassName := "test-runtime"
+
+	original := &MinimalPod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-uid-12345"),
+			Labels: map[string]string{
+				"app": "test-app",
+			},
+			Annotations: map[string]string{
+				"test-annotation": "test-value",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       "test-rs",
+					UID:        types.UID("owner-uid"),
+					APIVersion: "apps/v1",
+				},
+			},
+			ResourceVersion: "12345",
+		},
+		Spec: MinimalPodSpec{
+			Containers: []MinimalContainer{
+				{
+					Name: "test-container-1",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: *resource.NewMilliQuantity(200, resource.DecimalSI),
+						},
+					},
+				},
+				{
+					Name: "test-container-2",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: *resource.NewMilliQuantity(50, resource.DecimalSI),
+						},
+					},
+				},
+			},
+			Volumes: []MinimalVolume{
+				{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "test-pvc",
+						ReadOnly:  false,
+					},
+				},
+			},
+			RuntimeClassName:  &runtimeClassName,
+			PriorityClassName: "high-priority",
+		},
+		Status: MinimalPodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			PodIP:    "10.0.0.1",
+			QOSClass: corev1.PodQOSBurstable,
+		},
+	}
+
+	copied := original.DeepCopyObject()
+
+	copiedPod, ok := copied.(*MinimalPod)
+	require.True(t, ok)
+
+	// Verify all fields are equal
+	assert.Equal(t, original.TypeMeta, copiedPod.TypeMeta)
+	assert.Equal(t, original.ObjectMeta, copiedPod.ObjectMeta)
+	assert.Equal(t, original.Spec, copiedPod.Spec)
+	assert.Equal(t, original.Status, copiedPod.Status)
+
+	// Verify it's a deep copy by modifying a few fields of the copy and
+	// checking the original did not change
+	copiedPod.Name = "modified-name"
+	assert.NotEqual(t, copiedPod.Name, original.Name)
+
+	copiedPod.Labels["new-label"] = "new-value"
+	_, existsInOriginal := original.Labels["new-label"]
+	assert.False(t, existsInOriginal)
+
+	copiedPod.Spec.Containers[0].Name = "modified-container"
+	assert.NotEqual(t, copiedPod.Spec.Containers[0].Name, original.Spec.Containers[0].Name)
+
+	copiedPod.Status.PodIP = "10.0.0.2"
+	assert.NotEqual(t, copiedPod.Status.PodIP, original.Status.PodIP)
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -148,6 +148,8 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 	// to be deleted.
 	case *corev1.Pod:
 		uid = v.UID
+	case *MinimalPod:
+		uid = v.UID
 	case *appsv1.Deployment:
 		uid = v.UID
 	case *metav1.PartialObjectMetadata:

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -70,9 +70,44 @@ func Test_AddDelete_Pod(t *testing.T) {
 	t.Parallel()
 	workloadmetaComponent := mockedWorkloadmeta(t)
 
-	podStore := newPodReflectorStore(workloadmetaComponent, workloadmetaComponent.GetConfig())
+	podStore := newPodReflectorStoreWithFullPodParser(workloadmetaComponent, workloadmetaComponent.GetConfig())
 
 	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			UID:       "pod-uid",
+			Labels: map[string]string{
+				"test-label": "test-value",
+			},
+			Annotations: map[string]string{
+				"test-annotation": "test-value",
+			},
+		},
+	}
+
+	err := podStore.Add(&pod)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = workloadmetaComponent.GetKubernetesPod(string(pod.UID))
+		return err == nil
+	}, timeout, interval)
+
+	err = podStore.Delete(&pod)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, err = workloadmetaComponent.GetKubernetesDeployment(string(pod.UID))
+		return err != nil
+	}, timeout, interval)
+}
+
+func Test_AddDelete_MinimalPod(t *testing.T) {
+	t.Parallel()
+	workloadmetaComponent := mockedWorkloadmeta(t)
+
+	podStore := newPodReflectorStoreWithMinimalPodParser(workloadmetaComponent, workloadmetaComponent.GetConfig())
+
+	pod := MinimalPod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
 			Namespace: "test-namespace",

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/deployment.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/deployment.go
@@ -26,7 +26,7 @@ type deploymentParser struct {
 
 // NewDeploymentParser initialises and returns a deployment parser
 func NewDeploymentParser(annotationsExclude []string) (ObjectParser, error) {
-	filters, err := parseFilters(annotationsExclude)
+	filters, err := ParseFilters(annotationsExclude)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (p deploymentParser) Parse(obj interface{}) workloadmeta.Entity {
 			Name:        deployment.Name,
 			Namespace:   deployment.Namespace,
 			Labels:      deployment.Labels,
-			Annotations: filterMapStringKey(deployment.Annotations, p.annotationsFilter),
+			Annotations: FilterMapStringKey(deployment.Annotations, p.annotationsFilter),
 		},
 		Env:                 deployment.Labels[ddkube.EnvTagLabelKey],
 		Service:             deployment.Labels[ddkube.ServiceTagLabelKey],

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/metadata.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/metadata.go
@@ -24,7 +24,7 @@ type metadataParser struct {
 
 // NewMetadataParser initialises and returns a metadata parser
 func NewMetadataParser(gvr schema.GroupVersionResource, annotationsExclude []string) (ObjectParser, error) {
-	filters, err := parseFilters(annotationsExclude)
+	filters, err := ParseFilters(annotationsExclude)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (p metadataParser) Parse(obj interface{}) workloadmeta.Entity {
 			Name:        partialObjectMetadata.Name,
 			Namespace:   partialObjectMetadata.Namespace,
 			Labels:      partialObjectMetadata.Labels,
-			Annotations: filterMapStringKey(partialObjectMetadata.Annotations, p.annotationsFilter),
+			Annotations: FilterMapStringKey(partialObjectMetadata.Annotations, p.annotationsFilter),
 			UID:         string(partialObjectMetadata.UID),
 		},
 		GVR: p.gvr,

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
@@ -23,7 +23,7 @@ type podParser struct {
 
 // NewPodParser creates and returns a pod parser based on annotations exclusion list
 func NewPodParser(annotationsExclude []string) (ObjectParser, error) {
-	filters, err := parseFilters(annotationsExclude)
+	filters, err := ParseFilters(annotationsExclude)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 		EntityMeta: workloadmeta.EntityMeta{
 			Name:        pod.Name,
 			Namespace:   pod.Namespace,
-			Annotations: filterMapStringKey(pod.Annotations, p.annotationsFilter),
+			Annotations: FilterMapStringKey(pod.Annotations, p.annotationsFilter),
 			Labels:      pod.Labels,
 		},
 		Phase:                      string(pod.Status.Phase),

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/utils.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/utils.go
@@ -14,7 +14,8 @@ import (
 	utilserror "k8s.io/apimachinery/pkg/util/errors"
 )
 
-func parseFilters(annotationsExclude []string) ([]*regexp.Regexp, error) {
+// ParseFilters parses a list of exclude annotations into regex objects
+func ParseFilters(annotationsExclude []string) ([]*regexp.Regexp, error) {
 	var parsedFilters []*regexp.Regexp
 	var errors []error
 	for _, exclude := range annotationsExclude {
@@ -39,7 +40,8 @@ func filterToRegex(filter string) (*regexp.Regexp, error) {
 	return r, nil
 }
 
-func filterMapStringKey(mapInput map[string]string, keyFilters []*regexp.Regexp) map[string]string {
+// FilterMapStringKey filters a map of strings based on a list of regex objects
+func FilterMapStringKey(mapInput map[string]string, keyFilters []*regexp.Regexp) map[string]string {
 	for key := range mapInput {
 		for _, filter := range keyFilters {
 			if filter.MatchString(key) {

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/utils_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/utils_test.go
@@ -63,11 +63,11 @@ func Test_filterMapStringKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filters, err := parseFilters(tt.excludeString)
+			filters, err := ParseFilters(tt.excludeString)
 			if err != nil {
 				t.Errorf("newParseOptions() return an error %v", err)
 			}
-			if got := filterMapStringKey(tt.annotations, filters); !reflect.DeepEqual(got, tt.want) {
+			if got := FilterMapStringKey(tt.annotations, filters); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("filterPodAnnotations() = %v, want %v", got, tt.want)
 			}
 		})

--- a/releasenotes-dca/notes/pod-informer-with-minimal-pod-3ae64cf321f39d0d.yaml
+++ b/releasenotes-dca/notes/pod-informer-with-minimal-pod-3ae64cf321f39d0d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Reduced memory usage when pod collection is enabled in the Cluster Agent.


### PR DESCRIPTION
### What does this PR do?

This PR optimizes the memory usage of the `kubeapiserver` workloadmeta collector.

The collector now uses a minimal pod struct with only the fields we actually need. This avoids unmarshalling the full pod. The saved memory is noticeable in clusters with many pods. It's specially important when the Cluster Agent starts, since it needs to fetch all pods from the API server. These changes help lower the memory spike at startup. This is useful when that peak is used to set Kubernetes memory requests.

I attach a screenshot from one of the clusters where I tested this.
The first chart shows `container.memory.usage.peak` and the second one `container.memory.usage`. In both of them, the second half are pods built from this PR.

<img width="1341" height="330" alt="dca_memory" src="https://github.com/user-attachments/assets/1fda6581-fd30-47d1-a929-36cc3b2a775e" />


### Describe how you validated your changes

CI + deploying custom image on some clusters to compare memory usage.
