### PR TITLE
[AGENTRUN-915] Bootstrap process-agent remoteAgent implementation

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -26,6 +26,7 @@ import (
 	logcomp "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/pid"
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
+	remoteagentfx "github.com/DataDog/datadog-agent/comp/core/remoteagent/fx-process"
 	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
@@ -220,6 +221,7 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 		}),
 		settingsimpl.Module(),
 		ipcfx.ModuleReadWrite(),
+		remoteagentfx.Module(),
 	)
 
 	err := app.Start(ctx)

--- a/comp/core/remoteagent/fx-process/fx.go
+++ b/comp/core/remoteagent/fx-process/fx.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the remoteagent component
+package fx
+
+import (
+	"go.uber.org/fx"
+
+	remoteagent "github.com/DataDog/datadog-agent/comp/core/remoteagent/def"
+	remoteagentimpl "github.com/DataDog/datadog-agent/comp/core/remoteagent/impl-process"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			remoteagentimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[remoteagent.Component](),
+
+		// Since no other component depends on remoteagent, we add this dummy invocation to ensure it gets instantiated when the module is used.
+		fx.Invoke(func(_ remoteagent.Component) {}),
+	)
+}

--- a/comp/core/remoteagent/impl-process/remoteagent.go
+++ b/comp/core/remoteagent/impl-process/remoteagent.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package traceimpl implements the remoteagent component interface
+package processimpl
+
+import (
+	"context"
+	"net"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	remoteagent "github.com/DataDog/datadog-agent/comp/core/remoteagent/def"
+	"github.com/DataDog/datadog-agent/comp/core/remoteagent/helper"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+)
+
+// Requires defines the dependencies for the remoteagent component
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+	Log       log.Component
+	IPC       ipc.Component
+	Config    config.Component
+	Telemetry telemetry.Component
+}
+
+// Provides defines the output of the remoteagent component
+type Provides struct {
+	Comp remoteagent.Component
+}
+
+// NewComponent creates a new remoteagent component
+func NewComponent(reqs Requires) (Provides, error) {
+	registryAddress := net.JoinHostPort(reqs.Config.GetString("cmd_host"), reqs.Config.GetString("cmd_port"))
+
+	remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(reqs.IPC, reqs.Log, reqs.Config, reqs.Lifecycle, registryAddress, flavor.GetFlavor(), flavor.GetHumanReadableFlavor())
+	if err != nil {
+		return Provides{}, err
+	}
+
+	remoteagentImpl := &remoteagentImpl{
+		log:               reqs.Log,
+		ipc:               reqs.IPC,
+		cfg:               reqs.Config,
+		telemetry:         reqs.Telemetry,
+		remoteAgentServer: remoteAgentServer,
+	}
+
+	// Add your gRPC services implementations here:
+	pbcore.RegisterTelemetryProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
+
+	provides := Provides{
+		Comp: remoteagentImpl,
+	}
+	return provides, nil
+}
+
+type remoteagentImpl struct {
+	log       log.Component
+	ipc       ipc.Component
+	cfg       config.Component
+	telemetry telemetry.Component
+
+	remoteAgentServer *helper.UnimplementedRemoteAgentServer
+	pbcore.UnimplementedTelemetryProviderServer
+}
+
+func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetryRequest) (*pbcore.GetTelemetryResponse, error) {
+	prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
+	// Add here the metric names that should be included in the telemetry response.
+	// This is useful to avoid sending too many metrics to the Core Agent.
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	return &pbcore.GetTelemetryResponse{
+		Payload: &pbcore.GetTelemetryResponse_PromText{
+			PromText: prometheusText,
+		},
+	}, nil
+}

--- a/comp/core/remoteagent/impl-process/remoteagent.go
+++ b/comp/core/remoteagent/impl-process/remoteagent.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package traceimpl implements the remoteagent component interface
+// Package processimpl implements the remoteagent component interface
 package processimpl
 
 import (

--- a/comp/core/remoteagent/impl-process/remoteagent.go
+++ b/comp/core/remoteagent/impl-process/remoteagent.go
@@ -37,6 +37,12 @@ type Provides struct {
 
 // NewComponent creates a new remoteagent component
 func NewComponent(reqs Requires) (Provides, error) {
+	// Check if the remoteAgentRegistry is enabled
+	if !reqs.Config.GetBool("remote_agent_registry.enabled") {
+		return Provides{}, nil
+	}
+
+	// Get the registry address
 	registryAddress := net.JoinHostPort(reqs.Config.GetString("cmd_host"), reqs.Config.GetString("cmd_port"))
 
 	remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(reqs.IPC, reqs.Log, reqs.Config, reqs.Lifecycle, registryAddress, flavor.GetFlavor(), flavor.GetHumanReadableFlavor())


### PR DESCRIPTION
### What does this PR do?

Bootstraps the process-agent with the remote agent component to enable telemetry forwarding to the core agent. This adds the necessary infrastructure for process-agent to register with the core agent and expose a gRPC TelemetryProvider service, initially with an empty metric filter.

### Motivation

This is part of the ongoing effort to standardize telemetry forwarding across all Datadog agent components using the remote agent architecture.

### Describe how you validated your changes
Confirmed metrics are forwarded properly through our internal experimental deployments.

### Additional Notes

- The metric filter in `GetTelemetry()` is currently empty - specific metrics will be added in follow-up PRs once we determine which process-agent metrics should be forwarded
- CODEOWNERS updated to ensure proper team oversight of the process-agent remote agent implementation