### PR TITLE
[AGNTLOG] Fix Logs Agent Restart Unit Tests

### DIFF
--- a/comp/logs/agent/agentimpl/agent_restart_test.go
+++ b/comp/logs/agent/agentimpl/agent_restart_test.go
@@ -151,6 +151,9 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 	}
 
 	agent.setupAgent()
+	suite.T().Cleanup(func() {
+		_ = agent.stop(context.TODO())
+	})
 
 	return agent, sources, services
 }


### PR DESCRIPTION
### What does this PR do?
Fix flaky unit tests in `RestartTestSuite` / `AgentTestSuite` due to goleaks. Update `RestartTestSuite` with `cleanup` function that `stop`s the Agent. 

### Motivation

### Describe how you validated your changes

### Additional Notes
