### PR TITLE
dyninst: add support for @duration exprs

### DIFF
--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -405,6 +405,9 @@ func (s *message) init(
 			_return:     &decoder._return,
 			template:    probe.Template,
 		}
+		if s.Duration != 0 {
+			s.Message.duration = &s.Duration
+		}
 	}
 
 	return probe, nil

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -38,6 +38,7 @@ type debuggerData struct {
 }
 
 type messageData struct {
+	duration    *uint64
 	entryOrLine *captureEvent
 	_return     *captureEvent
 	template    *ir.Template
@@ -79,12 +80,14 @@ func (m *messageData) MarshalJSONTo(enc *jsontext.Encoder) error {
 			// Update limits after processing segment.
 			limits.maxBytes = maxLogLineBytes - result.Len()
 		case ir.InvalidSegment:
-			// Check limits for invalid segment.
-			limits.maxBytes = maxLogLineBytes - result.Len()
-			limits.consume(2)
-			result.WriteRune('{')
-			writeBoundedString(&result, limits, seg.Error)
-			result.WriteRune('}')
+			writeBoundedError(&result, limits, "error", seg.Error)
+		case *ir.DurationSegment:
+			if m.duration == nil {
+				writeBoundedError(&result, limits, "error", "@duration is not available")
+			} else {
+				n, _ := fmt.Fprintf(&result, "%f", time.Duration(*m.duration).Seconds()*1000)
+				limits.consume(n)
+			}
 
 		default:
 			return fmt.Errorf(

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -185,6 +185,11 @@ type InvalidSegment struct {
 
 func (s InvalidSegment) templateSegment() {}
 
+// DurationSegment is a segment that is a simple reference to @duration.
+type DurationSegment struct{}
+
+func (s *DurationSegment) templateSegment() {}
+
 // Probe represents a probe from the config as it applies to the program.
 type Probe struct {
 	ProbeDefinition

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -567,6 +567,10 @@ func newTemplate(td ir.TemplateDefinition) *ir.Template {
 			} else {
 				switch expr := expr.(type) {
 				case *exprlang.RefExpr:
+					if expr.Ref == "@duration" {
+						addSegment(&ir.DurationSegment{})
+						continue
+					}
 					addSegment(&ir.JSONSegment{
 						DSL:  segment.GetDSL(),
 						JSON: expr,

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -3794,8 +3794,7 @@ Probes:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
         Segments:
             - 'Executed main.testMultipleNamedReturn, it took '
-            - Error: failed to resolve reference "@duration"
-              DSL: '@duration'
+            - '@duration'
             - ms
     - id: testThreeStrings
       version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -3794,8 +3794,7 @@ Probes:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
         Segments:
             - 'Executed main.testMultipleNamedReturn, it took '
-            - Error: failed to resolve reference "@duration"
-              DSL: '@duration'
+            - '@duration'
             - ms
     - id: testThreeStrings
       version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -3794,8 +3794,7 @@ Probes:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
         Segments:
             - 'Executed main.testMultipleNamedReturn, it took '
-            - Error: failed to resolve reference "@duration"
-              DSL: '@duration'
+            - '@duration'
             - ms
     - id: testThreeStrings
       version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -3794,8 +3794,7 @@ Probes:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
         Segments:
             - 'Executed main.testMultipleNamedReturn, it took '
-            - Error: failed to resolve reference "@duration"
-              DSL: '@duration'
+            - '@duration'
             - ms
     - id: testThreeStrings
       version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -3794,8 +3794,7 @@ Probes:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
         Segments:
             - 'Executed main.testMultipleNamedReturn, it took '
-            - Error: failed to resolve reference "@duration"
-              DSL: '@duration'
+            - '@duration'
             - ms
     - id: testThreeStrings
       version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -3794,8 +3794,7 @@ Probes:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
         Segments:
             - 'Executed main.testMultipleNamedReturn, it took '
-            - Error: failed to resolve reference "@duration"
-              DSL: '@duration'
+            - '@duration'
             - ms
     - id: testThreeStrings
       version: 0

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -102,6 +102,9 @@ func PrintJSON(p *ir.Program) ([]byte, error) {
 		json.MarshalToFunc(func(enc *jsontext.Encoder, v ir.VariableRole) error {
 			return enc.WriteToken(jsontext.String(v.String()))
 		}),
+		json.MarshalToFunc(func(enc *jsontext.Encoder, _ *ir.DurationSegment) error {
+			return enc.WriteToken(jsontext.String("@duration"))
+		}),
 	)
 	probeMarshalers := json.JoinMarshalers(
 		basicMarshalers,

--- a/pkg/dyninst/json_redaction_test.go
+++ b/pkg/dyninst/json_redaction_test.go
@@ -264,6 +264,13 @@ var defaultRedactors = []jsonRedactor{
 			`{mutex internals}`,
 		),
 	),
+	redactor(
+		exactMatcher(`/message`),
+		regexpStringReplacer(
+			`[0-9]+\.[0-9]+ms`,
+			`[duration]ms`,
+		),
+	),
 }
 
 const mutexInternalsRegexp = `\{state: [[:digit:]]+, sema: [[:digit:]]+\}`

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -73,6 +73,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "{failed to resolve reference \"nonexistentVariable\"}"
+    "message": "{error: failed to resolve reference \"nonexistentVariable\"}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -73,6 +73,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "{unsupported operation: foobar}"
+    "message": "{error: unsupported operation: foobar}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -73,6 +73,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "Executed main.testMultipleNamedReturn, it took {failed to resolve reference \"@duration\"}ms"
+    "message": "Executed main.testMultipleNamedReturn, it took [duration]ms"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/logProbe_no_snapshot_stringArg_bad_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/logProbe_no_snapshot_stringArg_bad_template.json
@@ -24,6 +24,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "x: {failed to resolve reference \"x\"}"
+    "message": "x: {error: failed to resolve reference \"x\"}"
   }
 ]


### PR DESCRIPTION
### What does this PR do?

Adds support for `@duration` in log templates.

### Motivation

Part of expression support in these templates. This is in the default template string, so worth having.

### Describe how you validated your changes

There's a test.

### Additional Notes

https://datadoghq.atlassian.net/browse/DEBUG-4426
