### PR TITLE
Support non-absolute trace-agent path in loader

### DIFF
--- a/cmd/loader/main_nix.go
+++ b/cmd/loader/main_nix.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -38,12 +39,19 @@ import (
 // os.Args[3:] are the arguments to the trace-agent command
 
 func main() {
+	// check if the trace-agent path is absolute or found in the PATH
+	fullPath, err := exec.LookPath(os.Args[2])
+	if err != nil {
+		log.Criticalf("Failed to look up the trace-agent binary: %v", err)
+		os.Exit(1)
+	}
+
 	cfg := pkgconfigsetup.GlobalConfigBuilder()
 	cfg.SetConfigFile(os.Args[1])
-	err := pkgconfigsetup.LoadDatadog(cfg, secretsnoop.NewComponent().Comp, nil)
+	err = pkgconfigsetup.LoadDatadog(cfg, secretsnoop.NewComponent().Comp, nil)
 	if err != nil {
 		log.Warnf("Failed to load the configuration: %v", err)
-		execOrExit(os.Environ())
+		execOrExit(os.Environ(), fullPath)
 	}
 
 	// comp/trace/config/config*.go
@@ -65,7 +73,7 @@ func main() {
 	)
 	if err != nil {
 		log.Warnf("Failed to initialize the logger: %v", err)
-		execOrExit(os.Environ())
+		execOrExit(os.Environ(), fullPath)
 	}
 
 	if !utils.IsAPMEnabled(cfg) {
@@ -75,7 +83,7 @@ func main() {
 
 	if !cfg.GetBool("apm_config.socket_activation.enabled") {
 		log.Infof("Socket-activation for the trace-agent is disabled, running the trace-agent directly...")
-		execOrExit(os.Environ())
+		execOrExit(os.Environ(), fullPath)
 	}
 
 	listeners, err := getListeners(cfg)
@@ -87,7 +95,7 @@ func main() {
 				log.Warnf("Failed to close file descriptor %s: %v", name, err)
 			}
 		}
-		execOrExit(os.Environ())
+		execOrExit(os.Environ(), fullPath)
 	}
 
 	if len(listeners) == 0 {
@@ -122,7 +130,7 @@ func main() {
 	}
 
 	// start the trace-agent whether there was an error or some data on a socket
-	execOrExit(env)
+	execOrExit(env, fullPath)
 }
 
 // Returns a string representation of the events that occurred on a socket
@@ -146,11 +154,11 @@ func reventToString(revents int16) string {
 	return ret
 }
 
-func execOrExit(env []string) {
+func execOrExit(env []string, fullPath string) {
 	log.Info("Starting the trace-agent...")
 	log.Tracef("Starting the trace-agent with env: %+q", env)
 	log.Flush()
-	err := unix.Exec(os.Args[2], os.Args[2:], env)
+	err := unix.Exec(fullPath, os.Args[2:], env)
 	log.Errorf("Failed to start the trace-agent with args %+q: %v", os.Args[2:], err)
 	log.Flush()
 	os.Exit(1)


### PR DESCRIPTION
### What does this PR do?
Support non-absolute paths for trace-agent binary in loader binary.

### Motivation
Simplify usage of the loader. Might be required for k8s where we just exec "trace-agent".

### Describe how you validated your changes
Local testing.

### Additional Notes
