### PR TITLE
Fix origin tag for ECS MI

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -662,7 +662,7 @@ func computeGlobalTags() map[string]string {
 
 	tags := make(map[string]string)
 	if inECSManagedInstancesSidecar() {
-		tags["origin"] = "ecs_managed_instances"
+		tags["_dd.origin"] = "ecs_managed_instances"
 	}
 	return tags
 }


### PR DESCRIPTION
### What does this PR do?
Changes the origin tag for ECS Managed Instances from `origin` to `_dd.origin` so this tag is not surfaced in the UI.

### Motivation
This tag is used in the backend to identify manged instances traces and is not meant to be surfaced. 

### Describe how you validated your changes
- deployed agent to ECS Managed instances cluster using image `datadog/agent-dev:stzou-ecs-mi-apm-full`
- confirmed that the origin tag is present and `_dd.origin` and not surfaced in UI.
Raw trace has the correct tag:
```
{
    "trace": {
        "root_id": "...",
        "spans": {
            "...": {
                "meta": {
                    "_dd.origin": "ecs_managed_instances",
                    ...
                },
                ...
            }
        }
    }
    ...
}
```

### Additional Notes
