### PR TITLE
[omnibus] Upgrade OpenSCAP to version 1.4.3

### DIFF
--- a/deps/openscap/openscap.MODULE.bazel
+++ b/deps/openscap/openscap.MODULE.bazel
@@ -2,14 +2,14 @@
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "1.4.2"
+VERSION = "1.4.3"
 
 http_archive(
     name = "openscap",
     files = {
         "BUILD.bazel": "//deps/openscap:overlay/overlay.BUILD.bazel",
     },
-    sha256 = "1d5309fadd9569190289d7296016dc534594f7f7d4fd870fe9e847e24940073d",
+    sha256 = "96ebe697aafc83eb297a8f29596d57319278112467c46e6aaf3649b311cf8fba",
     strip_prefix = "openscap-{version}".format(version = VERSION),
     url = "https://github.com/OpenSCAP/openscap/releases/download/{version}/openscap-{version}.tar.gz".format(version = VERSION),
 )

--- a/deps/openscap/overlay/overlay.BUILD.bazel
+++ b/deps/openscap/overlay/overlay.BUILD.bazel
@@ -13,7 +13,7 @@ package(
     ],
 )
 
-VERSION = "1.4.2"
+VERSION = "1.4.3"
 
 package_metadata(
     name = "package_metadata",

--- a/omnibus/config/patches/openscap/dpkginfo-virtual-packages-revert.patch
+++ b/omnibus/config/patches/openscap/dpkginfo-virtual-packages-revert.patch
@@ -1,0 +1,70 @@
+--- b/src/OVAL/probes/unix/linux/dpkginfo-helper.c
++++ a/src/OVAL/probes/unix/linux/dpkginfo-helper.c
+@@ -68,7 +68,7 @@ err:
+ struct dpkginfo_reply_t* dpkginfo_get_by_name(const char *name, int *err)
+ {
+ 	FILE *f;
+-	char buf[DPKG_STATUS_BUFFER_SIZE], path[PATH_MAX], *root, *key, *value, *p;
++	char buf[DPKG_STATUS_BUFFER_SIZE], path[PATH_MAX], *root, *key, *value;
+ 	struct dpkginfo_reply_t *reply;
+ 
+ 	*err = 0;
+@@ -93,14 +93,8 @@ struct dpkginfo_reply_t* dpkginfo_get_by_name(const char *name, int *err)
+ 		if (buf[0] == '\n') {
+ 			// New package entry.
+ 			if (reply != NULL) {
+-				if (reply->name != NULL) {
+-					// Package found.
+-					goto out;
+-				} else {
+-					// Package not found yet.
+-					dpkginfo_free_reply(reply);
+-					reply = NULL;
+-				}
++				// Package found.
++				goto out;
+ 			}
+ 			continue;
+ 		}
+@@ -119,12 +113,12 @@ struct dpkginfo_reply_t* dpkginfo_get_by_name(const char *name, int *err)
+ 		value = trimleft(value);
+ 		// Package should be the first line.
+ 		if (strcmp(key, "Package") == 0) {
+-			if (reply != NULL)
+-				continue;
+-			reply = calloc(1, sizeof(*reply));
+-			if (reply == NULL)
+-				goto err;
+ 			if (strcmp(value, name) == 0) {
++				if (reply != NULL)
++					continue;
++				reply = calloc(1, sizeof(*reply));
++				if (reply == NULL)
++					goto err;
+ 				reply->name = strdup(value);
+ 				if (reply->name == NULL)
+ 					goto err;
+@@ -148,23 +142,6 @@ struct dpkginfo_reply_t* dpkginfo_get_by_name(const char *name, int *err)
+ 					goto err;
+ 				if (version(reply) < 0)
+ 					goto err;
+-			} else if (strcmp(key, "Provides") == 0) {
+-				// Handle virtual packages.
+-				char *s = strtok(value, ",");
+-				while (s != NULL) {
+-					s = trimleft(s);
+-					// Ignore version.
+-					p = strchr(s, ' ');
+-					if (p != NULL)
+-						*p++ = '\0';
+-					if (strcmp(s, name) == 0) {
+-						reply->name = strdup(value);
+-						if (reply->name == NULL)
+-							goto err;
+-						break;
+-					}
+-					s = strtok(NULL, ",");
+-				}
+ 			}
+ 		}
+ 	}

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -4,12 +4,12 @@
 # Copyright 2016-present Datadog, Inc.
 
 name 'openscap'
-default_version '1.4.2'
+default_version '1.4.3'
 
 license "LGPL-3.0-or-later"
 license_file "COPYING"
 
-version("1.4.2") { source sha256: "1d5309fadd9569190289d7296016dc534594f7f7d4fd870fe9e847e24940073d" }
+version("1.4.3") { source sha256: "96ebe697aafc83eb297a8f29596d57319278112467c46e6aaf3649b311cf8fba" }
 
 ship_source_offer true
 
@@ -74,6 +74,7 @@ build do
   patch source: "oval_probe_session_reset.patch", env: env # use oval_probe_session_reset instead of oval_probe_session_reinit
   patch source: "sysctl-probe-offline-skip.patch", env: env # skip sysctl probe in offline mode
   patch source: "probes-no-procfs.patch", env: env # handle systems with no procfs available
+  patch source: "dpkginfo-virtual-packages-revert.patch", env: env # revert handling of virtual packages in dpkginfo probe
 
   patch source: "oscap-io.patch", env: env # add new oscap-io tool
 


### PR DESCRIPTION
### What does this PR do?

This change upgrades OpenSCAP to version 1.4.3.

This change also reverts the handling of virtual packages
in dpkginfo probe, since it causes a regression on
Ubuntu 20.04 and 22.04.

See https://github.com/ComplianceAsCode/content/issues/14187

### Motivation

### Describe how you validated your changes

### Additional Notes
