### PR TITLE
dyninst: send logs to the DEBUGGER track

### DIFF
--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -310,6 +310,11 @@ func (s *message) init(
 	}
 	probeEvent := decoder.probeEvents[decoder.entryOrLine.rootType.ID]
 	probe := probeEvent.probe
+
+	if probe.GetKind() == ir.ProbeKindSnapshot || probe.GetKind() == ir.ProbeKindLog {
+		s.Debugger.Type = payloadTypeSnapshot
+	}
+
 	header, err := event.EntryOrLine.Header()
 	if err != nil {
 		return probe, fmt.Errorf("error getting header %w", err)

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -240,7 +240,6 @@ func (d *Decoder) resetForNextMessage() {
 // Event wraps the output Event from the BPF program. It also adds fields
 // that are not present in the BPF program.
 type Event struct {
-	Probe       *ir.Probe
 	EntryOrLine output.Event
 	Return      output.Event
 	ServiceName string

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -32,8 +32,15 @@ type logger struct {
 	ThreadName string `json:"thread_name"`
 }
 
+type payloadType string
+
+const (
+	payloadTypeSnapshot payloadType = "snapshot"
+)
+
 type debuggerData struct {
 	Snapshot         snapshotData      `json:"snapshot,omitempty"`
+	Type             payloadType       `json:"type,omitempty"`
 	EvaluationErrors []evaluationError `json:"evaluationErrors,omitempty"`
 }
 

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -29,6 +29,7 @@ import (
 // Config is the configuration for the dynamic instrumentation module.
 type Config struct {
 	ebpf.Config
+	// The URL to upload logs (with or without snapshots) to.
 	LogUploaderURL     string
 	DiagsUploaderURL   string
 	SymDBUploadEnabled bool
@@ -147,7 +148,7 @@ const (
 
 	traceAgentURLEnvVar = "DD_TRACE_AGENT_URL"
 
-	logUploaderPath   = "/debugger/v1/input"
+	logUploaderPath   = "/debugger/v2/input"
 	diagsUploaderPath = "/debugger/v1/diagnostics"
 	symdbUploaderPath = "/symdb/v1/input"
 )

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -204,19 +204,17 @@ func makeRealDependencies(
 		}
 	}()
 
-	logUploaderURL, err := url.Parse(config.LogUploaderURL)
+	logsURL, err := url.Parse(config.LogUploaderURL)
 	if err != nil {
 		return ret, fmt.Errorf("error parsing log uploader URL: %w", err)
 	}
-	ret.logUploader = uploader.NewLogsUploaderFactory(
-		uploader.WithURL(logUploaderURL),
-	)
+	ret.logUploader = uploader.NewLogsUploaderFactory(logsURL)
 
 	diagsUploaderURL, err := url.Parse(config.DiagsUploaderURL)
 	if err != nil {
 		return ret, fmt.Errorf("error parsing diagnostics uploader URL: %w", err)
 	}
-	diagsUploader := uploader.NewDiagnosticsUploader(uploader.WithURL(diagsUploaderURL))
+	diagsUploader := uploader.NewDiagnosticsUploader(diagsUploaderURL)
 	ret.diagsUploader = diagsUploader
 
 	var symdbUploaderURL *url.URL

--- a/pkg/dyninst/module/module_test.go
+++ b/pkg/dyninst/module/module_test.go
@@ -855,6 +855,9 @@ func (f *fakeLogsUploaderFactory) GetUploader(
 	return ul
 }
 
+// fakeLogsUploader implements module.LogsUploader.
+var _ module.LogsUploader = (*fakeLogsUploader)(nil)
+
 type fakeLogsUploader struct {
 	messages []json.RawMessage
 	closed   bool

--- a/pkg/dyninst/module/sink.go
+++ b/pkg/dyninst/module/sink.go
@@ -8,7 +8,6 @@
 package module
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"slices"
@@ -228,10 +227,10 @@ func (s *sink) HandleEvent(msg dispatcher.Message) error {
 		return nil
 	}
 	s.runtime.setProbeMaybeEmitting(s.programID, probe)
-	s.logUploader.Enqueue(json.RawMessage(decodedBytes))
 	if missingTypes := s.missingTypes.drain(); len(missingTypes) > 0 {
 		s.runtime.actuator.ReportMissingTypes(s.processID, missingTypes)
 	}
+	s.logUploader.Enqueue(decodedBytes)
 	return nil
 }
 

--- a/pkg/dyninst/testdata/decoded/fault/callMe.json
+++ b/pkg/dyninst/testdata/decoded/fault/callMe.json
@@ -62,7 +62,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -67,7 +67,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -70,7 +70,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -147,7 +148,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -224,7 +226,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -301,7 +304,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -378,7 +382,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -455,7 +460,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -527,7 +533,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -604,7 +611,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -682,7 +690,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -759,7 +768,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -138,7 +139,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -216,7 +218,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -294,7 +297,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -378,7 +382,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -468,7 +473,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -93,7 +93,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -88,6 +88,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -128,6 +128,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -112,6 +112,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
@@ -86,6 +86,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -82,7 +82,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
@@ -83,6 +83,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -66,6 +66,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -75,6 +75,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -100,6 +100,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -69,6 +69,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -81,6 +81,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -81,6 +81,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -99,6 +99,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -59,6 +59,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -63,6 +63,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -126,6 +127,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
@@ -59,6 +59,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -69,6 +69,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -128,7 +128,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -89,7 +89,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -87,7 +87,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -87,7 +87,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2, 3, ...]"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
@@ -62,7 +62,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
@@ -66,7 +66,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
@@ -67,7 +67,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -52,7 +52,8 @@
             "method": "main.testInlinedBC"
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
@@ -64,7 +64,8 @@
             "63": {}
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testInlinedBCA"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
@@ -64,7 +64,8 @@
             "67": {}
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testInlinedBCB"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
@@ -48,6 +48,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -63,6 +63,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -142,6 +143,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -221,6 +223,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -305,6 +308,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -378,7 +382,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
@@ -66,7 +66,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "25"
@@ -143,7 +144,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "3"
@@ -220,7 +222,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "150"
@@ -302,7 +305,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "150"
@@ -374,7 +378,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "1"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -63,6 +63,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
@@ -66,7 +66,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "10"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -80,6 +80,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -176,6 +177,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -148,6 +149,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -227,6 +229,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -307,6 +310,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -381,6 +385,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -450,6 +455,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -147,7 +147,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -87,6 +87,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -54,7 +54,8 @@
             "211": {}
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -136,7 +137,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -207,7 +209,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -278,7 +281,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -349,7 +353,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -420,7 +425,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -491,7 +497,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -562,7 +569,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -633,7 +641,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -704,7 +713,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB_geq_go1.26rc1.json
@@ -69,7 +69,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -136,7 +137,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -207,7 +209,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -278,7 +281,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -349,7 +353,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -420,7 +425,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -491,7 +497,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -562,7 +569,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -633,7 +641,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"
@@ -704,7 +713,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
@@ -69,7 +69,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testLongFunctionWithChangingState"

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -107,7 +107,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -174,6 +174,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -645,6 +645,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -70,6 +70,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -70,6 +70,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -70,6 +70,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -160,6 +160,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -520,6 +520,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -144,6 +144,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -60,6 +60,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -60,6 +60,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -144,6 +144,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -160,6 +160,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -160,6 +160,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -100,6 +100,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -98,6 +98,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -269,6 +269,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -160,6 +160,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -2610,6 +2610,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -160,6 +160,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -60,6 +60,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -60,6 +60,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
@@ -60,6 +60,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -138,7 +138,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -107,7 +107,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -192,7 +192,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -69,7 +69,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -74,6 +74,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
@@ -74,6 +74,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots.json
@@ -21,6 +21,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots_bad_expr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots_bad_expr.json
@@ -21,6 +21,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots_low_limit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots_low_limit.json
@@ -21,6 +21,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -62,6 +62,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -62,6 +62,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -66,6 +66,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -64,6 +64,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -69,6 +69,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -81,6 +81,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -147,7 +148,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -231,7 +233,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -89,7 +89,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -179,7 +180,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -71,7 +71,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -63,7 +63,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -58,7 +58,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -89,7 +89,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -61,7 +61,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -61,7 +61,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -76,7 +76,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -148,7 +149,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -65,7 +65,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -69,7 +69,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -66,7 +66,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -70,7 +70,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -162,7 +163,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
@@ -255,7 +257,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -98,7 +98,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -118,7 +118,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -73,7 +73,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -57,7 +57,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -61,7 +61,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -57,7 +57,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -85,7 +85,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -76,7 +76,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -102,7 +102,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
@@ -69,7 +69,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -102,6 +102,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -80,6 +80,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -73,7 +73,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -95,7 +95,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -59,6 +59,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -72,6 +72,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -59,6 +59,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct.json
@@ -83,7 +83,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -90,6 +90,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -78,6 +78,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -107,7 +107,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
@@ -82,7 +82,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
@@ -83,6 +83,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -488,6 +488,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -75,6 +75,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
@@ -84,6 +84,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSubslices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubslices.json
@@ -96,6 +96,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
@@ -66,6 +66,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -69,7 +69,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -69,7 +69,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -69,7 +69,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -66,6 +66,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
@@ -70,7 +70,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructExpr.json
@@ -20,7 +20,8 @@
             "method": "main.testThreeStringsInStruct"
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructExpr_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructExpr_geq_go1.26rc1.json
@@ -21,6 +21,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -72,6 +72,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer_expression_with_dots.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer_expression_with_dots.json
@@ -21,6 +21,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
@@ -71,6 +71,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -68,6 +68,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -59,6 +59,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -72,6 +72,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -58,6 +58,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -460,6 +460,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -317,6 +317,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
@@ -317,6 +317,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
@@ -63,6 +63,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -75,7 +75,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -53,6 +53,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -54,6 +54,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -612,7 +612,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -53,6 +53,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",
@@ -120,7 +121,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -52,7 +52,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -66,7 +66,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -67,6 +67,7 @@
           }
         }
       },
