### PR TITLE
add peds-based docker proxy filter for direct send

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -47,6 +47,12 @@ const (
 	UDP ConnectionType = 1
 )
 
+// ConnectionTypeFromString is a map from a lowercase string to ConnectionType
+var ConnectionTypeFromString = map[string]ConnectionType{
+	"tcp": TCP,
+	"udp": UDP,
+}
+
 var (
 	tcpLabels = map[string]string{"ip_proto": TCP.String()}
 	udpLabels = map[string]string{"ip_proto": UDP.String()}

--- a/pkg/network/sender/doc.go
+++ b/pkg/network/sender/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package sender handles sending CNM data to the backend
+package sender

--- a/pkg/network/sender/docker_proxy.go
+++ b/pkg/network/sender/docker_proxy.go
@@ -1,0 +1,266 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package sender
+
+import (
+	"maps"
+	"net/netip"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	ddmaps "github.com/DataDog/datadog-agent/pkg/util/maps"
+	"github.com/DataDog/datadog-agent/pkg/util/os"
+)
+
+type containerAddr struct {
+	addr  netip.AddrPort
+	proto network.ConnectionType
+}
+
+type proxy struct {
+	pid    uint32
+	ip     netip.Addr
+	target containerAddr
+	alive  bool
+}
+
+var _ eventmonitor.EventConsumerHandler = &dockerProxyFilter{}
+var _ eventmonitor.EventConsumer = &dockerProxyFilter{}
+
+// proxyFilterInstance contains the instance of the docker proxy filter (if there is one).
+// this is necessary due to the out-of-order initialization between CNM and Event Monitor.
+var proxyFilterInstance atomic.Pointer[dockerProxyFilter]
+
+type dockerProxyFilter struct {
+	log log.Component
+
+	mtx           sync.Mutex
+	proxyByTarget map[containerAddr]*proxy
+	proxyByPID    map[uint32]*proxy
+}
+
+// NewDockerProxyConsumer creates the docker proxy filter and returns it for event monitor registration
+func NewDockerProxyConsumer(em *eventmonitor.EventMonitor, log log.Component) (eventmonitor.EventConsumer, error) {
+	pf := newDockerProxyFilter(log)
+	err := em.AddEventConsumerHandler(pf)
+	if err != nil {
+		return nil, err
+	}
+	proxyFilterInstance.Store(pf)
+	return pf, nil
+}
+
+func newDockerProxyFilter(log log.Component) *dockerProxyFilter {
+	return &dockerProxyFilter{
+		log: log,
+	}
+}
+
+// ID implements eventmonitor.EventConsumer and eventmonitor.EventConsumerHandler
+func (d *dockerProxyFilter) ID() string {
+	return "dockerproxy"
+}
+
+// ChanSize implements eventmonitor.EventConsumerHandler
+func (d *dockerProxyFilter) ChanSize() int {
+	return 100
+}
+
+type dockerProcess struct {
+	Pid       uint32
+	Cmdline   []string
+	EventType model.EventType
+}
+
+// EventTypes implements eventmonitor.EventConsumerHandler
+func (d *dockerProxyFilter) EventTypes() []model.EventType {
+	return []model.EventType{
+		model.ExecEventType,
+		model.ExitEventType,
+	}
+}
+
+// Start implements eventmonitor.EventConsumer
+func (d *dockerProxyFilter) Start() error {
+	return nil
+}
+
+// Stop implements eventmonitor.EventConsumer
+func (d *dockerProxyFilter) Stop() {}
+
+// Copy implements eventmonitor.EventConsumerHandler
+func (d *dockerProxyFilter) Copy(ev *model.Event) any {
+	p := &dockerProcess{
+		Pid:       ev.GetProcessPid(),
+		EventType: ev.GetEventType(),
+		Cmdline:   ev.GetExecCmdargv(),
+	}
+	return p
+}
+
+// HandleEvent implements eventmonitor.EventConsumerHandler
+func (d *dockerProxyFilter) HandleEvent(ev any) {
+	p, ok := ev.(*dockerProcess)
+	if !ok {
+		return
+	}
+	d.process(p)
+}
+
+func (d *dockerProxyFilter) process(event *dockerProcess) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	// TODO if we miss the exec event, we will never consider that process a docker-proxy
+
+	if proxy, seen := d.proxyByPID[event.Pid]; seen {
+		if event.EventType == model.ExitEventType {
+			// mark proxy as dead so it will be removed after next set of connections are filtered
+			proxy.alive = false
+			return
+		}
+		if event.EventType != model.ExecEventType {
+			return
+		}
+		// we've received a new exec event with the same PID as an existing entry.
+		// mark the previous one as dead and remove it from the pid->proxy map.
+		// the target map will be cleaned up by marking it as dead
+		proxy.alive = false
+		delete(d.proxyByPID, event.Pid)
+	}
+
+	if proxy := extractProxyTarget(event); proxy != nil {
+		d.log.Debugf("detected docker-proxy with pid=%d target.ip=%s target.port=%d target.proto=%s",
+			proxy.pid,
+			proxy.target.addr.Addr(),
+			proxy.target.addr.Port(),
+			proxy.target.proto,
+		)
+
+		d.proxyByPID[proxy.pid] = proxy
+		d.proxyByTarget[proxy.target] = proxy
+	}
+}
+
+// FilterProxies removes all connections that are related to docker-proxy processes
+func (d *dockerProxyFilter) FilterProxies(conns *network.Connections) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	if len(d.proxyByPID) == 0 {
+		return
+	}
+
+	undiscoveredProxies := ddmaps.Filter(d.proxyByPID, func(_ uint32, p *proxy) bool {
+		return !p.ip.IsValid()
+	})
+	for _, conn := range conns.Conns {
+		// early break if we've already discovered all the proxies
+		if len(undiscoveredProxies) == 0 {
+			break
+		}
+
+		if proxy, ok := undiscoveredProxies[conn.Pid]; ok {
+			if proxyIP := d.discoverProxyIP(proxy, conn); proxyIP.IsValid() {
+				proxy.ip = proxyIP
+				delete(undiscoveredProxies, conn.Pid)
+			}
+		}
+	}
+
+	conns.Conns = slices.DeleteFunc(conns.Conns, func(c network.ConnectionStats) bool {
+		return d.isProxied(c)
+	})
+
+	for pid, p := range d.proxyByPID {
+		// if already marked dead, no reason to re-interrogate
+		if p.alive {
+			p.alive = os.PidExists(int(pid))
+		}
+	}
+	maps.DeleteFunc(d.proxyByPID, func(_ uint32, p *proxy) bool { return !p.alive })
+	maps.DeleteFunc(d.proxyByTarget, func(_ containerAddr, p *proxy) bool { return !p.alive })
+}
+
+func (d *dockerProxyFilter) isProxied(c network.ConnectionStats) bool {
+	if p, ok := d.proxyByTarget[containerAddr{addr: netip.AddrPortFrom(c.Source.Addr, c.SPort), proto: c.Type}]; ok {
+		return p.ip == c.Dest.Addr
+	}
+	if p, ok := d.proxyByTarget[containerAddr{addr: netip.AddrPortFrom(c.Dest.Addr, c.DPort), proto: c.Type}]; ok {
+		return p.ip == c.Source.Addr
+	}
+	return false
+}
+
+func (d *dockerProxyFilter) discoverProxyIP(p *proxy, c network.ConnectionStats) netip.Addr {
+	// The heuristic here goes as follows:
+	// One of the ends of this connections must match p.target;
+	// The proxy IP will be the other end;
+	if netip.AddrPortFrom(c.Source.Addr, c.SPort) == p.target.addr {
+		return c.Dest.Addr
+	}
+	if netip.AddrPortFrom(c.Dest.Addr, c.DPort) == p.target.addr {
+		return c.Source.Addr
+	}
+
+	return netip.Addr{}
+}
+
+func extractProxyTarget(p *dockerProcess) *proxy {
+	if len(p.Cmdline) == 0 {
+		return nil
+	}
+	cmd := p.Cmdline
+	if !strings.HasSuffix(cmd[0], "docker-proxy") {
+		return nil
+	}
+
+	// Extract proxy target address
+	proxy := &proxy{pid: p.Pid, alive: true}
+	var ip netip.Addr
+	var port uint16
+	var err error
+	// len(cmd)-1 because the value of the argument will be next
+	for i := 1; i < len(cmd)-1; i++ {
+		switch cmd[i] {
+		case "-container-ip":
+			ip, err = netip.ParseAddr(cmd[i+1])
+			if err != nil {
+				return nil
+			}
+			i++
+		case "-container-port":
+			port64, err := strconv.ParseUint(cmd[i+1], 10, 16)
+			if err != nil {
+				return nil
+			}
+			port = uint16(port64)
+			i++
+		case "-proto":
+			name := cmd[i+1]
+			proto, ok := network.ConnectionTypeFromString[name]
+			if !ok {
+				return nil
+			}
+			proxy.target.proto = proto
+			i++
+		}
+	}
+
+	if !ip.IsValid() || port == 0 {
+		return nil
+	}
+	proxy.target.addr = netip.AddrPortFrom(ip, port)
+	return proxy
+}

