### PR TITLE
[FA] Lower log level for files metadata

### DIFF
--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
@@ -293,7 +293,7 @@ func (ic *inventorychecksImpl) writePayloadAsJSON(w http.ResponseWriter, _ *http
 func (ic *inventorychecksImpl) getFilesMetadata() metadata {
 	configFiles := providers.ReadConfigFormats()
 	if len(configFiles) == 0 {
-		ic.log.Errorf("could not read files metadata")
+		ic.log.Debug("could not read files metadata")
 		return metadata{}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Lower log level for files metadata not found.
This should not happen frequently, but in some cases the agent can log it every 10min, which is noisy for a few customers

### Motivation

### Describe how you validated your changes

### Additional Notes
