### PR TITLE
fix(fleet): Pass through env variables when downloading the installer in the install script

### DIFF
--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -57,12 +57,12 @@ fi
 
 echo "Downloading the Datadog installer..."
 if command -v curl >/dev/null; then
-  if ! "${sudo_cmd[@]+"${sudo_cmd[@]}"}" curl -L --retry 3 "$installer_url" --output "$tmp_bin" >/dev/null; then
+  if ! "${sudo_env_cmd[@]+"${sudo_env_cmd[@]}"}" curl -L --retry 3 "$installer_url" --output "$tmp_bin" >/dev/null; then
     echo "Error: Download failed with curl." >&2
     exit 1
   fi
 else
-  if ! "${sudo_cmd[@]+"${sudo_cmd[@]}"}" wget --tries=3 -O "$tmp_bin" "$installer_url" >/dev/null; then
+  if ! "${sudo_env_cmd[@]+"${sudo_env_cmd[@]}"}" wget --tries=3 -O "$tmp_bin" "$installer_url" >/dev/null; then
     echo "Error: Download failed with wget." >&2
     exit 1
   fi


### PR DESCRIPTION
### What does this PR do?
Proxies weren't passed properly when downloading the installer in the installer install script; causing failures for SSI in air-gapped environments. This PR fixes it.

### Motivation

### Describe how you validated your changes

### Additional Notes