--- a/pkg/network/sender/docker_proxy_test.go
+++ b/pkg/network/sender/docker_proxy_test.go
@@ -1,0 +1,208 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package sender
+
+import (
+	"net/netip"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+func TestDockerProxyExtract(t *testing.T) {
+	// non docker-proxy processes
+	require.Nil(t, extractProxyTarget(&dockerProcess{Pid: 1}))
+	require.Nil(t, extractProxyTarget(&dockerProcess{Pid: 1, Cmdline: []string{"/usr/bin/true"}}))
+
+	cases := []struct {
+		ip, port, proto string
+		target          containerAddr
+	}{
+		{},
+		{ip: "asdf"},
+		{port: "asdf"},
+		{proto: "asdf"},
+		{ip: "127.0.0.2"},
+		{ip: "127.0.0.2", port: "0"},
+		{"127.0.0.2", "9999", "tcp", containerAddr{netip.MustParseAddrPort("127.0.0.2:9999"), network.TCP}},
+		{"127.0.0.2", "9999", "TCP", containerAddr{netip.MustParseAddrPort("127.0.0.2:9999"), network.TCP}},
+		{"127.0.0.2", "9999", "udp", containerAddr{netip.MustParseAddrPort("127.0.0.2:9999"), network.UDP}},
+		{"::1", "9999", "udp", containerAddr{netip.MustParseAddrPort("[::1]:9999"), network.UDP}},
+	}
+	for _, c := range cases {
+		cmdline := dockerProxyCmdLine(c.ip, c.port, c.proto)
+		p := extractProxyTarget(&dockerProcess{Pid: 1, Cmdline: cmdline})
+		if !c.target.addr.IsValid() {
+			require.Nil(t, p, "%+v", c)
+		} else {
+			require.NotNil(t, p, "%+v", c)
+			require.Equal(t, c.target, p.target, "%+v", c)
+		}
+	}
+}
+
+func dockerProxyCmdLine(ip, port, proto string) []string {
+	cmdline := []string{"/usr/local/bin/docker-proxy"}
+	if ip != "" {
+		cmdline = append(cmdline, "-container-ip", ip)
+	}
+	if port != "" {
+		cmdline = append(cmdline, "-container-port", port)
+	}
+	if proto != "" {
+		cmdline = append(cmdline, "-proto", proto)
+	}
+	return cmdline
+}
+
+// The example below represents the following scenario:
+//
+//   - Two containers (in this example a redis-client and a redis-server) are
+//     running on the same host (IP 10.0.2.15)
+//
+//   - The redis-server binds to host port 32769
+//     (`docker run --rm -d -p 6379:32769 redis:alpine`)
+//
+//   - The redis-client communicates to redis-server via the host IP/port
+//     (`docker run --rm redis:alpine redis-cli -h 10.0.2.15 -p 32769 set foo bar`)
+//
+// Since the two containers are co-located within the same host and the communication
+// is done via the Host IP/Port, network traffic flows through docker-proxy.
+// This ends up generating the following flows:
+//
+// 1) redis-client -> redis-server (via host IP)
+// 2) redis-server (via host IP) <- redis-client
+// 3) docker-proxy -> redis-server (redundant)
+// 4) redis-server <- docker-proxy (redundant)
+//
+// The purpose of this package is to filter flows like (3) and (4) in order to
+// avoid double counting traffic represented similar to flows (1) and (2)
+func TestDockerProxyFiltering(t *testing.T) {
+	dpf := newDockerProxyFilter(logmock.New(t))
+	// ensure connections are filtered out
+	dockerProxyPID := uint32(23211)
+	redisServerPort := uint16(6379)
+	redisServerContainerIP := "172.17.0.2"
+	redisClientIP := "172.17.0.3"
+	redisClientPort := uint16(37340)
+	redisServerHostIP := "10.0.2.15"
+	redisServerHostPort := uint16(32769)
+	dockerProxyIP := "172.17.0.1"
+	dockerProxyPort := uint16(34050)
+	dpf.HandleEvent(&dockerProcess{Pid: dockerProxyPID, Cmdline: dockerProxyCmdLine(redisServerContainerIP, strconv.Itoa(int(redisServerPort)), "tcp"), EventType: model.ExecEventType})
+
+	// (1) This represents the *outgoing* connection from redis client to redis server (via host IP)
+	// It should be *kept*
+	c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
+		Pid:       24296,
+		Source:    util.AddressFromString(redisClientIP),
+		SPort:     redisClientPort,
+		Dest:      util.AddressFromString(redisServerHostIP),
+		DPort:     redisServerHostPort,
+		Direction: network.OUTGOING,
+	}}
+
+	// (2) This represents the *incoming* connection on redis server from redis client (via host IP)
+	// It should be *kept*
+	c2 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
+		Pid:       dockerProxyPID,
+		Source:    util.AddressFromString(redisServerHostIP),
+		SPort:     redisServerHostPort,
+		Dest:      util.AddressFromString(redisClientIP),
+		DPort:     redisClientPort,
+		Direction: network.INCOMING,
+	}}
+
+	// (3) This represents the *outgoing* connection from docker-proxy to redis server
+	// It should be *dropped*
+	c3 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
+		Pid:       dockerProxyPID,
+		Source:    util.AddressFromString(dockerProxyIP),
+		SPort:     dockerProxyPort,
+		Dest:      util.AddressFromString(redisServerContainerIP),
+		DPort:     redisServerPort,
+		Direction: network.OUTGOING,
+	}}
+
+	// (4) This represents the *incoming* connection on redis server from docker proxy
+	// It should be *dropped*
+	c4 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
+		Pid:       23233,
+		Source:    util.AddressFromString(redisServerContainerIP),
+		SPort:     redisServerPort,
+		Dest:      util.AddressFromString(dockerProxyIP),
+		DPort:     dockerProxyPort,
+		Direction: network.INCOMING,
+	}}
+
+	conns := &network.Connections{BufferedData: network.BufferedData{Conns: []network.ConnectionStats{c1, c2, c3, c4}}}
+	dpf.FilterProxies(conns)
+	require.Len(t, conns.Conns, 2)
+	assert.Equal(t, c1, conns.Conns[0])
+	assert.Equal(t, c2, conns.Conns[1])
+}
+
+func TestDockerProxyEvents(t *testing.T) {
+	dpf := newDockerProxyFilter(logmock.New(t))
+	dpf.pidAliveFunc = func(pid int) bool { return true }
+	// ensure connections are filtered out
+	dpf.HandleEvent(&dockerProcess{Pid: 10, Cmdline: dockerProxyCmdLine("127.0.0.2", "9999", "tcp"), EventType: model.ExecEventType})
+	c0 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 10, Source: util.AddressFromString("127.0.0.2"), SPort: 10000, Dest: util.AddressFromString("127.0.0.2"), DPort: 9999}}
+	c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 11, Source: util.AddressFromString("127.0.0.2"), SPort: 9999, Dest: util.AddressFromString("127.0.0.2"), DPort: 10000}}
+	conns := &network.Connections{BufferedData: network.BufferedData{Conns: []network.ConnectionStats{c0, c1}}}
+	dpf.FilterProxies(conns)
+	require.Empty(t, conns.Conns)
+
+	// send exit event and ensure next iteration of FilterProxies still filters them out
+	dpf.HandleEvent(&dockerProcess{Pid: 10, EventType: model.ExitEventType})
+	conns = &network.Connections{BufferedData: network.BufferedData{Conns: []network.ConnectionStats{c0, c1}}}
+	dpf.FilterProxies(conns)
+	require.Empty(t, conns.Conns)
+
+	// another filter run should not filter anything
+	conns = &network.Connections{BufferedData: network.BufferedData{Conns: []network.ConnectionStats{c0, c1}}}
+	dpf.FilterProxies(conns)
+	require.Len(t, conns.Conns, 2)
+}
+
+func TestDockerProxyPIDOverwrite(t *testing.T) {
+	dpf := newDockerProxyFilter(logmock.New(t))
+	dpf.pidAliveFunc = func(pid int) bool { return true }
+	dpf.HandleEvent(&dockerProcess{Pid: 10, Cmdline: dockerProxyCmdLine("127.0.0.2", "9999", "tcp"), EventType: model.ExecEventType})
+	c0 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 10, Source: util.AddressFromString("127.0.0.2"), SPort: 10000, Dest: util.AddressFromString("127.0.0.2"), DPort: 9999}}
+	c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 11, Source: util.AddressFromString("127.0.0.2"), SPort: 9999, Dest: util.AddressFromString("127.0.0.2"), DPort: 10000}}
+	conns := &network.Connections{BufferedData: network.BufferedData{Conns: []network.ConnectionStats{c0, c1}}}
+	dpf.FilterProxies(conns)
+	require.Empty(t, conns.Conns)
+
+	// new process with same PID as previous docker-proxy
+	dpf.HandleEvent(&dockerProcess{Pid: 10, Cmdline: []string{"/usr/bin/true"}})
+	conns = &network.Connections{BufferedData: network.BufferedData{Conns: []network.ConnectionStats{c0, c1}}}
+	dpf.FilterProxies(conns)
+	require.Empty(t, conns.Conns)
+}
+
+func TestDockerProxyDeadProcess(t *testing.T) {
+	dpf := newDockerProxyFilter(logmock.New(t))
+	dpf.pidAliveFunc = func(pid int) bool { return false }
+	dpf.HandleEvent(&dockerProcess{Pid: 10, Cmdline: dockerProxyCmdLine("127.0.0.2", "9999", "tcp"), EventType: model.ExecEventType})
+	c0 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 10, Source: util.AddressFromString("127.0.0.2"), SPort: 10000, Dest: util.AddressFromString("127.0.0.2"), DPort: 9999}}
+	c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 11, Source: util.AddressFromString("127.0.0.2"), SPort: 9999, Dest: util.AddressFromString("127.0.0.2"), DPort: 10000}}
+	conns := &network.Connections{BufferedData: network.BufferedData{Conns: []network.ConnectionStats{c0, c1}}}
+	dpf.FilterProxies(conns)
+	require.Empty(t, conns.Conns)
+
+	conns = &network.Connections{BufferedData: network.BufferedData{Conns: []network.ConnectionStats{c0, c1}}}
+	dpf.FilterProxies(conns)
+	require.Len(t, conns.Conns, 2)
+}

