### PR TITLE
[CSPM] add compliance endpoint config path to configsync allowlist

### DIFF
--- a/comp/api/api/def/component.go
+++ b/comp/api/api/def/component.go
@@ -72,6 +72,7 @@ var AuthorizedConfigPathsCore = buildAuthorizedSet(
 	"service_discovery.forwarder.additional_endpoints",
 	"runtime_security_config.endpoints.additional_endpoints",
 	"runtime_security_config.activity_dump.remote_storage.endpoints",
+	"compliance_config.endpoints",
 )
 
 func buildAuthorizedSet(paths ...string) AuthorizedSet {


### PR DESCRIPTION
### What does this PR do?

This config path controls the sending of CSPM payloads, currently running in the security agent but soon running in the system-probe.

### Motivation

### Describe how you validated your changes

### Additional Notes
