### PR TITLE
Bump rules pkg

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,7 +34,7 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 # Temporary until a future rules_pkg release
 git_override(
     module_name = "rules_pkg",
-    commit = "daa496412d12598d6b24619a9a6cd6fc137de384",
+    commit = "46bd2689886984c2b77d6005595f351e404dfa57",
     remote = "https://github.com/bazelbuild/rules_pkg",
 )
 


### PR DESCRIPTION
We need code integrated to head of rules_pkg, but that is not released yet.

Split from #43302 because that is failing to merge for inexplicable reasons.
I am working through the changes their in the smallest possible chunks to find the root cause.