### PR TITLE
[Backport 7.73.x] secure create config backup dir (#43440)

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -224,6 +224,9 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestRevertsConfigExperimentWhenServiceDies$"
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestRevertsConfigExperimentWhenTimeout$"
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestManagedConfigActiveAfterUpgrade$"
+      - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigAltDir$"
+      - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigCustomUser$"
+      - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigCustomUserAndAltDir$"
       # install-exe
       - EXTRA_PARAMS: --run "TestInstallExe$/TestInstallAgentPackage$"
       - EXTRA_PARAMS: --run "TestInstallExeWithProxy$/TestInstallAgentPackageWithProxy$"

--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -232,9 +232,7 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestInstallExeWithProxy$/TestInstallAgentPackageWithProxy$"
       # install-script
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallAgentPackage$"
-      - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallFromOldInstaller$"
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallIgnoreMajorMinor$"
-      - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallCurrentWithOldInstallerScript$"
       - EXTRA_PARAMS: --run "TestInstallScript$/TestReinstallAfterMSIUninstall$"
       - EXTRA_PARAMS: --run "TestInstallScriptWithAgentUser$/TestInstallScriptWithAgentUser"
       - EXTRA_PARAMS: --run "TestInstallScriptWithAgentUser$/TestInstallScriptChangesAgentUser$"

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -16,7 +16,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -50,9 +53,14 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 	if state.ExperimentDeploymentID != "" {
 		return fmt.Errorf("there is already an experiment in progress")
 	}
+	// Clear and recreate the experiment/backup directory
 	err = os.RemoveAll(d.ExperimentPath)
 	if err != nil {
 		return fmt.Errorf("error removing experiment directory: %w", err)
+	}
+	err = secureCreateTargetDirectoryWithSourcePermissions(d.StablePath, d.ExperimentPath)
+	if err != nil {
+		return fmt.Errorf("error creating target directory: %w", err)
 	}
 	err = backupOrRestoreDirectory(ctx, d.StablePath, d.ExperimentPath)
 	if err != nil {
@@ -121,10 +129,13 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 	if os.IsNotExist(err) {
 		return nil
 	}
-	// Ensure target directory exists before trying to write to it
-	err = os.MkdirAll(targetPath, 0755)
-	if err != nil {
-		return fmt.Errorf("error creating target directory: %w", err)
+	// target path must already exist, caller must ensure it has the correct permissions.
+	// We must not allow robocopy to create the target directory, as it may not safely create the directory,
+	// see paths.SecureCreateDirectory for more details.
+	// This function is reused for the restore operation, too, so this is also a safety to ensure
+	// we don't modify the original directory.
+	if _, err := os.Stat(targetPath); err != nil {
+		return fmt.Errorf("failed to open target directory: %w", err)
 	}
 	deploymentID, err := os.ReadFile(filepath.Join(sourcePath, deploymentIDFile))
 	if err != nil && !os.IsNotExist(err) {
@@ -158,4 +169,16 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 		return fmt.Errorf("error executing robocopy: %w\n%s\n%s", err, stdout.String(), stderr.String())
 	}
 	return nil
+}
+
+// secureCreateTargetDirectoryWithSourcePermissions creates targetPath with the same permissions as srcPath.
+//
+// See paths.SecureCreateDirectory for more details.
+func secureCreateTargetDirectoryWithSourcePermissions(sourcePath, targetPath string) error {
+	sd, err := windows.GetNamedSecurityInfo(sourcePath, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return fmt.Errorf("error getting security info for source directory: %w", err)
+	}
+	sddl := sd.String()
+	return paths.SecureCreateDirectory(targetPath, sddl)
 }

--- a/pkg/fleet/installer/paths/installer_paths_windows.go
+++ b/pkg/fleet/installer/paths/installer_paths_windows.go
@@ -86,8 +86,8 @@ func init() {
 		DatadogDataDir, _ = getProgramDataDirForProduct("Datadog Agent")
 	}
 	AgentConfigDir = DatadogDataDir
-	DatadogInstallerData = filepath.Join(DatadogDataDir, "Installer")
 	AgentConfigDirExp = filepath.Clean(DatadogDataDir) + "-exp"
+	DatadogInstallerData = filepath.Join(DatadogDataDir, "Installer")
 	PackagesPath = filepath.Join(DatadogInstallerData, "packages")
 	ConfigsPath = filepath.Join(DatadogInstallerData, "managed")
 	RootTmpDir = filepath.Join(DatadogInstallerData, "tmp")
@@ -167,7 +167,7 @@ func EnsureInstallerDataDir() error {
 
 	return winio.RunWithPrivileges(privilegesRequired, func() error {
 		// Create root path: `C:\ProgramData\Datadog\Installer`
-		err := secureCreateDirectory(DatadogInstallerData, sddl)
+		err := SecureCreateDirectory(DatadogInstallerData, sddl)
 		if err != nil {
 			return fmt.Errorf("failed to create DatadogInstallerData: %w", err)
 		}
@@ -207,11 +207,11 @@ func EnsureInstallerDataDir() error {
 	})
 }
 
-// secureCreateDirectory creates a directory with the specified SDDL string.
+// SecureCreateDirectory creates a directory with the specified SDDL string.
 //
 // If the directory already exists and it is owned by Administrators or SYSTEM, the permissions
 // are set to the expected state. If the directory is owned by an unknown party, an error is returned.
-func secureCreateDirectory(path string, sddl string) error {
+func SecureCreateDirectory(path string, sddl string) error {
 	// Try to create the directory with the desired permissions.
 	// We avoid TOCTOU issues because CreateDirectory fails if the directory already exists.
 	// This is of concern because Windows by default grants Users write access to ProgramData.
@@ -324,6 +324,14 @@ func createDirectoryWithSDDL(path string, sddl string) error {
 		// CreateDirectory does not apply the security descriptor if the directory already exists
 		// so treat it as an error if the directory already exists.
 		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// CreateDirectory creates the directory with the Owner,Group,DACL,
+	// but does not apply the AI (SeDaclAutoInherit) flag, so we reapply the SDDL
+	// here to ensure the AI flag is set.
+	err = setNamedSecurityInfoFromSecurityDescriptor(path, sd)
+	if err != nil {
+		return fmt.Errorf("failed to set named security info: %w", err)
 	}
 
 	return nil

--- a/releasenotes/notes/windows-remote-config-updates-newdir-95821056691d3d51.yaml
+++ b/releasenotes/notes/windows-remote-config-updates-newdir-95821056691d3d51.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    Remote Agent Management now creates a new directory that is at the same level as the current Agent configuration directory.
+  
+    * Linux: /etc/datadog-agent-exp
+    * Windows: C:\ProgramData\Datadog-exp
+  
+    This directory is used during remote configuration updates and is deleted after the update is complete.

--- a/test/new-e2e/tests/installer/windows/installer.go
+++ b/test/new-e2e/tests/installer/windows/installer.go
@@ -543,9 +543,14 @@ func WithDevEnvOverrides(prefix string) PackageOption {
 
 // SetConfigExperiment sets the config catalog for the Datadog Installer daemon.
 func (d *DatadogInstaller) SetConfigExperiment(config ConfigExperiment) (string, error) {
-	serializedConfig, err := json.Marshal(map[string]ConfigExperiment{
-		config.ID: config,
-	})
+	// Convert ConfigExperiment to installerConfig format
+	installerConfig := map[string]interface{}{
+		config.ID: map[string]interface{}{
+			"deployment_id":   config.ID,
+			"file_operations": convertFilesToOperations(config.Files),
+		},
+	}
+	serializedConfig, err := json.Marshal(installerConfig)
 	if err != nil {
 		return "", err
 	}
@@ -557,13 +562,21 @@ func (d *DatadogInstaller) SetConfigExperiment(config ConfigExperiment) (string,
 // StartConfigExperiment starts a config experiment using the provided InstallerConfig through the daemon.
 // It first sets the config catalog and then starts the experiment.
 func (d *DatadogInstaller) StartConfigExperiment(packageName string, config ConfigExperiment) (string, error) {
-	// First set the config catalog
-	_, err := d.SetConfigExperiment(config)
+	// Convert ConfigExperiment to installerConfig format
+	operations := map[string]interface{}{
+		"deployment_id":   config.ID,
+		"file_operations": convertFilesToOperations(config.Files),
+	}
+
+	serializedOps, err := json.Marshal(operations)
 	if err != nil {
 		return "", err
 	}
+	// Escape quotes in the JSON string to handle PowerShell quoting properly
+	opsStr := strings.ReplaceAll(string(serializedOps), `"`, `\"`)
+
 	// Then start the config experiment
-	return d.execute(fmt.Sprintf("daemon start-config-experiment %s %s", packageName, config.ID))
+	return d.execute(fmt.Sprintf("daemon start-config-experiment %s '%s'", packageName, opsStr))
 }
 
 // PromoteConfigExperiment promotes a config experiment through the daemon.
@@ -633,4 +646,17 @@ func (d *DatadogInstallerGA) StopExperiment(packageName string) (string, error) 
 		return out, ignoreEOF(err)
 	}
 	return out, err
+}
+
+// convertFilesToOperations converts ConfigExperimentFiles to file operations
+func convertFilesToOperations(files []ConfigExperimentFile) []map[string]interface{} {
+	operations := make([]map[string]interface{}, len(files))
+	for i, file := range files {
+		operations[i] = map[string]interface{}{
+			"file_op":   "merge-patch",
+			"file_path": file.Path,
+			"patch":     file.Contents,
+		}
+	}
+	return operations
 }

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
@@ -8,8 +8,9 @@ package assertions
 import (
 	"strings"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 )
 
 // RemoteWindowsAgentAssertions is a type that extends the SuiteAssertions to add assertions
@@ -29,9 +30,11 @@ type RemoteWindowsAgentConfigAssertions struct {
 //
 // The `config get` subcommand only supports a small set of keys, so this method
 // fetches the full config and unmarshals it into a map.
-func (r *RemoteWindowsAgentAssertions) RuntimeConfig() *RemoteWindowsAgentConfigAssertions {
+func (r *RemoteWindowsAgentAssertions) RuntimeConfig(commandArgs ...string) *RemoteWindowsAgentConfigAssertions {
 	r.context.T().Helper()
-	output, err := r.agentClient.ConfigWithError()
+	output, err := r.agentClient.ConfigWithError(
+		agentclient.WithArgs(commandArgs),
+	)
 	r.require.NoError(err)
 
 	var config map[interface{}]interface{}

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
@@ -246,11 +246,18 @@ func (r *RemoteWindowsHostAssertions) HasDatadogInstaller() *RemoteWindowsInstal
 // HasDDAgentUserFileAccess verifies that ddagentuser has appropriate permissions
 // on key Agent files and directories. This is to verify that config updates
 // or upgrades haven't broken file permissions.
-func (r *RemoteWindowsHostAssertions) HasDDAgentUserFileAccess() *RemoteWindowsHostAssertions {
+func (r *RemoteWindowsHostAssertions) HasDDAgentUserFileAccess(args ...string) *RemoteWindowsHostAssertions {
 	r.context.T().Helper()
 
+	var agentUserName string
+	if len(args) > 0 {
+		agentUserName = args[0]
+	} else {
+		agentUserName = windowsagent.DefaultAgentUserName
+	}
+
 	// Get ddagentuser identity
-	ddAgentUser, err := common.GetIdentityForUser(r.remoteHost, windowsagent.DefaultAgentUserName)
+	ddAgentUser, err := common.GetIdentityForUser(r.remoteHost, agentUserName)
 	r.require.NoError(err, "should get ddagentuser identity")
 
 	// Get config root from registry

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
@@ -8,7 +8,10 @@ package assertions
 import (
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strings"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	e2ecommon "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
@@ -17,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsagent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -239,4 +241,82 @@ func (r *RemoteWindowsHostAssertions) HasDatadogInstaller() *RemoteWindowsInstal
 	return &RemoteWindowsInstallerAssertions{
 		RemoteWindowsBinaryAssertions: bin,
 	}
+}
+
+// HasDDAgentUserFileAccess verifies that ddagentuser has appropriate permissions
+// on key Agent files and directories. This is to verify that config updates
+// or upgrades haven't broken file permissions.
+func (r *RemoteWindowsHostAssertions) HasDDAgentUserFileAccess() *RemoteWindowsHostAssertions {
+	r.context.T().Helper()
+
+	// Get ddagentuser identity
+	ddAgentUser, err := common.GetIdentityForUser(r.remoteHost, windowsagent.DefaultAgentUserName)
+	r.require.NoError(err, "should get ddagentuser identity")
+
+	// Get config root from registry
+	configRoot, err := windowsagent.GetConfigRootFromRegistry(r.remoteHost)
+	r.require.NoError(err, "should get config root from registry")
+
+	// Test critical paths that ddagentuser needs access to
+	criticalPaths := []struct {
+		path        string
+		minRights   int
+		description string
+		fileType    string
+	}{
+		{
+			path:        filepath.Join(configRoot, "datadog.yaml"),
+			minRights:   common.FileFullControl,
+			description: "datadog.yaml must be readable by ddagentuser",
+			fileType:    "file",
+		},
+		{
+			path:        filepath.Join(configRoot, "conf.d"),
+			minRights:   common.FileFullControl,
+			description: "conf.d must be readable by ddagentuser",
+			fileType:    "directory",
+		},
+		{
+			path:        filepath.Join(configRoot, "logs"),
+			minRights:   common.FileFullControl,
+			description: "logs directory must be writable by ddagentuser",
+			fileType:    "directory",
+		},
+	}
+
+	for _, cp := range criticalPaths {
+		switch cp.fileType {
+		case "file":
+			exists, err := r.remoteHost.FileExists(cp.path)
+			r.require.NoError(err, "should check if file exists")
+			if !exists {
+				r.require.Failf("path %s does not exist", cp.path)
+			}
+		case "directory":
+			_, err := r.remoteHost.Lstat(cp.path)
+			r.require.NoError(err, "should check if directory exists")
+		}
+
+		security, err := common.GetSecurityInfoForPath(r.remoteHost, cp.path)
+		r.require.NoError(err, "should get security info for %s", cp.path)
+
+		// Filter to get ddagentuser rules
+		ddagentRules := common.FilterRulesForIdentity(security.Access, ddAgentUser)
+		r.require.NotEmpty(ddagentRules,
+			"ddagentuser should have access rules on %s", cp.path)
+
+		// Verify at least one rule grants the minimum required rights
+		hasRequiredRights := false
+		for _, rule := range ddagentRules {
+			if rule.IsAllow() && (rule.Rights&cp.minRights) == cp.minRights {
+				hasRequiredRights = true
+				break
+			}
+		}
+
+		r.require.True(hasRequiredRights,
+			"%s (path: %s)", cp.description, cp.path)
+	}
+
+	return r
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -36,6 +36,9 @@ func TestAgentConfig(t *testing.T) {
 // TestConfigUpgradeSuccessful tests that the Agent's config can be upgraded
 // through the experiment (start/promote) workflow.
 func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
+	configRoot := windowsagent.DefaultConfigRoot
+	configBackupRoot := windowsagent.DefaultConfigRoot + "-exp"
+
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -45,6 +48,11 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", true)
+
+	// collect permissions snapshot before config experiment
+	perms, err := windowscommon.GetSecurityInfoForPath(s.Env().RemoteHost, configRoot)
+	s.Require().NoError(err, "should get security info for config root")
+	configSDDLBeforeExperiment := perms.SDDL
 
 	// Act
 	config := installerwindows.ConfigExperiment{
@@ -64,18 +72,31 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_to_console", false).
 		HasDDAgentUserFileAccess()
+	perms, err = windowscommon.GetSecurityInfoForPath(s.Env().RemoteHost, configBackupRoot)
+	s.Require().NoError(err, "should get security info for config backup root")
+	s.Require().Equal(configSDDLBeforeExperiment, perms.SDDL, "backup dir permissions should be the same as the config dir permissions")
 
 	// Promote config experiment
 	s.mustPromoteConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("--all").
-		WithValueEqual("log_to_console", false)
+		WithValueEqual("log_to_console", false).
+		HasDDAgentUserFileAccess().
+		NoDirExists(configBackupRoot) // backup dir should be deleted
+
+	// assert that the config dir permissions have not changed
+	perms, err = windowscommon.GetSecurityInfoForPath(s.Env().RemoteHost, configRoot)
+	s.Require().NoError(err, "should get security info for config root")
+	s.Require().Equal(configSDDLBeforeExperiment, perms.SDDL, "config dir permissions should not have changed")
 }
 
 // TestConfigUpgradeFailure tests that the Agent's config can be rolled back
 // through the experiment (start/promote) workflow.
 func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
+	configRoot := windowsagent.DefaultConfigRoot
+	configBackupRoot := windowsagent.DefaultConfigRoot + "-exp"
+
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
@@ -85,6 +106,11 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_level", "debug")
+
+	// collect permissions snapshot before config experiment
+	perms, err := windowscommon.GetSecurityInfoForPath(s.Env().RemoteHost, configRoot)
+	s.Require().NoError(err, "should get security info for config root")
+	configSDDLBeforeExperiment := perms.SDDL
 
 	// Act
 	config := installerwindows.ConfigExperiment{
@@ -118,7 +144,8 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig("--all").
 		WithValueEqual("log_level", "debug").
-		HasDDAgentUserFileAccess()
+		HasDDAgentUserFileAccess().
+		NoDirExists(configBackupRoot) // backup dir should be deleted
 
 	// backend will send stop experiment now
 	s.WaitForDaemonToStop(func() {
@@ -126,6 +153,11 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 		s.Require().NoError(err, "daemon should stop cleanly")
 		s.AssertSuccessfulConfigStopExperiment()
 	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
+
+	// assert that the config dir permissions have not changed
+	perms, err = windowscommon.GetSecurityInfoForPath(s.Env().RemoteHost, configRoot)
+	s.Require().NoError(err, "should get security info for config root")
+	s.Require().Equal(configSDDLBeforeExperiment, perms.SDDL, "config dir permissions should not have changed")
 }
 
 // TestConfigUpgradeNewAgents tests that config experiments can enable security agent and system probe

--- a/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
@@ -21,13 +21,6 @@ type testInstallScriptSuite struct {
 	installerwindows.BaseSuite
 }
 
-const (
-	oldInstallerURL     = "http://dd-agent.s3.amazonaws.com/datadog-installer-7.63.0-installer-0.12.5-1-x86_64.exe"
-	oldInstallerScript  = "http://dd-agent.s3.amazonaws.com/Install-Datadog-7.63.0-installer-0.12.5-1.ps1"
-	oldInstallerVersion = "7.62"
-	oldAgentVersion     = "7.63.2"
-)
-
 // TestInstallScript tests the usage of the Datadog installer script to install the Datadog Agent package.
 func TestInstallScript(t *testing.T) {
 	e2e.Run(t, &testInstallScriptSuite{},
@@ -46,17 +39,6 @@ func (s *testInstallScriptSuite) TestInstallAgentPackage() {
 			s.Run("Reinstall last stable", func() {
 				s.installPrevious()
 			})
-		})
-	})
-}
-
-// TestInstallFromOldInstaller tests installing the Datadog Agent package from an old installer.
-// shows we can correctly use the script to uninstall the old agent + installer MSIs
-func (s *testInstallScriptSuite) TestInstallFromOldInstaller() {
-	s.Run("Install from old installer", func() {
-		s.installOldInstallerAndAgent()
-		s.Run("Install New Version", func() {
-			s.installCurrent()
 		})
 	})
 }
@@ -134,77 +116,6 @@ func (s *testInstallScriptSuite) upgradeToLatestExperiment() {
 	s.AssertSuccessfulAgentStartExperiment(s.CurrentAgentVersion().PackageVersion())
 	_, err := s.Installer().PromoteExperiment(consts.AgentPackage)
 	s.Require().NoError(err, "daemon should respond to request")
-	s.AssertSuccessfulAgentPromoteExperiment(s.CurrentAgentVersion().PackageVersion())
-}
-
-func (s *testInstallScriptSuite) installOldInstallerAndAgent() {
-	// Arrange
-	agentVersion := fmt.Sprintf("%s-1", oldAgentVersion)
-	// Act
-	opts := []installerwindows.Option{
-		installerwindows.WithExtraEnvVars(map[string]string{
-			// all of these make sure we install old versions from install.datadoghq.com
-			"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER": oldInstallerVersion,
-			"DD_INSTALLER_REGISTRY_URL_DATADOG_INSTALLER":        "dd-agent.s3.amazonaws.com",
-			"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT":     agentVersion,
-			"DD_INSTALLER_REGISTRY_URL_DATADOG_AGENT":            "dd-agent.s3.amazonaws.com",
-			"DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE":            "dd-agent.s3.amazonaws.com",
-			"DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE":        "dd-agent.s3.amazonaws.com",
-		}),
-		installerwindows.WithInstallerURL(oldInstallerURL),
-		installerwindows.WithInstallerScript(oldInstallerScript),
-	}
-
-	output, err := s.InstallScript().Run(opts...)
-	if s.NoError(err) {
-		fmt.Printf("%s\n", output)
-	}
-
-	// Assert
-	s.Require().NoErrorf(err, "failed to install the Datadog Agent package: %s", output)
-	s.Require().NoError(s.WaitForInstallerService("Running"))
-	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogInstallerService().
-		HasARunningDatadogAgentService().
-		WithVersionMatchPredicate(func(version string) {
-			s.Require().Contains(version, oldAgentVersion)
-		})
-}
-
-// TestInstallCurrentWithOldInstallerScript ensures the old installer script can install the current Agent version
-//
-// We're switching from .ps1 setup script that runs `bootstrap` subcommand to .exe itself. Some customers
-// may have a cached or modified copy of the .ps1 script. This test ensures they can still install the current Agent version.
-func (s *testInstallScriptSuite) TestInstallCurrentWithOldInstallerScript() {
-	// Arrange
-	packageConfig, err := installerwindows.NewPackageConfig(
-		installerwindows.WithPackage(s.CurrentAgentVersion().OCIPackage()),
-	)
-	s.Require().NoError(err)
-
-	// Act
-	opts := []installerwindows.Option{
-		installerwindows.WithExtraEnvVars(map[string]string{
-			"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT": packageConfig.Version,
-			"DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE":        packageConfig.Registry,
-		}),
-		installerwindows.WithInstallerScript(oldInstallerScript),
-	}
-
-	output, err := s.InstallScript().Run(opts...)
-	if s.NoError(err) {
-		fmt.Printf("%s\n", output)
-	}
-
-	// Assert
-	s.Require().NoErrorf(err, "failed to install the Datadog Agent package: %s", output)
-	s.Require().NoError(s.WaitForInstallerService("Running"))
-	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogInstallerService().
-		HasARunningDatadogAgentService().
-		WithVersionMatchPredicate(func(version string) {
-			s.Require().Contains(version, s.CurrentAgentVersion().Version())
-		})
 	s.AssertSuccessfulAgentPromoteExperiment(s.CurrentAgentVersion().PackageVersion())
 }
 


### PR DESCRIPTION
Backport a6b6f6a4873195760f8b9cdaf2baf2ddc299765c from #43440 

also pulls a couple other required e2e test changes