--- a/pkg/network/sender/docker_proxy_test.go
+++ b/pkg/network/sender/docker_proxy_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
+//go:build linux
+
 package sender
 
 import (

--- a/pkg/network/sender/docker_proxy_test.go
+++ b/pkg/network/sender/docker_proxy_test.go
@@ -154,7 +154,7 @@ func TestDockerProxyFiltering(t *testing.T) {
 
 func TestDockerProxyEvents(t *testing.T) {
 	dpf := newDockerProxyFilter(logmock.New(t))
-	dpf.pidAliveFunc = func(pid int) bool { return true }
+	dpf.pidAliveFunc = func(_ int) bool { return true }
 	// ensure connections are filtered out
 	dpf.HandleEvent(&dockerProcess{Pid: 10, Cmdline: dockerProxyCmdLine("127.0.0.2", "9999", "tcp"), EventType: model.ExecEventType})
 	c0 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 10, Source: util.AddressFromString("127.0.0.2"), SPort: 10000, Dest: util.AddressFromString("127.0.0.2"), DPort: 9999}}
@@ -177,7 +177,7 @@ func TestDockerProxyEvents(t *testing.T) {
 
 func TestDockerProxyPIDOverwrite(t *testing.T) {
 	dpf := newDockerProxyFilter(logmock.New(t))
-	dpf.pidAliveFunc = func(pid int) bool { return true }
+	dpf.pidAliveFunc = func(_ int) bool { return true }
 	dpf.HandleEvent(&dockerProcess{Pid: 10, Cmdline: dockerProxyCmdLine("127.0.0.2", "9999", "tcp"), EventType: model.ExecEventType})
 	c0 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 10, Source: util.AddressFromString("127.0.0.2"), SPort: 10000, Dest: util.AddressFromString("127.0.0.2"), DPort: 9999}}
 	c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 11, Source: util.AddressFromString("127.0.0.2"), SPort: 9999, Dest: util.AddressFromString("127.0.0.2"), DPort: 10000}}
