### PR TITLE
[AGENTRUN] Disable remoteAgent if remoteAgentRegistry is disabled

### DIFF
--- a/comp/core/remoteagent/impl-securityagent/remoteagent.go
+++ b/comp/core/remoteagent/impl-securityagent/remoteagent.go
@@ -37,6 +37,12 @@ type Provides struct {
 
 // NewComponent creates a new remoteagent component
 func NewComponent(reqs Requires) (Provides, error) {
+	// Check if the remoteAgentRegistry is enabled
+	if !reqs.Config.GetBool("remote_agent_registry.enabled") {
+		return Provides{}, nil
+	}
+
+	// Get the registry address
 	registryAddress := net.JoinHostPort(reqs.Config.GetString("cmd_host"), reqs.Config.GetString("cmd_port"))
 
 	remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(reqs.IPC, reqs.Log, reqs.Config, reqs.Lifecycle, registryAddress, flavor.GetFlavor(), flavor.GetHumanReadableFlavor())

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -37,6 +37,12 @@ type Provides struct {
 
 // NewComponent creates a new remoteagent component
 func NewComponent(reqs Requires) (Provides, error) {
+	// Check if the remoteAgentRegistry is enabled
+	if !reqs.Config.GetBool("remote_agent_registry.enabled") {
+		return Provides{}, nil
+	}
+
+	// Get the registry address
 	registryAddress := net.JoinHostPort(reqs.Config.GetString("cmd_host"), reqs.Config.GetString("cmd_port"))
 
 	remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(reqs.IPC, reqs.Log, reqs.Config, reqs.Lifecycle, registryAddress, flavor.GetFlavor(), flavor.GetHumanReadableFlavor())

--- a/comp/core/remoteagent/impl-template/remoteagent.go
+++ b/comp/core/remoteagent/impl-template/remoteagent.go
@@ -34,6 +34,12 @@ type Provides struct {
 
 // NewComponent creates a new remoteagent component
 func NewComponent(reqs Requires) (Provides, error) {
+	// Check if the remoteAgentRegistry is enabled
+	if !reqs.Config.GetBool("remote_agent_registry.enabled") {
+		return Provides{}, nil
+	}
+
+	// Get the registry address
 	registryAddress := net.JoinHostPort(reqs.Config.GetString("cmd_host"), reqs.Config.GetString("cmd_port"))
 
 	remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(reqs.IPC, reqs.Log, reqs.Config, reqs.Lifecycle, registryAddress, flavor.GetFlavor(), flavor.GetHumanReadableFlavor())

--- a/comp/core/remoteagent/impl-trace/remoteagent.go
+++ b/comp/core/remoteagent/impl-trace/remoteagent.go
@@ -37,6 +37,12 @@ type Provides struct {
 
 // NewComponent creates a new remoteagent component
 func NewComponent(reqs Requires) (Provides, error) {
+	// Check if the remoteAgentRegistry is enabled
+	if !reqs.Config.GetBool("remote_agent_registry.enabled") {
+		return Provides{}, nil
+	}
+
+	// Get the registry address
 	registryAddress := net.JoinHostPort(reqs.Config.GetString("cmd_host"), reqs.Config.GetString("cmd_port"))
 
 	remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(reqs.IPC, reqs.Log, reqs.Config, reqs.Lifecycle, registryAddress, flavor.GetFlavor(), flavor.GetHumanReadableFlavor())


### PR DESCRIPTION
### What does this PR do?

Adds a configuration check to disable the `remoteagent` component across all agent flavors (security-agent, system-probe, trace-agent, and template) when `remote_agent_registry.enabled` is set to `false`.

### Motivation

The remote agent component was previously instantiated regardless of whether the remote agent registry feature in the core-agent was enabled. This meant unnecessary initialization and resource allocation even when the feature was disabled via configuration.

### Describe how you validated your changes

- Verify that agents start successfully with `remote_agent_registry.enabled: false` in the configuration
- Verify that agents start successfully with `remote_agent_registry.enabled: true` and the remote agent component functions as expected
- Confirm no errors or warnings are logged when the feature is disabled

### Additional Notes
