### PR TITLE
Mark new-e2e-installer-windows: [TestAgentUpgradesOnDCWithGMSA$/TestUpgradeMSI$] flakey

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -26,5 +26,8 @@ test/new-e2e/tests/containers:
   - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
   - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
 
+/tests/installer/windows:
+  - test: TestAgentUpgradesOnDCWithGMSA
+
 on-log:
   - "panic: Expected to find a single pod" # K8s Agent Executor can be flaky with the current implementation


### PR DESCRIPTION
This tests is failing on multiple unrelated PRs, blocking merges.
For example: https://github.com/DataDog/datadog-agent/pull/44239