### PR TITLE
secure create config backup dir

### DIFF
--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -130,7 +130,9 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 		return nil
 	}
 	// target path must already exist, caller must ensure it has the correct permissions.
-	// this function is reused for the restore operation, too, so this is just a safety to ensure
+	// We must not allow robocopy to create the target directory, as it may not safely create the directory,
+	// see paths.SecureCreateDirectory for more details.
+	// This function is reused for the restore operation, too, so this is also a safety to ensure
 	// we don't modify the original directory.
 	if _, err := os.Stat(targetPath); err != nil {
 		return fmt.Errorf("failed to open target directory: %w", err)

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -16,7 +16,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -50,9 +53,14 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 	if state.ExperimentDeploymentID != "" {
 		return fmt.Errorf("there is already an experiment in progress")
 	}
+	// Clear and recreate the experiment/backup directory
 	err = os.RemoveAll(d.ExperimentPath)
 	if err != nil {
 		return fmt.Errorf("error removing experiment directory: %w", err)
+	}
+	err = secureCreateTargetDirectoryWithSourcePermissions(d.StablePath, d.ExperimentPath)
+	if err != nil {
+		return fmt.Errorf("error creating target directory: %w", err)
 	}
 	err = backupOrRestoreDirectory(ctx, d.StablePath, d.ExperimentPath)
 	if err != nil {
@@ -121,10 +129,11 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 	if os.IsNotExist(err) {
 		return nil
 	}
-	// Ensure target directory exists before trying to write to it
-	err = os.MkdirAll(targetPath, 0755)
-	if err != nil {
-		return fmt.Errorf("error creating target directory: %w", err)
+	// target path must already exist, caller must ensure it has the correct permissions.
+	// this function is reused for the restore operation, too, so this is just a safety to ensure
+	// we don't modify the original directory.
+	if _, err := os.Stat(targetPath); err != nil {
+		return fmt.Errorf("failed to open target directory: %w", err)
 	}
 	deploymentID, err := os.ReadFile(filepath.Join(sourcePath, deploymentIDFile))
 	if err != nil && !os.IsNotExist(err) {
@@ -158,4 +167,16 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 		return fmt.Errorf("error executing robocopy: %w\n%s\n%s", err, stdout.String(), stderr.String())
 	}
 	return nil
+}
+
+// secureCreateTargetDirectoryWithSourcePermissions creates targetPath with the same permissions as srcPath.
+//
+// See paths.SecureCreateDirectory for more details.
+func secureCreateTargetDirectoryWithSourcePermissions(sourcePath, targetPath string) error {
+	sd, err := windows.GetNamedSecurityInfo(sourcePath, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return fmt.Errorf("error getting security info for source directory: %w", err)
+	}
+	sddl := sd.String()
+	return paths.SecureCreateDirectory(targetPath, sddl)
 }

--- a/pkg/fleet/installer/config/config_windows_test.go
+++ b/pkg/fleet/installer/config/config_windows_test.go
@@ -205,8 +205,7 @@ func TestSecureCreateTargetDirectoryWithSourcePermissions(t *testing.T) {
 	sourcePath := filepath.Join(t.TempDir(), "source")
 	targetPath := filepath.Join(t.TempDir(), "target")
 	// Set the source path to a directory with known SDDL
-	// TODO: We want to have the AI flag here, but there might be a bug in CreateDirectory winapi, need to check.
-	sddl := "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;CI;FA;;;WD)"
+	sddl := "D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;CI;FA;;;WD)"
 	assert.NoError(t, paths.SecureCreateDirectory(sourcePath, sddl))
 
 	// Create the target directory with the same permissions as the source directory

--- a/pkg/fleet/installer/config/config_windows_test.go
+++ b/pkg/fleet/installer/config/config_windows_test.go
@@ -13,7 +13,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
 )
 
 func writeConfigV2(t *testing.T, v2Dir string) {
@@ -196,4 +199,23 @@ func TestConfigV2Rollback(t *testing.T) {
 	assertConfigV3(t, originalDirPath) // Make sure it changed
 
 	assertDeploymentID(t, dirs, "experiment-789", "")
+}
+
+func TestSecureCreateTargetDirectoryWithSourcePermissions(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "source")
+	targetPath := filepath.Join(t.TempDir(), "target")
+	// Set the source path to a directory with known SDDL
+	// TODO: We want to have the AI flag here, but there might be a bug in CreateDirectory winapi, need to check.
+	sddl := "D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;CI;FA;;;WD)"
+	assert.NoError(t, paths.SecureCreateDirectory(sourcePath, sddl))
+
+	// Create the target directory with the same permissions as the source directory
+	assert.NoError(t, secureCreateTargetDirectoryWithSourcePermissions(sourcePath, targetPath))
+
+	// Check the target directory has the same permissions as the source directory
+	targetSD, err := windows.GetNamedSecurityInfo(targetPath, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	assert.NoError(t, err)
+	sourceSD, err := windows.GetNamedSecurityInfo(sourcePath, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	assert.NoError(t, err)
+	assert.Equal(t, sourceSD.String(), targetSD.String())
 }

--- a/pkg/fleet/installer/paths/installer_paths_windows.go
+++ b/pkg/fleet/installer/paths/installer_paths_windows.go
@@ -326,6 +326,14 @@ func createDirectoryWithSDDL(path string, sddl string) error {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
+	// CreateDirectory creates the directory with the Owner,Group,DACL,
+	// but does not apply the AI (SeDaclAutoInherit) flag, so we reapply the SDDL
+	// here to ensure the AI flag is set.
+	err = setNamedSecurityInfoFromSecurityDescriptor(path, sd)
+	if err != nil {
+		return fmt.Errorf("failed to set named security info: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/fleet/installer/paths/installer_paths_windows.go
+++ b/pkg/fleet/installer/paths/installer_paths_windows.go
@@ -86,8 +86,8 @@ func init() {
 		DatadogDataDir, _ = getProgramDataDirForProduct("Datadog Agent")
 	}
 	AgentConfigDir = DatadogDataDir
-	DatadogInstallerData = filepath.Join(DatadogDataDir, "Installer")
 	AgentConfigDirExp = filepath.Clean(DatadogDataDir) + "-exp"
+	DatadogInstallerData = filepath.Join(DatadogDataDir, "Installer")
 	PackagesPath = filepath.Join(DatadogInstallerData, "packages")
 	ConfigsPath = filepath.Join(DatadogInstallerData, "managed")
 	RootTmpDir = filepath.Join(DatadogInstallerData, "tmp")
@@ -167,7 +167,7 @@ func EnsureInstallerDataDir() error {
 
 	return winio.RunWithPrivileges(privilegesRequired, func() error {
 		// Create root path: `C:\ProgramData\Datadog\Installer`
-		err := secureCreateDirectory(DatadogInstallerData, sddl)
+		err := SecureCreateDirectory(DatadogInstallerData, sddl)
 		if err != nil {
 			return fmt.Errorf("failed to create DatadogInstallerData: %w", err)
 		}
@@ -207,11 +207,11 @@ func EnsureInstallerDataDir() error {
 	})
 }
 
-// secureCreateDirectory creates a directory with the specified SDDL string.
+// SecureCreateDirectory creates a directory with the specified SDDL string.
 //
 // If the directory already exists and it is owned by Administrators or SYSTEM, the permissions
 // are set to the expected state. If the directory is owned by an unknown party, an error is returned.
-func secureCreateDirectory(path string, sddl string) error {
+func SecureCreateDirectory(path string, sddl string) error {
 	// Try to create the directory with the desired permissions.
 	// We avoid TOCTOU issues because CreateDirectory fails if the directory already exists.
 	// This is of concern because Windows by default grants Users write access to ProgramData.

--- a/pkg/fleet/installer/paths/paths_windows_test.go
+++ b/pkg/fleet/installer/paths/paths_windows_test.go
@@ -28,7 +28,7 @@ func TestSecureCreateDirectory(t *testing.T) {
 		root := t.TempDir()
 		subdir := filepath.Join(root, "A")
 		sddl := "D:PAI(A;OICI;FA;;;AU)"
-		err := secureCreateDirectory(subdir, sddl)
+		err := SecureCreateDirectory(subdir, sddl)
 		require.NoError(t, err)
 		sd, err := getSecurityDescriptor(subdir)
 		require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestSecureCreateDirectory(t *testing.T) {
 			err := os.Mkdir(subdir, 0)
 			require.NoError(t, err)
 			sddl := "O:BAG:BAD:PAI(A;OICI;FA;;;AU)"
-			err = secureCreateDirectory(subdir, sddl)
+			err = SecureCreateDirectory(subdir, sddl)
 			require.Error(t, err)
 			assert.ErrorContains(t, err, "installer data directory has unexpected owner")
 		})
@@ -58,7 +58,7 @@ func TestSecureCreateDirectory(t *testing.T) {
 			})
 			require.NoError(t, err)
 			sddl = "O:BAG:BAD:PAI(A;OICI;FA;;;AU)"
-			err = secureCreateDirectory(subdir, sddl)
+			err = SecureCreateDirectory(subdir, sddl)
 			require.NoError(t, err)
 			sd, err := getSecurityDescriptor(subdir)
 			require.NoError(t, err)

--- a/releasenotes/notes/windows-remote-config-updates-newdir-95821056691d3d51.yaml
+++ b/releasenotes/notes/windows-remote-config-updates-newdir-95821056691d3d51.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    Remote Agent Management now creates a new directory that is a peer to the current Agent configuration directory.
+  
+    * Linux: /etc/datadog-agent-exp
+    * Windows: C:\ProgramData\Datadog-exp
+  
+    This directory is used during remote configuration updates and is deleted after the update is complete.

--- a/releasenotes/notes/windows-remote-config-updates-newdir-95821056691d3d51.yaml
+++ b/releasenotes/notes/windows-remote-config-updates-newdir-95821056691d3d51.yaml
@@ -1,7 +1,7 @@
 ---
 upgrade:
   - |
-    Remote Agent Management now creates a new directory that is a peer to the current Agent configuration directory.
+    Remote Agent Management now creates a new directory that is at the same level as the current Agent configuration directory.
   
     * Linux: /etc/datadog-agent-exp
     * Windows: C:\ProgramData\Datadog-exp

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -82,7 +82,8 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", false).
-		HasDDAgentUserFileAccess()
+		HasDDAgentUserFileAccess().
+		NoDirExists(configBackupRoot) // backup dir should be deleted
 
 	// assert that the config dir permissions have not changed
 	perms, err = windowscommon.GetSecurityInfoForPath(s.Env().RemoteHost, configRoot)
@@ -143,7 +144,8 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_level", "debug").
-		HasDDAgentUserFileAccess()
+		HasDDAgentUserFileAccess().
+		NoDirExists(configBackupRoot) // backup dir should be deleted
 
 	// backend will send stop experiment now
 	s.WaitForDaemonToStop(func() {


### PR DESCRIPTION
### What does this PR do?
Create config backup directory with the same permissions as the original config directory

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2050
bugfix for https://github.com/DataDog/datadog-agent/pull/42840, see also https://github.com/DataDog/datadog-agent/pull/42385#discussion_r2476174034