+      "type": "snapshot",
       "evaluationErrors": [
         {
           "expr": "@duration",

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -66,7 +66,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/simple/logProbe_no_snapshot_stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/logProbe_no_snapshot_stringArg.json
@@ -20,7 +20,8 @@
             "method": "main.stringArg"
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/logProbe_no_snapshot_stringArg_bad_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/logProbe_no_snapshot_stringArg_bad_template.json
@@ -20,7 +20,8 @@
             "method": "main.stringArg"
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/mapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapArg.json
@@ -64,7 +64,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/noArgs.json
+++ b/pkg/dyninst/testdata/decoded/simple/noArgs.json
@@ -42,7 +42,8 @@
             "method": "main.noArgs"
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/simple/stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArg.json
@@ -52,7 +52,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -66,7 +66,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -66,7 +66,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -81,7 +81,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -31,7 +31,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -230,7 +231,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -267,7 +269,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -466,7 +469,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -503,7 +507,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -702,7 +707,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/e2e/rc_tester_v1.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester_v1.json
@@ -31,7 +31,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -230,7 +231,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -267,7 +269,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -466,7 +469,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -503,7 +507,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"
@@ -702,7 +707,8 @@
             }
           }
         }
-      }
+      },
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/uploader/config.go
+++ b/pkg/dyninst/uploader/config.go
@@ -9,7 +9,6 @@ package uploader
 
 import (
 	"net/http"
-	"net/url"
 	"time"
 )
 
