### PR TITLE
Always shut down `bazel` on Windows

### DIFF
--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -59,7 +59,7 @@ set "bazel_exit=!errorlevel!"
 :: Diagnostics: dump logs on non-trivial failures (https://bazel.build/run/scripts#exit-codes)
 :: TODO(regis): adjust (probably `== 37`) next time a `cannot connect to Bazel server` error happens (#incident-42947)
 if !bazel_exit! geq 2 (
-  >&2 echo 🟡 Bazel failed [!bazel_exit!], dumping available info in !BAZEL_OUTPUT_USER_ROOT! ^(excluding junctions^):
+  >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !BAZEL_OUTPUT_USER_ROOT! ^(excluding junctions^):
   for /f "delims=" %%d in ('dir /a:d-l /b "!BAZEL_OUTPUT_USER_ROOT!"') do (
     >&2 echo 🟡 [%%d]
     for %%f in ("!BAZEL_OUTPUT_USER_ROOT!\%%d\java.log.*" "!BAZEL_OUTPUT_USER_ROOT!\%%d\server\*") do (
@@ -73,11 +73,10 @@ if !bazel_exit! geq 2 (
     )
   )
 )
-if !bazel_exit! neq 0 exit /b !bazel_exit!
 
 :: Stop `bazel` (if still running) to close files and proceed with cleanup
 >&2 "%BAZEL_REAL%" shutdown --ui_event_filters=-info
 >&2 del /f /q "%~dp0..\user.bazelrc"
 
 :: Done
-exit /b 0
+exit /b !bazel_exit!


### PR DESCRIPTION
### What does this PR do?
Always attempt to shut down `bazel` in CI on Windows.

### Motivation
There are occurrences like:
```
WARNING: Remote Cache: 3 errors during bulk transfer:
com.google.devtools.build.lib.vfs.FileAccessException: c:\bzl\bazel\disk\tmp\1358cf03-4e57-4a65-a1a9-04a78f47d54d -> c:\bzl\bazel\disk\cas\78\786f29b88771e439187dd2e86ad4d255dd185e0c1ea3f8c37d21770fd1df253a (Permission denied)
com.google.devtools.build.lib.vfs.FileAccessException: c:\bzl\bazel\disk\tmp\c3241ce0-3a1c-431b-bf15-80d33e5a9a4a -> c:\bzl\bazel\disk\cas\72\72f6b34d3c8f424ff0a290a793fcfbf34fd5630a916cd02e0a5dda0144b5957f (Permission denied)
com.google.devtools.build.lib.vfs.FileAccessException: c:\bzl\bazel\disk\tmp\82486007-6835-499f-886d-d4390cf6bce2 -> c:\bzl\bazel\disk\cas\78\786f29b88771e439187dd2e86ad4d255dd185e0c1ea3f8c37d21770fd1df253a (Permission denied)
com.google.devtools.build.lib.remote.common.BulkTransferException: 3 errors during bulk transfer:
com.google.devtools.build.lib.vfs.FileAccessException: c:\bzl\bazel\disk\tmp\1358cf03-4e57-4a65-a1a9-04a78f47d54d -> c:\bzl\bazel\disk\cas\78\786f29b88771e439187dd2e86ad4d255dd185e0c1ea3f8c37d21770fd1df253a (Permission denied)
com.google.devtools.build.lib.vfs.FileAccessException: c:\bzl\bazel\disk\tmp\c3241ce0-3a1c-431b-bf15-80d33e5a9a4a -> c:\bzl\bazel\disk\cas\72\72f6b34d3c8f424ff0a290a793fcfbf34fd5630a916cd02e0a5dda0144b5957f (Permission denied)
com.google.devtools.build.lib.vfs.FileAccessException: c:\bzl\bazel\disk\tmp\82486007-6835-499f-886d-d4390cf6bce2 -> c:\bzl\bazel\disk\cas\78\786f29b88771e439187dd2e86ad4d255dd185e0c1ea3f8c37d21770fd1df253a (Permission denied)
```

### Additional Notes
TBH, we don't really know how `docker` works on Windows: does it scavenge orphaned processes by default?

So, for the time being, it's more to eliminate a _potential_ culprit...