### PR TITLE
[dyninst] Relax throttler test

### DIFF
--- a/pkg/dyninst/throttler_test.go
+++ b/pkg/dyninst/throttler_test.go
@@ -9,8 +9,6 @@ package dyninst_test
 
 import (
 	"context"
-	"log"
-	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -98,12 +96,6 @@ func enforcesBudget(t *testing.T, busyloopPath string) {
 		require.NoError(t, err)
 	}
 
-	// Check there are no more events after a short delay.
-	rd.SetDeadline(time.Now().Add(10 * time.Millisecond))
-	v, err := rd.Read()
-	log.Printf("err: %v", err)
-	require.ErrorIs(t, err, os.ErrDeadlineExceeded, "expected deadline exceeded, got %#+v, %#+v", err, v)
-
 	// Check that throttling happened.
 	perCoreStats := program.RuntimeStats()
 	var stats loader.RuntimeStats
@@ -114,6 +106,12 @@ func enforcesBudget(t *testing.T, busyloopPath string) {
 	}
 	require.Greater(t, int(stats.HitCnt), expectedEvents)
 	require.Greater(t, int(stats.ThrottledCnt), 0)
+	// It may happen that different threads execute probe at the same nanosecond,
+	// allowing both to reset the budget, discounting the capture done by the other.
+	// In this test the one refresh would happen at the very beginning. We relax
+	// the expectations, allowing all threads to hit the same nanosecond, but we assume
+	// that no thread will execute more than once before the other resets the budget.
+	require.LessOrEqual(t, int(stats.HitCnt)-int(stats.ThrottledCnt), expectedEvents+2)
 }
 
 func refreshesBudget(t *testing.T, busyloopPath string) {


### PR DESCRIPTION
We don't synchronize perfectly, make sure we throttle, see code comment on the new expectation.