### PR TITLE
Check *actual* `bazel` version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -160,3 +160,5 @@ include("//deps/libpcap:libpcap.MODULE.bazel")
 # Simply add --platforms=@apple_support//platforms:macos_x86_64
 # to the build command to enable it.
 bazel_dep(name = "apple_support", version = "1.23.1")
+
+use_repo_rule("//bazel/tools:check_bazel_version.bzl", "check_bazel_version")(name = "check_bazel_version")

--- a/bazel/tools/BUILD.bazel
+++ b/bazel/tools/BUILD.bazel
@@ -1,5 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@check_bazel_version//:defs.bzl", "check_bazel_version")
 load("@rules_python//python:py_binary.bzl", "py_binary")
+
+check_bazel_version()
 
 py_binary(
     name = "generate_module_bazel",

--- a/bazel/tools/check_bazel_version.bzl
+++ b/bazel/tools/check_bazel_version.bzl
@@ -1,0 +1,30 @@
+"""Check Bazel version against .bazelversion file.
+
+This implements the idiom described in the Bazelisk README for ensuring users don't mistakenly bypass Bazelisk by having
+a Bazel binary in their PATH:
+- https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#ensuring-that-your-developers-use-bazelisk-rather-than-bazel
+- https://gerrit.googlesource.com/prolog-cafe/+/master/tools/bzl/bazelisk_version.bzl
+"""
+
+_template = """
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+def check_bazel_version():
+    versions.check(
+        bazel_version = "{current_version}",
+        maximum_bazel_version = "{required_version}",
+        minimum_bazel_version = "{required_version}",
+    )
+""".strip()
+
+def _impl(repository_ctx):
+    repository_ctx.file("BUILD.bazel")
+    repository_ctx.file(
+        "defs.bzl",
+        content = _template.format(
+            current_version = native.bazel_version,
+            required_version = repository_ctx.read(Label("//:.bazelversion")).strip(),
+        ),
+    )
+
+check_bazel_version = repository_rule(configure = True, implementation = _impl, local = True)


### PR DESCRIPTION
### What does this PR do?
Implement version checking to ensure developers use `bazelisk` rather than a `bazel` binary directly in their PATH. The check verifies that the current `bazel` version exactly matches the version specified in `.bazelversion`.

### Motivation
Following the [idiom recommended](https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#ensuring-that-your-developers-use-bazelisk-rather-than-bazel) in the `bazelisk` documentation, we want to ensure that developers and CI setups don't accidentally bypass it by having a `bazel` binary in their PATH. This prevents version mismatches that can lead to
build inconsistencies across different environments.

This is to avoid:
- initial rationale due to `--lockfile_mode=error` behaving inconsistently: dependency resolution issues with bzlmod,
- potential subtle build failures or differences between local and CI builds,
- potential incompatible flag usage between `bazel` versions.

### Describe how you validated your changes
Tested with correct `bazel` version (8.4.2 via `bazelisk`):
```bash
bazel build //...  # Success
```

Tested with wrong `bazel` version (8.3.1):
```bash
/path/to/bazel-8.3.1 build //...
# Error: Current Bazel version is 8.3.1; expected at least 8.4.2
```

### Additional Notes
Inspired by a [community example](https://gerrit.googlesource.com/prolog-cafe/+/master/tools/bzl/bazelisk_version.bzl), the solution uses a `repository_rule` that:
1. reads the required version from `.bazelversion` at repository evaluation time,
2. captures the current `native.bazel_version` (only available in repository context),
3. generates a `defs.bzl` file that calls `versions.check()` with both versions,
4. is invoked from `bazel/tools/BUILD.bazel` to trigger evaluation.

The `repository_rule` is marked with:
- `configure = True`: indicates this rule depends on the environment (i.e. actual `bazel_version`),
- `local = True`: marks the rule as non-hermetic, preventing aggressive caching ([lesson learned](https://blog.bazel.build/2017/02/22/repository-invalidation.html)).
  Without it, `bazel` would cache the repository across different `bazel` versions, defeating the purpose of the check.
