### PR TITLE
Configure fakeintake override after update env

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/health/health_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_common_test.go
@@ -65,14 +65,15 @@ func (v *baseHealthSuite) TestDefaultInstallUnhealthy() {
 	err := v.Env().FakeIntake.Client().ConfigureOverride(override)
 	require.NoError(v.T(), err)
 
-	var svcManager svcmanager.ServiceManager
+	var out string
 	if v.descriptor.Family() == os.WindowsFamily {
-		svcManager = svcmanager.NewWindows(v.Env().RemoteHost)
+		svcManager := svcmanager.NewWindows(v.Env().RemoteHost)
+		out, err = svcManager.Restart("datadogagent")
 	} else {
-		svcManager = svcmanager.NewSystemctl(v.Env().RemoteHost)
+		svcManager := svcmanager.NewSystemctl(v.Env().RemoteHost)
+		out, err = svcManager.Restart("datadog-agent")
 	}
 
-	out, err := svcManager.Restart("datadog-agent")
 	v.T().Log(out)
 	require.NoError(v.T(), err)
 


### PR DESCRIPTION
### What does this PR do?
Configure the fakeintake override after update env

### Motivation
It can happen that `UpdateEnv` needs to recreate the fakeintake, which removes the override.
This should fix it.

I needed to increase the timeout as the agent checks api key health every minute in the test, so we need to wait more than 1min.

### Describe how you validated your changes
CI

### Additional Notes
Ideally the framework should be fixed to avoid this issue.
