### PR TITLE
mrf: add support for api key refresh and configsync

### DIFF
--- a/comp/api/api/def/component.go
+++ b/comp/api/api/def/component.go
@@ -53,6 +53,8 @@ var AuthorizedConfigPathsCore = buildAuthorizedSet(
 	"dd_url",
 	"additional_endpoints",
 
+	"multi_region_failover.api_key",
+
 	"external_metrics_provider.api_key",
 	"external_metrics_provider.app_key",
 

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -257,7 +257,9 @@ func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigK
 			return nil, fmt.Errorf("could not parse %s: %v", mrfURL, err)
 		}
 
-		e := NewEndpoint(coreConfig.GetString("multi_region_failover.api_key"), "multi_region_failover.api_key", mrfHost, mrfPort, "", logsConfig.logsNoSSL())
+		apiKeyConfigPath := "multi_region_failover.api_key"
+
+		e := NewEndpoint(coreConfig.GetString(apiKeyConfigPath), apiKeyConfigPath, mrfHost, mrfPort, "", logsConfig.logsNoSSL())
 		e.IsMRF = true
 		e.UseCompression = main.UseCompression
 		e.CompressionLevel = main.CompressionLevel
@@ -269,6 +271,7 @@ func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigK
 		e.useSSL = main.useSSL
 		e.ConnectionResetInterval = logsConfig.connectionResetInterval()
 		e.ProxyAddress = logsConfig.socks5ProxyAddress()
+		e.onConfigUpdateFromReaderMainEndpoint(coreConfig)
 
 		additionals = append(additionals, e)
 	}
@@ -360,7 +363,9 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 			return nil, fmt.Errorf("could not parse %s: %v", mrfURL, err)
 		}
 
-		e := NewEndpoint(coreConfig.GetString("multi_region_failover.api_key"), "multi_region_failover.api_key", mrfHost, mrfPort, mrfPathPrefix, mrfUseSSL)
+		apiKeyConfigPath := "multi_region_failover.api_key"
+
+		e := NewEndpoint(coreConfig.GetString(apiKeyConfigPath), apiKeyConfigPath, mrfHost, mrfPort, mrfPathPrefix, mrfUseSSL)
 		e.IsMRF = true
 		e.UseCompression = main.UseCompression
 		e.CompressionKind = main.CompressionKind
@@ -374,6 +379,7 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 		e.TrackType = intakeTrackType
 		e.Protocol = intakeProtocol
 		e.Origin = intakeOrigin
+		e.onConfigUpdateFromReaderMainEndpoint(coreConfig)
 
 		additionals = append(additionals, e)
 	}

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 )
@@ -937,6 +938,56 @@ func (suite *EndpointsTestSuite) TestCompressionKindWithAdditionalEndpoints() {
 			suite.Nil(err)
 			suite.Equal(tt.expectedMain.CompressionKind, endpoints.Main.CompressionKind)
 			suite.Equal(tt.expectedMain.CompressionLevel, endpoints.Main.CompressionLevel)
+		})
+	}
+}
+
+func (suite *EndpointsTestSuite) TestMRFApiKeyUpdate() {
+	testEntries := []struct {
+		name           string
+		endpointGetter func(cfg model.Reader) (*Endpoints, error)
+	}{
+		{
+			name: "HTTP",
+			endpointGetter: func(cfg model.Reader) (*Endpoints, error) {
+				return BuildHTTPEndpoints(cfg, "", "", "")
+			},
+		},
+		{
+			name: "TCP",
+			endpointGetter: func(cfg model.Reader) (*Endpoints, error) {
+				return buildTCPEndpoints(cfg, defaultLogsConfigKeys(cfg))
+			},
+		},
+	}
+
+	for _, tt := range testEntries {
+		suite.Run(tt.name, func() {
+			suite.config.SetWithoutSource("multi_region_failover.enabled", true)
+			suite.config.SetWithoutSource("multi_region_failover.site", "mrf_fake_site.com:12")
+			suite.config.SetWithoutSource("multi_region_failover.api_key", "1234")
+
+			endpoints, err := tt.endpointGetter(suite.config)
+			suite.Nil(err)
+
+			mrfFound := false
+			for _, endpoint := range endpoints.Endpoints {
+				if endpoint.IsMRF {
+					suite.False(mrfFound, "multiple MRF endpoints found")
+					mrfFound = true
+				}
+			}
+			suite.True(mrfFound, "MRF endpoint not found among endpoints")
+
+			// update mrf API key
+			suite.config.SetWithoutSource("multi_region_failover.api_key", "5678")
+
+			for _, endpoint := range endpoints.Endpoints {
+				if endpoint.IsMRF {
+					suite.Equal("5678", endpoint.GetAPIKey())
+					break
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds support for api key rotation in the mrf (multi region failover) endpoint, similar to all other logs/event platform endpoints.

In addition to that, the mrf api key is added to the list of config paths that can be shared through configsync, similar to other api key config paths (main api key + extra endpoints definitions, especially since mrf is basically an extra endpoints from the forwarder point of view).

### Motivation

### Describe how you validated your changes

### Additional Notes
