### PR TITLE
[CSPM] add new compliance cli code to system-probe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -261,6 +261,7 @@
 /cmd/system-probe/subcommands/runtime/  @DataDog/agent-security
 /cmd/system-probe/subcommands/usm/      @DataDog/universal-service-monitoring
 /cmd/system-probe/subcommands/ebpf/     @DataDog/ebpf-platform @DataDog/universal-service-monitoring
+/cmd/system-probe/subcommands/compliance/     @DataDog/agent-cspm
 /cmd/systray/                           @DataDog/windows-products
 /cmd/security-agent/                    @DataDog/agent-security
 /cmd/security-agent/subcommands/compliance/ @DataDog/agent-cspm

--- a/cmd/system-probe/subcommands/compliance/command.go
+++ b/cmd/system-probe/subcommands/compliance/command.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build unix
+
+// Package compliance implements compliance related subcommands
+package compliance
+
+import (
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
+	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
+	"github.com/DataDog/datadog-agent/pkg/compliance/cli"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Commands returns the compliance commands
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	complianceCmd := &cobra.Command{
+		Use:   "compliance",
+		Short: "Compliance Agent utility commands",
+	}
+
+	complianceCmd.AddCommand(CheckCommand(globalParams))
+	complianceCmd.AddCommand(complianceLoadCommand(globalParams))
+
+	return []*cobra.Command{complianceCmd}
+}
+
+// CheckCommand returns the 'compliance check' command
+func CheckCommand(_ *command.GlobalParams) *cobra.Command {
+	checkArgs := &cli.CheckParams{}
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Run compliance check(s)",
+		RunE: func(_ *cobra.Command, args []string) error {
+			bundleParams := core.BundleParams{
+				ConfigParams: config.NewAgentParams(""),
+				LogParams:    log.ForOneShot(command.LoggerName, "info", true),
+			}
+
+			checkArgs.Args = args
+			if checkArgs.Verbose {
+				bundleParams.LogParams = log.ForOneShot(bundleParams.LogParams.LoggerName(), "trace", true)
+			}
+
+			return fxutil.OneShot(cli.RunCheck,
+				fx.Supply(checkArgs),
+				fx.Supply(bundleParams),
+				core.Bundle(),
+				secretsnoopfx.Module(),
+				logscompressionfx.Module(),
+				statsd.Module(),
+				ipcfx.ModuleReadOnly(),
+			)
+		},
+	}
+
+	cli.FillCheckFlags(cmd.Flags(), checkArgs)
+
+	return cmd
+}
+
+func complianceLoadCommand(_ *command.GlobalParams) *cobra.Command {
+	loadArgs := &cli.LoadParams{}
+
+	loadCmd := &cobra.Command{
+		Use:   "load <conf-type>",
+		Short: "Load compliance config",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			loadArgs.ConfType = args[0]
+			return fxutil.OneShot(cli.RunLoad,
+				fx.Supply(loadArgs),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(""),
+					LogParams:    log.ForOneShot(command.LoggerName, "info", true),
+				}),
+				core.Bundle(),
+				secretsnoopfx.Module(),
+			)
+		},
+	}
+
+	cli.FillLoadFlags(loadCmd.Flags(), loadArgs)
+
+	return loadCmd
+}

--- a/cmd/system-probe/subcommands/compliance/command.go
+++ b/cmd/system-probe/subcommands/compliance/command.go
@@ -27,8 +27,9 @@ import (
 // Commands returns the compliance commands
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	complianceCmd := &cobra.Command{
-		Use:   "compliance",
-		Short: "Compliance Agent utility commands",
+		Use:    "compliance",
+		Short:  "Compliance Agent utility commands",
+		Hidden: true,
 	}
 
 	complianceCmd.AddCommand(CheckCommand(globalParams))

--- a/cmd/system-probe/subcommands/compliance/command_test.go
+++ b/cmd/system-probe/subcommands/compliance/command_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build unix
+
+package compliance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/compliance/cli"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// TestCheckSubcommand ultimately uses the check package, so its dependencies are different from the event subcommand
+func TestCheckSubcommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cliInput []string
+		check    func(cliParams *cli.CheckParams, params core.BundleParams)
+	}{
+		{
+			name:     "compliance check",
+			cliInput: []string{"compliance", "check"},
+			check: func(_ *cli.CheckParams, params core.BundleParams) {
+				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
+				require.Equal(t, "info", params.LogLevelFn(nil), "params.LogLevelFn not matching")
+			},
+		},
+		{
+			name:     "compliance check verbose",
+			cliInput: []string{"compliance", "check", "--verbose"},
+			check: func(_ *cli.CheckParams, params core.BundleParams) {
+				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
+				require.Equal(t, "trace", params.LogLevelFn(nil), "params.LogLevelFn not matching")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		fxutil.TestOneShotSubcommand(t,
+			Commands(&command.GlobalParams{}),
+			test.cliInput,
+			cli.RunCheck,
+			test.check,
+		)
+	}
+}
+
+func TestLoadSubcommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cliInput []string
+		check    func(cliParams *cli.LoadParams, params core.BundleParams)
+	}{
+		{
+			name:     "compliance load",
+			cliInput: []string{"compliance", "load", "k8s"},
+			check: func(cliParams *cli.LoadParams, params core.BundleParams) {
+				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
+				require.Equal(t, "info", params.LogLevelFn(nil), "params.LogLevelFn not matching")
+				require.Equal(t, "k8s", cliParams.ConfType)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		fxutil.TestOneShotSubcommand(t,
+			Commands(&command.GlobalParams{}),
+			test.cliInput,
+			cli.RunLoad,
+			test.check,
+		)
+	}
+}

--- a/cmd/system-probe/subcommands/compliance/command_unsupported.go
+++ b/cmd/system-probe/subcommands/compliance/command_unsupported.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !unix
+
+// Package compliance implements compliance related subcommands
+package compliance
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+	"github.com/spf13/cobra"
+)
+
+// Commands returns the compliance commands
+func Commands(_ *command.GlobalParams) []*cobra.Command {
+	// no compliance commands on non-unix platforms
+	return nil
+}

--- a/cmd/system-probe/subcommands/subcommands.go
+++ b/cmd/system-probe/subcommands/subcommands.go
@@ -8,6 +8,7 @@ package subcommands
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+	cmdcompliance "github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/compliance"
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/config"
 	cmdcoverage "github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/coverage"
 	cmddebug "github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/debug"
@@ -29,6 +30,7 @@ func SysprobeSubcommands() []command.SubcommandFactory {
 		cmddebug.Commands,
 		cmdconfig.Commands,
 		cmdruntime.Commands,
+		cmdcompliance.Commands,
 		cmdcoverage.Commands,
 		cmdebpf.Commands,
 		cmdusm.Commands,


### PR DESCRIPTION
### What does this PR do?

This PR allows the system-probe to have access to the same `compliance` cli as the security agent. This in preparation of making the compliance code itself run fully in system-probe.

For now this new CLI subcommand is hidden, until we can make sure this satisfies all the same edge cases as the current security agent CLI.

### Motivation

### Describe how you validated your changes

### Additional Notes
