### PR TITLE
[AMCC-160] Add field `metric_filterlist`.

### DIFF
--- a/comp/dogstatsd/server/rc.go
+++ b/comp/dogstatsd/server/rc.go
@@ -37,7 +37,8 @@ func (s *server) onFilterListUpdateCallback(updates map[string]state.RawConfig, 
 	// special case: we received a response from RC, but RC didn't have any
 	// configuration for this agent, let's restore the local config and return
 	if len(updates) == 0 {
-		s.config.UnsetForSource("metric_blocklist", model.SourceRC)
+		s.config.UnsetForSource("metric_filterlist", model.SourceRC)
+		s.config.UnsetForSource("metric_filterlist_match_prefix", model.SourceRC)
 		s.config.UnsetForSource("statsd_metric_blocklist", model.SourceRC)
 		s.config.UnsetForSource("statsd_metric_blocklist_match_prefix", model.SourceRC)
 		s.restoreFilterListFromLocalConfig()
@@ -87,11 +88,12 @@ func (s *server) onFilterListUpdateCallback(updates map[string]state.RawConfig, 
 	if len(metricNames) > 0 {
 		// update the runtime config to be consistent
 		// in `agent config` calls.
-		s.config.Set("metric_blocklist", metricNames, model.SourceRC)
+		s.config.Set("metric_filterlist", metricNames, model.SourceRC)
+		s.config.Set("metric_filterlist_match_prefix", false, model.SourceRC)
 		if len(s.localFilterListConfig.metricNames) > 0 {
 			s.config.Set("statsd_metric_blocklist", []string{}, model.SourceRC)
+			s.config.Set("statsd_metric_blocklist_match_prefix", false, model.SourceRC)
 		}
-		s.config.Set("statsd_metric_blocklist_match_prefix", false, model.SourceRC)
 
 		// apply this new blocklist to all the running workers
 		s.tlmFilterListUpdates.Inc()
@@ -99,7 +101,8 @@ func (s *server) onFilterListUpdateCallback(updates map[string]state.RawConfig, 
 		s.SetFilterList(metricNames, false)
 	} else {
 		// special case: if the metric names list is empty, fallback to local
-		s.config.UnsetForSource("metric_blocklist", model.SourceRC)
+		s.config.UnsetForSource("metric_filterlist", model.SourceRC)
+		s.config.UnsetForSource("metric_filterlist_match_prefix", model.SourceRC)
 		s.config.UnsetForSource("statsd_metric_blocklist", model.SourceRC)
 		s.config.UnsetForSource("statsd_metric_blocklist_match_prefix", model.SourceRC)
 		s.restoreFilterListFromLocalConfig()

--- a/comp/dogstatsd/server/rc.go
+++ b/comp/dogstatsd/server/rc.go
@@ -37,6 +37,7 @@ func (s *server) onFilterListUpdateCallback(updates map[string]state.RawConfig, 
 	// special case: we received a response from RC, but RC didn't have any
 	// configuration for this agent, let's restore the local config and return
 	if len(updates) == 0 {
+		s.config.UnsetForSource("metric_blocklist", model.SourceRC)
 		s.config.UnsetForSource("statsd_metric_blocklist", model.SourceRC)
 		s.config.UnsetForSource("statsd_metric_blocklist_match_prefix", model.SourceRC)
 		s.restoreFilterListFromLocalConfig()
@@ -86,16 +87,19 @@ func (s *server) onFilterListUpdateCallback(updates map[string]state.RawConfig, 
 	if len(metricNames) > 0 {
 		// update the runtime config to be consistent
 		// in `agent config` calls.
-		s.config.Set("statsd_metric_blocklist", metricNames, model.SourceRC)
+		s.config.Set("metric_blocklist", metricNames, model.SourceRC)
+		if len(s.localFilterListConfig.metricNames) > 0 {
+			s.config.Set("statsd_metric_blocklist", []string{}, model.SourceRC)
+		}
 		s.config.Set("statsd_metric_blocklist_match_prefix", false, model.SourceRC)
 
 		// apply this new blocklist to all the running workers
 		s.tlmFilterListUpdates.Inc()
 		s.tlmFilterListSize.Set(float64(len(metricNames)))
 		s.SetFilterList(metricNames, false)
-
 	} else {
 		// special case: if the metric names list is empty, fallback to local
+		s.config.UnsetForSource("metric_blocklist", model.SourceRC)
 		s.config.UnsetForSource("statsd_metric_blocklist", model.SourceRC)
 		s.config.UnsetForSource("statsd_metric_blocklist_match_prefix", model.SourceRC)
 		s.restoreFilterListFromLocalConfig()

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -627,14 +627,16 @@ func (s *server) handleMessages() {
 	}
 
 	// init the metric names filterlist
-	blocklist := s.config.GetStringSlice("metric_blocklist")
-	if len(blocklist) == 0 {
-		blocklist = s.config.GetStringSlice("statsd_metric_blocklist")
+	filterlist := s.config.GetStringSlice("metric_filterlist")
+	filterlist_prefix := s.config.GetBool("metric_filterlist_match_prefix")
+	if len(filterlist) == 0 {
+		filterlist = s.config.GetStringSlice("statsd_metric_blocklist")
+		filterlist_prefix = s.config.GetBool("statsd_metric_blocklist_match_prefix")
 	}
 
 	s.localFilterListConfig = localFilterListConfig{
-		metricNames: blocklist,
-		matchPrefix: s.config.GetBool("statsd_metric_blocklist_match_prefix"),
+		metricNames: filterlist,
+		matchPrefix: filterlist_prefix,
 	}
 	s.restoreFilterListFromLocalConfig()
 }

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -627,9 +627,13 @@ func (s *server) handleMessages() {
 	}
 
 	// init the metric names filterlist
+	blocklist := s.config.GetStringSlice("metric_blocklist")
+	if len(blocklist) == 0 {
+		blocklist = s.config.GetStringSlice("statsd_metric_blocklist")
+	}
 
 	s.localFilterListConfig = localFilterListConfig{
-		metricNames: s.config.GetStringSlice("statsd_metric_blocklist"),
+		metricNames: blocklist,
 		matchPrefix: s.config.GetBool("statsd_metric_blocklist_match_prefix"),
 	}
 	s.restoreFilterListFromLocalConfig()

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -628,15 +628,15 @@ func (s *server) handleMessages() {
 
 	// init the metric names filterlist
 	filterlist := s.config.GetStringSlice("metric_filterlist")
-	filterlist_prefix := s.config.GetBool("metric_filterlist_match_prefix")
+	filterlistPrefix := s.config.GetBool("metric_filterlist_match_prefix")
 	if len(filterlist) == 0 {
 		filterlist = s.config.GetStringSlice("statsd_metric_blocklist")
-		filterlist_prefix = s.config.GetBool("statsd_metric_blocklist_match_prefix")
+		filterlistPrefix = s.config.GetBool("statsd_metric_blocklist_match_prefix")
 	}
 
 	s.localFilterListConfig = localFilterListConfig{
 		metricNames: filterlist,
-		matchPrefix: filterlist_prefix,
+		matchPrefix: filterlistPrefix,
 	}
 	s.restoreFilterListFromLocalConfig()
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1222,6 +1222,11 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cel_workload_exclude", []interface{}{})
 
 	config.BindEnvAndSetDefault("vsock_addr", "")
+
+	// Blocklist
+	config.BindEnvAndSetDefault("metric_blocklist", []string{})
+	config.BindEnvAndSetDefault("statsd_metric_blocklist", []string{})
+	config.BindEnvAndSetDefault("statsd_metric_blocklist_match_prefix", false)
 }
 
 func agent(config pkgconfigmodel.Setup) {
@@ -1742,8 +1747,6 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("statsd_forward_port", 0)
 	config.BindEnvAndSetDefault("statsd_metric_namespace", "")
 	config.BindEnvAndSetDefault("statsd_metric_namespace_blacklist", StandardStatsdPrefixes)
-	config.BindEnvAndSetDefault("statsd_metric_blocklist", []string{})
-	config.BindEnvAndSetDefault("statsd_metric_blocklist_match_prefix", false)
 
 	config.BindEnvAndSetDefault("histogram_copy_to_distribution", false)
 	config.BindEnvAndSetDefault("histogram_copy_to_distribution_prefix", "")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1223,9 +1223,10 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("vsock_addr", "")
 
-	// Blocklist
-	config.BindEnvAndSetDefault("metric_blocklist", []string{})
+	// Filterlist
+	config.BindEnvAndSetDefault("metric_filterlist", []string{})
 	config.BindEnvAndSetDefault("statsd_metric_blocklist", []string{})
+	config.BindEnvAndSetDefault("metric_filterlist_match_prefix", false)
 	config.BindEnvAndSetDefault("statsd_metric_blocklist_match_prefix", false)
 }
 


### PR DESCRIPTION
### What does this PR do?

This updates the `statsd_metric_blocklist` configuration field to be called `metric_filterlist`.

### Motivation

Given metrics can now be filtered from dogstatsd and checks, the new name captures both these scenarios.

### Describe how you validated your changes

Tested manually with configurations using both names.


### Additional Notes
