### PR TITLE
[CONTP-1102]  Optimize ksm ownertag build

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -1287,16 +1287,15 @@ func ownerTags(kind, name string) []string {
 		return nil
 	}
 
-	tagFormat := "%s:%s"
-	tagList := []string{fmt.Sprintf(tagFormat, tagKey, name)}
+	tagList := []string{tagKey + ":" + name}
 	switch kind {
 	case kubernetes.JobKind:
 		if cronjob, _ := kubernetes.ParseCronJobForJob(name); cronjob != "" {
-			return append(tagList, fmt.Sprintf(tagFormat, tags.KubeCronjob, cronjob))
+			return append(tagList, tags.KubeCronjob+":"+cronjob)
 		}
 	case kubernetes.ReplicaSetKind:
 		if deployment := kubernetes.ParseDeploymentForReplicaSet(name); deployment != "" {
-			return append(tagList, fmt.Sprintf(tagFormat, tags.KubeDeployment, deployment))
+			return append(tagList, tags.KubeDeployment+":"+deployment)
 		}
 	}
 

--- a/releasenotes/notes/ksm-ownerTags-sprintf-optimization-6eb26ff036a6c99d.yaml
+++ b/releasenotes/notes/ksm-ownerTags-sprintf-optimization-6eb26ff036a6c99d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Optimized the Kubernetes State Metrics (KSM) check by replacing ``fmt.Sprintf()``
+    calls with direct string concatenation in the ``ownerTags()`` function. This reduces
+    memory allocation churn and saves approximately 20% CPU usage for the KSM check.


### PR DESCRIPTION
### What does this PR do?
Optimizes the `ownerTags()` function in the KSM (Kubernetes State Metrics) check by replacing `fmt.Sprintf()` calls with direct string concatenation for simple tag formatting.  ownerTags() is in the hotpath of ksm check, especially in large cluster check. 

### Motivation
  For simple patterns like `"%s:%s"`, `fmt.Sprintf()` has substantial overhead:
  - Reflection-based format string parsing
  - Interface boxing of arguments
  - Internal buffer allocation
  - ~1.5 KB per call vs ~100 bytes for direct concatenation


  Deployed and profiled in a production Kubernetes cluster with 144,749 metrics:

  | Metric                  | Before           | After            | Improvement |
  |-------------------------|------------------|------------------|-------------|
  | Check execution time (agent status)    | 5.963s           | 4.796s           | -19.6%      |
  | ownerTags() CPU         | 1.45s            | 0.51s            | -65%        |
  | fmt.Sprintf allocations | 211 GB           | 98.5 MB          | -99.5%      |
  | GC CPU time             | 4.23s            | 3.54s            | -16%        |
  | Throughput              | 24,277 metrics/s | 30,181 metrics/s | +24%        |
  
  
<img width="879" height="529" alt="Screenshot 2025-11-24 at 10 37 42 AM" src="https://github.com/user-attachments/assets/07151e74-63b6-46e6-a003-6ec374660bf0" />
Benchmark show 20% cpu usage reduction in ksm check with 140,000 pods collection

### Describe how you validated your changes
A simple unit test in TestOwnerTags should cover it. 


### Additional Notes
