### PR TITLE
fix(ssi): resolve an issue with namespace collection

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -156,29 +155,13 @@ func resourcesWithExplicitMetadataCollectionEnabled(cfg config.Reader) []string 
 
 // resourcesForAPMConfig returns the list of resources to collect metadata from
 // for the auto instrumentation configuration. Namespaces are collected in order
-// to utilize namespace labels for target based configuration.
+// to utilize namespace labels for target based configuration and to determine
+// pod security policies to apply to restricted namespaces.
 func resourcesForAPMConfig(cfg config.Reader) []string {
 	// If APM is not enabled, we don't need to collect any resources for the
 	// auto instrumentation configuration.
 	apmEnabled := cfg.GetBool("apm_config.instrumentation.enabled")
 	if !apmEnabled {
-		return nil
-	}
-
-	// Targets is a custom struct type, so we unmarshal it into an interface
-	// slice to avoid the import while still being able to check if it's empty.
-	// For simplicity, we enable the namespace collection if there are any
-	// targets defined and do not check if the targets actually require
-	// namespace labels.
-	targets := []interface{}{}
-	err := structure.UnmarshalKey(cfg, "apm_config.instrumentation.targets", &targets)
-	if err != nil {
-		log.Errorf("failed to unmarshal apm_config.instrumentation.targets: %v", err)
-		return nil
-	}
-
-	// If there are no targets, we don't need to collect any resources.
-	if len(targets) == 0 {
 		return nil
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -544,7 +544,6 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			name: "resources explicitly requested with apm enabled and also needed for namespace labels as tags",
 			cfg: map[string]interface{}{
 				"apm_config.instrumentation.enabled":                                     true,
-				"apm_config.instrumentation.targets":                                     []interface{}{"target-1"},
 				"cluster_agent.kube_metadata_collection.enabled":                         true,
 				"cluster_agent.kube_metadata_collection.resources":                       "namespaces apps/deployments",
 				"kubernetes_namespace_labels_as_tagkubernetes_namespace_labels_as_tagss": `{"label1": "tag1"}`,
@@ -555,7 +554,6 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			name: "apm enabled enables namespace collection",
 			cfg: map[string]interface{}{
 				"apm_config.instrumentation.enabled": true,
-				"apm_config.instrumentation.targets": []interface{}{"target-1"},
 			},
 			expectedResources: []string{"//nodes", "//namespaces"},
 		},

--- a/releasenotes-dca/notes/collect-namespace-apm-ssi-b217042860f2bfad.yaml
+++ b/releasenotes-dca/notes/collect-namespace-apm-ssi-b217042860f2bfad.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    We collect namespaces in Kubernetes for Single Step Instrumentation. We need this information to utilize namespace
+    labels for workload selection. However, we also use this information to generate pod security polices for restricted
+    namespaces. This change fixes an issue where we would only collect namespace information when target based workload
+    selection was utilized instead of collecting namespaces for all Single Step Instrumentation configurations.


### PR DESCRIPTION
### What does this PR do?
This commit resolves an issue for namespace collection when customers are using enabled namespaces.

### Motivation
While debugging a tangential customer case, I discovered that we were getting an error generating pod security polices when `enabledNamespaces` was set:
```bash
error getting labels for namespace=apptest4: error getting namespace metadata for ns=apptest4: "/namespaces//apptest4" not found
```

We generate a security policy here, but only if we have access to the namespace: https://github.com/DataDog/datadog-agent/blob/db6f5e290c660cdfd14010f44d160754daefa5b9/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go#L196-L202

### Describe how you validated your changes
The updated unit tests. I also used [injector-dev](https://github.com/DataDog/injector-dev):

<details><summary>psp.yaml</summary>

```yaml
helm:
  namespaces:
    - name: "application"
      labels:
        pod-security.kubernetes.io/enforce: restricted
        pod-security.kubernetes.io/enforce-version: latest
        pod-security.kubernetes.io/warn: restricted
        pod-security.kubernetes.io/audit: restricted
  apps:
    - name: psp-example
      namespace: application
      values:
        env:
          - name: DD_TRACE_DEBUG
            value: "true"
          - name: DD_APM_INSTRUMENTATION_DEBUG
            value: "true"
        image:
          repository: registry.ddbuild.io/ci/injector-dev/python
          tag: 2cd78ded
        podLabels:
          language: python
          tags.datadoghq.com/env: local
        service:
          port: "8080"
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop: ["ALL"]
          runAsNonRoot: true
          runAsUser: 1000
          seccompProfile:
            type: RuntimeDefault
  versions:
    agent: 7.72.2
    cluster_agent:
      version: 7.72.2
      build: {}
    injector: 0.52.0
  config:
    datadog:
      apm:
        portEnabled: true
        socketEnabled: false
        instrumentation:
          enabled: true
          enabledNamespaces:
            - "application"
          libVersions:
            python: "3"
```

</details> 

Before this change:
```
Warning  FailedCreate  2s (x6 over 82s)  replicaset-controller  (combined from similar events): Error creating: pods "psp-example-7bf46cdd69-lcvks" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (containers "datadog-init-apm-inject", "datadog-lib-python-init" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "datadog-init-apm-inject", "datadog-lib-python-init" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "datadog-init-apm-inject", "datadog-lib-python-init" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "datadog-init-apm-inject", "datadog-lib-python-init" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

When I build against this change, the pod gets the appropriate psp:
```bash
injector-dev apply -f psp.yaml --build
```

### Additional Notes
We have more bugs to work through for this specific customer case, but this is one discrete bug that we need to resolve.
