### PR TITLE
[Process] Attach discovered log file paths to services

### DIFF
--- a/pkg/process/checks/process_linux.go
+++ b/pkg/process/checks/process_linux.go
@@ -99,6 +99,7 @@ func mapWLMProcToProc(wlmProc *workloadmetacomp.Process, stats *procutil.Stats) 
 			TracerMetadata:           wlmProc.Service.TracerMetadata,
 			DDService:                wlmProc.Service.UST.Service,
 			APMInstrumentation:       wlmProc.Service.APMInstrumentation,
+			LogFiles:                 wlmProc.Service.LogFiles,
 		}
 		tcpPorts = wlmProc.Service.TCPPorts
 		udpPorts = wlmProc.Service.UDPPorts
@@ -230,11 +231,23 @@ func formatServiceDiscovery(service *procutil.Service) *model.ServiceDiscovery {
 		})
 	}
 
+	var resources []*model.Resource
+	for _, logPath := range service.LogFiles {
+		resources = append(resources, &model.Resource{
+			Resource: &model.Resource_Logs{
+				Logs: &model.LogResource{
+					Path: logPath,
+				},
+			},
+		})
+	}
+
 	return &model.ServiceDiscovery{
 		GeneratedServiceName:     generatedServiceName,
 		DdServiceName:            ddServiceName,
 		AdditionalGeneratedNames: additionalGeneratedNames,
 		TracerMetadata:           tracerMetadata,
 		ApmInstrumentation:       service.APMInstrumentation,
+		Resources:                resources,
 	}
 }

--- a/pkg/process/checks/process_linux_test.go
+++ b/pkg/process/checks/process_linux_test.go
@@ -365,6 +365,7 @@ func TestFormatServiceDiscovery(t *testing.T) {
 				},
 				DDService:          "dd_service_name",
 				APMInstrumentation: true,
+				LogFiles:           []string{"/var/log/app.log", "/var/log/error.log"},
 			},
 			expectedService: &model.ServiceDiscovery{
 				GeneratedServiceName: &model.ServiceName{
@@ -396,6 +397,22 @@ func TestFormatServiceDiscovery(t *testing.T) {
 					},
 				},
 				ApmInstrumentation: true,
+				Resources: []*model.Resource{
+					{
+						Resource: &model.Resource_Logs{
+							Logs: &model.LogResource{
+								Path: "/var/log/app.log",
+							},
+						},
+					},
+					{
+						Resource: &model.Resource_Logs{
+							Logs: &model.LogResource{
+								Path: "/var/log/error.log",
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -418,6 +435,87 @@ func TestFormatServiceDiscovery(t *testing.T) {
 			description:     "empty service",
 			service:         &procutil.Service{},
 			expectedService: &model.ServiceDiscovery{},
+		},
+		{
+			description: "service with log files only",
+			service: &procutil.Service{
+				LogFiles: []string{"/var/log/nginx/access.log", "/var/log/nginx/error.log", "/var/log/app/application.log"},
+			},
+			expectedService: &model.ServiceDiscovery{
+				Resources: []*model.Resource{
+					{
+						Resource: &model.Resource_Logs{
+							Logs: &model.LogResource{
+								Path: "/var/log/nginx/access.log",
+							},
+						},
+					},
+					{
+						Resource: &model.Resource_Logs{
+							Logs: &model.LogResource{
+								Path: "/var/log/nginx/error.log",
+							},
+						},
+					},
+					{
+						Resource: &model.Resource_Logs{
+							Logs: &model.LogResource{
+								Path: "/var/log/app/application.log",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "service with single log file",
+			service: &procutil.Service{
+				GeneratedName: "my-service",
+				LogFiles:      []string{"/var/log/service.log"},
+			},
+			expectedService: &model.ServiceDiscovery{
+				GeneratedServiceName: &model.ServiceName{
+					Name:   "my-service",
+					Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_UNKNOWN,
+				},
+				Resources: []*model.Resource{
+					{
+						Resource: &model.Resource_Logs{
+							Logs: &model.LogResource{
+								Path: "/var/log/service.log",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "service with nil log files",
+			service: &procutil.Service{
+				GeneratedName: "my-service",
+				LogFiles:      nil,
+			},
+			expectedService: &model.ServiceDiscovery{
+				GeneratedServiceName: &model.ServiceName{
+					Name:   "my-service",
+					Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_UNKNOWN,
+				},
+				Resources: nil,
+			},
+		},
+		{
+			description: "service with empty log files slice",
+			service: &procutil.Service{
+				GeneratedName: "my-service",
+				LogFiles:      []string{},
+			},
+			expectedService: &model.ServiceDiscovery{
+				GeneratedServiceName: &model.ServiceName{
+					Name:   "my-service",
+					Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_UNKNOWN,
+				},
+				Resources: nil,
+			},
 		},
 		{
 			description:     "service not collected",

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -151,6 +151,9 @@ type Service struct {
 
 	// APMInstrumentation indicates the APM instrumentation status
 	APMInstrumentation bool
+
+	// LogFiles contains paths to log files associated with this service
+	LogFiles []string
 }
 
 // DeepCopy creates a deep copy of Stats


### PR DESCRIPTION
### What does this PR do?
This [PR](https://datadoghq.atlassian.net/browse/DSCVR-236) populates the ServiceDiscovery.resources protobuf field with log file information collected during service discovery. The field was introduced in agent-payload v5.0.176 ([PR](https://github.com/DataDog/agent-payload/pull/426)), which was added to the Agent in the corresponding payload [bump](https://github.com/DataDog/datadog-agent/pull/43442).

The change adds the required data structures and mapping logic to propagate log file paths from workloadmeta → procutil → process check → protobuf payload, representing each entry as a Resource containing a LogResource.

This enables better log collection automation and log–service correlation on the backend.
In the future, we may want to enrich these log resources with additional metadata (e.g., log size, write rate, or other attributes) depending on upcoming use cases. More details are available in the referenced [RFC](https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/5580787035/Processes+have+logs+attached).

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-236

### Describe how you validated your changes.

Added unit tests covering normal cases and edge cases for log file propagation.

[DSCVR-236]: https://datadoghq.atlassian.net/browse/DSCVR-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