### PR TITLE
[Backport 7.73.x] Change MacOS jobs to use sonoma runners (#42926) 

### DIFF
--- a/.gitlab/bazel/build-deps.yaml
+++ b/.gitlab/bazel/build-deps.yaml
@@ -17,13 +17,13 @@ bazel:build-deps:linux-arm64:
 
 bazel:build-deps:macos-amd64:
   extends: .bazel:build-deps
-  tags: [ "macos:ventura-amd64", "specific:true" ]
+  tags: [ "macos:sonoma-amd64", "specific:true" ]
   script:
     - bazel build //deps/...
 
 bazel:build-deps:macos-arm64:
   extends: .bazel:build-deps
-  tags: [ "macos:ventura-arm64", "specific:true" ]
+  tags: [ "macos:sonoma-arm64", "specific:true" ]
   script:
     - bazel build //deps/...
 

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -17,8 +17,8 @@ include:
 
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:sonoma-amd64", "specific:true"]
 
 lint_macos_gitlab_arm64:
   extends: .lint_macos_gitlab
-  tags: ["macos:ventura-arm64", "specific:true"]
+  tags: ["macos:sonoma-arm64", "specific:true"]

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -71,8 +71,8 @@
 
 agent_dmg-x64-a7:
   extends: .agent_dmg
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:sonoma-amd64", "specific:true"]
 
 agent_dmg-arm64-a7:
   extends: .agent_dmg
-  tags: ["macos:ventura-arm64", "specific:true"]
+  tags: ["macos:sonoma-arm64", "specific:true"]

--- a/.gitlab/source_test/kmt_tasks.yml
+++ b/.gitlab/source_test/kmt_tasks.yml
@@ -7,6 +7,10 @@
   rules:
     - !reference [.on_invoke_tasks_changes]
     - !reference [.except_mergequeue]
+    - changes:
+        paths:
+          - .gitlab/source_test/kmt_tasks.yml
+        compare_to: $COMPARE_TO_BRANCH
   script:
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "git@github.com:"
     # Avoid rate limits when running kmt.init (pulumi queries the Github API to get the releases of plugins)
@@ -32,7 +36,7 @@ test_kmt_local_setup_macos:
   extends: .test_kmt_local_setup
   before_script:
     - !reference [.macos_gitlab, before_script]
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:sonoma-amd64", "specific:true"]
   variables:
      # Some requirements cannot be tested in the CI yet:
     # - Docker,Compiler,UserInDockerGroup: no docker-in-docker support in these jobs yet

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -40,8 +40,8 @@ include:
 
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab
-  tags: ["macos:ventura-amd64", "specific:true"]
+  tags: ["macos:sonoma-amd64", "specific:true"]
 
 tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
-  tags: ["macos:ventura-arm64", "specific:true"]
+  tags: ["macos:sonoma-arm64", "specific:true"]


### PR DESCRIPTION
We've added a new group of macOS runners which use a newer version of macOS (see https://github.com/DataDog/ci-platform-machine-images/pull/503 and https://github.com/DataDog/cloud-inventory/pull/46351) with the intention of using that for datadog-agent CI moving forward. This makes it so that we start to use those runners in our CI.

[ABLD-293](https://datadoghq.atlassian.net/browse/ABLD-293)

CI passing.

[ABLD-293]: https://datadoghq.atlassian.net/browse/ABLD-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


(cherry picked from commit bd631bdb9050278bf29d9c14d74784d6d9a1535f)

**Note: in backporting this from main, there was enough divergence that I had to manually make sure all ventura tags were switched to sonoma.**

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
