### PR TITLE
[CWS] Fix move_mount test

### DIFF
--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -344,15 +344,15 @@ func TestMoveMountRecursivePropagation(t *testing.T) {
 			}
 
 			allMounts[event.Mount.MountID]++
-			return len(allMounts) == 3
+			return false
 		}, 5*time.Second, model.FileMoveMountEventType)
 
-		assert.Equal(t, 3, len(allMounts), "Not all mount events were obtained")
+		assert.GreaterOrEqual(t, len(allMounts), 3, "Not all mount events were obtained")
 
 		p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
 		for i := range allMounts {
 			path, _, _, _ := p.Resolvers.MountResolver.ResolveMountPath(i, 0, 0, "")
-			if len(path) == 0 {
+			if len(path) == 0 || !strings.Contains(path, "tmp1") || !strings.Contains(path, "tmp2") {
 				// Some paths aren't being fully resolved due to missing mounts in the chain
 				// Need to figure out what are these mount points and why they aren't to be found anywhere
 				continue


### PR DESCRIPTION
### What does this PR do?

This PR makes `TestMoveMountRecursivePropagation` ignore unrelated `move_mount` events that can be interfering and making the test flaky. It also now checks if all the propagated mounts are correct.

### Motivation

This test is very flaky