@@ -25,7 +24,6 @@ const (
 type config struct {
 	batcherConfig
 	client *http.Client
-	url    *url.URL
 	// Key-value pairs to be added to all upload HTTP requests as headers.
 	headers [][2]string
 	// The timeout for sending a batch of messages.
@@ -44,7 +42,6 @@ type batcherConfig struct {
 func defaultConfig() config {
 	return config{
 		client:      http.DefaultClient,
-		url:         nil,
 		sendTimeout: defaultSendTimeout,
 
 		batcherConfig: batcherConfig{
@@ -62,13 +59,6 @@ type Option func(*config)
 func WithClient(client *http.Client) Option {
 	return func(c *config) {
 		c.client = client
-	}
-}
-
-// WithURL sets the URL for the uploader.
-func WithURL(u *url.URL) Option {
-	return func(c *config) {
-		c.url = u
 	}
 }
 

--- a/pkg/dyninst/uploader/diagnostics.go
+++ b/pkg/dyninst/uploader/diagnostics.go
@@ -16,6 +16,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"time"
 )
 
@@ -103,12 +104,12 @@ type DiagnosticsUploader struct {
 }
 
 // NewDiagnosticsUploader creates a new uploader for sending diagnostics batches.
-func NewDiagnosticsUploader(opts ...Option) *DiagnosticsUploader {
+func NewDiagnosticsUploader(url *url.URL, opts ...Option) *DiagnosticsUploader {
 	cfg := defaultConfig()
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	sender := newDiagnosticsSender(cfg.client, cfg.url.String(), cfg.sendTimeout)
+	sender := newDiagnosticsSender(cfg.client, url.String(), cfg.sendTimeout)
 	return &DiagnosticsUploader{
 		batcher: newBatcher("diagnostics", sender, cfg.batcherConfig, &Metrics{}),
 	}

--- a/pkg/dyninst/uploader/logs.go
+++ b/pkg/dyninst/uploader/logs.go
@@ -23,11 +23,14 @@ import (
 
 // LogsUploaderFactory is a factory for creating and managing log uploaders for different tags.
 type LogsUploaderFactory struct {
+	// The URL to send logs to (with or without snapshots).
+	logsURL *url.URL
+	cfg     config
+	metrics *Metrics
+
 	mu            sync.Mutex
 	uploaders     map[LogsUploaderMetadata]*refCountedUploader
 	maxUploaderID uint64
-	cfg           config
-	metrics       *Metrics
 }
 
 // LogsUploaderMetadata is the metadata applied to the requests sent by an
@@ -50,9 +53,9 @@ type refCountedUploader struct {
 	refCount int
 }
 
-// LogsUploader is an uploader for sending log-like batches with a specific set
-// of tags. It wraps a batcher and provides a Close() method to remove itself
-// from the parent LogsUploaderFactory.
+// LogsUploader uploads logs and snapshots in batches, adding headers
+// corresponding to a set of tags. It wraps logs batchers and provides a Close()
+// method to remove itself from the parent LogsUploaderFactory.
 type LogsUploader struct {
 	batcher *batcher
 	// onClose is called when the uploader is closed to decrement its refcount
@@ -61,11 +64,12 @@ type LogsUploader struct {
 }
 
 // NewLogsUploaderFactory creates a new uploader factory.
-func NewLogsUploaderFactory(opts ...Option) *LogsUploaderFactory {
+func NewLogsUploaderFactory(logsURL *url.URL, opts ...Option) *LogsUploaderFactory {
 	lu := &LogsUploaderFactory{
 		uploaders: make(map[LogsUploaderMetadata]*refCountedUploader),
 		cfg:       defaultConfig(),
 		metrics:   &Metrics{},
+		logsURL:   logsURL,
 	}
 	for _, opt := range opts {
 		opt(&lu.cfg)
@@ -111,29 +115,20 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 	for _, keyVal := range u.cfg.headers {
 		addHeader(keyVal[0], keyVal[1])
 	}
-	var logsURL, name string
-	if metadata.Tags == "" {
-		logsURL = u.cfg.url.String()
-	} else {
-		query, _ := url.ParseQuery(u.cfg.url.RawQuery)
-		// If we failed to parse the query, we'll use an empty query.
-		query.Set("ddtags", metadata.Tags)
-		tagURL := *u.cfg.url
-		tagURL.RawQuery = query.Encode()
-		logsURL = tagURL.String()
-	}
+
+	logsURL := makeIntakeURL(u.logsURL, metadata.Tags)
+
 	if metadata.EntityID != "" {
 		addHeader(ddHeaderEntityID, metadata.EntityID)
 	}
 	if metadata.ContainerID != "" {
 		addHeader(ddHeaderContainerID, metadata.ContainerID)
 	}
-	name = fmt.Sprintf("logs:%d", uploaderID)
+	name := fmt.Sprintf("logs:%d", uploaderID)
 	log.Debugf("creating uploader %s with metadata %v", name, metadata)
 
-	sender := newLogSender(u.cfg.client, logsURL, headers, u.cfg.sendTimeout)
 	taggedUploader := &LogsUploader{
-		batcher: newBatcher(name, sender, u.cfg.batcherConfig, u.metrics),
+		batcher: newBatcher(name, newLogSender(u.cfg.client, logsURL, headers, u.cfg.sendTimeout), u.cfg.batcherConfig, u.metrics),
 		onClose: func() {
 			u.closeUploader(metadata)
 		},
@@ -145,6 +140,18 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 	}
 
 	return taggedUploader
+}
+
+func makeIntakeURL(baseURL *url.URL, tags string) string {
+	if tags == "" {
+		return baseURL.String()
+	}
+	query, _ := url.ParseQuery(baseURL.RawQuery)
+	// If we failed to parse the query, we'll use an empty query.
+	query.Set("ddtags", tags)
+	tagURL := *baseURL
+	tagURL.RawQuery = query.Encode()
+	return tagURL.String()
 }
 
 // Enqueue adds a message to the uploader's queue.

--- a/pkg/dyninst/uploader/logs.go
+++ b/pkg/dyninst/uploader/logs.go
@@ -30,7 +30,7 @@ type LogsUploaderFactory struct {
 	metrics       *Metrics
 }
 
-// LogsUploaderMetadata is the metadata applied to the requests sent by this
+// LogsUploaderMetadata is the metadata applied to the requests sent by an
 // uploader.
 type LogsUploaderMetadata struct {
 	Tags        string
@@ -50,11 +50,14 @@ type refCountedUploader struct {
 	refCount int
 }
 
-// LogsUploader is an uploader for sending log-like batches with a specific set of tags.
+// LogsUploader is an uploader for sending log-like batches with a specific set
+// of tags. It wraps a batcher and provides a Close() method to remove itself
+// from the parent LogsUploaderFactory.
 type LogsUploader struct {
 	*batcher
-	metadata LogsUploaderMetadata
-	factory  *LogsUploaderFactory
+	// onClose is called when the uploader is closed to decrement its refcount
+	// in the parent LogsUploaderFactory.
+	onClose func()
 }
 
 // NewLogsUploaderFactory creates a new uploader factory.
@@ -131,8 +134,9 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 	sender := newLogSender(u.cfg.client, logsURL, headers, u.cfg.sendTimeout)
 	taggedUploader := &LogsUploader{
 		batcher:  newBatcher(name, sender, u.cfg.batcherConfig, u.metrics),
-		metadata: metadata,
-		factory:  u,
+		onClose: func() {
+			u.closeUploader(metadata)
+		},
 	}
 
 	u.uploaders[metadata] = &refCountedUploader{
@@ -151,22 +155,29 @@ func (u *LogsUploader) Enqueue(data json.RawMessage) {
 // Close decrements the reference count of the uploader. If the ref count reaches zero,
 // the uploader is stopped and removed from the factory.
 func (u *LogsUploader) Close() {
-	u.factory.mu.Lock()
-	defer u.factory.mu.Unlock()
+	u.onClose()
+}
 
-	rc, ok := u.factory.uploaders[u.metadata]
+// closeUploader decrements the reference count of the uploader with the given
+// metadata. If the ref count reaches zero, the uploader is stopped and removed
+// from the factory.
+func (u *LogsUploaderFactory) closeUploader(metadata LogsUploaderMetadata) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	rc, ok := u.uploaders[metadata]
 	if !ok {
 		log.Warnf(
-			"closing a tagged uploader (%s) that is not in the factory: metadata=%v",
-			u.name, u.metadata,
+			"closing a tagged uploader that is not in the factory: metadata=%v",
+			metadata,
 		)
 		return
 	}
 
 	rc.refCount--
 	if rc.refCount <= 0 {
-		log.Debugf("stopping uploader %s with metadata %v", u.name, u.metadata)
-		delete(u.factory.uploaders, u.metadata)
+		log.Debugf("stopping uploader with metadata %v", metadata)
+		delete(u.uploaders, metadata)
 		rc.LogsUploader.stop()
 	}
 }

--- a/pkg/dyninst/uploader/logs.go
+++ b/pkg/dyninst/uploader/logs.go
@@ -54,7 +54,7 @@ type refCountedUploader struct {
 // of tags. It wraps a batcher and provides a Close() method to remove itself
 // from the parent LogsUploaderFactory.
 type LogsUploader struct {
-	*batcher
+	batcher *batcher
 	// onClose is called when the uploader is closed to decrement its refcount
 	// in the parent LogsUploaderFactory.
 	onClose func()
@@ -133,7 +133,7 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 
 	sender := newLogSender(u.cfg.client, logsURL, headers, u.cfg.sendTimeout)
 	taggedUploader := &LogsUploader{
-		batcher:  newBatcher(name, sender, u.cfg.batcherConfig, u.metrics),
+		batcher: newBatcher(name, sender, u.cfg.batcherConfig, u.metrics),
 		onClose: func() {
 			u.closeUploader(metadata)
 		},
@@ -149,7 +149,7 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 
 // Enqueue adds a message to the uploader's queue.
 func (u *LogsUploader) Enqueue(data json.RawMessage) {
-	u.enqueue(data)
+	u.batcher.enqueue(data)
 }
 
 // Close decrements the reference count of the uploader. If the ref count reaches zero,
@@ -178,7 +178,7 @@ func (u *LogsUploaderFactory) closeUploader(metadata LogsUploaderMetadata) {
 	if rc.refCount <= 0 {
 		log.Debugf("stopping uploader with metadata %v", metadata)
 		delete(u.uploaders, metadata)
-		rc.LogsUploader.stop()
+		rc.LogsUploader.batcher.stop()
 	}
 }
 
@@ -188,7 +188,7 @@ func (u *LogsUploaderFactory) Stop() {
 	defer u.mu.Unlock()
 
 	for tags, rc := range u.uploaders {
-		rc.LogsUploader.stop()
+		rc.LogsUploader.batcher.stop()
 		delete(u.uploaders, tags)
 	}
 }

--- a/pkg/dyninst/uploader/uploader_test.go
+++ b/pkg/dyninst/uploader/uploader_test.go
@@ -31,6 +31,7 @@ type testServer struct {
 
 func (s *testServer) Close() {
 	close(s.close)
+	s.server.CloseClientConnections()
 	s.server.Close()
 }
 
@@ -124,7 +125,7 @@ func TestDiagnosticsUploader(t *testing.T) {
 		defer ts.Close()
 
 		uploader := NewDiagnosticsUploader(
-			WithURL(ts.serverURL),
+			ts.serverURL,
 			WithMaxBatchItems(2),
 			WithMaxBufferDuration(0), // disable timers
 		)
@@ -166,7 +167,7 @@ func TestDiagnosticsUploader(t *testing.T) {
 		defer ts.Close()
 
 		uploader := NewDiagnosticsUploader(
-			WithURL(ts.serverURL),
+			ts.serverURL,
 			WithMaxBatchItems(2),
 			WithMaxBufferDuration(10*time.Millisecond),
 		)
@@ -207,7 +208,7 @@ func TestDiagnosticsUploader(t *testing.T) {
 		defer ts.Close()
 
 		uploader := NewDiagnosticsUploader(
-			WithURL(ts.serverURL),
+			ts.serverURL,
 			WithMaxBatchItems(1),
 		)
 		defer uploader.Stop()
@@ -238,10 +239,7 @@ func TestLogsUploader(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		uploaderFactory := NewLogsUploaderFactory(
-			WithURL(ts.serverURL),
-			WithMaxBatchItems(2),
-		)
+		uploaderFactory := NewLogsUploaderFactory(ts.serverURL, WithMaxBatchItems(2))
 		defer uploaderFactory.Stop()
 		uploader := uploaderFactory.GetUploader(LogsUploaderMetadata{
 			ContainerID: "test_id",
@@ -251,6 +249,7 @@ func TestLogsUploader(t *testing.T) {
 		msg1 := json.RawMessage(`{"key":"value1"}`)
 		msg2 := json.RawMessage(`{"key":"value2"}`)
 
+		// Upload two logs.
 		uploader.Enqueue(msg1)
 		uploader.Enqueue(msg2)
 
@@ -278,10 +277,7 @@ func TestLogsUploader(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		uploaderFactory := NewLogsUploaderFactory(
-			WithURL(ts.serverURL),
-			WithMaxBatchItems(1),
-		)
+		uploaderFactory := NewLogsUploaderFactory(ts.serverURL, WithMaxBatchItems(1))
 		defer uploaderFactory.Stop()
 		uploader := uploaderFactory.GetUploader(LogsUploaderMetadata{
 			Tags: "service:test",


### PR DESCRIPTION
Before this patch, logs (including snapshots) were sent to
/debugger/v1/input. Now, they will be sent to /debugger/v2/input. The
v2/input URL pipes the snapshots to our DEBUGGER EvP track, where we'll
do redaction.

Closes https://datadoghq.atlassian.net/browse/DEBUG-4344