### PR TITLE
[Backport 7.73.x] [CWS] Revert "Re-apply "[CWS] SECL variables refactoring"" (#43398)

### DIFF
--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -74,11 +74,23 @@ func evalRule(provider rules.PolicyProvider, decoder *json.Decoder, evalArgs Eva
 
 	report.Event = event
 
+	// store the variables values so that we can reapply them after policies are loaded
+	variablesValues := make(map[string]any)
+	for k, v := range variables {
+		rv, ok := v.(eval.Variable)
+		if !ok {
+			continue
+		}
+
+		value, _ := rv.GetValue()
+		variablesValues[k] = value
+	}
+
 	// enabled all the rules
 	enabled := map[eval.EventType]bool{"*": true}
 
 	ruleOpts := rules.NewRuleOpts(enabled)
-	evalOpts := newEvalOpts(evalArgs.UseWindowsModel)
+	evalOpts := newEvalOpts(evalArgs.UseWindowsModel).WithVariables(variables)
 	ruleOpts.WithLogger(seclog.DefaultLogger)
 
 	agentVersionFilter, err := newAgentVersionFilter()
@@ -104,27 +116,15 @@ func evalRule(provider rules.PolicyProvider, decoder *json.Decoder, evalArgs Eva
 		return report, err
 	}
 
-	ctx := eval.NewContext(event)
-
-	for varName, value := range variables {
-		definition, ok := evalOpts.VariableStore.GetDefinition(eval.VariableName(varName))
-		if definition == nil || !ok {
-			var definedVariableNames []string
-			evalOpts.VariableStore.IterVariableDefinitions(func(definition eval.VariableDefinition) {
-				definedVariableNames = append(definedVariableNames, definition.VariableName(true))
-			})
-			return report, fmt.Errorf("no variable named `%s` was found in current ruleset (found: %q)", varName, definedVariableNames)
-		}
-		instance, added, err := definition.AddNewInstance(ctx)
-		if err != nil {
-			return report, fmt.Errorf("failed to register new variable instance `%s`: %s", varName, err)
-		}
-		if !added {
-			return report, fmt.Errorf("failed to add new variable instance `%s`", varName)
-		}
-		err = instance.Set(value)
-		if err != nil {
-			return report, fmt.Errorf("failed to set value of variable `%s` to value `%v`: %s", varName, value, err)
+	// reapply the variables values
+	vars := ruleSet.GetVariables()
+	for k, v := range variablesValues {
+		if _, ok := vars[k]; ok {
+			if mv, ok := vars[k].(eval.MutableVariable); ok {
+				if err := mv.Set(nil, v); err != nil {
+					return report, fmt.Errorf("failed to set variable %s: %w", k, err)
+				}
+			}
 		}
 	}
 
@@ -222,62 +222,92 @@ func eventFromTestData(testData TestData) (eval.Event, error) {
 	return event, nil
 }
 
-func variablesFromTestData(testData TestData) (map[string]any, error) {
-	variables := make(map[string]any)
+func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, error) {
+	variables := make(map[string]eval.SECLVariable)
 
-	for varName, value := range testData.Variables {
-		switch value := value.(type) {
+	// copy the embedded variables
+	for k, v := range model.SECLVariables {
+		variables[k] = v
+	}
+
+	varOpts := eval.VariableOpts{
+		TTL: 10000000,
+	}
+
+	// add the variables from the test data
+	for k, v := range testData.Variables {
+		switch v := v.(type) {
 		case string:
-			variables[varName] = value
-		case json.Number:
-			v, err := value.Int64()
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert %s to int: %w", varName, err)
+			if rules.IsScopeVariable(k) {
+				variables[k] = eval.NewScopedStringVariable(func(_ *eval.Context) (string, bool) {
+					return v, true
+				}, nil)
+			} else {
+				variables[k] = eval.NewStringVariable(v, varOpts)
 			}
-			variables[varName] = int(v)
-		case float64:
-			variables[varName] = int(value)
-		case bool:
-			variables[varName] = value
 		case []any:
-			if len(value) == 0 {
-				return nil, fmt.Errorf("test variable `%s` has unknown type: %T", varName, value)
-			}
-			switch value[0].(type) {
+			switch v[0].(type) {
 			case string:
-				values := make([]string, 0, len(value))
-				for _, v := range value {
-					values = append(values, v.(string))
+				values := make([]string, len(v))
+				for i, value := range v {
+					values[i] = value.(string)
 				}
-				variables[varName] = values
+				if rules.IsScopeVariable(k) {
+					variables[k] = eval.NewScopedStringArrayVariable(func(_ *eval.Context) ([]string, bool) {
+						return values, true
+					}, nil)
+				} else {
+					variables[k] = eval.NewStringArrayVariable(values, varOpts)
+				}
 			case json.Number:
-				values := make([]int, 0, len(value))
-				for _, v := range value {
-					v, err := v.(json.Number).Int64()
+				values := make([]int, len(v))
+				for i, value := range v {
+					v64, err := value.(json.Number).Int64()
 					if err != nil {
-						return nil, fmt.Errorf("failed to convert %s to int: %w", varName, err)
+						return nil, fmt.Errorf("failed to convert %s to int: %w", v, err)
 					}
-					values = append(values, int(v))
+					values[i] = int(v64)
 				}
-				variables[varName] = values
-			case float64:
-				values := make([]int, 0, len(value))
-				for _, v := range value {
-					values = append(values, int(v.(float64)))
+
+				if rules.IsScopeVariable(k) {
+					variables[k] = eval.NewScopedIntArrayVariable(func(_ *eval.Context) ([]int, bool) {
+						return values, true
+					}, nil)
+				} else {
+					variables[k] = eval.NewIntArrayVariable(values, varOpts)
 				}
-				variables[varName] = values
 			default:
-				return nil, fmt.Errorf("test variable `%s` has unknown type: %T", varName, value)
+				return nil, fmt.Errorf("unknown variable type %s: %T", k, v)
+			}
+		case json.Number:
+			value, err := v.Int64()
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert %s to int: %w", v, err)
+			}
+			if rules.IsScopeVariable(k) {
+				variables[k] = eval.NewScopedIntVariable(func(_ *eval.Context) (int, bool) {
+					return int(value), true
+				}, nil)
+			} else {
+				variables[k] = eval.NewIntVariable(int(value), varOpts)
+			}
+		case bool:
+			if rules.IsScopeVariable(k) {
+				variables[k] = eval.NewScopedBoolVariable(func(_ *eval.Context) (bool, bool) {
+					return v, true
+				}, nil)
+			} else {
+				variables[k] = eval.NewBoolVariable(v, varOpts)
 			}
 		default:
-			return nil, fmt.Errorf("test variable `%s` has unknown type: %T", varName, value)
+			return nil, fmt.Errorf("unknown variable type %s: %T", k, v)
 		}
 	}
 
 	return variables, nil
 }
 
-func dataFromJSON(decoder *json.Decoder) (eval.Event, map[string]any, error) {
+func dataFromJSON(decoder *json.Decoder) (eval.Event, map[string]eval.SECLVariable, error) {
 	var testData TestData
 	if err := decoder.Decode(&testData); err != nil {
 		return nil, nil, err

--- a/pkg/security/clihelpers/eval_test.go
+++ b/pkg/security/clihelpers/eval_test.go
@@ -12,9 +12,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/hashicorp/go-multierror"
 )
 
 type fakeProvider struct {
@@ -89,7 +88,7 @@ rules:
 
 		decoder := json.NewDecoder(bytes.NewBufferString(testData))
 
-		report, err := evalRule(provider, decoder, EvalRuleParams{RuleID: "IMDS"})
+		report, err := evalRule(provider, decoder, EvalRuleParams{})
 		if err != nil {
 			t.Fatalf("error evaluating rule: %s", err)
 		}
@@ -115,12 +114,12 @@ rules:
 
 		decoder := json.NewDecoder(bytes.NewBufferString(testData))
 
-		report, err := evalRule(provider, decoder, EvalRuleParams{RuleID: "IMDS"})
+		report, err := evalRule(provider, decoder, EvalRuleParams{})
 		if err != nil {
 			t.Fatalf("error evaluating rule: %s", err)
 		}
 
-		if !report.Succeeded {
+		if report.Succeeded {
 			t.Fatalf("expected rule to fail")
 		}
 	})

--- a/pkg/security/rules/engine_linux.go
+++ b/pkg/security/rules/engine_linux.go
@@ -5,3 +5,97 @@
 
 // Package rules holds rules related files
 package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// GetSECLVariables returns the set of SECL variables along with theirs values
+func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
+	rs := e.GetRuleSet()
+	if rs == nil {
+		return nil
+	}
+
+	preparator := e.newSECLVariableEventPreparator()
+
+	rsVariables := rs.GetVariables()
+	seclVariables := make(map[string]*api.SECLVariableState, len(rsVariables))
+
+	e.fillCommonSECLVariables(rsVariables, seclVariables, preparator)
+
+	for name, value := range rsVariables {
+		if strings.HasPrefix(name, "container.") {
+			scopedVariable := value.(eval.ScopedVariable)
+			ebpfProbe, ok := e.probe.PlatformProbe.(*probe.EBPFProbe)
+			if !ok {
+				continue
+			}
+
+			ebpfProbe.Walk(func(entry *model.ProcessCacheEntry) {
+				entry.Retain()
+				defer entry.Release()
+
+				if entry.ContainerContext.ContainerID == "" {
+					return
+				}
+
+				ctx := preparator.get(func(event *model.Event) {
+					event.ProcessCacheEntry = entry
+				})
+				defer preparator.put(ctx)
+
+				value, found := scopedVariable.GetValue(ctx)
+				if !found {
+					return
+				}
+
+				scopedName := fmt.Sprintf("%s.%s", name, entry.ContainerContext.ContainerID)
+				scopedValue := fmt.Sprintf("%v", value)
+				seclVariables[scopedName] = &api.SECLVariableState{
+					Name:  scopedName,
+					Value: scopedValue,
+				}
+			})
+		} else if !e.probe.Opts.EBPFLessEnabled && strings.HasPrefix(name, "cgroup.") {
+			scopedVariable := value.(eval.ScopedVariable)
+			ebpfProbe, ok := e.probe.PlatformProbe.(*probe.EBPFProbe)
+			if !ok {
+				continue
+			}
+
+			ebpfProbe.Walk(func(entry *model.ProcessCacheEntry) {
+				entry.Retain()
+				defer entry.Release()
+
+				if entry.ProcessContext.Process.CGroup.CGroupFile.IsNull() {
+					return
+				}
+
+				ctx := preparator.get(func(event *model.Event) {
+					event.ProcessCacheEntry = entry
+				})
+				defer preparator.put(ctx)
+
+				value, found := scopedVariable.GetValue(ctx)
+				if !found {
+					return
+				}
+
+				scopedName := fmt.Sprintf("%s.%s", name, entry.ProcessContext.CGroup.CGroupID)
+				scopedValue := fmt.Sprintf("%v", value)
+				seclVariables[scopedName] = &api.SECLVariableState{
+					Name:  scopedName,
+					Value: scopedValue,
+				}
+			})
+		}
+	}
+	return seclVariables
+}

--- a/pkg/security/rules/engine_others.go
+++ b/pkg/security/rules/engine_others.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+// Package rules holds rules related files
+package rules
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+)
+
+// GetSECLVariables returns the set of SECL variables along with theirs values
+func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
+	rs := e.GetRuleSet()
+	if rs == nil {
+		return nil
+	}
+
+	preparator := e.newSECLVariableEventPreparator()
+
+	rsVariables := rs.GetVariables()
+	seclVariables := make(map[string]*api.SECLVariableState, len(rsVariables))
+
+	e.fillCommonSECLVariables(rsVariables, seclVariables, preparator)
+
+	return seclVariables
+}

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -225,14 +225,16 @@ func isVariableName(str string) (string, bool) {
 }
 
 func evaluatorFromVariable(varname string, pos lexer.Position, opts *Opts) (interface{}, lexer.Position, error) {
-	variableEvaluator, err := opts.VariableStore.GetEvaluator(VariableName(varname))
-	if err == nil {
-		return variableEvaluator, pos, nil
+	var variableEvaluator interface{}
+	variable := opts.VariableStore.Get(varname)
+	if variable != nil {
+		return variable.GetEvaluator(), pos, nil
 	}
 
 	if strings.HasSuffix(varname, ".length") {
 		trimmedVariable := strings.TrimSuffix(varname, ".length")
-		if variableEvaluator, _ := opts.VariableStore.GetEvaluator(VariableName(trimmedVariable)); variableEvaluator != nil {
+		if variable = opts.VariableStore.Get(trimmedVariable); variable != nil {
+			variableEvaluator = variable.GetEvaluator()
 			switch evaluator := variableEvaluator.(type) {
 			case *StringArrayEvaluator:
 				return &IntEvaluator{
@@ -266,6 +268,7 @@ func evaluatorFromVariable(varname string, pos lexer.Position, opts *Opts) (inte
 				return nil, pos, NewError(pos, "'length' cannot be used on '%s'", trimmedVariable)
 			}
 		}
+
 	}
 
 	return nil, pos, NewError(pos, "variable '%s' doesn't exist", varname)

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -29,13 +29,13 @@ func newOptsWithParams(constants map[string]interface{}, legacyFields map[Field]
 		LegacyFields: legacyFields,
 	}
 
-	variables := map[string]StaticVariable{
-		"pid": NewStaticVariable[int](func(_ *Context) int {
-			return os.Getpid()
-		}),
-		"str": NewStaticVariable[string](func(_ *Context) string {
-			return "aaa"
-		}),
+	variables := map[string]SECLVariable{
+		"pid": NewScopedIntVariable(func(_ *Context) (int, bool) {
+			return os.Getpid(), true
+		}, nil),
+		"str": NewScopedStringVariable(func(_ *Context) (string, bool) {
+			return "aaa", true
+		}, nil),
 	}
 
 	return opts.WithVariables(variables).WithMacroStore(&MacroStore{})
@@ -500,10 +500,15 @@ func TestPartial(t *testing.T) {
 		},
 	}
 
-	variables := make(map[string]StaticVariable)
-	variables["var"] = NewStaticVariable[bool](func(_ *Context) bool {
-		return false
-	})
+	variables := make(map[string]SECLVariable)
+	variables["var"] = NewScopedBoolVariable(
+		func(_ *Context) (bool, bool) {
+			return false, true
+		},
+		func(_ *Context, _ interface{}) error {
+			return nil
+		},
+	)
 
 	tests := []struct {
 		Expr        string

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -54,6 +54,28 @@ func (s *MacroStore) Contains(id string) bool {
 	return s.Get(id) != nil
 }
 
+// VariableStore represents a store of SECL variables
+type VariableStore struct {
+	Variables map[string]SECLVariable
+}
+
+// Add adds a variable
+func (s *VariableStore) Add(name string, variable SECLVariable) *VariableStore {
+	if s.Variables == nil {
+		s.Variables = make(map[string]SECLVariable)
+	}
+	s.Variables[name] = variable
+	return s
+}
+
+// Get returns the variable
+func (s *VariableStore) Get(name string) SECLVariable {
+	if s == nil || s.Variables == nil {
+		return nil
+	}
+	return s.Variables[name]
+}
+
 // Opts are the options to be passed to the evaluator
 type Opts struct {
 	LegacyFields  map[Field]Field
@@ -70,15 +92,14 @@ func (o *Opts) WithConstants(constants map[string]interface{}) *Opts {
 }
 
 // WithVariables set variables
-func (o *Opts) WithVariables(variables map[string]StaticVariable) *Opts {
+func (o *Opts) WithVariables(variables map[string]SECLVariable) *Opts {
 	if o.VariableStore == nil {
-		o.VariableStore = NewVariableStore()
+		o.VariableStore = &VariableStore{}
 	}
 
 	for n, v := range variables {
-		o.VariableStore.AddStaticVariable(VariableName(n), v)
+		o.VariableStore.Add(n, v)
 	}
-
 	return o
 }
 
@@ -110,11 +131,11 @@ func (o *Opts) AddMacro(macro *Macro) *Opts {
 }
 
 // AddVariable add a variable
-func (o *Opts) AddVariable(name string, variable StaticVariable) *Opts {
+func (o *Opts) AddVariable(name string, variable SECLVariable) *Opts {
 	if o.VariableStore == nil {
-		o.VariableStore = NewVariableStore()
+		o.VariableStore = &VariableStore{}
 	}
-	o.VariableStore.AddStaticVariable(VariableName(name), variable)
+	o.VariableStore.Add(name, variable)
 	return o
 }
 

--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -58,7 +58,7 @@ func NewRule(id string, expression string, parsingContext *ast.ParsingContext, o
 		opts.WithMacroStore(&MacroStore{})
 	}
 	if opts.VariableStore == nil {
-		opts.VariableStore = NewVariableStore()
+		opts.WithVariableStore(&VariableStore{})
 	}
 
 	labelSet, err := utils.NewLabelSet("rule_id", id)

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -9,718 +9,992 @@ package eval
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"net"
+	"reflect"
 	"regexp"
 	"sync"
 	"time"
 
-	ttlcache "github.com/jellydator/ttlcache/v3"
+	"github.com/jellydator/ttlcache/v3"
 )
-
-var variableRegex = regexp.MustCompile(`\${[^}]*}`)
 
 const defaultMaxVariables = 100
 
-// VariableScope represents the scope of a variable
-type VariableScope interface {
-	Key() (string, bool)
-	ParentScope() (VariableScope, bool)
-}
-
-// ReleasableVariableScope represents a scope that can be released
-type ReleasableVariableScope interface {
-	AppendReleaseCallback(callback func())
-}
-
-// VariableScoper represents a variable scoper
-type VariableScoper struct {
-	scoperType InternalScoperType
-	getScopeCb func(ctx *Context) (VariableScope, error)
-}
-
-// NewVariableScoper returns a new variable scoper
-func NewVariableScoper(scoperType InternalScoperType, cb func(ctx *Context) (VariableScope, error)) *VariableScoper {
-	return &VariableScoper{
-		scoperType: scoperType,
-		getScopeCb: cb,
-	}
-}
-
-// Type returns the type of the variable scoper
-func (vs *VariableScoper) Type() InternalScoperType {
-	return vs.scoperType
-}
-
-// GetScope returns a variable scope based on the given Context
-func (vs *VariableScoper) GetScope(ctx *Context) (VariableScope, error) {
-	return vs.getScopeCb(ctx)
-}
-
-// InternalScoperType represents the type of a scoper
-type InternalScoperType int
-
-const (
-	// UndefinedScoperType is the undefinied scoper
-	UndefinedScoperType InternalScoperType = iota
-	// GlobalScoperType handles the global scope
-	GlobalScoperType
-	// ProcessScoperType handles process scopes
-	ProcessScoperType
-	// ContainerScoperType handles container scopes
-	ContainerScoperType
-	// CGroupScoperType handles cgroup scopes
-	CGroupScoperType
+var (
+	variableRegex         = regexp.MustCompile(`\${[^}]*}`)
+	errAppendNotSupported = errors.New("append is not supported")
 )
-
-// String returns the name of the scoper
-func (isn InternalScoperType) String() string {
-	switch isn {
-	case GlobalScoperType:
-		return "global"
-	case ProcessScoperType:
-		return "process"
-	case ContainerScoperType:
-		return "container"
-	case CGroupScoperType:
-		return "cgroup"
-	default:
-		return ""
-	}
-}
-
-// VariablePrefix returns the variable prefix that corresponds to this scoper type
-func (isn InternalScoperType) VariablePrefix() string {
-	switch isn {
-	case ProcessScoperType:
-		return "process"
-	case ContainerScoperType:
-		return "container"
-	case CGroupScoperType:
-		return "cgroup"
-	default:
-		return ""
-	}
-}
-
-// VariableType lists the types that a SECL variable can take
-type VariableType interface {
-	string | int | bool | net.IPNet |
-		[]string | []int | []net.IPNet
-}
-
-type staticVariable[T VariableType] struct {
-	getValueCb func(ctx *Context) T
-}
-
-// GetValue returns the value of the variable
-func (s *staticVariable[T]) GetValue(ctx *Context) any {
-	return s.getValueCb(ctx)
-}
-
-// StaticVariable represents a hard-coded variable
-type StaticVariable interface {
-	GetValue(ctx *Context) any
-}
-
-// NewStaticVariable returns a new static variable
-func NewStaticVariable[T VariableType](getValue func(ctx *Context) T) StaticVariable {
-	return &staticVariable[T]{
-		getValueCb: getValue,
-	}
-}
-
-// VariableDefinition represents the definition of a SECL variable
-type VariableDefinition interface {
-	VariableName(withScopePrefix bool) string
-	DefaultValue() any
-	IsPrivate() bool
-	Scoper() *VariableScoper
-	AddNewInstance(ctx *Context) (VariableInstance, bool, error)
-	GetInstance(ctx *Context) (VariableInstance, bool, error)
-	GetInstancesCount() int
-	CleanupExpiredVariables()
-	getInstances() map[string]VariableInstance
-}
-
-// VariableOpts represents the options of a SECL variable
-type VariableOpts struct {
-	TTL       time.Duration
-	Size      int
-	Private   bool
-	Inherited bool
-	Append    bool
-	Telemetry *Telemetry
-}
-
-type definition[T VariableType] struct {
-	name         string
-	valueType    string
-	defaultValue T
-	scoper       *VariableScoper
-	opts         *VariableOpts
-
-	instancesLock sync.RWMutex
-	instances     map[string]VariableInstance
-}
-
-// NewVariableDefinition returns a new definition of a SECL variable
-func NewVariableDefinition[T VariableType](name string, scoper *VariableScoper, defaultValue T, opts VariableOpts) VariableDefinition {
-	return &definition[T]{
-		name:         name,
-		defaultValue: defaultValue,
-		valueType:    getValueType[T](defaultValue),
-		scoper:       scoper,
-		opts:         &opts,
-		instances:    make(map[string]VariableInstance),
-	}
-}
-
-// Name returns the name of the variable
-func (def *definition[T]) VariableName(withScopePrefix bool) string {
-	if !withScopePrefix || def.scoper.Type() == GlobalScoperType {
-		return def.name
-	}
-	return def.scoper.Type().VariablePrefix() + "." + def.name
-}
-
-// DefaultValue returns the default value of the definition
-func (def *definition[T]) DefaultValue() any {
-	return def.defaultValue
-}
-
-// IsPrivate returns whether the variable is definied as private
-func (def *definition[T]) IsPrivate() bool {
-	return def.opts.Private
-}
-
-// Scoper returns the scoper of the variable definition
-func (def *definition[T]) Scoper() *VariableScoper {
-	return def.scoper
-}
-
-// AddNewInstance instanciates and adds a new variable instance for the given Context
-func (def *definition[T]) AddNewInstance(ctx *Context) (VariableInstance, bool, error) {
-	scope, err := def.scoper.GetScope(ctx)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to get scope `%s` of variable `%s`: %w", def.scoper.Type(), def.name, err)
-	}
-
-	var newInstance VariableInstance
-	key, ok := scope.Key()
-	if ok {
-		newInstance = def.newInstance(func() {
-			if def.opts.Telemetry != nil {
-				def.opts.Telemetry.TotalVariables.Dec(def.valueType, def.scoper.Type().String())
-			}
-			delete(def.instances, key) // instancesLock must be held when this closure is called
-		})
-
-		if def.opts.Telemetry != nil {
-			def.opts.Telemetry.TotalVariables.Inc(def.valueType, def.scoper.Type().String())
-		}
-
-		if releaseable, ok := scope.(ReleasableVariableScope); ok {
-			releaseable.AppendReleaseCallback(func() {
-				def.instancesLock.Lock()
-				defer def.instancesLock.Unlock()
-				newInstance.free()
-			})
-		}
-
-		def.instancesLock.Lock()
-		defer def.instancesLock.Unlock()
-		def.instances[key] = newInstance
-	}
-
-	return newInstance, ok, nil // newInstance can be nil here
-}
-
-// GetInstance returns a variable instance that corresponds to the given Context or nil if no instance was found
-func (def *definition[T]) GetInstance(ctx *Context) (VariableInstance, bool, error) {
-	var instance VariableInstance
-	var instanceOk bool
-
-	scope, err := def.scoper.GetScope(ctx)
-	if err != nil {
-		return nil, false, &ErrScopeFailure{VarName: def.name, ScoperType: def.scoper.scoperType, ScoperErr: err}
-	}
-
-	def.instancesLock.RLock()
-	defer def.instancesLock.RUnlock()
-
-	key, scopeOk := scope.Key()
-	if scopeOk {
-		instance, instanceOk = def.instances[key]
-	}
-
-	if !instanceOk && def.opts.Inherited {
-		var parentScopeOk bool
-		scope, parentScopeOk = scope.ParentScope()
-		for parentScopeOk && !instanceOk {
-			key, scopeOk = scope.Key()
-			if scopeOk {
-				instance, instanceOk = def.instances[key]
-			}
-			scope, parentScopeOk = scope.ParentScope()
-		}
-	}
-
-	// instance can be nil here if no instance exists
-	return instance, instanceOk, nil
-}
-
-// GetInstancesCount returns the number of instances this variable current has
-func (def *definition[T]) GetInstancesCount() int {
-	def.instancesLock.RLock()
-	defer def.instancesLock.RUnlock()
-	return len(def.instances)
-}
-
-// CleanupExpiredVariables deletes expired variable instances
-func (def *definition[T]) CleanupExpiredVariables() {
-	def.instancesLock.Lock()
-	defer def.instancesLock.Unlock()
-	for _, instance := range def.instances {
-		if instance.IsExpired() {
-			instance.free()
-		}
-	}
-}
-
-func (def *definition[T]) getInstances() map[string]VariableInstance {
-	def.instancesLock.RLock()
-	defer def.instancesLock.RUnlock()
-	return maps.Clone(def.instances) // return a shallow clone of the map to avoid concurrency issues
-}
-
-func (def *definition[T]) newInstance(freeCb func()) VariableInstance {
-	switch def := any(def).(type) {
-	case *definition[string]:
-		return newScalarInstance[string](def.defaultValue, def.opts.TTL, freeCb)
-	case *definition[int]:
-		return newScalarInstance[int](def.defaultValue, def.opts.TTL, freeCb)
-	case *definition[bool]:
-		return newScalarInstance[bool](def.defaultValue, def.opts.TTL, freeCb)
-	case *definition[net.IPNet]:
-		return newScalarInstance[net.IPNet](def.defaultValue, def.opts.TTL, freeCb)
-	case *definition[[]string]:
-		return newArrayInstance[string](def.opts.TTL, def.opts.Size, freeCb)
-	case *definition[[]int]:
-		return newArrayInstance[int](def.opts.TTL, def.opts.Size, freeCb)
-	case *definition[[]net.IPNet]:
-		return newIPArrayInstance(def.opts.TTL, def.opts.Size, freeCb)
-	default:
-		panic("unexpected type")
-	}
-}
-
-// VariableInstance represents an instance of a variable, indenpdently of its type
-type VariableInstance interface {
-	Set(any) error
-	Append(any) error
-	GetValue() any
-	IsExpired() bool
-	free()
-}
-
-type instanceCommon struct {
-	freeOnce sync.Once
-	freeCb   func()
-}
-
-// instancesLock must be held when free() is called
-func (ic *instanceCommon) free() {
-	if ic.freeCb != nil {
-		ic.freeOnce.Do(ic.freeCb)
-	}
-}
-
-type scalarInstanceType interface {
-	string | int | bool | net.IPNet
-}
-
-type scalarInstance[T scalarInstanceType] struct {
-	instanceCommon
-
-	value          T
-	ttl            time.Duration
-	expirationDate time.Time
-}
-
-func newScalarInstance[T scalarInstanceType](defaultValue T, ttl time.Duration, freeCb func()) *scalarInstance[T] {
-	newInstance := &scalarInstance[T]{
-		value: defaultValue,
-		ttl:   ttl,
-		instanceCommon: instanceCommon{
-			freeCb: freeCb,
-		},
-	}
-
-	newInstance.touchTTL()
-
-	return newInstance
-}
-
-func (i *scalarInstance[T]) touchTTL() {
-	if i.ttl > 0 {
-		i.expirationDate = time.Now().Add(i.ttl)
-	}
-}
-
-// Set sets the value of the variable instance
-func (i *scalarInstance[T]) Set(value any) error {
-	if v, ok := value.(T); ok {
-		i.value = v
-		i.touchTTL()
-		return nil
-	}
-	var expected T
-	return &ErrUnexpectedValueType{Expected: expected, Got: value}
-}
-
-// Append appends the given value to the variable instance
-func (i *scalarInstance[T]) Append(_ any) error {
-	return ErrOperatorNotSupported
-}
-
-// GetValue returns the value of the variable instance
-func (i *scalarInstance[T]) GetValue() any {
-	if i.IsExpired() {
-		var value T
-		return value
-	}
-	return i.value
-}
-
-// IsExpired returns whether the variable instance is expired
-func (i *scalarInstance[T]) IsExpired() bool {
-	return i.ttl > 0 && time.Now().After(i.expirationDate)
-}
-
-type arrayInstanceType interface {
-	string | int
-}
-
-type arrayInstance[T arrayInstanceType] struct {
-	instanceCommon
-
-	lru *ttlcache.Cache[T, bool]
-}
-
-func newArrayInstance[T arrayInstanceType](ttl time.Duration, size int, freeCb func()) *arrayInstance[T] {
-	if size <= 0 {
-		size = defaultMaxVariables
-	}
-
-	newInstance := &arrayInstance[T]{
-		lru: ttlcache.New(ttlcache.WithCapacity[T, bool](uint64(size)), ttlcache.WithTTL[T, bool](ttl)),
-		instanceCommon: instanceCommon{
-			freeCb: freeCb,
-		},
-	}
-
-	return newInstance
-}
-
-// Set sets the value of the variable instance
-func (ai *arrayInstance[T]) Set(value any) error {
-	return ai.Append(value)
-}
-
-// Append appends the given value to the variable instance
-func (ai *arrayInstance[T]) Append(value any) error {
-	switch value := value.(type) {
-	case T:
-		ai.lru.Set(value, true, ttlcache.DefaultTTL)
-	case []T:
-		for _, v := range value {
-			ai.lru.Set(v, true, ttlcache.DefaultTTL)
-		}
-	default:
-		var expected []T
-		return &ErrUnexpectedValueType{Expected: expected, Got: value}
-	}
-	return nil
-}
-
-// GetValue returns the value of the variable instance
-func (ai *arrayInstance[T]) GetValue() any {
-	return ai.lru.Keys()
-}
-
-// IsExpired returns whether the variable instance is expired
-func (ai *arrayInstance[T]) IsExpired() bool {
-	ai.lru.DeleteExpired()
-	return ai.lru.Len() == 0
-}
-
-type ipArrayInstance struct {
-	instanceCommon
-
-	lru *ttlcache.Cache[string, bool]
-}
-
-func newIPArrayInstance(ttl time.Duration, size int, freeCb func()) *ipArrayInstance {
-	if size <= 0 {
-		size = defaultMaxVariables
-	}
-
-	newInstance := &ipArrayInstance{
-		lru: ttlcache.New(ttlcache.WithCapacity[string, bool](uint64(size)), ttlcache.WithTTL[string, bool](ttl)),
-		instanceCommon: instanceCommon{
-			freeCb: freeCb,
-		},
-	}
-
-	return newInstance
-}
-
-// Set sets the value of the variable instance
-func (iai *ipArrayInstance) Set(value any) error {
-	return iai.Append(value)
-}
-
-// Append appends the given value to the variable instance
-func (iai *ipArrayInstance) Append(value any) error {
-	switch value := value.(type) {
-	case net.IPNet:
-		iai.lru.Set(value.String(), true, ttlcache.DefaultTTL)
-	case []net.IPNet:
-		for _, v := range value {
-			iai.lru.Set(v.String(), true, ttlcache.DefaultTTL)
-		}
-	default:
-		var expected []net.IPNet
-		return &ErrUnexpectedValueType{Expected: expected, Got: value}
-	}
-	return nil
-}
-
-// GetValue returns the value of the variable instance
-func (iai *ipArrayInstance) GetValue() any {
-	keys := iai.lru.Keys()
-	ips := make([]net.IPNet, 0, len(keys))
-	for _, key := range keys {
-		_, ipNet, err := net.ParseCIDR(key)
-		if err == nil {
-			ips = append(ips, *ipNet)
-		}
-	}
-	return ips
-}
-
-// IsExpired returns whether the variable instance is expired
-func (iai *ipArrayInstance) IsExpired() bool {
-	iai.lru.DeleteExpired()
-	return iai.lru.Len() == 0
-}
-
-// VariableStore represents a collection of variables
-type VariableStore struct {
-	staticVars  map[VariableName]StaticVariable
-	definitions map[VariableName]VariableDefinition
-}
-
-// NewVariableStore returns a new VariableStore
-func NewVariableStore() *VariableStore {
-	return &VariableStore{
-		staticVars:  make(map[VariableName]StaticVariable),
-		definitions: make(map[VariableName]VariableDefinition),
-	}
-}
-
-// AddStaticVariable adds a static variable to the store
-func (s *VariableStore) AddStaticVariable(varName VariableName, variable StaticVariable) {
-	s.staticVars[varName] = variable
-}
-
-// AddDefinition adds a variable definition to the store
-func (s *VariableStore) AddDefinition(varName VariableName, definition VariableDefinition) {
-	s.definitions[varName] = definition
-}
-
-// GetEvaluator returns an evaluator based on the given variable name
-func (s *VariableStore) GetEvaluator(varName VariableName) (any, error) {
-	static, ok := s.staticVars[varName]
-	if ok {
-		switch static := static.(type) {
-		case *staticVariable[string]:
-			return &StringEvaluator{
-				EvalFnc: func(ctx *Context) string {
-					return static.getValueCb(ctx)
-				},
-			}, nil
-		case *staticVariable[int]:
-			return &IntEvaluator{
-				EvalFnc: func(ctx *Context) int {
-					return static.getValueCb(ctx)
-				},
-			}, nil
-		case *staticVariable[bool]:
-			return &BoolEvaluator{
-				EvalFnc: func(ctx *Context) bool {
-					return static.getValueCb(ctx)
-				},
-			}, nil
-		case *staticVariable[net.IPNet]:
-			return &CIDREvaluator{
-				EvalFnc: func(ctx *Context) net.IPNet {
-					return static.getValueCb(ctx)
-				},
-			}, nil
-		case *staticVariable[[]string]:
-			return &StringArrayEvaluator{
-				EvalFnc: func(ctx *Context) []string {
-					return static.getValueCb(ctx)
-				},
-			}, nil
-		case *staticVariable[[]int]:
-			return &IntArrayEvaluator{
-				EvalFnc: func(ctx *Context) []int {
-					return static.getValueCb(ctx)
-				},
-			}, nil
-		case *staticVariable[[]net.IPNet]:
-			return &CIDRArrayEvaluator{
-				EvalFnc: func(ctx *Context) []net.IPNet {
-					return static.getValueCb(ctx)
-				},
-			}, nil
-		default:
-			return nil, fmt.Errorf("variable `%s` has unsupported type", varName)
-		}
-	}
-
-	def, ok := s.definitions[varName]
-	if !ok {
-		return nil, fmt.Errorf("variable `%s` is not defined", varName)
-	}
-
-	switch def := def.(type) {
-	case *definition[string]:
-		return &StringEvaluator{
-			EvalFnc: func(ctx *Context) string {
-				instance, exists, _ := def.GetInstance(ctx)
-				if !exists || instance.IsExpired() {
-					return def.defaultValue
-				}
-				return instance.GetValue().(string)
-			},
-		}, nil
-	case *definition[int]:
-		return &IntEvaluator{
-			EvalFnc: func(ctx *Context) int {
-				instance, exists, _ := def.GetInstance(ctx)
-				if !exists || instance.IsExpired() {
-					return def.defaultValue
-				}
-				return instance.GetValue().(int)
-			},
-		}, nil
-	case *definition[bool]:
-		return &BoolEvaluator{
-			EvalFnc: func(ctx *Context) bool {
-				instance, exists, _ := def.GetInstance(ctx)
-				if !exists || instance.IsExpired() {
-					return def.defaultValue
-				}
-				return instance.GetValue().(bool)
-			},
-		}, nil
-	case *definition[net.IPNet]:
-		return &CIDREvaluator{
-			EvalFnc: func(ctx *Context) net.IPNet {
-				instance, exists, _ := def.GetInstance(ctx)
-				if !exists || instance.IsExpired() {
-					return def.defaultValue
-				}
-				return instance.GetValue().(net.IPNet)
-			},
-		}, nil
-	case *definition[[]string]:
-		return &StringArrayEvaluator{
-			EvalFnc: func(ctx *Context) []string {
-				instance, exists, _ := def.GetInstance(ctx)
-				if !exists || instance.IsExpired() {
-					return def.defaultValue
-				}
-				return instance.GetValue().([]string)
-			},
-		}, nil
-	case *definition[[]int]:
-		return &IntArrayEvaluator{
-			EvalFnc: func(ctx *Context) []int {
-				instance, exists, _ := def.GetInstance(ctx)
-				if !exists || instance.IsExpired() {
-					return def.defaultValue
-				}
-				return instance.GetValue().([]int)
-			},
-		}, nil
-	case *definition[[]net.IPNet]:
-		return &CIDRArrayEvaluator{
-			EvalFnc: func(ctx *Context) []net.IPNet {
-				instance, exists, _ := def.GetInstance(ctx)
-				if !exists || instance.IsExpired() {
-					return def.defaultValue
-				}
-				return instance.GetValue().([]net.IPNet)
-			},
-		}, nil
-	}
-
-	return nil, fmt.Errorf("variable `%s` has unexpected type definition: %T", varName, def.DefaultValue())
-}
-
-// GetDefinition returns the definition of a variable based on the given name
-func (s *VariableStore) GetDefinition(varName VariableName) (VariableDefinition, bool) {
-	def, exists := s.definitions[varName]
-	return def, exists
-}
-
-// CleanupExpiredVariables deletes expired variable instances from the store
-func (s *VariableStore) CleanupExpiredVariables() {
-	for _, definition := range s.definitions {
-		definition.CleanupExpiredVariables()
-	}
-}
-
-// IterVariables calls the given callback function on all variables
-func (s *VariableStore) IterVariables(cb func(definition VariableDefinition, instances map[string]VariableInstance)) {
-	for _, definition := range s.definitions {
-		cb(definition, definition.getInstances())
-	}
-}
-
-// IterVariableDefinitions calls the given callback function on all variable defintions
-func (s *VariableStore) IterVariableDefinitions(cb func(definition VariableDefinition)) {
-	for _, definition := range s.definitions {
-		cb(definition)
-	}
-}
-
-// Gauge tracks the amount of a metric
-type Gauge interface {
-	// Inc increments the Gauge value.
-	Inc(tagsValue ...string)
-	// Dec decrements the Gauge value.
-	Dec(tagsValue ...string)
-}
 
 // Telemetry tracks the values of evaluation metrics
 type Telemetry struct {
 	TotalVariables Gauge
 }
 
-func getValueType[T VariableType](value T) string {
-	switch any(value).(type) {
-	case string:
-		return "string"
+// Gauge tracks the amount of a metric
+type Gauge interface {
+	// Inc increments the Gauge value.
+	Inc(tagsValue ...string)
+	// Sub subtracts the value to the Gauge value.
+	Sub(value float64, tagsValue ...string)
+}
+
+// SECLVariable describes a SECL variable value
+type SECLVariable interface {
+	GetEvaluator() interface{}
+	GetVariableOpts() VariableOpts
+	SetVariableOpts(opts VariableOpts)
+}
+
+// Variable is the interface implemented by variables
+type Variable interface {
+	GetValue() (interface{}, bool)
+}
+
+// ScopedVariable is the interface implemented by scoped variables
+type ScopedVariable interface {
+	GetValue(ctx *Context) (interface{}, bool)
+	IsMutable() bool
+}
+
+// MutableVariable is the interface by variables whose value can be changed
+type MutableVariable interface {
+	Set(ctx *Context, value interface{}) error
+	Append(ctx *Context, value interface{}) error
+	GetVariableOpts() VariableOpts
+	SetVariableOpts(opts VariableOpts)
+}
+
+// settableVariable describes a SECL variable
+type settableVariable struct {
+	setFnc func(ctx *Context, value interface{}) error
+	opts   VariableOpts
+}
+
+type expirableVariable interface {
+	CleanupExpired()
+}
+
+// Set the variable with the specified value
+func (v *settableVariable) Set(ctx *Context, value interface{}) error {
+	if v.setFnc == nil {
+		return errors.New("variable is not mutable")
+	}
+
+	return v.setFnc(ctx, value)
+}
+
+// Append a value to the variable
+func (v *settableVariable) Append(_ *Context, _ interface{}) error {
+	return errAppendNotSupported
+}
+
+// IsMutable returns whether the variable is settable
+func (v *settableVariable) IsMutable() bool {
+	return v.setFnc != nil
+}
+
+// GetVariableOpts returns the variable options
+func (v *settableVariable) GetVariableOpts() VariableOpts {
+	return v.opts
+}
+
+// SetVariableOpts sets the variable VariableOpts
+func (v *settableVariable) SetVariableOpts(opts VariableOpts) {
+	v.opts = opts
+}
+
+// ScopedIntVariable describes a scoped integer variable
+type ScopedIntVariable struct {
+	settableVariable
+	intFnc func(ctx *Context) (int, bool)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (i *ScopedIntVariable) GetEvaluator() interface{} {
+	return &IntEvaluator{
+		EvalFnc: func(ctx *Context) int {
+			i, _ := i.intFnc(ctx)
+			return i
+		},
+	}
+}
+
+// GetValue returns the variable value
+func (i *ScopedIntVariable) GetValue(ctx *Context) (interface{}, bool) {
+	return i.intFnc(ctx)
+}
+
+// NewScopedIntVariable returns a new integer variable
+func NewScopedIntVariable(intFnc func(ctx *Context) (int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntVariable {
+	return &ScopedIntVariable{
+		settableVariable: settableVariable{
+			setFnc: setFnc,
+			opts: VariableOpts{
+				Private: false,
+			},
+		},
+		intFnc: intFnc,
+	}
+}
+
+// ScopedStringVariable describes a string variable
+type ScopedStringVariable struct {
+	settableVariable
+	strFnc func(ctx *Context) (string, bool)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (s *ScopedStringVariable) GetEvaluator() interface{} {
+	return &StringEvaluator{
+		ValueType: VariableValueType,
+		EvalFnc: func(ctx *Context) string {
+			v, _ := s.strFnc(ctx)
+			return v
+		},
+	}
+}
+
+// GetValue returns the variable value
+func (s *ScopedStringVariable) GetValue(ctx *Context) (interface{}, bool) {
+	return s.strFnc(ctx)
+}
+
+// NewScopedStringVariable returns a new scoped string variable
+func NewScopedStringVariable(strFnc func(ctx *Context) (string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringVariable {
+	return &ScopedStringVariable{
+		strFnc: strFnc,
+		settableVariable: settableVariable{
+			setFnc: setFnc,
+			opts: VariableOpts{
+				Private: false,
+			},
+		},
+	}
+}
+
+// ScopedBoolVariable describes a boolean variable
+type ScopedBoolVariable struct {
+	settableVariable
+	boolFnc func(ctx *Context) (bool, bool)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (b *ScopedBoolVariable) GetEvaluator() interface{} {
+	return &BoolEvaluator{
+		EvalFnc: func(ctx *Context) bool {
+			v, _ := b.boolFnc(ctx)
+			return v
+		},
+	}
+}
+
+// GetValue returns the variable value
+func (b *ScopedBoolVariable) GetValue(ctx *Context) (interface{}, bool) {
+	return b.boolFnc(ctx)
+}
+
+// NewScopedBoolVariable returns a new boolean variable
+func NewScopedBoolVariable(boolFnc func(ctx *Context) (bool, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedBoolVariable {
+	return &ScopedBoolVariable{
+		boolFnc: boolFnc,
+		settableVariable: settableVariable{
+			setFnc: setFnc,
+			opts: VariableOpts{
+				Private: false,
+			},
+		},
+	}
+}
+
+// ScopedIPVariable describes a scoped IP variable
+type ScopedIPVariable struct {
+	settableVariable
+	ipFnc func(ctx *Context) (net.IPNet, bool)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (i *ScopedIPVariable) GetEvaluator() interface{} {
+	return &CIDREvaluator{
+		EvalFnc: func(ctx *Context) net.IPNet {
+			i, _ := i.ipFnc(ctx)
+			return i
+		},
+	}
+}
+
+// GetValue returns the variable value
+func (i *ScopedIPVariable) GetValue(ctx *Context) (interface{}, bool) {
+	return i.ipFnc(ctx)
+}
+
+// NewScopedIPVariable returns a new scoped IP variable
+func NewScopedIPVariable(ipFnc func(ctx *Context) (net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIPVariable {
+	return &ScopedIPVariable{
+		ipFnc: ipFnc,
+		settableVariable: settableVariable{
+			setFnc: setFnc,
+			opts: VariableOpts{
+				Private: false,
+			},
+		},
+	}
+}
+
+// ScopedStringArrayVariable describes a scoped string array variable
+type ScopedStringArrayVariable struct {
+	settableVariable
+	strFnc func(ctx *Context) ([]string, bool)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (s *ScopedStringArrayVariable) GetEvaluator() interface{} {
+	return &StringArrayEvaluator{
+		EvalFnc: func(ctx *Context) []string {
+			v, _ := s.strFnc(ctx)
+			return v
+		},
+	}
+}
+
+// GetValue returns the variable value
+func (s *ScopedStringArrayVariable) GetValue(ctx *Context) (interface{}, bool) {
+	return s.strFnc(ctx)
+}
+
+// Set the array values
+func (s *ScopedStringArrayVariable) Set(ctx *Context, value interface{}) error {
+	if s, ok := value.(string); ok {
+		value = []string{s}
+	}
+	return s.settableVariable.Set(ctx, value)
+}
+
+// Append a value to the array
+func (s *ScopedStringArrayVariable) Append(ctx *Context, value interface{}) error {
+	if val, ok := value.(string); ok {
+		value = []string{val}
+	}
+	values, _ := s.strFnc(ctx)
+	return s.Set(ctx, append(values, value.([]string)...))
+}
+
+// NewScopedStringArrayVariable returns a new scoped string array variable
+func NewScopedStringArrayVariable(strFnc func(ctx *Context) ([]string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringArrayVariable {
+	return &ScopedStringArrayVariable{
+		strFnc: strFnc,
+		settableVariable: settableVariable{
+			setFnc: setFnc,
+			opts: VariableOpts{
+				Private: false,
+			},
+		},
+	}
+}
+
+// ScopedIntArrayVariable describes a scoped integer array variable
+type ScopedIntArrayVariable struct {
+	settableVariable
+	intFnc func(ctx *Context) ([]int, bool)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (v *ScopedIntArrayVariable) GetEvaluator() interface{} {
+	return &IntArrayEvaluator{
+		EvalFnc: func(ctx *Context) []int {
+			s, _ := v.intFnc(ctx)
+			return s
+		},
+	}
+}
+
+// GetValue returns the variable value
+func (v *ScopedIntArrayVariable) GetValue(ctx *Context) (interface{}, bool) {
+	return v.intFnc(ctx)
+}
+
+// Set the array values
+func (v *ScopedIntArrayVariable) Set(ctx *Context, value interface{}) error {
+	if i, ok := value.(int); ok {
+		value = []int{i}
+	}
+	return v.settableVariable.Set(ctx, value)
+}
+
+// Append a value to the array
+func (v *ScopedIntArrayVariable) Append(ctx *Context, value interface{}) error {
+	if val, ok := value.(int); ok {
+		value = []int{val}
+	}
+	values, _ := v.intFnc(ctx)
+	return v.Set(ctx, append(values, value.([]int)...))
+}
+
+// NewScopedIntArrayVariable returns a new integer array variable
+func NewScopedIntArrayVariable(intFnc func(ctx *Context) ([]int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntArrayVariable {
+	return &ScopedIntArrayVariable{
+		intFnc: intFnc,
+		settableVariable: settableVariable{
+			setFnc: setFnc,
+			opts: VariableOpts{
+				Private: false,
+			},
+		},
+	}
+}
+
+// ScopedIPArrayVariable describes a scoped IP array variable
+type ScopedIPArrayVariable struct {
+	settableVariable
+	ipFnc func(ctx *Context) ([]net.IPNet, bool)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (i *ScopedIPArrayVariable) GetEvaluator() interface{} {
+	return &CIDRArrayEvaluator{
+		EvalFnc: func(ctx *Context) []net.IPNet {
+			i, _ := i.ipFnc(ctx)
+			return i
+		},
+	}
+}
+
+// GetValue returns the variable value
+func (i *ScopedIPArrayVariable) GetValue(ctx *Context) (interface{}, bool) {
+	return i.ipFnc(ctx)
+}
+
+// Set the array values
+func (i *ScopedIPArrayVariable) Set(ctx *Context, value interface{}) error {
+	if ip, ok := value.(net.IPNet); ok {
+		value = []net.IPNet{ip}
+	}
+	return i.settableVariable.Set(ctx, value)
+}
+
+// Append a value to the array
+func (i *ScopedIPArrayVariable) Append(ctx *Context, value interface{}) error {
+	if val, ok := value.(net.IPNet); ok {
+		value = []net.IPNet{val}
+	}
+	values, _ := i.ipFnc(ctx)
+	return i.Set(ctx, append(values, value.([]net.IPNet)...))
+}
+
+// NewScopedIPArrayVariable returns a new IP array variable
+func NewScopedIPArrayVariable(ipFnc func(ctx *Context) ([]net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIPArrayVariable {
+	return &ScopedIPArrayVariable{
+		ipFnc: ipFnc,
+		settableVariable: settableVariable{
+			setFnc: setFnc,
+			opts: VariableOpts{
+				Private: false,
+			},
+		},
+	}
+}
+
+type variableWithTTL struct {
+	ttl       time.Duration
+	expiresAt time.Time
+}
+
+func (v *variableWithTTL) isExpired() bool {
+	return v.ttl > 0 && v.expiresAt.Before(time.Now())
+}
+
+func (v *variableWithTTL) touchTTL() {
+	if v.ttl > 0 {
+		v.expiresAt = time.Now().Add(v.ttl)
+	}
+}
+
+// IntVariable describes a global integer variable
+type IntVariable struct {
+	isSet bool
+	Value int
+	variableWithTTL
+	opts VariableOpts
+}
+
+// GetValue returns the variable value
+func (m *IntVariable) GetValue() (interface{}, bool) {
+	if m.isExpired() {
+		var defaultValue int
+		return defaultValue, false
+	}
+	return m.Value, m.isSet
+}
+
+// Set the variable with the specified value
+func (m *IntVariable) Set(_ *Context, value interface{}) error {
+	m.Value = value.(int)
+	m.isSet = true
+	m.touchTTL()
+	return nil
+}
+
+// Append a value to the integer
+func (m *IntVariable) Append(_ *Context, value interface{}) error {
+	switch value := value.(type) {
 	case int:
-		return "int"
+		m.Value += value
+		m.isSet = true
+		m.touchTTL()
+	default:
+		return errAppendNotSupported
+	}
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *IntVariable) GetEvaluator() interface{} {
+	return &IntEvaluator{
+		EvalFnc: func(*Context) int {
+			value, _ := m.GetValue()
+			return value.(int)
+		},
+	}
+}
+
+// GetVariableOpts returns the variable VariableOpts
+func (m *IntVariable) GetVariableOpts() VariableOpts {
+	return m.opts
+}
+
+// SetVariableOpts sets the variable VariableOpts
+func (m *IntVariable) SetVariableOpts(opts VariableOpts) {
+	m.opts = opts
+}
+
+// BoolVariable describes a mutable boolean variable
+type BoolVariable struct {
+	isSet bool
+	Value bool
+	variableWithTTL
+	opts VariableOpts
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *BoolVariable) GetEvaluator() interface{} {
+	return &BoolEvaluator{
+		EvalFnc: func(*Context) bool {
+			value, _ := m.GetValue()
+			return value.(bool)
+		},
+	}
+}
+
+// GetVariableOpts returns the variable VariableOpts
+func (m *BoolVariable) GetVariableOpts() VariableOpts {
+	return m.opts
+}
+
+// SetVariableOpts sets the variable VariableOpts
+func (m *BoolVariable) SetVariableOpts(opts VariableOpts) {
+	m.opts = opts
+}
+
+// NewIntVariable returns a new mutable integer variable
+func NewIntVariable(value int, opts VariableOpts) *IntVariable {
+	return &IntVariable{
+		Value: value,
+		variableWithTTL: variableWithTTL{
+			ttl: opts.TTL,
+		},
+		opts: opts,
+	}
+}
+
+// GetValue returns the variable value
+func (m *BoolVariable) GetValue() (interface{}, bool) {
+	if m.isExpired() {
+		var defaultValue bool
+		return defaultValue, false
+	}
+	return m.Value, m.isSet
+}
+
+// Set the variable with the specified value
+func (m *BoolVariable) Set(_ *Context, value interface{}) error {
+	m.Value = value.(bool)
+	m.isSet = true
+	m.touchTTL()
+	return nil
+}
+
+// Append a value to the boolean
+func (m *BoolVariable) Append(_ *Context, _ interface{}) error {
+	return errAppendNotSupported
+}
+
+// NewBoolVariable returns a new mutable boolean variable
+func NewBoolVariable(value bool, opts VariableOpts) *BoolVariable {
+	return &BoolVariable{
+		Value: value,
+		variableWithTTL: variableWithTTL{
+			ttl: opts.TTL,
+		},
+		opts: opts,
+	}
+}
+
+// StringVariable describes a mutable string variable
+type StringVariable struct {
+	Value string
+	isSet bool
+	variableWithTTL
+	opts VariableOpts
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *StringVariable) GetEvaluator() interface{} {
+	return &StringEvaluator{
+		ValueType: VariableValueType,
+		EvalFnc: func(_ *Context) string {
+			value, _ := m.GetValue()
+			return value.(string)
+		},
+	}
+}
+
+// GetVariableOpts returns the variable VariableOpts
+func (m *StringVariable) GetVariableOpts() VariableOpts {
+	return m.opts
+}
+
+// SetVariableOpts sets the variable VariableOpts
+func (m *StringVariable) SetVariableOpts(opts VariableOpts) {
+	m.opts = opts
+}
+
+// GetValue returns the variable value
+func (m *StringVariable) GetValue() (interface{}, bool) {
+	if m.isExpired() {
+		var defaultValue string
+		return defaultValue, false
+	}
+	return m.Value, m.isSet
+}
+
+// Append a value to the string
+func (m *StringVariable) Append(_ *Context, value interface{}) error {
+	switch value := value.(type) {
+	case string:
+		m.Value += value
+		m.isSet = true
+		m.touchTTL()
+	default:
+		return errAppendNotSupported
+	}
+	return nil
+}
+
+// Set the variable with the specified value
+func (m *StringVariable) Set(_ *Context, value interface{}) error {
+	m.Value = value.(string)
+	m.isSet = true
+	m.touchTTL()
+	return nil
+}
+
+// NewStringVariable returns a new mutable string variable
+func NewStringVariable(value string, opts VariableOpts) *StringVariable {
+	return &StringVariable{
+		Value: value,
+		variableWithTTL: variableWithTTL{
+			ttl: opts.TTL,
+		},
+		opts: opts,
+	}
+}
+
+// IPVariable describes a global IP variable
+type IPVariable struct {
+	Value net.IPNet
+	isSet bool
+	variableWithTTL
+	opts VariableOpts
+}
+
+// GetValue returns the variable value
+func (m *IPVariable) GetValue() (interface{}, bool) {
+	if m.isExpired() {
+		var defaultValue net.IPNet
+		return defaultValue, false
+	}
+	return m.Value, m.isSet
+}
+
+// Set the variable with the specified value
+func (m *IPVariable) Set(_ *Context, value interface{}) error {
+	m.Value = value.(net.IPNet)
+	m.isSet = true
+	m.touchTTL()
+	return nil
+}
+
+// Append a value to the IP
+func (m *IPVariable) Append(_ *Context, _ interface{}) error {
+	return errAppendNotSupported
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *IPVariable) GetEvaluator() interface{} {
+	return &CIDREvaluator{
+		EvalFnc: func(*Context) net.IPNet {
+			value, _ := m.GetValue()
+			return value.(net.IPNet)
+		},
+	}
+}
+
+// GetVariableOpts returns the variable VariableOpts
+func (m *IPVariable) GetVariableOpts() VariableOpts {
+	return m.opts
+}
+
+// SetVariableOpts sets the variable VariableOpts
+func (m *IPVariable) SetVariableOpts(opts VariableOpts) {
+	m.opts = opts
+}
+
+// NewIPVariable returns a new mutable IP variable
+func NewIPVariable(value net.IPNet, opts VariableOpts) *IPVariable {
+	return &IPVariable{
+		Value: value,
+		variableWithTTL: variableWithTTL{
+			ttl: opts.TTL,
+		},
+		opts: opts,
+	}
+}
+
+// StringArrayVariable describes a mutable string array variable
+type StringArrayVariable struct {
+	isSet bool
+	LRU   *ttlcache.Cache[string, bool]
+	opts  VariableOpts
+}
+
+// GetValue returns the variable value
+func (m *StringArrayVariable) GetValue() (interface{}, bool) {
+	keys := m.LRU.Keys()
+	return keys, len(keys) != 0 && m.isSet
+}
+
+func (m *StringArrayVariable) set(_ *Context, values interface{}) error {
+	if s, ok := values.(string); ok {
+		values = []string{s}
+	}
+	for _, v := range values.([]string) {
+		m.LRU.Set(v, true, ttlcache.DefaultTTL)
+	}
+	return nil
+}
+
+// Set the variable with the specified value
+func (m *StringArrayVariable) Set(ctx *Context, values interface{}) error {
+	if err := m.set(ctx, values); err != nil {
+		return err
+	}
+	m.isSet = true
+	return nil
+}
+
+// Append a value to the array
+func (m *StringArrayVariable) Append(_ *Context, value interface{}) error {
+	switch value := value.(type) {
+	case string:
+		m.LRU.Set(value, true, ttlcache.DefaultTTL)
+	case []string:
+		for _, v := range value {
+			m.LRU.Set(v, true, ttlcache.DefaultTTL)
+		}
+	default:
+		return errAppendNotSupported
+	}
+	m.isSet = true
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *StringArrayVariable) GetEvaluator() interface{} {
+	return &StringArrayEvaluator{
+		EvalFnc: func(*Context) []string {
+			return m.LRU.Keys()
+		},
+	}
+}
+
+// GetVariableOpts returns the variable VariableOpts
+func (m *StringArrayVariable) GetVariableOpts() VariableOpts {
+	return m.opts
+}
+
+// SetVariableOpts sets the variable VariableOpts
+func (m *StringArrayVariable) SetVariableOpts(opts VariableOpts) {
+	m.opts = opts
+}
+
+// CleanupExpired cleans up expired values from the variable
+// note that this method in only used to free up memory
+// as expired entries are already not returned by the LRU.Keys() method
+func (m *StringArrayVariable) CleanupExpired() {
+	m.LRU.DeleteExpired()
+}
+
+// NewStringArrayVariable returns a new mutable string array variable
+func NewStringArrayVariable(value []string, opts VariableOpts) *StringArrayVariable {
+	if opts.Size == 0 {
+		opts.Size = defaultMaxVariables
+	}
+
+	lru := ttlcache.New(ttlcache.WithCapacity[string, bool](uint64(opts.Size)), ttlcache.WithTTL[string, bool](opts.TTL))
+
+	v := &StringArrayVariable{
+		LRU:  lru,
+		opts: opts,
+	}
+	_ = v.set(nil, value)
+	return v
+}
+
+// IntArrayVariable describes a mutable integer array variable
+type IntArrayVariable struct {
+	isSet bool
+	LRU   *ttlcache.Cache[int, bool]
+	opts  VariableOpts
+}
+
+// GetValue returns the variable value
+func (m *IntArrayVariable) GetValue() (interface{}, bool) {
+	keys := m.LRU.Keys()
+	return keys, len(keys) != 0 && m.isSet
+}
+
+func (m *IntArrayVariable) set(_ *Context, values interface{}) error {
+	if i, ok := values.(int); ok {
+		values = []int{i}
+	}
+
+	for _, v := range values.([]int) {
+		m.LRU.Set(v, true, ttlcache.DefaultTTL)
+	}
+
+	return nil
+}
+
+// Set the variable with the specified value
+func (m *IntArrayVariable) Set(ctx *Context, values interface{}) error {
+	if err := m.set(ctx, values); err != nil {
+		return err
+	}
+	m.isSet = true
+	return nil
+}
+
+// Append a value to the array
+func (m *IntArrayVariable) Append(_ *Context, value interface{}) error {
+	switch value := value.(type) {
+	case int:
+		m.LRU.Set(value, true, ttlcache.DefaultTTL)
+	case []int:
+		for _, v := range value {
+			m.LRU.Set(v, true, ttlcache.DefaultTTL)
+		}
+	default:
+		return errAppendNotSupported
+	}
+	m.isSet = true
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *IntArrayVariable) GetEvaluator() interface{} {
+	return &IntArrayEvaluator{
+		EvalFnc: func(*Context) []int {
+			return m.LRU.Keys()
+		},
+	}
+}
+
+// GetVariableOpts returns the variable VariableOpts
+func (m *IntArrayVariable) GetVariableOpts() VariableOpts {
+	return m.opts
+}
+
+// SetVariableOpts sets the variable VariableOpts
+func (m *IntArrayVariable) SetVariableOpts(opts VariableOpts) {
+	m.opts = opts
+}
+
+// CleanupExpired cleans up expired values from the variable
+// note that this method in only used to free up memory
+// as expired entries are already not returned by the LRU.Keys() method
+func (m *IntArrayVariable) CleanupExpired() {
+	m.LRU.DeleteExpired()
+}
+
+// NewIntArrayVariable returns a new mutable integer array variable
+func NewIntArrayVariable(value []int, opts VariableOpts) *IntArrayVariable {
+	if opts.Size == 0 {
+		opts.Size = defaultMaxVariables
+	}
+
+	lru := ttlcache.New(ttlcache.WithCapacity[int, bool](uint64(opts.Size)), ttlcache.WithTTL[int, bool](opts.TTL))
+
+	v := &IntArrayVariable{
+		LRU:  lru,
+		opts: opts,
+	}
+	_ = v.set(nil, value)
+	return v
+}
+
+// IPArrayVariable describes a global IP array variable
+type IPArrayVariable struct {
+	LRU   *ttlcache.Cache[string, bool]
+	isSet bool
+	opts  VariableOpts
+}
+
+// GetValue returns the variable value
+func (m *IPArrayVariable) GetValue() (interface{}, bool) {
+	keys := []net.IPNet{}
+	for _, v := range m.LRU.Keys() {
+		_, ipNet, err := net.ParseCIDR(v)
+		if err == nil {
+			keys = append(keys, *ipNet)
+		}
+	}
+	return keys, len(keys) != 0 && m.isSet
+}
+
+func (m *IPArrayVariable) set(_ *Context, values interface{}) error {
+	if ip, ok := values.(net.IPNet); ok {
+		values = []net.IPNet{ip}
+	}
+
+	for _, v := range values.([]net.IPNet) {
+		m.LRU.Set(v.String(), true, ttlcache.DefaultTTL)
+	}
+
+	return nil
+}
+
+// Set the variable with the specified value
+func (m *IPArrayVariable) Set(ctx *Context, values interface{}) error {
+	if err := m.set(ctx, values); err != nil {
+		return err
+	}
+	m.isSet = true
+	return nil
+}
+
+// Append a value to the array
+func (m *IPArrayVariable) Append(_ *Context, value interface{}) error {
+	switch value := value.(type) {
+	case net.IPNet:
+		m.LRU.Set(value.String(), true, ttlcache.DefaultTTL)
+	case []net.IPNet:
+		for _, v := range value {
+			m.LRU.Set(v.String(), true, ttlcache.DefaultTTL)
+		}
+	default:
+		return errAppendNotSupported
+	}
+
+	m.isSet = true
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *IPArrayVariable) GetEvaluator() interface{} {
+	return &CIDRArrayEvaluator{
+		EvalFnc: func(*Context) []net.IPNet {
+			keys := []net.IPNet{}
+			for _, v := range m.LRU.Keys() {
+				_, ipNet, err := net.ParseCIDR(v)
+				if err == nil {
+					keys = append(keys, *ipNet)
+				}
+			}
+			return keys
+		},
+	}
+}
+
+// GetVariableOpts returns the variable VariableOpts
+func (m *IPArrayVariable) GetVariableOpts() VariableOpts {
+	return m.opts
+}
+
+// SetVariableOpts sets the variable VariableOpts
+func (m *IPArrayVariable) SetVariableOpts(opts VariableOpts) {
+	m.opts = opts
+}
+
+// CleanupExpired cleans up expired values from the variable
+// note that this method in only used to free up memory
+// as expired entries are already not returned by the LRU.Keys() method
+func (m *IPArrayVariable) CleanupExpired() {
+	m.LRU.DeleteExpired()
+}
+
+// NewIPArrayVariable returns a new mutable IP array variable
+func NewIPArrayVariable(value []net.IPNet, opts VariableOpts) *IPArrayVariable {
+	if opts.Size == 0 {
+		opts.Size = defaultMaxVariables
+	}
+
+	lru := ttlcache.New(ttlcache.WithCapacity[string, bool](uint64(opts.Size)), ttlcache.WithTTL[string, bool](opts.TTL))
+
+	v := &IPArrayVariable{
+		LRU:  lru,
+		opts: opts,
+	}
+	_ = v.set(nil, value)
+	return v
+}
+
+// VariableScope is the interface to be implemented by scoped variable in order to be released
+type VariableScope interface {
+	AppendReleaseCallback(callback func())
+	Hash() string
+	ParentScope() (VariableScope, bool)
+}
+
+// Scoper maps a variable to the entity its scoped to
+type Scoper func(ctx *Context) VariableScope
+
+// Variables holds a set of variables
+type Variables struct {
+	expirablesLock sync.RWMutex
+	expirables     []expirableVariable
+}
+
+// VariableOpts holds the options of a variable set
+type VariableOpts struct {
+	Size      int
+	TTL       time.Duration
+	Private   bool // When a variable is marked as private, it will not be included in the serialized event
+	Inherited bool
+	Telemetry *Telemetry
+}
+
+// NewVariables returns a new set of global variables
+func NewVariables() *Variables {
+	return &Variables{}
+}
+
+func getVariableType(value interface{}) string {
+	switch value.(type) {
 	case bool:
 		return "bool"
+	case int:
+		return "integer"
+	case string:
+		return "string"
 	case net.IPNet:
 		return "ip"
 	case []string:
@@ -730,59 +1004,232 @@ func getValueType[T VariableType](value T) string {
 	case []net.IPNet:
 		return "ips"
 	default:
-		panic("unsupported type")
+		panic("unsupported variable type")
 	}
 }
 
-// VariableName represents the name of a variable with its scope prefix included
-type VariableName string
-
-// GetVariableName returns a VariableName based on the given scope and variable names
-func GetVariableName(scope, name string) VariableName {
-	if scope == "" {
-		return VariableName(name)
+func newSECLVariable(value interface{}, opts VariableOpts) (MutableSECLVariable, error) {
+	switch value := value.(type) {
+	case bool:
+		return NewBoolVariable(value, opts), nil
+	case int:
+		return NewIntVariable(value, opts), nil
+	case string:
+		return NewStringVariable(value, opts), nil
+	case net.IPNet:
+		return NewIPVariable(value, opts), nil
+	case []string:
+		return NewStringArrayVariable(value, opts), nil
+	case []int:
+		return NewIntArrayVariable(value, opts), nil
+	case []net.IPNet:
+		return NewIPArrayVariable(value, opts), nil
+	default:
+		return nil, fmt.Errorf("unsupported value type: %v", reflect.TypeOf(value))
 	}
-	return VariableName(scope + "." + name)
 }
 
-// ErrUnexpectedValueType represents an invalid variable type assignment
-type ErrUnexpectedValueType struct {
-	Expected any
-	Got      any
+// NewSECLVariable returns new variable of the type of the specified value
+func (v *Variables) NewSECLVariable(_ string, value interface{}, _ string, opts VariableOpts) (SECLVariable, error) {
+	varType := getVariableType(value)
+	if opts.Telemetry != nil {
+		opts.Telemetry.TotalVariables.Inc(varType, "global")
+	}
+
+	seclVariable, err := newSECLVariable(value, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if expirable, ok := seclVariable.(expirableVariable); ok && opts.TTL > 0 {
+		v.expirablesLock.Lock()
+		v.expirables = append(v.expirables, expirable)
+		v.expirablesLock.Unlock()
+	}
+
+	return seclVariable.(SECLVariable), nil
 }
 
-// Error returns the error message of the error
-func (e *ErrUnexpectedValueType) Error() string {
-	return fmt.Sprintf("unexpected value type: expected %T, got %T", e.Expected, e.Got)
+// CleanupExpiredVariables cleans up expired variables
+func (v *Variables) CleanupExpiredVariables() {
+	v.expirablesLock.RLock()
+	defer v.expirablesLock.RUnlock()
+	for _, expirable := range v.expirables {
+		expirable.CleanupExpired()
+	}
 }
 
-// ErrUnsupportedScope represents an unsupported scope error
-type ErrUnsupportedScope struct {
-	VarName string
-	Scope   string
+// MutableSECLVariable describes the interface implemented by mutable SECL variable
+type MutableSECLVariable interface {
+	Variable
+	MutableVariable
+	SECLVariable
 }
 
-// Error returns the error message of the error
-func (e *ErrUnsupportedScope) Error() string {
-	return fmt.Sprintf("variable `%s` has unsupported scope: `%s`", e.VarName, e.Scope)
+// ScopedVariables holds a set of scoped variables
+type ScopedVariables struct {
+	scoperName     string
+	scoper         Scoper
+	vars           map[string]map[string]MutableSECLVariable
+	expirablesLock sync.RWMutex
+	expirables     map[string][]expirableVariable
 }
 
-// ErrOperatorNotSupported represents an invalid variable assignment
-var ErrOperatorNotSupported = errors.New("operation not supported")
-
-// ErrScopeFailure wraps an error coming from a variable scoper
-type ErrScopeFailure struct {
-	VarName    string
-	ScoperType InternalScoperType
-	ScoperErr  error
+// Len returns the length of the variable map
+func (v *ScopedVariables) Len() int {
+	return len(v.vars)
 }
 
-// Error returns the error message of the error
-func (e *ErrScopeFailure) Error() string {
-	return fmt.Sprintf("failed to get scope `%s` of variable `%s`: %s", e.ScoperType.String(), e.VarName, e.ScoperErr)
+// NewSECLVariable returns new variable of the type of the specified value
+func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName string, opts VariableOpts) (SECLVariable, error) {
+	getVariable := func(ctx *Context) MutableSECLVariable {
+		scope := v.scoper(ctx)
+		if scope == nil {
+			return nil
+		}
+		key := scope.Hash()
+		vars := v.vars[key]
+		if (vars == nil || vars[name] == nil) && opts.Inherited {
+			var ok bool
+			scope, ok = scope.ParentScope()
+			for vars == nil && ok {
+				key := scope.Hash()
+				vars = v.vars[key]
+				scope, ok = scope.ParentScope()
+			}
+		}
+		return vars[name]
+	}
+
+	setVariable := func(ctx *Context, value any) error {
+		scope := v.scoper(ctx)
+		if scope == nil {
+			return fmt.Errorf("`%s` scoper failed to scope variable '%s'", v.scoperName, name)
+		}
+
+		key := scope.Hash()
+		vars := v.vars[key]
+		varType := getVariableType(value)
+
+		if vars == nil {
+			scope.AppendReleaseCallback(func() {
+				if opts.Telemetry != nil {
+					opts.Telemetry.TotalVariables.Sub(float64(len(v.vars[key])), varType, scopeName)
+				}
+				v.ReleaseVariable(key)
+			})
+
+			v.vars[key] = make(map[string]MutableSECLVariable)
+		}
+
+		if _, found := v.vars[key][name]; !found {
+			if opts.Telemetry != nil {
+				opts.Telemetry.TotalVariables.Inc(varType, scopeName)
+			}
+
+			seclVariable, err := newSECLVariable(value, opts)
+			if err != nil {
+				return err
+			}
+			v.vars[key][name] = seclVariable
+			if expirable, ok := seclVariable.(expirableVariable); ok && opts.TTL > 0 {
+				v.expirablesLock.Lock()
+				v.expirables[key] = append(v.expirables[key], expirable)
+				v.expirablesLock.Unlock()
+			}
+		}
+
+		return v.vars[key][name].Set(ctx, value)
+	}
+
+	switch value.(type) {
+	case int:
+		return NewScopedIntVariable(func(ctx *Context) (int, bool) {
+			if v := getVariable(ctx); v != nil {
+				value, set := v.GetValue()
+				return value.(int), set
+			}
+			return 0, false
+		}, setVariable), nil
+	case bool:
+		return NewScopedBoolVariable(func(ctx *Context) (bool, bool) {
+			if v := getVariable(ctx); v != nil {
+				value, set := v.GetValue()
+				return value.(bool), set
+			}
+			return false, false
+		}, setVariable), nil
+	case string:
+		return NewScopedStringVariable(func(ctx *Context) (string, bool) {
+			if v := getVariable(ctx); v != nil {
+				value, set := v.GetValue()
+				return value.(string), set
+			}
+			return "", false
+		}, setVariable), nil
+	case net.IPNet:
+		return NewScopedIPVariable(func(ctx *Context) (net.IPNet, bool) {
+			if v := getVariable(ctx); v != nil {
+				value, set := v.GetValue()
+				return value.(net.IPNet), set
+			}
+			return net.IPNet{}, false
+		}, setVariable), nil
+	case []string:
+		return NewScopedStringArrayVariable(func(ctx *Context) ([]string, bool) {
+			if v := getVariable(ctx); v != nil {
+				value, set := v.GetValue()
+				return value.([]string), set
+			}
+			return nil, false
+		}, setVariable), nil
+	case []int:
+		return NewScopedIntArrayVariable(func(ctx *Context) ([]int, bool) {
+			if v := getVariable(ctx); v != nil {
+				value, set := v.GetValue()
+				return value.([]int), set
+			}
+			return nil, false
+
+		}, setVariable), nil
+	case []net.IPNet:
+		return NewScopedIPArrayVariable(func(ctx *Context) ([]net.IPNet, bool) {
+			if v := getVariable(ctx); v != nil {
+				value, set := v.GetValue()
+				return value.([]net.IPNet), set
+			}
+			return nil, false
+		}, setVariable), nil
+	default:
+		return nil, fmt.Errorf("unsupported variable type %s for '%s'", reflect.TypeOf(value), name)
+	}
 }
 
-// Unwrap unwraps the error
-func (e *ErrScopeFailure) Unwrap() error {
-	return e.ScoperErr
+// CleanupExpiredVariables cleans up expired variables
+func (v *ScopedVariables) CleanupExpiredVariables() {
+	v.expirablesLock.RLock()
+	defer v.expirablesLock.RUnlock()
+	for _, expirables := range v.expirables {
+		for _, expirable := range expirables {
+			expirable.CleanupExpired()
+		}
+	}
+}
+
+// ReleaseVariable releases a scoped variable
+func (v *ScopedVariables) ReleaseVariable(key string) {
+	delete(v.vars, key)
+	v.expirablesLock.Lock()
+	delete(v.expirables, key)
+	v.expirablesLock.Unlock()
+}
+
+// NewScopedVariables returns a new set of scope variables
+func NewScopedVariables(scoperName string, scoper Scoper) *ScopedVariables {
+	return &ScopedVariables{
+		scoperName: scoperName,
+		scoper:     scoper,
+		vars:       make(map[string]map[string]MutableSECLVariable),
+		expirables: make(map[string][]expirableVariable),
+	}
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -100,10 +100,9 @@ type ContainerContext struct {
 	Resolved    bool                       `field:"-"`
 }
 
-// Key returns a unique key for the entity
-func (c *ContainerContext) Key() (string, bool) {
-	cID := string(c.ContainerID)
-	return cID, cID != ""
+// Hash returns a unique key for the entity
+func (c *ContainerContext) Hash() string {
+	return string(c.ContainerID)
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -190,10 +190,9 @@ func (cg *CGroupContext) Merge(cg2 *CGroupContext) {
 	}
 }
 
-// Key returns a unique key for the entity
-func (cg *CGroupContext) Key() (string, bool) {
-	cgrpID := string(cg.CGroupID)
-	return cgrpID, cgrpID != ""
+// Hash returns a unique key for the entity
+func (cg *CGroupContext) Hash() string {
+	return string(cg.CGroupID)
 }
 
 // ParentScope returns the parent entity scope
@@ -399,9 +398,9 @@ func SetAncestorFields(pce *ProcessCacheEntry, subField string, _ interface{}) (
 	return true, nil
 }
 
-// Key returns a unique key for the entity
-func (pc *ProcessCacheEntry) Key() (string, bool) {
-	return fmt.Sprintf("%d/%s", pc.Pid, pc.Comm), true
+// Hash returns a unique key for the entity
+func (pc *ProcessCacheEntry) Hash() string {
+	return fmt.Sprintf("%d/%s", pc.Pid, pc.Comm)
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -242,9 +242,9 @@ func SetAncestorFields(_ *ProcessCacheEntry, _ string, _ interface{}) (bool, err
 	return true, nil
 }
 
-// Key returns a unique key for the entity
-func (pc *ProcessCacheEntry) Key() (string, bool) {
-	return strconv.Itoa(int(pc.Pid)), true
+// Hash returns a unique key for the entity
+func (pc *ProcessCacheEntry) Hash() string {
+	return strconv.Itoa(int(pc.Pid))
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/secl/model/variables.go
+++ b/pkg/security/secl/model/variables.go
@@ -7,23 +7,22 @@
 package model
 
 import (
-	"github.com/google/uuid"
-
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/google/uuid"
 )
 
 var (
 	// SECLVariables set of variables
-	SECLVariables = map[string]eval.StaticVariable{
-		"process.pid": eval.NewStaticVariable[int](func(ctx *eval.Context) int {
+	SECLVariables = map[string]eval.SECLVariable{
+		"process.pid": eval.NewScopedIntVariable(func(ctx *eval.Context) (int, bool) {
 			pc := ctx.Event.(*Event).ProcessContext
 			if pc == nil {
-				return 0
+				return 0, false
 			}
-			return int(pc.Process.Pid)
-		}),
-		"builtins.uuid4": eval.NewStaticVariable[string](func(_ *eval.Context) string {
-			return uuid.New().String()
-		}),
+			return int(pc.Process.Pid), true
+		}, nil),
+		"builtins.uuid4": eval.NewScopedStringVariable(func(_ *eval.Context) (string, bool) {
+			return uuid.New().String(), true
+		}, nil),
 	}
 )

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"testing"
@@ -22,8 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/xeipuuv/gojsonschema"
 
-	semver "github.com/Masterminds/semver/v3"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/Masterminds/semver/v3"
+	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -296,8 +297,6 @@ func TestActionSetVariable(t *testing.T) {
 		t.Error(err)
 	}
 
-	vStore := rs.evalOpts.VariableStore
-
 	rule := rs.GetRules()["test_rule"]
 	if rule == nil {
 		t.Fatal("failed to find test_rule in ruleset")
@@ -326,13 +325,11 @@ func TestActionSetVariable(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	var4Definition, ok := vStore.GetDefinition(eval.GetVariableName("process", "var4"))
-	require.True(t, ok)
-	require.NotNil(t, var4Definition)
+	scopedVariables := rs.scopedVariables["process"].(*eval.ScopedVariables)
 
-	assert.Equal(t, var4Definition.GetInstancesCount(), 1)
+	assert.Equal(t, scopedVariables.Len(), 1)
 	event.ProcessCacheEntry.Release()
-	assert.Equal(t, var4Definition.GetInstancesCount(), 0)
+	assert.Equal(t, scopedVariables.Len(), 0)
 }
 
 func TestActionSetVariableTTL(t *testing.T) {
@@ -432,86 +429,81 @@ func TestActionSetVariableTTL(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	vStore := rs.evalOpts.VariableStore
+	opts := rs.evalOpts
 
-	definition, ok := vStore.GetDefinition("var1")
-	assert.True(t, ok)
-	assert.NotNil(t, definition)
-	stringArrayVar, exists, err := definition.GetInstance(eval.NewContext(model.NewFakeEvent()))
-	assert.NoError(t, err)
-	assert.True(t, exists)
+	existingVariable := opts.VariableStore.Get("var1")
+	assert.NotNil(t, existingVariable)
+	stringArrayVar, ok := existingVariable.(eval.Variable)
 	assert.NotNil(t, stringArrayVar)
-	value := stringArrayVar.GetValue()
-	assert.NotNil(t, value)
-	assert.IsType(t, value, []string{})
-	assert.Contains(t, value, "foo")
-
-	definition, ok = vStore.GetDefinition("var2")
 	assert.True(t, ok)
-	assert.NotNil(t, definition)
-	intArrayVar, exists, err := definition.GetInstance(eval.NewContext(model.NewFakeEvent()))
-	assert.NoError(t, err)
-	assert.True(t, exists)
+	strValue, _ := stringArrayVar.GetValue()
+	assert.NotNil(t, strValue)
+	assert.Contains(t, strValue, "foo")
+	assert.IsType(t, strValue, []string{})
+
+	existingVariable = opts.VariableStore.Get("var2")
+	assert.NotNil(t, existingVariable)
+	intArrayVar, ok := existingVariable.(eval.Variable)
 	assert.NotNil(t, intArrayVar)
-	value = intArrayVar.GetValue()
+	assert.True(t, ok)
+	value, _ := intArrayVar.GetValue()
 	assert.NotNil(t, value)
-	assert.IsType(t, value, []int{})
 	assert.Contains(t, value, 123)
+	assert.IsType(t, value, []int{})
 
 	ctx := eval.NewContext(event)
-
-	definition, ok = vStore.GetDefinition("process.scopedvar1")
-	assert.True(t, ok)
-	assert.NotNil(t, definition)
-	stringArrayScopedVar, exists, err := definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
+	existingScopedVariable := opts.VariableStore.Get("process.scopedvar1")
+	assert.NotNil(t, existingScopedVariable)
+	stringArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
 	assert.NotNil(t, stringArrayScopedVar)
-	value = stringArrayScopedVar.GetValue()
+	assert.True(t, ok)
+	value, _ = stringArrayScopedVar.GetValue(ctx)
 	assert.NotNil(t, value)
-	assert.IsType(t, value, []string{})
 	assert.Contains(t, value, "bar")
+	assert.IsType(t, value, []string{})
 
-	definition, ok = vStore.GetDefinition("process.scopedvar2")
-	assert.True(t, ok)
-	assert.NotNil(t, definition)
-	intArrayScopedVar, exists, err := definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
+	existingScopedVariable = opts.VariableStore.Get("process.scopedvar2")
+	assert.NotNil(t, existingScopedVariable)
+	intArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
 	assert.NotNil(t, intArrayScopedVar)
-	value = intArrayScopedVar.GetValue()
-	assert.NotNil(t, value)
-	assert.IsType(t, value, []int{})
-	assert.Contains(t, value, 123)
-
-	definition, ok = vStore.GetDefinition("container.simplevarwithttl")
 	assert.True(t, ok)
-	assert.NotNil(t, definition)
-	intScopedVar, exists, err := definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, intScopedVar)
-	assert.Equal(t, 456, intScopedVar.GetValue())
+	value, _ = intArrayScopedVar.GetValue(ctx)
+	assert.NotNil(t, value)
+	assert.Contains(t, value, 123)
+	assert.IsType(t, value, []int{})
+
+	existingContainerScopedVariable := opts.VariableStore.Get("container.simplevarwithttl")
+	assert.NotNil(t, existingContainerScopedVariable)
+	intVarScopedVar, ok := existingContainerScopedVariable.(eval.ScopedVariable)
+	assert.NotNil(t, intVarScopedVar)
+	assert.True(t, ok)
+	value, isSet := intVarScopedVar.GetValue(ctx)
+	assert.True(t, isSet)
+	assert.NotNil(t, value)
+	assert.Equal(t, 456, value)
+	assert.IsType(t, int(0), value)
 
 	time.Sleep(time.Second + 100*time.Millisecond)
 
-	value = stringArrayVar.GetValue()
+	value, _ = stringArrayVar.GetValue()
 	assert.NotContains(t, value, "foo")
 	assert.Len(t, value, 0)
 
-	value = intArrayVar.GetValue()
+	value, _ = intArrayVar.GetValue()
 	assert.NotContains(t, value, 123)
 	assert.Len(t, value, 0)
 
-	value = stringArrayScopedVar.GetValue()
+	value, _ = stringArrayScopedVar.GetValue(ctx)
 	assert.NotContains(t, value, "foo")
 	assert.Len(t, value, 0)
 
-	value = intArrayScopedVar.GetValue()
+	value, _ = intArrayScopedVar.GetValue(ctx)
 	assert.NotContains(t, value, 123)
 	assert.Len(t, value, 0)
 
-	assert.Equal(t, 0, intScopedVar.GetValue())
+	value, isSet = intVarScopedVar.GetValue(ctx)
+	assert.False(t, isSet)
+	assert.Equal(t, 0, value)
 }
 
 func TestActionSetVariableSize(t *testing.T) {
@@ -573,6 +565,39 @@ func TestActionSetVariableSize(t *testing.T) {
 		t.Error(err)
 	}
 
+	opts := rs.evalOpts
+
+	existingVariable := opts.VariableStore.Get("var1")
+	assert.NotNil(t, existingVariable)
+
+	stringArrayVar, ok := existingVariable.(eval.Variable)
+	assert.NotNil(t, stringArrayVar)
+	assert.True(t, ok)
+	value, set := stringArrayVar.GetValue()
+	assert.NotNil(t, value)
+	assert.False(t, set)
+
+	existingVariable = opts.VariableStore.Get("var2")
+	assert.NotNil(t, existingVariable)
+
+	intArrayVar, ok := existingVariable.(eval.Variable)
+	assert.NotNil(t, intArrayVar)
+	assert.True(t, ok)
+	_, set = intArrayVar.GetValue()
+	assert.False(t, set)
+
+	existingScopedVariable := opts.VariableStore.Get("process.scopedvar1")
+	assert.NotNil(t, existingScopedVariable)
+	stringArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
+	assert.NotNil(t, stringArrayScopedVar)
+	assert.True(t, ok)
+
+	existingScopedVariable = opts.VariableStore.Get("process.scopedvar2")
+	assert.NotNil(t, existingScopedVariable)
+	intArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
+	assert.NotNil(t, intArrayScopedVar)
+	assert.True(t, ok)
+
 	event := model.NewFakeEvent()
 	event.Type = uint32(model.FileOpenEventType)
 	processCacheEntry := &model.ProcessCacheEntry{}
@@ -582,39 +607,11 @@ func TestActionSetVariableSize(t *testing.T) {
 
 	ctx := eval.NewContext(event)
 
-	vStore := rs.evalOpts.VariableStore
+	_, set = stringArrayScopedVar.GetValue(ctx)
+	assert.False(t, set)
 
-	var1Definition, ok := vStore.GetDefinition("var1")
-	assert.True(t, ok)
-	assert.NotNil(t, var1Definition)
-	stringArrayVar, exists, err := var1Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, stringArrayVar)
-
-	var2Definition, ok := vStore.GetDefinition("var2")
-	assert.True(t, ok)
-	assert.NotNil(t, var2Definition)
-	intArrayVar, exists, err := var2Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, intArrayVar)
-
-	scopedVar1Definition, ok := vStore.GetDefinition("process.scopedvar1")
-	assert.True(t, ok)
-	assert.NotNil(t, scopedVar1Definition)
-	stringArrayScopedVar, exists, err := scopedVar1Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, stringArrayScopedVar)
-
-	scopedVar2Definition, ok := vStore.GetDefinition("process.scopedvar2")
-	assert.True(t, ok)
-	assert.NotNil(t, scopedVar2Definition)
-	intArrayScopedVar, exists, err := scopedVar1Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, intArrayScopedVar)
+	_, set = intArrayScopedVar.GetValue(ctx)
+	assert.False(t, set)
 
 	if !rs.Evaluate(event) {
 		t.Errorf("Expected event to match rule")
@@ -623,45 +620,31 @@ func TestActionSetVariableSize(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	stringArrayVar, exists, err = var1Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, stringArrayVar)
-	value := stringArrayVar.GetValue()
-	assert.NotNil(t, value)
-	assert.IsType(t, value, []string{})
+	value, set = stringArrayVar.GetValue()
 	assert.Contains(t, value, "foo")
 	assert.Len(t, value, 1)
+	assert.IsType(t, value, []string{})
+	assert.True(t, set)
 
-	intArrayVar, exists, err = var2Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, intArrayVar)
-	value = intArrayVar.GetValue()
-	assert.NotNil(t, value)
+	value, set = intArrayVar.GetValue()
 	assert.IsType(t, value, []int{})
 	assert.Contains(t, value, 1)
 	assert.Len(t, value, 1)
+	assert.True(t, set)
 
-	stringArrayScopedVar, exists, err = scopedVar1Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, stringArrayScopedVar)
-	value = stringArrayScopedVar.GetValue()
+	value, set = stringArrayScopedVar.GetValue(ctx)
 	assert.NotNil(t, value)
-	assert.IsType(t, value, []string{})
 	assert.Contains(t, value, "bar")
+	assert.IsType(t, value, []string{})
 	assert.Len(t, value, 1)
+	assert.True(t, set)
 
-	intArrayScopedVar, exists, err = scopedVar2Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, intArrayScopedVar)
-	value = intArrayScopedVar.GetValue()
+	value, set = intArrayScopedVar.GetValue(ctx)
 	assert.NotNil(t, value)
-	assert.IsType(t, value, []int{})
 	assert.Contains(t, value, 123)
+	assert.IsType(t, value, []int{})
 	assert.Len(t, value, 1)
+	assert.True(t, set)
 }
 
 func TestActionSetEmptyScope(t *testing.T) {
@@ -700,39 +683,26 @@ func TestActionSetEmptyScope(t *testing.T) {
 		t.Error(err)
 	}
 
-	vStore := rs.evalOpts.VariableStore
+	opts := rs.evalOpts
+
+	existingScopedVariable := opts.VariableStore.Get("process.scopedvar1")
+	assert.NotNil(t, existingScopedVariable)
+	stringArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
+	assert.NotNil(t, stringArrayScopedVar)
+	assert.True(t, ok)
 
 	event := model.NewFakeEvent()
 	event.Type = uint32(model.FileOpenEventType)
 	event.SetFieldValue("open.file.path", "/tmp/test")
 
 	ctx := eval.NewContext(event)
-
-	definition, ok := vStore.GetDefinition("process.scopedvar1")
-	assert.True(t, ok)
-	assert.NotNil(t, definition)
-	stringArrayScopedVar, exists, err := definition.GetInstance(ctx)
-	var expectedErr *eval.ErrScopeFailure
-	assert.ErrorAs(t, err, &expectedErr)
-	assert.Equal(t, expectedErr.VarName, "scopedvar1")
-	assert.Equal(t, expectedErr.ScoperType, eval.ProcessScoperType)
-	assert.Equal(t, expectedErr.ScoperErr.Error(), "failed to get process scope")
-	assert.False(t, exists)
-	assert.Nil(t, stringArrayScopedVar)
-	assert.Equal(t, definition.GetInstancesCount(), 0)
-
 	if !rs.Evaluate(event) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	stringArrayScopedVar, exists, err = definition.GetInstance(ctx)
-	assert.ErrorAs(t, err, &expectedErr)
-	assert.Equal(t, expectedErr.VarName, "scopedvar1")
-	assert.Equal(t, expectedErr.ScoperType, eval.ProcessScoperType)
-	assert.Equal(t, expectedErr.ScoperErr.Error(), "failed to get process scope")
-	assert.False(t, exists)
-	assert.Nil(t, stringArrayScopedVar)
-	assert.Equal(t, definition.GetInstancesCount(), 0)
+	value, set := stringArrayScopedVar.GetValue(ctx)
+	assert.Nil(t, value)
+	assert.False(t, set)
 }
 
 func TestActionSetVariableConflict(t *testing.T) {
@@ -812,17 +782,18 @@ func TestActionSetVariableInitialValue(t *testing.T) {
 		t.Error(err)
 	}
 
-	vStore := rs.evalOpts.VariableStore
+	opts := rs.evalOpts
 
-	evaluator, err := vStore.GetEvaluator("var1")
-	assert.NoError(t, err)
-	assert.NotNil(t, evaluator)
-	intEvaluator, ok := evaluator.(*eval.IntEvaluator)
+	existingVariable := opts.VariableStore.Get("var1")
+	assert.NotNil(t, existingVariable)
+
+	intVar, ok := existingVariable.(eval.Variable)
+	assert.NotNil(t, intVar)
 	assert.True(t, ok)
-	if ok {
-		value := intEvaluator.EvalFnc(eval.NewContext(model.NewFakeEvent()))
-		assert.Equal(t, value, 123)
-	}
+	value, set := intVar.GetValue()
+	assert.NotNil(t, value)
+	assert.Equal(t, 123, value)
+	assert.False(t, set)
 
 	event := model.NewFakeEvent()
 	event.Type = uint32(model.FileOpenEventType)
@@ -835,14 +806,9 @@ func TestActionSetVariableInitialValue(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	definition, ok := vStore.GetDefinition("var1")
-	assert.True(t, ok)
-	assert.NotNil(t, definition)
-	variable, exists, err := definition.GetInstance(eval.NewContext(event))
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, variable)
-	assert.Equal(t, 456, variable.GetValue())
+	value, set = intVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, 456, value)
 
 	if rs.Evaluate(event) {
 		t.Errorf("Expected event to not match rule")
@@ -914,11 +880,10 @@ func TestActionSetVariableInherited(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vStore := rs.evalOpts.VariableStore
+	opts := rs.evalOpts
 
-	processVar1Definition, ok := vStore.GetDefinition("process.var1")
-	assert.True(t, ok)
-	assert.NotNil(t, processVar1Definition)
+	existingScopedVariable := opts.VariableStore.Get("process.var1")
+	assert.NotNil(t, existingScopedVariable)
 
 	event := model.NewFakeEvent()
 	event.Type = uint32(model.FileOpenEventType)
@@ -936,21 +901,25 @@ func TestActionSetVariableInherited(t *testing.T) {
 
 	ctx := eval.NewContext(event)
 
-	variable, exists, err := processVar1Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
+	assert.NotNil(t, existingScopedVariable)
+	stringScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
+	assert.NotNil(t, stringScopedVar)
+	assert.True(t, ok)
+
+	value, set := stringScopedVar.GetValue(ctx)
+	assert.NotNil(t, value)
 	// TODO(lebauce): should be 123. default_value are not properly handled
-	assert.Nil(t, variable)
+	assert.Equal(t, 0, value)
+	assert.False(t, set)
 
 	if !rs.Evaluate(event) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	variable, exists, err = processVar1Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, variable)
-	assert.Equal(t, 456, variable.GetValue())
+	value, set = stringScopedVar.GetValue(ctx)
+	assert.NotNil(t, value)
+	assert.Equal(t, 456, value)
+	assert.True(t, set)
 
 	event2 := model.NewFakeEvent()
 	event2.Type = uint32(model.FileOpenEventType)
@@ -972,11 +941,10 @@ func TestActionSetVariableInherited(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	variable, exists, err = processVar1Definition.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, variable)
-	assert.Equal(t, 1000, variable.GetValue())
+	value, set = stringScopedVar.GetValue(ctx)
+	assert.NotNil(t, value)
+	assert.Equal(t, 1000, value)
+	assert.True(t, set)
 }
 
 func stringPtr(input string) *string {
@@ -1093,58 +1061,65 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vStore := rs.evalOpts.VariableStore
+	opts := rs.evalOpts
 
-	correlationKeySECLVariableDef, ok := vStore.GetDefinition("process.correlation_key")
+	// Fetch process.correlation_key variable
+	correlationKeySECLVariable := opts.VariableStore.Get("process.correlation_key")
+	assert.NotNil(t, correlationKeySECLVariable)
+	correlationKeyScopedVariable, ok := correlationKeySECLVariable.(eval.ScopedVariable)
+	assert.NotNil(t, correlationKeyScopedVariable)
 	assert.True(t, ok)
-	assert.NotNil(t, correlationKeySECLVariableDef)
 
-	parentCorrelationKeysSECLVariableDef, ok := vStore.GetDefinition("process.parent_correlation_keys")
+	// Fetch process.parent_correlation_keys variable
+	parentCorrelationKeysSECLVariable := opts.VariableStore.Get("process.parent_correlation_keys")
+	assert.NotNil(t, parentCorrelationKeysSECLVariable)
+	parentCorrelationKeysScopedVariable, ok := parentCorrelationKeysSECLVariable.(eval.ScopedVariable)
+	assert.NotNil(t, parentCorrelationKeysScopedVariable)
 	assert.True(t, ok)
-	assert.NotNil(t, parentCorrelationKeysSECLVariableDef)
 
 	event := fakeOpenEvent("/tmp/first", 1, nil)
 	ctx := eval.NewContext(event)
 
-	correlationKeyVariable, exists, err := correlationKeySECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, correlationKeyVariable)
+	// test correlation key initial value
+	correlationKeyValue, set := correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, "", correlationKeyValue)
+	assert.False(t, set)
 
 	if !rs.Evaluate(event) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	correlationKeyFromFirstRule := correlationKeyVariable.GetValue().(string)
-	assert.True(t, strings.HasPrefix(correlationKeyFromFirstRule, "first_"))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.True(t, strings.HasPrefix(correlationKeyValue.(string), "first_"))
+	assert.True(t, set)
 
-	assert.Equal(t, parentCorrelationKeysSECLVariableDef.GetInstancesCount(), 0)
+	parentCorrelationKeysValue, _ := parentCorrelationKeysScopedVariable.GetValue(ctx)
+	assert.Equal(t, len(parentCorrelationKeysValue.([]string)), 0)
+
+	correlationKeyFromFirstRule := correlationKeyValue.(string)
 
 	// trigger the first rule again, and make sure nothing changes
 	event2 := fakeOpenEvent("/tmp/first", 2, event.ProcessCacheEntry)
 	ctx = eval.NewContext(event2)
 
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, correlationKeyFromFirstRule, correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
+	assert.True(t, set)
 
 	if rs.Evaluate(event2) {
 		t.Errorf("Didn't expected event to match rule")
 	}
 
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, correlationKeyFromFirstRule, correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
+	assert.True(t, set)
 
-	assert.Equal(t, parentCorrelationKeysSECLVariableDef.GetInstancesCount(), 0)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	assert.Equal(t, len(parentCorrelationKeysValue.([]string)), 0)
 
 	// jump to the third rule, check:
 	//  - that the correlation key is updated with the pattern from the third rule
@@ -1152,62 +1127,45 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	event3 := fakeOpenEvent("/tmp/third", 3, event2.ProcessCacheEntry)
 	ctx = eval.NewContext(event3)
 
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, correlationKeyFromFirstRule, correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
+	assert.True(t, set)
 
 	if !rs.Evaluate(event3) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	correlationKeyFromThirdRule := correlationKeyVariable.GetValue().(string)
-	assert.True(t, strings.HasPrefix(correlationKeyFromThirdRule, "third_"))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.True(t, strings.HasPrefix(correlationKeyValue.(string), "third_"))
+	assert.True(t, set)
 
-	parentCorrelationKeysSECLVariable, exists, err := parentCorrelationKeysSECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, parentCorrelationKeysSECLVariable)
-	parentCorrelationKeysValue := parentCorrelationKeysSECLVariable.GetValue()
-	assert.NotNil(t, parentCorrelationKeysValue)
-	assert.IsType(t, parentCorrelationKeysValue, []string{})
-	assert.Len(t, parentCorrelationKeysValue, 1)
-	assert.Contains(t, parentCorrelationKeysValue, correlationKeyFromFirstRule)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	assert.True(t, len(parentCorrelationKeysValue.([]string)) == 1 && slices.Contains(parentCorrelationKeysValue.([]string), correlationKeyFromFirstRule))
+
+	correlationKeyFromThirdRule := correlationKeyValue.(string)
 
 	// trigger the second rule, make sure nothing changes
 	event4 := fakeOpenEvent("/tmp/second", 4, event3.ProcessCacheEntry)
 	ctx = eval.NewContext(event4)
 
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, correlationKeyFromThirdRule, correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromThirdRule)
+	assert.True(t, set)
 
 	if rs.Evaluate(event4) {
 		t.Errorf("Didn't expected event to match rule")
 	}
 
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, correlationKeyFromThirdRule, correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromThirdRule)
+	assert.True(t, set)
 
-	parentCorrelationKeysSECLVariable, exists, err = parentCorrelationKeysSECLVariableDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	parentCorrelationKeysValue = parentCorrelationKeysSECLVariable.GetValue()
-	assert.NotNil(t, parentCorrelationKeysValue)
-	assert.IsType(t, parentCorrelationKeysValue, []string{})
-	assert.Len(t, parentCorrelationKeysValue, 1)
-	assert.Contains(t, parentCorrelationKeysValue, correlationKeyFromFirstRule)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	assert.True(t, len(parentCorrelationKeysValue.([]string)) == 1 && slices.Contains(parentCorrelationKeysValue.([]string), correlationKeyFromFirstRule))
 }
 
 func newFakeCGroupWrite(cgroupWritePID int, path string, pid uint32, ancestor *model.ProcessCacheEntry) *model.Event {
@@ -1364,17 +1322,21 @@ func TestActionSetVariableScopeField(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vStore := rs.evalOpts.VariableStore
+	opts := rs.evalOpts
 
 	// Fetch process.correlation_key variable
-	correlationKeySECLVariableDef, ok := vStore.GetDefinition("process.correlation_key")
+	correlationKeySECLVariable := opts.VariableStore.Get("process.correlation_key")
+	assert.NotNil(t, correlationKeySECLVariable)
+	correlationKeyScopedVariable, ok := correlationKeySECLVariable.(eval.ScopedVariable)
+	assert.NotNil(t, correlationKeyScopedVariable)
 	assert.True(t, ok)
-	assert.NotNil(t, correlationKeySECLVariableDef)
 
 	// Fetch process.parent_correlation_keys variable
-	parentCorrelationKeysSECLVariableDef, ok := vStore.GetDefinition("process.parent_correlation_keys")
+	parentCorrelationKeysSECLVariable := opts.VariableStore.Get("process.parent_correlation_keys")
+	assert.NotNil(t, parentCorrelationKeysSECLVariable)
+	parentCorrelationKeysScopedVariable, ok := parentCorrelationKeysSECLVariable.(eval.ScopedVariable)
+	assert.NotNil(t, parentCorrelationKeysScopedVariable)
 	assert.True(t, ok)
-	assert.NotNil(t, parentCorrelationKeysSECLVariableDef)
 
 	// create cgroup_write event
 	event1 := newFakeCGroupWrite(2, "/tmp/one", 1, nil)
@@ -1389,97 +1351,63 @@ func TestActionSetVariableScopeField(t *testing.T) {
 	}
 
 	// check the correlation_key of the current process
-	correlationKeyVariable, exists, err := correlationKeySECLVariableDef.GetInstance(ctx1)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, "cgroup_write_first", correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set := correlationKeyScopedVariable.GetValue(ctx1)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, "cgroup_write_first", correlationKeyValue.(string))
+	assert.True(t, set)
 
 	// check the correlation key of the PID from the cgroup_write
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx3)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, "first", correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, "first", correlationKeyValue.(string))
+	assert.True(t, set)
 
 	if !rs.Evaluate(event2) {
 		t.Errorf("Expected event2 to match a rule")
 	}
 
 	// check the correlation_key of the current process
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx1)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, "cgroup_write_second", correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx1)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, "cgroup_write_second", correlationKeyValue.(string))
+	assert.True(t, set)
 
 	// check the parent_correlation_keys of the current process
-	parentCorrelationKeysVariable, exists, err := parentCorrelationKeysSECLVariableDef.GetInstance(ctx1)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, parentCorrelationKeysVariable)
-	parentCorrelationKeysValue := parentCorrelationKeysVariable.GetValue()
-	assert.NotNil(t, parentCorrelationKeysValue)
-	assert.IsType(t, parentCorrelationKeysValue, []string{})
-	assert.Len(t, parentCorrelationKeysValue, 1)
-	assert.Contains(t, parentCorrelationKeysValue, "cgroup_write_first")
+	parentCorrelationKeysValue, _ := parentCorrelationKeysScopedVariable.GetValue(ctx1)
+	assert.Equal(t, []string{"cgroup_write_first"}, parentCorrelationKeysValue.([]string))
 
 	// check the correlation key of the PID from the cgroup_write
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx3)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, "second", correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, "second", correlationKeyValue.(string))
+	assert.True(t, set)
 
 	// check the parent_correlation_keys of the PID from the cgroup_write
-	parentCorrelationKeysVariable, exists, err = parentCorrelationKeysSECLVariableDef.GetInstance(ctx3)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, parentCorrelationKeysVariable)
-	parentCorrelationKeysValue = parentCorrelationKeysVariable.GetValue()
-	assert.NotNil(t, parentCorrelationKeysValue)
-	assert.IsType(t, parentCorrelationKeysValue, []string{})
-	assert.Len(t, parentCorrelationKeysValue, 1)
-	assert.Contains(t, parentCorrelationKeysValue, "first")
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx3)
+	assert.Equal(t, []string{"first"}, parentCorrelationKeysValue.([]string))
 
 	if !rs.Evaluate(event3) {
 		t.Errorf("Expected event3 to match a rule")
 	}
 
 	// check the correlation_key of the current process
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx1)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, "cgroup_write_second", correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx1)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, "cgroup_write_second", correlationKeyValue.(string))
+	assert.True(t, set)
 
 	// check the parent_correlation_keys of the current process
-	parentCorrelationKeysVariable, exists, err = parentCorrelationKeysSECLVariableDef.GetInstance(ctx1)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, parentCorrelationKeysVariable)
-	parentCorrelationKeysValue = parentCorrelationKeysVariable.GetValue()
-	assert.NotNil(t, parentCorrelationKeysValue)
-	assert.IsType(t, parentCorrelationKeysValue, []string{})
-	assert.Len(t, parentCorrelationKeysValue, 1)
-	assert.Contains(t, parentCorrelationKeysValue, "cgroup_write_first")
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx1)
+	assert.Equal(t, []string{"cgroup_write_first"}, parentCorrelationKeysValue.([]string))
 
 	// check the correlation key of the PID from the cgroup_write
-	correlationKeyVariable, exists, err = correlationKeySECLVariableDef.GetInstance(ctx3)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, correlationKeyVariable)
-	assert.Equal(t, "third", correlationKeyVariable.GetValue().(string))
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, "third", correlationKeyValue.(string))
+	assert.True(t, set)
 
 	// check the parent_correlation_keys of the PID from the cgroup_write
-	parentCorrelationKeysVariable, exists, err = parentCorrelationKeysSECLVariableDef.GetInstance(ctx3)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, parentCorrelationKeysVariable)
-	parentCorrelationKeysValue = parentCorrelationKeysVariable.GetValue()
-	assert.NotNil(t, parentCorrelationKeysValue)
-	assert.IsType(t, parentCorrelationKeysValue, []string{})
-	assert.Len(t, parentCorrelationKeysValue, 2)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx3)
 	assert.ElementsMatch(t, []string{"first", "second"}, parentCorrelationKeysValue.([]string))
 }
 
@@ -1558,44 +1486,47 @@ func TestActionSetVariableExpression(t *testing.T) {
 		t.Error(err)
 	}
 
-	vStore := rs.evalOpts.VariableStore
-	ctx := eval.NewContext(model.NewFakeEvent())
+	opts := rs.evalOpts
 
-	var1Def, ok := vStore.GetDefinition("var1")
+	existingVariable := opts.VariableStore.Get("var1")
+	assert.NotNil(t, existingVariable)
+
+	existingVariable2 := opts.VariableStore.Get("var3")
+	assert.NotNil(t, existingVariable2)
+
+	existingVariable3 := opts.VariableStore.Get("connected")
+	assert.NotNil(t, existingVariable3)
+
+	existingVariable4 := opts.VariableStore.Get("connected_to")
+	assert.NotNil(t, existingVariable4)
+
+	intVar, ok := existingVariable.(eval.Variable)
+	assert.NotNil(t, intVar)
 	assert.True(t, ok)
-	assert.NotNil(t, var1Def)
+	value, set := intVar.GetValue()
+	assert.NotNil(t, value)
+	assert.False(t, set)
 
-	var3Def, ok := vStore.GetDefinition("var3")
+	strVar, ok := existingVariable2.(eval.Variable)
+	assert.NotNil(t, strVar)
 	assert.True(t, ok)
-	assert.NotNil(t, var3Def)
+	value, set = strVar.GetValue()
+	assert.NotNil(t, value)
+	assert.False(t, set)
 
-	connectedDef, ok := vStore.GetDefinition("connected")
+	connectedVar, ok := existingVariable3.(eval.Variable)
+	assert.NotNil(t, connectedVar)
 	assert.True(t, ok)
-	assert.NotNil(t, connectedDef)
+	value, set = connectedVar.GetValue()
+	assert.NotNil(t, value)
+	assert.False(t, set)
 
-	connectedToDef, ok := vStore.GetDefinition("connected_to")
+	connectedToVar, ok := existingVariable4.(eval.Variable)
+	assert.NotNil(t, connectedToVar)
 	assert.True(t, ok)
-	assert.NotNil(t, connectedToDef)
-
-	var1Var, exists, err := var1Def.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, var1Var)
-
-	var3Var, exists, err := var3Def.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, var3Var)
-
-	connectedVar, exists, err := connectedDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, connectedVar)
-
-	connectedToVar, exists, err := connectedToDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-	assert.Nil(t, connectedToVar)
+	value, set = connectedToVar.GetValue()
+	assert.NotNil(t, value)
+	assert.False(t, set)
 
 	event := model.NewFakeEvent()
 	event.Type = uint32(model.FileOpenEventType)
@@ -1608,37 +1539,25 @@ func TestActionSetVariableExpression(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	var1Var, exists, err = var1Def.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, var1Var)
-	var1Val := var1Var.GetValue().(int)
-	assert.Equal(t, 247, var1Val)
+	value, set = intVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, 247, value)
 
-	var3Var, exists, err = var3Def.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, var3Var)
-	var3Val := var3Var.GetValue().(string)
-	assert.Equal(t, "foo:foo", var3Val)
+	value, set = strVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, "foo:foo", value)
 
 	if !rs.Evaluate(event) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	var1Var, exists, err = var1Def.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, var1Var)
-	var1Val = var1Var.GetValue().(int)
-	assert.Equal(t, 495, var1Val)
+	value, set = intVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, 495, value)
 
-	var3Var, exists, err = var3Def.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, var3Var)
-	var3Val = var3Var.GetValue().(string)
-	assert.Equal(t, "foo:foo", var3Val)
+	value, set = strVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, "foo:foo", value)
 
 	event2 := model.NewFakeEvent()
 	event2.Type = uint32(model.ConnectEventType)
@@ -1655,22 +1574,16 @@ func TestActionSetVariableExpression(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	connectedVar, exists, err = connectedDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, connectedVar)
-	connectedVal := connectedVar.GetValue().(bool)
-	assert.Equal(t, true, connectedVal)
+	value, set = connectedVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, true, value)
 
-	connectedToVar, exists, err = connectedToDef.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, connectedToVar)
-	connectedToVal := connectedToVar.GetValue().([]net.IPNet)
-	assert.Equal(t, connectedToVal, []net.IPNet{{
+	value, set = connectedToVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, []net.IPNet{{
 		IP:   net.IPv4(192, 168, 1, 0).To4(),
 		Mask: connectIP.Mask,
-	}})
+	}}, value)
 }
 
 func loadPolicy(t *testing.T, testPolicy *PolicyDef, policyOpts PolicyLoaderOpts) (*RuleSet, *multierror.Error) {
@@ -2263,28 +2176,25 @@ func TestActionSetVariableLength(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	vStore := rs.evalOpts.VariableStore
-	ctx := eval.NewContext(model.NewFakeEvent())
+	opts := rs.evalOpts
 
-	var2Def, ok := vStore.GetDefinition("var2")
+	existingVariable := opts.VariableStore.Get("var2")
+	assert.NotNil(t, existingVariable)
+	intArrayVar, ok := existingVariable.(eval.Variable)
+	assert.NotNil(t, intArrayVar)
 	assert.True(t, ok)
-	assert.NotNil(t, var2Def)
-	var2Var, exists, err := var2Def.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, var2Var)
-	var2Val := var2Var.GetValue().(int)
-	assert.Equal(t, 3, var2Val)
+	intValue, _ := intArrayVar.GetValue()
+	assert.NotNil(t, intValue)
+	assert.Equal(t, 3, intValue)
 
-	var4Def, ok := vStore.GetDefinition("var4")
+	existingVariable = opts.VariableStore.Get("var4")
+	assert.NotNil(t, existingVariable)
+	intArrayVar, ok = existingVariable.(eval.Variable)
+	assert.NotNil(t, intArrayVar)
 	assert.True(t, ok)
-	assert.NotNil(t, var4Def)
-	var4Var, exists, err := var4Def.GetInstance(ctx)
-	assert.NoError(t, err)
-	assert.True(t, exists)
-	assert.NotNil(t, var4Var)
-	var4Val := var4Var.GetValue().(int)
-	assert.Equal(t, 2, var4Val)
+	intValue, _ = intArrayVar.GetValue()
+	assert.NotNil(t, intValue)
+	assert.Equal(t, 2, intValue)
 }
 
 // go test -v github.com/DataDog/datadog-agent/pkg/security/secl/rules --run="TestLoadPolicy"

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/spf13/cast"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -67,6 +67,8 @@ type RuleSet struct {
 	fakeEventCtor    func() eval.Event
 	listenersLock    sync.RWMutex
 	listeners        []RuleSetListener
+	globalVariables  *eval.Variables
+	scopedVariables  map[Scope]VariableProvider
 	// fields holds the list of event field queries (like "process.uid") used by the entire set of rules
 	fields []eval.Field
 	logger log.Logger
@@ -221,12 +223,12 @@ func (rs *RuleSet) ListMacroIDs() []MacroID {
 	return ids
 }
 
-// IterVariables calls the given callback function on all variables
-func (rs *RuleSet) IterVariables(cb func(definition eval.VariableDefinition, instances map[string]eval.VariableInstance)) {
+// GetVariables returns the variables store
+func (rs *RuleSet) GetVariables() map[string]eval.SECLVariable {
 	if rs.evalOpts == nil || rs.evalOpts.VariableStore == nil {
-		return
+		return nil
 	}
-	rs.evalOpts.VariableStore.IterVariables(cb)
+	return rs.evalOpts.VariableStore.Variables
 }
 
 // AddMacros parses the macros AST and adds them to the list of macros of the ruleset
@@ -337,26 +339,21 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 
 			switch {
 			case actionDef.Set != nil:
-				name := actionDef.Set.Name
-				if !validators.CheckRuleID(name) {
-					errs = multierror.Append(errs, fmt.Errorf("invalid variable name '%s'", name))
+				varName := actionDef.Set.Name
+				if !validators.CheckRuleID(varName) {
+					errs = multierror.Append(errs, fmt.Errorf("invalid variable name '%s'", varName))
 					continue
 				}
-
-				scoper := rs.opts.VariableScopers[actionDef.Set.Scope]
-				if scoper == nil {
-					errs = multierror.Append(errs, fmt.Errorf("variable '%s' has invalid scope name: %s", name, actionDef.Set.Scope))
-					continue
+				if actionDef.Set.Scope != "" {
+					varName = string(actionDef.Set.Scope) + "." + varName
 				}
 
-				varName := eval.GetVariableName(string(actionDef.Set.Scope), name)
-
-				if _, err := rs.eventCtor().GetFieldValue(string(varName)); err == nil {
+				if _, err := rs.eventCtor().GetFieldValue(varName); err == nil {
 					errs = multierror.Append(errs, fmt.Errorf("variable '%s' conflicts with field", varName))
 					continue
 				}
 
-				if _, found := rs.evalOpts.Constants[string(varName)]; found {
+				if _, found := rs.evalOpts.Constants[varName]; found {
 					errs = multierror.Append(errs, fmt.Errorf("variable '%s' conflicts with constant", varName))
 					continue
 				}
@@ -433,6 +430,25 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					}
 				}
 
+				var variable eval.SECLVariable
+				var variableProvider VariableProvider
+
+				if actionDef.Set.Scope != "" {
+					if _, found := rs.scopedVariables[actionDef.Set.Scope]; !found {
+						stateScopeBuilder := rs.opts.StateScopes[actionDef.Set.Scope]
+						if stateScopeBuilder == nil {
+							errs = multierror.Append(errs, fmt.Errorf("invalid scope '%s'", actionDef.Set.Scope))
+							continue
+						}
+
+						rs.scopedVariables[actionDef.Set.Scope] = stateScopeBuilder()
+					}
+
+					variableProvider = rs.scopedVariables[actionDef.Set.Scope]
+				} else {
+					variableProvider = rs.globalVariables
+				}
+
 				opts := eval.VariableOpts{
 					TTL:       actionDef.Set.TTL.GetDuration(),
 					Size:      actionDef.Set.Size,
@@ -441,70 +457,23 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					Telemetry: rs.evalOpts.Telemetry,
 				}
 
-				existingDefiniton, exists := rs.evalOpts.VariableStore.GetDefinition(varName)
-				if exists {
-					existingValue := existingDefiniton.DefaultValue()
-					if reflect.TypeOf(variableValue) != reflect.TypeOf(existingValue) {
-						errs = multierror.Append(errs, fmt.Errorf("conflicting types for variable '%s': %s != %s", varName, reflect.TypeOf(variableValue), reflect.TypeOf(existingValue)))
-						continue
-					}
-					if existingDefiniton.IsPrivate() != opts.Private {
-						errs = multierror.Append(errs, fmt.Errorf("conflicting private flag for variable '%s'", varName))
-						continue
-					}
-				}
-
-				var newVariableDefinition eval.VariableDefinition
-
-				switch value := variableValue.(type) {
-				case string:
-					var defaultValue string
-					if actionDef.Set.DefaultValue != nil {
-						defaultValue = value
-					}
-					newVariableDefinition = eval.NewVariableDefinition[string](actionDef.Set.Name, scoper, defaultValue, opts)
-				case int:
-					var defaultValue int
-					if actionDef.Set.DefaultValue != nil {
-						defaultValue = value
-					}
-					newVariableDefinition = eval.NewVariableDefinition[int](actionDef.Set.Name, scoper, defaultValue, opts)
-				case bool:
-					var defaultValue bool
-					if actionDef.Set.DefaultValue != nil {
-						defaultValue = value
-					}
-					newVariableDefinition = eval.NewVariableDefinition[bool](actionDef.Set.Name, scoper, defaultValue, opts)
-				case net.IPNet:
-					var defaultValue net.IPNet
-					if actionDef.Set.DefaultValue != nil {
-						defaultValue = value
-					}
-					newVariableDefinition = eval.NewVariableDefinition[net.IPNet](actionDef.Set.Name, scoper, defaultValue, opts)
-				case []string:
-					var defaultValue []string
-					if actionDef.Set.DefaultValue != nil {
-						defaultValue = value
-					}
-					newVariableDefinition = eval.NewVariableDefinition[[]string](actionDef.Set.Name, scoper, defaultValue, opts)
-				case []int:
-					var defaultValue []int
-					if actionDef.Set.DefaultValue != nil {
-						defaultValue = value
-					}
-					newVariableDefinition = eval.NewVariableDefinition[[]int](actionDef.Set.Name, scoper, defaultValue, opts)
-				case []net.IPNet:
-					var defaultValue []net.IPNet
-					if actionDef.Set.DefaultValue != nil {
-						defaultValue = value
-					}
-					newVariableDefinition = eval.NewVariableDefinition[[]net.IPNet](actionDef.Set.Name, scoper, defaultValue, opts)
-				default:
-					errs = multierror.Append(errs, fmt.Errorf("rule `%s` has unsupported set action value type: %T", rule.Def.ID, variableValue))
+				variable, err := variableProvider.NewSECLVariable(actionDef.Set.Name, variableValue, string(actionDef.Set.Scope), opts)
+				if err != nil {
+					errs = multierror.Append(errs, fmt.Errorf("invalid type '%s' for variable '%s' (%+v): %w", reflect.TypeOf(variableValue), actionDef.Set.Name, actionDef.Set, err))
 					continue
 				}
 
-				rs.evalOpts.VariableStore.AddDefinition(varName, newVariableDefinition)
+				if existingVariable := rs.evalOpts.VariableStore.Get(varName); existingVariable != nil && reflect.TypeOf(variable) != reflect.TypeOf(existingVariable) {
+					errs = multierror.Append(errs, fmt.Errorf("conflicting types for variable '%s': %s != %s", varName, reflect.TypeOf(variable), reflect.TypeOf(existingVariable)))
+					continue
+				}
+
+				if existingVariable := rs.evalOpts.VariableStore.Get(varName); existingVariable != nil && existingVariable.GetVariableOpts().Private != variable.GetVariableOpts().Private {
+					errs = multierror.Append(errs, fmt.Errorf("conflicting private flag for variable '%s'", varName))
+					continue
+				}
+
+				rs.evalOpts.VariableStore.Add(varName, variable)
 			}
 
 			rule.Actions = append(rule.Actions, &Action{
@@ -851,46 +820,36 @@ func (rs *RuleSet) runSetActions(_ eval.Event, ctx *eval.Context, rule *Rule) er
 		switch {
 		// other actions are handled by ruleset listeners
 		case action.Def.Set != nil:
-			varName := eval.GetVariableName(string(action.Def.Set.Scope), action.Def.Set.Name)
+			name := string(action.Def.Set.Scope)
+			if name != "" {
+				name += "."
+			}
+			name += action.Def.Set.Name
 
-			definition, exists := rs.evalOpts.VariableStore.GetDefinition(varName)
-			if !exists {
-				return fmt.Errorf("unknown variable '%s' in rule '%s'", varName, rule.ID)
+			variable := rs.evalOpts.VariableStore.Get(name)
+			if variable == nil {
+				return fmt.Errorf("unknown variable `%s` in rule `%s`", name, rule.ID)
 			}
 
-			instance, exists, err := definition.GetInstance(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to apply set action for variable '%s' of rule '%s': %w", varName, rule.ID, err)
-			} else if !exists { // the variable has no instance for this context
-				newInstance, added, err := definition.AddNewInstance(ctx)
-				if err != nil {
-					return fmt.Errorf("failed to instantiate new '%s' variable for rule '%s': %w", varName, rule.ID, err)
+			if mutable, ok := variable.(eval.MutableVariable); ok {
+				value := action.Def.Set.Value
+				if field := action.Def.Set.Field; field != "" {
+					if evaluator := rs.fieldEvaluators[field]; evaluator != nil {
+						value = evaluator.Eval(ctx)
+					}
+				} else if expression := action.Def.Set.Expression; expression != "" {
+					if evaluator := rs.fieldEvaluators[expression]; evaluator != nil {
+						value = evaluator.Eval(ctx)
+					}
 				}
-				if !added {
-					rs.logger.Warnf("failed to instantiate new '%s' variable for rule '%s'", varName, rule.ID)
-					return nil
-				}
-				instance = newInstance
-			}
-
-			value := action.Def.Set.Value
-			if field := action.Def.Set.Field; field != "" {
-				if evaluator := rs.fieldEvaluators[field]; evaluator != nil {
-					value = evaluator.Eval(ctx)
-				}
-			} else if expression := action.Def.Set.Expression; expression != "" {
-				if evaluator := rs.fieldEvaluators[expression]; evaluator != nil {
-					value = evaluator.Eval(ctx)
-				}
-			}
-
-			if action.Def.Set.Append {
-				if err := instance.Append(value); err != nil {
-					return fmt.Errorf("failed to append %s value to variable '%s' in rule '%s': %w", reflect.TypeOf(value), varName, rule.ID, err)
-				}
-			} else {
-				if err := instance.Set(value); err != nil {
-					return fmt.Errorf("failed to set %s value for variable '%s' in rule '%s': %w", reflect.TypeOf(value), varName, rule.ID, err)
+				if action.Def.Set.Append {
+					if err := mutable.Append(ctx, value); err != nil {
+						return fmt.Errorf("append is not supported for type `%s` with variable `%s` in rule `%s`: %w", reflect.TypeOf(value), name, rule.ID, err)
+					}
+				} else {
+					if err := mutable.Set(ctx, value); err != nil {
+						return err
+					}
 				}
 			}
 
@@ -1213,7 +1172,13 @@ func (rs *RuleSet) NewFakeEvent() eval.Event {
 
 // CleanupExpiredVariables cleans up all epxired variables in the ruleset
 func (rs *RuleSet) CleanupExpiredVariables() {
-	rs.evalOpts.VariableStore.CleanupExpiredVariables()
+	if rs.globalVariables != nil {
+		rs.globalVariables.CleanupExpiredVariables()
+	}
+
+	for _, variableProvider := range rs.scopedVariables {
+		variableProvider.CleanupExpiredVariables()
+	}
 }
 
 // NewRuleSet returns a new ruleset for the specified data model
@@ -1225,7 +1190,7 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalO
 	}
 
 	if evalOpts.VariableStore == nil {
-		evalOpts.VariableStore = eval.NewVariableStore()
+		evalOpts.WithVariableStore(&eval.VariableStore{})
 	}
 
 	// Set legacy fields mapping on the model if it has the method
@@ -1245,6 +1210,8 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalO
 		logger:           logger,
 		pool:             eval.NewContextPool(),
 		fieldEvaluators:  make(map[string]eval.Evaluator),
+		scopedVariables:  make(map[Scope]VariableProvider),
+		globalVariables:  eval.NewVariables(),
 	}
 }
 

--- a/pkg/security/secl/rules/scope_linux.go
+++ b/pkg/security/secl/rules/scope_linux.go
@@ -7,20 +7,27 @@
 package rules
 
 import (
-	"fmt"
-
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
-// DefaultVariableScopers returns the default variable scopers
-func DefaultVariableScopers() map[Scope]*eval.VariableScoper {
-	variableScopers := getCommonVariableScopers()
-	variableScopers[ScopeCGroup] = eval.NewVariableScoper(eval.CGroupScoperType, func(ctx *eval.Context) (eval.VariableScope, error) {
-		if ctx.Event.(*model.Event).ProcessContext == nil || ctx.Event.(*model.Event).ProcessContext.Process.CGroup.CGroupFile.IsNull() {
-			return nil, fmt.Errorf("failed to get cgroup scope")
-		}
-		return &ctx.Event.(*model.Event).ProcessContext.Process.CGroup, nil
-	})
-	return variableScopers
+// VariableScopes is the list of scopes for variables
+var VariableScopes = []string{
+	ScopeCGroup,
+	ScopeProcess,
+	ScopeContainer,
+}
+
+// DefaultStateScopes returns the default state scopes for variables
+func DefaultStateScopes() map[Scope]VariableProviderFactory {
+	stateScopes := getCommonStateScopes()
+	stateScopes[ScopeCGroup] = func() VariableProvider {
+		return eval.NewScopedVariables(ScopeCGroup, func(ctx *eval.Context) eval.VariableScope {
+			if ctx.Event.(*model.Event).ProcessContext == nil || ctx.Event.(*model.Event).ProcessContext.Process.CGroup.CGroupFile.IsNull() {
+				return nil
+			}
+			return &ctx.Event.(*model.Event).ProcessContext.CGroup
+		})
+	}
+	return stateScopes
 }

--- a/pkg/security/secl/rules/scope_others.go
+++ b/pkg/security/secl/rules/scope_others.go
@@ -8,9 +8,13 @@
 // Package rules holds rules related files
 package rules
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+// VariableScopes is the list of scopes for variables
+var VariableScopes = []string{
+	ScopeProcess,
+	ScopeContainer,
+}
 
-// DefaultVariableScopers returns the default variable scopers
-func DefaultVariableScopers() map[Scope]*eval.VariableScoper {
-	return getCommonVariableScopers()
+// DefaultStateScopes returns the default state scopes for variables
+func DefaultStateScopes() map[Scope]VariableProviderFactory {
+	return getCommonStateScopes()
 }

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -100,10 +100,9 @@ type ContainerContext struct {
 	Resolved    bool                       `field:"-"`
 }
 
-// Key returns a unique key for the entity
-func (c *ContainerContext) Key() (string, bool) {
-	cID := string(c.ContainerID)
-	return cID, cID != ""
+// Hash returns a unique key for the entity
+func (c *ContainerContext) Hash() string {
+	return string(c.ContainerID)
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -242,9 +242,9 @@ func SetAncestorFields(_ *ProcessCacheEntry, _ string, _ interface{}) (bool, err
 	return true, nil
 }
 
-// Key returns a unique key for the entity
-func (pc *ProcessCacheEntry) Key() (string, bool) {
-	return strconv.Itoa(int(pc.Pid)), true
+// Hash returns a unique key for the entity
+func (pc *ProcessCacheEntry) Hash() string {
+	return strconv.Itoa(int(pc.Pid))
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -10,6 +10,7 @@ package serializers
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/bundled"
@@ -433,14 +434,14 @@ func NewBaseEventSerializer(event *model.Event, rule *rules.Rule) *BaseEventSeri
 	s := &BaseEventSerializer{
 		EventContextSerializer: EventContextSerializer{
 			Name:        eventType.String(),
-			Variables:   newVariablesContext(event, rule, eval.GlobalScoperType),
+			Variables:   newVariablesContext(event, rule, ""),
 			RuleContext: newRuleContext(event, rule),
 		},
 		ProcessContextSerializer: newProcessContextSerializer(pc, event),
 		Date:                     utils.NewEasyjsonTime(event.ResolveEventTime()),
 	}
 	if s.ProcessContextSerializer != nil {
-		s.ProcessContextSerializer.Variables = newVariablesContext(event, rule, eval.ProcessScoperType)
+		s.ProcessContextSerializer.Variables = newVariablesContext(event, rule, "process.")
 	}
 
 	if event.IsAnomalyDetectionEvent() && len(event.Rules) > 0 {
@@ -504,46 +505,56 @@ func newRuleContext(e *model.Event, rule *rules.Rule) RuleContext {
 	return ruleContext
 }
 
-func newVariablesContext(e *model.Event, rule *rules.Rule, scope eval.InternalScoperType) (variables Variables) {
+func newVariablesContext(e *model.Event, rule *rules.Rule, prefix string) (variables Variables) {
 	if rule != nil && rule.Opts.VariableStore != nil {
-		rule.Opts.VariableStore.IterVariableDefinitions(func(definition eval.VariableDefinition) {
-			if definition.Scoper().Type() != scope {
-				return
+		store := rule.Opts.VariableStore
+		for name, variable := range store.Variables {
+			// do not serialize hardcoded variables like process.pid
+			if _, found := model.SECLVariables[name]; found {
+				continue
 			}
-			if slices.Contains(bundled.InternalVariables[:], definition.VariableName(true)) {
-				return
+
+			if slices.Contains(bundled.InternalVariables[:], name) {
+				continue
 			}
-			if definition.IsPrivate() {
-				return
+
+			if (prefix != "" && !strings.HasPrefix(name, prefix)) ||
+				(prefix == "" && strings.Contains(name, ".")) {
+				continue
 			}
-			instance, exists, err := definition.GetInstance(eval.NewContext(e))
-			// do not check whether the instance has expired here because we want to serialize variables
-			// that were used during the evaluation of the rule.
-			if !exists || err != nil {
-				return
+
+			// Skip private variables
+			if variable.GetVariableOpts().Private {
+				continue
 			}
-			if variables == nil {
-				variables = Variables{}
-			}
-			name := definition.VariableName(false)
-			value := instance.GetValue()
-			switch value := value.(type) {
-			case []string:
-				scrubbedValues := make([]string, 0, len(value))
-				for _, elem := range value {
-					if scrubbed, err := scrubber.ScrubString(elem); err == nil {
-						scrubbedValues = append(scrubbedValues, scrubbed)
+
+			evaluator := variable.GetEvaluator()
+			if evaluator, ok := evaluator.(eval.Evaluator); ok {
+				value := evaluator.Eval(eval.NewContext(e))
+				if variables == nil {
+					variables = Variables{}
+				}
+				if value != nil {
+					trimmedName := strings.TrimPrefix(name, prefix)
+					switch value := value.(type) {
+					case []string:
+						scrubbedValues := make([]string, 0, len(value))
+						for _, elem := range value {
+							if scrubbed, err := scrubber.ScrubString(elem); err == nil {
+								scrubbedValues = append(scrubbedValues, scrubbed)
+							}
+						}
+						variables[trimmedName] = scrubbedValues
+					case string:
+						if scrubbed, err := scrubber.ScrubString(value); err == nil {
+							variables[trimmedName] = scrubbed
+						}
+					default:
+						variables[trimmedName] = value
 					}
 				}
-				variables[name] = scrubbedValues
-			case string:
-				if scrubbed, err := scrubber.ScrubString(value); err == nil {
-					variables[name] = scrubbed
-				}
-			default:
-				variables[name] = value
 			}
-		})
+		}
 	}
 	return variables
 }

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1479,14 +1479,14 @@ func NewEventSerializer(event *model.Event, rule *rules.Rule) *EventSerializer {
 		s.ContainerContextSerializer = &ContainerContextSerializer{
 			ID:        string(ctx.ContainerID),
 			CreatedAt: utils.NewEasyjsonTimeIfNotZero(time.Unix(0, int64(ctx.CreatedAt))),
-			Variables: newVariablesContext(event, rule, eval.ContainerScoperType),
+			Variables: newVariablesContext(event, rule, "container."),
 		}
 	}
 
 	if cgroupID := event.FieldHandlers.ResolveCGroupID(event, &event.ProcessContext.CGroup); cgroupID != "" {
 		s.CGroupContextSerializer = &CGroupContextSerializer{
 			ID:        string(event.ProcessContext.CGroup.CGroupID),
-			Variables: newVariablesContext(event, rule, eval.CGroupScoperType),
+			Variables: newVariablesContext(event, rule, "cgroup."),
 		}
 	}
 

--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -101,10 +101,8 @@ func TestEventHeartbeatSent(t *testing.T) {
 	})
 }
 
-func TestEventRateLimiters(t *testing.T) {
+func TestEventRaleLimiters(t *testing.T) {
 	SkipIfNotAvailable(t)
-
-	const testTTL = 5 * time.Second
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
@@ -116,7 +114,7 @@ func TestEventRateLimiters(t *testing.T) {
 						Name:  "test_unique_id_services",
 						Field: "process.file.name",
 						TTL: &rules.HumanReadableDuration{
-							Duration: testTTL,
+							Duration: 5 * time.Second,
 						},
 						Append: true,
 					},
@@ -178,7 +176,6 @@ func TestEventRateLimiters(t *testing.T) {
 			t.Error(err)
 		}
 
-		const noEventTimeout = 3 * time.Second
 		// open from the first process
 		err = test.GetEventSent(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_CREATE, 0)
@@ -188,24 +185,9 @@ func TestEventRateLimiters(t *testing.T) {
 			return f.Close()
 		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
-		}, noEventTimeout, "test_unique_id")
+		}, time.Second*3, "test_unique_id")
 		if err == nil {
 			t.Error("unexpected event")
-		}
-
-		// wait for the first process name to expire
-		time.Sleep(testTTL - noEventTimeout + 100*time.Millisecond)
-		err = test.GetEventSent(t, func() error {
-			f, err := os.OpenFile(testFile, os.O_CREATE, 0)
-			if err != nil {
-				t.Fatal(err)
-			}
-			return f.Close()
-		}, func(_ *rules.Rule, _ *model.Event) bool {
-			return true
-		}, time.Second*3, "test_unique_id")
-		if err != nil {
-			t.Error(err)
 		}
 	})
 


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/commit/edef109f14dbee395e884c05682d4238b3f2b887 from https://github.com/DataDog/datadog-agent/pull/43398.

---

### What does this PR do?

Reverts PR https://github.com/DataDog/datadog-agent/pull/42315

The reverted PR introduced a regression in the way inherited variables are being set. This regression was not caught by existing tests so we are reverting the PR for now, and will reintroduce it after we added new tests that would have caught the regression.

### Motivation

### Describe how you validated your changes

### Additional Notes