@@ -194,7 +194,7 @@ func TestDockerProxyPIDOverwrite(t *testing.T) {
 
 func TestDockerProxyDeadProcess(t *testing.T) {
 	dpf := newDockerProxyFilter(logmock.New(t))
-	dpf.pidAliveFunc = func(pid int) bool { return false }
+	dpf.pidAliveFunc = func(_ int) bool { return false }
 	dpf.HandleEvent(&dockerProcess{Pid: 10, Cmdline: dockerProxyCmdLine("127.0.0.2", "9999", "tcp"), EventType: model.ExecEventType})
 	c0 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 10, Source: util.AddressFromString("127.0.0.2"), SPort: 10000, Dest: util.AddressFromString("127.0.0.2"), DPort: 9999}}
 	c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{Pid: 11, Source: util.AddressFromString("127.0.0.2"), SPort: 9999, Dest: util.AddressFromString("127.0.0.2"), DPort: 10000}}

--- a/pkg/network/sender/docker_proxy_unsupported.go
+++ b/pkg/network/sender/docker_proxy_unsupported.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package sender
+
+import (
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
+)
+
+// NewDockerProxyConsumer is not supported on non-linux systems
+func NewDockerProxyConsumer(_ *eventmonitor.EventMonitor, _ log.Component) (eventmonitor.EventConsumer, error) {
+	return nil, nil
+}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -37,7 +37,6 @@ import (
 	filter "github.com/DataDog/datadog-agent/pkg/network/tracer/networkfilter"
 	"github.com/DataDog/datadog-agent/pkg/network/usm"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
-	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -45,6 +44,7 @@ import (
 	netnsutil "github.com/DataDog/datadog-agent/pkg/util/kernel/netns"
 	"github.com/DataDog/datadog-agent/pkg/util/ktime"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/os"
 )
 
 const defaultUDPConnTimeoutNanoSeconds = uint64(time.Duration(120) * time.Second)
@@ -789,7 +789,7 @@ func (t *Tracer) connectionExpired(conn *network.ConnectionStats, latestTime uin
 	// skip connection check for udp connections or if
 	// the pid for the connection is dead
 	// conn.Pid can be 0 when ebpf-less tracer is running
-	if conn.Type == network.UDP || (conn.Pid > 0 && !procutil.PidExists(int(conn.Pid))) {
+	if conn.Type == network.UDP || (conn.Pid > 0 && !os.PidExists(int(conn.Pid))) {
 		return true
 	}
 

--- a/pkg/util/maps/filter.go
+++ b/pkg/util/maps/filter.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package maps provides utility functions for dealing with maps
+package maps
+
+// Filter returns a copy of the map with only the key/value pairs the provided function returns true for.
+func Filter[K comparable, V any](m map[K]V, fn func(key K, value V) bool) map[K]V {
+	result := make(map[K]V)
+	for k, v := range m {
+		if fn(k, v) {
+			result[k] = v
+		}
+	}
+	return result
+}

--- a/pkg/util/os/process_posix.go
+++ b/pkg/util/os/process_posix.go
@@ -1,20 +1,24 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2025-present Datadog, Inc.
 
 //go:build linux || freebsd || openbsd || darwin
 
-package procutil
+// Package os provides additional OS utilities
+package os
 
-import "syscall"
+import (
+	"errors"
+	"syscall"
+)
 
 // PidExists returns true if the pid is still alive
 func PidExists(pid int) bool {
 	// the kill syscall will check for the existence of a process
 	// if the signal is 0. See
 	// https://man7.org/linux/man-pages/man2/kill.2.html
-	if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+	if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
 		return false
 	}
 

--- a/pkg/util/os/process_posix_test.go
+++ b/pkg/util/os/process_posix_test.go
@@ -1,11 +1,11 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2025-present Datadog, Inc.
 
 //go:build linux || freebsd || openbsd || darwin
 
-package procutil
+package os
 
 import (
 	"os"


### PR DESCRIPTION
### What does this PR do?

Adds a "process event data stream" (PEDS) based docker proxy filter. It is used to filter out connections that related to `docker-proxy` processes that are not useful for customers to see.

### Motivation

This will be used in CNM when sending data directly to the backend. 

### Describe how you validated your changes

Added tests.

### Additional Notes

This is a "port" of existing behavior in `pkg/process/metadata/parser/dockerproxy.go` used when CNM data is flowing through `process-agent`. It had to be adapted to a different data source for processes AND different data types for the network connections data.
