### PR TITLE
usm: native-tls: Fix a leak while terminating the context

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -360,14 +360,18 @@ SEC("uprobe/SSL_shutdown")
 int BPF_BYPASSABLE_UPROBE(uprobe__SSL_shutdown, void *ssl_ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/SSL_shutdown: pid_tgid=%llx ctx=%p", pid_tgid, ssl_ctx);
-    conn_tuple_t *t = tup_from_ssl_ctx(ssl_ctx, pid_tgid);
     ssl_ctx_pid_tgid_t key = {
         .pid_tgid = pid_tgid,
         .ctx = ssl_ctx,
     };
+    ssl_sock_t *ssl_sock = bpf_map_lookup_elem(&ssl_sock_by_ctx, &key);
+    if (ssl_sock == NULL) {
+        return 0;
+    }
+    conn_tuple_t tup = ssl_sock->tup;
     bpf_map_delete_elem(&ssl_sock_by_ctx, &key);
-    if (t != NULL) {
-        tls_finish(ctx, t, false);
+    if (tup.dport != 0 && tup.sport != 0) {
+        tls_finish(ctx, &tup, false);
     }
     return 0;
 }
@@ -525,15 +529,18 @@ cleanup:
 static __always_inline void gnutls_goodbye(struct pt_regs *ctx, void *ssl_session) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("gnutls_goodbye: pid=%llu ctx=%p", pid_tgid, ssl_session);
-    conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
-    // tls_finish can launch a tail call, thus cleanup should be done before.
     ssl_ctx_pid_tgid_t key = {
         .pid_tgid = pid_tgid,
         .ctx = ssl_session,
     };
+    ssl_sock_t *ssl_sock = bpf_map_lookup_elem(&ssl_sock_by_ctx, &key);
+    if (ssl_sock == NULL) {
+        return;
+    }
+    conn_tuple_t tup = ssl_sock->tup;
     bpf_map_delete_elem(&ssl_sock_by_ctx, &key);
-    if (t != NULL) {
-        tls_finish(ctx, t, false);
+    if (tup.dport != 0 && tup.sport != 0) {
+        tls_finish(ctx, &tup, false);
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes a use-after-free bug in native TLS (OpenSSL and GnuTLS) connection termination that could cause memory leaks.

## Changes
- Modified `uprobe__SSL_shutdown` (OpenSSL) to copy the connection tuple before deleting the map entry
- Modified `gnutls_goodbye` (GnuTLS) to copy the connection tuple before deleting the map entry

## Problem
The previous implementation called `tup_from_ssl_ctx()` which returned a pointer to data inside the eBPF map, then later deleted the map entry via `bpf_map_delete_elem()`. This created a use-after-free scenario where:
1. `tup_from_ssl_ctx()` returns a pointer to map data
2. Map entry gets deleted
3. `tls_finish()` uses the now-invalid pointer

## Solution
Now we:
1. Look up the `ssl_sock` object from the map
2. Copy the `conn_tuple_t` to a local stack variable
3. Delete the map entry
4. Use the local copy for `tls_finish()`

This ensures we're working with valid data and properly cleaning up the map entry before processing the connection termination.

## Test plan
- Existing USM native TLS tests should continue to pass
- Memory leak should be resolved in production workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)