### PR TITLE
[AMCC-160] Tidy `metric_filterlist` field

### DIFF
--- a/comp/dogstatsd/server/rc.go
+++ b/comp/dogstatsd/server/rc.go
@@ -39,8 +39,6 @@ func (s *server) onFilterListUpdateCallback(updates map[string]state.RawConfig, 
 	if len(updates) == 0 {
 		s.config.UnsetForSource("metric_filterlist", model.SourceRC)
 		s.config.UnsetForSource("metric_filterlist_match_prefix", model.SourceRC)
-		s.config.UnsetForSource("statsd_metric_blocklist", model.SourceRC)
-		s.config.UnsetForSource("statsd_metric_blocklist_match_prefix", model.SourceRC)
 		s.restoreFilterListFromLocalConfig()
 		return
 	}
@@ -90,10 +88,6 @@ func (s *server) onFilterListUpdateCallback(updates map[string]state.RawConfig, 
 		// in `agent config` calls.
 		s.config.Set("metric_filterlist", metricNames, model.SourceRC)
 		s.config.Set("metric_filterlist_match_prefix", false, model.SourceRC)
-		if len(s.localFilterListConfig.metricNames) > 0 {
-			s.config.Set("statsd_metric_blocklist", []string{}, model.SourceRC)
-			s.config.Set("statsd_metric_blocklist_match_prefix", false, model.SourceRC)
-		}
 
 		// apply this new blocklist to all the running workers
 		s.tlmFilterListUpdates.Inc()
@@ -103,8 +97,6 @@ func (s *server) onFilterListUpdateCallback(updates map[string]state.RawConfig, 
 		// special case: if the metric names list is empty, fallback to local
 		s.config.UnsetForSource("metric_filterlist", model.SourceRC)
 		s.config.UnsetForSource("metric_filterlist_match_prefix", model.SourceRC)
-		s.config.UnsetForSource("statsd_metric_blocklist", model.SourceRC)
-		s.config.UnsetForSource("statsd_metric_blocklist_match_prefix", model.SourceRC)
 		s.restoreFilterListFromLocalConfig()
 	}
 }

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -648,8 +648,6 @@ func (s *server) restoreFilterListFromLocalConfig() {
 	s.tlmFilterListUpdates.Inc()
 	s.tlmFilterListSize.Set(float64(len(filterList)))
 
-	fmt.Println("\033[035m", "Setting filterlist", filterList, "\033[0m")
-
 	s.SetFilterList(filterList, filterListPrefix)
 }
 

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -622,10 +622,9 @@ func (s *server) handleMessages() {
 
 	// init the metric names filterlist
 	filterlist := s.config.GetStringSlice("metric_filterlist")
-	filterlistPrefix := s.config.GetBool("metric_filterlist_match_prefix")
 	if len(filterlist) == 0 {
 		filterlist = s.config.GetStringSlice("statsd_metric_blocklist")
-		filterlistPrefix = s.config.GetBool("statsd_metric_blocklist_match_prefix")
+		filterlistPrefix := s.config.GetBool("statsd_metric_blocklist_match_prefix")
 
 		if len(filterlist) > 0 {
 			s.config.Set("metric_filterlist", filterlist, model.SourceAgentRuntime)

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -373,7 +373,7 @@ func TestDogstatsdServerSetsAndResetsRCFilterlist(t *testing.T) {
 
 	// RC Sends two metrics
 	updates := map[string]state.RawConfig{
-		"metric_filterlist": state.RawConfig{
+		"metric_filterlist": {
 			Config: []byte(
 				"{\"blocked_metrics\":{\"by_name\":{\"values\":[{\"created_at\":1751045727,\"metric_name\":\"ning.nong\"},{\"created_at\":1754328117,\"metric_name\":\"wiggle.wiggle\"}]}},\"policy_name\":\"test\"}",
 			),
@@ -390,7 +390,7 @@ func TestDogstatsdServerSetsAndResetsRCFilterlist(t *testing.T) {
 
 	// RC Sends an empty list, we should reset to the original configured list
 	updates = map[string]state.RawConfig{
-		"metric_filterlist": state.RawConfig{
+		"metric_filterlist": {
 			Config: []byte(
 				"{\"blocked_metrics\":{\"by_name\":{\"values\":[]}},\"policy_name\":\"test\"}",
 			),

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -350,7 +350,6 @@ func TestDogstatsdMappingProfilesEnv(t *testing.T) {
 	assert.Equal(t, expected, mappings)
 }
 
-/*
 func TestDogstatsdServerUsesConfiguredFilterlist(t *testing.T) {
 	cfg := make(map[string]interface{})
 
@@ -359,13 +358,10 @@ func TestDogstatsdServerUsesConfiguredFilterlist(t *testing.T) {
 	deps := fulfillDepsWithConfigOverride(t, cfg)
 	s := deps.Server.(*server)
 
-	require.True(t, waitForMatcherUpdate(s, 1, time.Second), "timeout waiting for matcher update")
-
-	for _, w := range s.workers {
-		assert.True(t, w.filterList.Test("zork.nork"))
-	}
+	require.True(t, waitUntil(time.Second, s, func(filterList *utilstrings.Matcher) bool {
+		return filterList.Test("zork.nork")
+	}), "timeout waiting for matcher update")
 }
-*/
 
 func TestDogstatsdServerSetsAndResetsRCFilterlist(t *testing.T) {
 	cfg := make(map[string]interface{})

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -78,7 +78,9 @@ func (w *worker) run() {
 			w.samples = w.samples[0:0]
 			// we return the samples in case the slice was extended
 			// when parsing the packets
+			w.filterListMtx.RLock()
 			w.samples = w.server.parsePackets(w.batcher, w.parser, ps, w.samples, &w.filterList)
+			w.filterListMtx.RUnlock()
 		}
 
 	}

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -155,7 +155,6 @@ func (c *safeConfig) UnsetForSource(key string, source model.Source) {
 	// modify the config then release the lock to avoid deadlocks while notifying
 	var receivers []model.NotificationReceiver
 	c.Lock()
-	defer c.Unlock()
 	previousValue := c.Viper.Get(key)
 	c.configSources[source].Set(key, nil)
 	c.mergeViperInstances(key)
@@ -165,6 +164,7 @@ func (c *safeConfig) UnsetForSource(key string, source model.Source) {
 		receivers = slices.Clone(c.notificationReceivers)
 		c.sequenceID++
 	}
+	c.Unlock()
 
 	// notifying all receiver about the updated setting
 	for _, receiver := range receivers {

--- a/pkg/util/strings/matcher.go
+++ b/pkg/util/strings/matcher.go
@@ -47,11 +47,6 @@ func NewMatcher(data []string, matchPrefix bool) Matcher {
 	}
 }
 
-// NumItems returns the number of items in our matcher list.
-func (m *Matcher) NumItems() int {
-	return len(m.data)
-}
-
 // Test returns true if the given string matches one in the matcher list.
 // or is matching by prefix if the matcher has been created with `matchPrefix`.
 func (m *Matcher) Test(name string) bool {

--- a/pkg/util/strings/matcher.go
+++ b/pkg/util/strings/matcher.go
@@ -47,6 +47,12 @@ func NewMatcher(data []string, matchPrefix bool) Matcher {
 	}
 }
 
+// NumItems returns the number of items in our matcher list.
+// Used for tests.
+func (m *Matcher) NumItems() int {
+	return len(m.data)
+}
+
 // Test returns true if the given string matches one in the matcher list.
 // or is matching by prefix if the matcher has been created with `matchPrefix`.
 func (m *Matcher) Test(name string) bool {

--- a/pkg/util/strings/matcher.go
+++ b/pkg/util/strings/matcher.go
@@ -48,7 +48,6 @@ func NewMatcher(data []string, matchPrefix bool) Matcher {
 }
 
 // NumItems returns the number of items in our matcher list.
-// Used for tests.
 func (m *Matcher) NumItems() int {
 	return len(m.data)
 }


### PR DESCRIPTION
### What does this PR do?

Tidies up the code a bit from #43454.

### Motivation

A better way to utilise configuration layers to handle updating the `metric_filterlist` field, both from the config (when set via the older `statsd_metric_blocklist` field) and via RC.

If the field is renamed from `statsd_metric_blocklist`, this setting will be overriden with an empty list and copied into the `metric_filterlist` field in the `model.SourceAgentRuntime` config layer.

Any updates from RC are added to the `model.SourceRC` layer. If an empty list is received from RC, then the settings are just Unset at this layer, restoring to the previously set values.

### Describe how you validated your changes

I have added extra unit tests to ensure it works.


### Additional Notes

There is a deadlock fix in Viper here. I believe @hush-hush will be submitting that in a separate PR before this will be merged..
