### PR TITLE
[AGENTRUN] Rely on IPC comp for otel-agent with DDExporter

### DIFF
--- a/comp/otelcol/collector/impl/collector.go
+++ b/comp/otelcol/collector/impl/collector.go
@@ -98,6 +98,7 @@ type RequiresNoAgent struct {
 	Converter        confmap.Converter
 	Tagger           tagger.Component
 	Hostname         hostnameinterface.Component
+	Ipc              ipc.Component
 }
 
 // Provides declares the output types from the constructor
@@ -167,7 +168,7 @@ func addFactories(reqs Requires, factories otelcol.Factories, gatewayUsage otel.
 	}
 	factories.Processors[infraattributesprocessor.Type] = infraattributesprocessor.NewFactoryForAgent(reqs.Tagger, reqs.Hostname.Get)
 	factories.Connectors[component.MustNewType("datadog")] = datadogconnector.NewFactoryForAgent(reqs.Tagger, reqs.Hostname.Get)
-	factories.Extensions[ddextension.Type] = ddextension.NewFactoryForAgent(&factories, newConfigProviderSettings(reqs.URIs, reqs.Converter, false), option.New(reqs.Ipc), byoc)
+	factories.Extensions[ddextension.Type] = ddextension.NewFactoryForAgent(&factories, newConfigProviderSettings(reqs.URIs, reqs.Converter, false), reqs.Ipc, byoc)
 	factories.Extensions[ddprofilingextension.Type] = ddprofilingextension.NewFactoryForAgent(reqs.TraceAgent, reqs.Log)
 }
 
@@ -237,7 +238,7 @@ func NewComponentNoAgent(reqs RequiresNoAgent) (Provides, error) {
 		return Provides{}, err
 	}
 	factories.Connectors[component.MustNewType("datadog")] = datadogconnector.NewFactory()
-	factories.Extensions[ddextension.Type] = ddextension.NewFactoryForAgent(&factories, newConfigProviderSettings(reqs.URIs, reqs.Converter, false), option.None[ipc.Component](), false)
+	factories.Extensions[ddextension.Type] = ddextension.NewFactoryForAgent(&factories, newConfigProviderSettings(reqs.URIs, reqs.Converter, false), reqs.Ipc, false)
 	factories.Processors[infraattributesprocessor.Type] = infraattributesprocessor.NewFactoryForAgent(reqs.Tagger, reqs.Hostname.Get)
 
 	converterEnabled := reqs.Config.GetBool("otelcollector.converter.enabled")

--- a/comp/otelcol/ddflareextension/impl/extension.go
+++ b/comp/otelcol/ddflareextension/impl/extension.go
@@ -27,7 +27,6 @@ import (
 	extensionDef "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/def"
 	"github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/impl/internal/metadata"
 	extensionTypes "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/types"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -144,7 +143,7 @@ func (ext *ddExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) erro
 }
 
 // NewExtension creates a new instance of the extension.
