### PR TITLE
Sign backported commits

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -21,19 +21,22 @@ jobs:
     permissions:
       id-token: write # This is required for getting the required OIDC token from GitHub
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install dda
+        uses: ./.github/actions/install-dda
+        with:
+          features: github
+
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
         with:
           scope: DataDog/datadog-agent
           policy: self.backport-pr.create-pr
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
-        with:
-          label_pattern: "^backport/(?<base>([^ ]+))$"
-          labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot']) %>"
-          github_token: ${{ steps.octo-sts.outputs.token }}
-          body_template: |
-            Backport <%- mergeCommitSha %> from #<%- number %>.
 
-            ___
-
-            <%- body %>
+      - name: Backport PR
+        run: dda gh backport
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -21,9 +21,6 @@ jobs:
     permissions:
       id-token: write # This is required for getting the required OIDC token from GitHub
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - name: Install dda
         uses: ./.github/actions/install-dda
         with:


### PR DESCRIPTION
### What does this PR do?

Replace https://github.com/tibdex/backport/tree/main with a `dda` command, implementing a backport without cherry-pick, allowing Github Action to generate a signed commit.

### Motivation

Backports are widely used during releases, when changes merged into a branch, often `main`, are required in a previous release. Changes are cherry-picked into the target release branch, and eventually generate a new release candidate. 

We are enforcing signed commits in `datadog-agent`, using the former backport action resulted in unsigned commits. This action leverages the Github API and ensures that Github signs commits with its own token. Backport commits are partially signed, as we keep the PR author in the commit's co-authors, and Github cannot sign for them as it does not hold their GPG key. Partially verified commits are enough to enforce the signature check in a branch. 

### Describe how you validated your changes

Tested my changes on [this test repo](https://github.com/pducolin/test-backport)

Here is [a PR](https://github.com/pducolin/test-backport/pull/35) where I added the `backport/xxx` label

<img width="1329" height="755" alt="image" src="https://github.com/user-attachments/assets/acdaeaa8-817d-42fa-87ab-df5e88db7ec4" />

This results in a [backport PR](https://github.com/pducolin/test-backport/pull/36) that keeps all of the labels, but the `backport/xxx` one,adding `bot` and `backport` labels. It adds the PR author as commit's `co-author

<img width="1351" height="813" alt="image" src="https://github.com/user-attachments/assets/5f7485f6-5d13-4a2d-93fb-e543e30e0e0c" />


### Additional Notes

[This](https://github.com/DataDog/datadog-agent-dev/pull/222) is the `dda gh backport` implementation PR
