### PR TITLE
Log Permissions Error Document Link

### DIFF
--- a/pkg/logs/status/utils/status.go
+++ b/pkg/logs/status/utils/status.go
@@ -46,7 +46,11 @@ func (s *LogStatus) Error(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.status = isError
-	s.err = fmt.Sprintf("Error: %s", err.Error())
+	if strings.Contains(err.Error(), "permission denied"){
+        s.err = fmt.Sprintf("Error: %s. See https://docs.datadoghq.com/logs/guide/log-collection-troubleshooting-guide/?tab=linux#permission-issues-tailing-log-files for details on how to troubleshoot this issue", err.Error())
+    } else {
+      s.err = fmt.Sprintf("Error: %s", err.Error())
+    }
 }
 
 // IsPending returns whether the current status is not yet determined.


### PR DESCRIPTION
### What does this PR do?
Adding an additional doc link when a permissions issue is evaluated for log files within the status.log
If statement to only trigger the relative doc link when a permission issue is present within the error message
### Motivation
Agent Log improvement project
### Describe how you validated your changes
Tested this in a local version of the Agent build and replicated the environment a customer may face