-func NewExtension(ctx context.Context, cfg *Config, telemetry component.TelemetrySettings, info component.BuildInfo, ipcComp option.Option[ipc.Component], providedConfigSupported bool, byoc bool) (extensionDef.Component, error) {
+func NewExtension(ctx context.Context, cfg *Config, telemetry component.TelemetrySettings, info component.BuildInfo, ipcComp ipc.Component, providedConfigSupported bool, byoc bool) (extensionDef.Component, error) {
 	ext := &ddExtension{
 		cfg:         cfg,
 		telemetry:   telemetry,

--- a/comp/otelcol/ddflareextension/impl/extension_test.go
+++ b/comp/otelcol/ddflareextension/impl/extension_test.go
@@ -18,7 +18,6 @@ import (
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
 	ddflareextension "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/def"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
@@ -59,13 +58,13 @@ func getExtensionTestConfig(t *testing.T) *Config {
 	}
 }
 
-func getTestExtension(t *testing.T, optIpc option.Option[ipc.Component]) (ddflareextension.Component, error) {
+func getTestExtension(t *testing.T, ipc ipc.Component) (ddflareextension.Component, error) {
 	c := context.Background()
 	telemetry := component.TelemetrySettings{}
 	info := component.NewDefaultBuildInfo()
 	cfg := getExtensionTestConfig(t)
 
-	return NewExtension(c, cfg, telemetry, info, optIpc, true, false)
+	return NewExtension(c, cfg, telemetry, info, ipc, true, false)
 }
 
 func getResponseToHandlerRequest(t *testing.T, ipc ipc.Component, tokenOverride string) *httptest.ResponseRecorder {
@@ -87,7 +86,7 @@ func getResponseToHandlerRequest(t *testing.T, ipc ipc.Component, tokenOverride 
 	rr := httptest.NewRecorder()
 
 	// Create an instance of your handler
-	ext, err := getTestExtension(t, option.New(ipc))
+	ext, err := getTestExtension(t, ipc)
 	require.NoError(t, err)
 
 	ddExt := ext.(*ddExtension)
@@ -114,7 +113,7 @@ func getResponseToHandlerRequest(t *testing.T, ipc ipc.Component, tokenOverride 
 }
 
 func TestNewExtension(t *testing.T) {
-	ext, err := getTestExtension(t, option.None[ipc.Component]())
+	ext, err := getTestExtension(t, ipcmock.New(t))
 	assert.NoError(t, err)
 	assert.NotNil(t, ext)
 

--- a/comp/otelcol/ddflareextension/impl/factory.go
+++ b/comp/otelcol/ddflareextension/impl/factory.go
@@ -17,7 +17,6 @@ import (
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	"github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/impl/internal/metadata"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 const (
@@ -30,7 +29,7 @@ type ddExtensionFactory struct {
 	factories              *otelcol.Factories
 	configProviderSettings otelcol.ConfigProviderSettings
 	byoc                   bool
-	ipcComp                option.Option[ipc.Component]
+	ipcComp                ipc.Component
 }
 
 // isOCB returns true if extension was built with OCB
@@ -44,7 +43,7 @@ func NewFactory() extension.Factory {
 }
 
 // NewFactoryForAgent creates a factory for Datadog Flare Extension for use with Agent
-func NewFactoryForAgent(factories *otelcol.Factories, configProviderSettings otelcol.ConfigProviderSettings, ipcComp option.Option[ipc.Component], byoc bool) extension.Factory {
+func NewFactoryForAgent(factories *otelcol.Factories, configProviderSettings otelcol.ConfigProviderSettings, ipcComp ipc.Component, byoc bool) extension.Factory {
 	return &ddExtensionFactory{
 		factories:              factories,
 		configProviderSettings: configProviderSettings,

--- a/comp/otelcol/ddflareextension/impl/factory_test.go
+++ b/comp/otelcol/ddflareextension/impl/factory_test.go
@@ -14,16 +14,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/extension"
 
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
 	"github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/impl/internal/metadata"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 func getTestFactory(t *testing.T) extension.Factory {
 	factories, err := components()
 	assert.NoError(t, err)
 
-	return NewFactoryForAgent(&factories, newConfigProviderSettings(uriFromFile("config.yaml"), false), option.None[ipc.Component](), false)
+	return NewFactoryForAgent(&factories, newConfigProviderSettings(uriFromFile("config.yaml"), false), ipcmock.New(t), false)
 }
 
 func TestNewFactoryForAgent(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Refactors the OTEL collector's DDFlareExtension to rely on the IPC component directly instead of wrapping it in an `option.Option` type. This change makes the IPC component a required dependency for the extension.

### Motivation

The DDFlareExtension previously used `option.Option[ipc.Component]` to make the IPC component optional, with fallback logic to generate self-signed certificates when the IPC component was unavailable. This added unnecessary complexity since:

1. The extension now always has access to an IPC component
2. The fallback certificate generation logic is no longer needed
3. Using `option.Option` adds indirection without providing actual value

By making the IPC component a required dependency, the code becomes simpler and more straightforward.

### Describe how you validated your changes

