### PR TITLE
[CWS] add activity dump endpoint config path to configsync allowlist

### DIFF
--- a/comp/api/api/def/component.go
+++ b/comp/api/api/def/component.go
@@ -71,6 +71,7 @@ var AuthorizedConfigPathsCore = buildAuthorizedSet(
 	"sbom.additional_endpoints",
 	"service_discovery.forwarder.additional_endpoints",
 	"runtime_security_config.endpoints.additional_endpoints",
+	"runtime_security_config.activity_dump.remote_storage.endpoints",
 )
 
 func buildAuthorizedSet(paths ...string) AuthorizedSet {


### PR DESCRIPTION
### What does this PR do?

This config path controls the sending of activity dump payloads from the CWS code, running in security agent or system probe.

### Motivation

### Describe how you validated your changes

### Additional Notes
