### PR TITLE
[SMP] Small tag fix for profiles in `quality_gate_metrics_logs`

### DIFF
--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -23,7 +23,7 @@ target:
     DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
     DD_PROFILING_WAIT_PROFILE: true
 
-    DD_INTERNAL_PROFILING_EXTRA_TAGS: experiment:uds_dogstatsd_to_api_cpu
+    DD_INTERNAL_PROFILING_EXTRA_TAGS: experiment:quality_gate_metrics_logs
 
 checks:
   - name: memory_usage


### PR DESCRIPTION
### What does this PR do?

Adjust the tags set `DD_INTERNAL_PROFILING_EXTRA_TAGS` for `quality_gate_metrics_logs`

