### PR TITLE
[AGENTCFG-524] loosening assertion check for TestBackoffWhenEarlyIntervalEqualsCollectionInterval

### DIFF
--- a/comp/metadata/host/hostimpl/host_test.go
+++ b/comp/metadata/host/hostimpl/host_test.go
@@ -154,7 +154,7 @@ func TestBackoffWhenEarlyIntervalEqualsCollectionInterval(t *testing.T) {
 
 	h.backoffPolicy.Reset()
 	for i := 0; i < 5; i++ {
-		assert.Equal(t, 300*time.Second, h.backoffPolicy.NextBackOff())
+		assert.InDelta(t, 300*time.Second, h.backoffPolicy.NextBackOff(), 1)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This test is currently flaky due to a floating-point error in the time comparison. This should fix the flakiness.

### Motivation

### Describe how you validated your changes

### Additional Notes
