### PR TITLE
[EBPF] gpu: cache tags in case of error

### DIFF
--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -391,6 +391,15 @@ func (v *gpuBaseSuite[Env]) TestVectorAddProgramDetected() {
 			}
 		}
 
+		hasPidTag := false
+		for _, tag := range usageMetricTags {
+			if strings.HasPrefix(tag, "pid:") {
+				hasPidTag = true
+				break
+			}
+		}
+		assert.True(c, hasPidTag, "no tag starting with 'pid:' found in usage metric tags")
+
 		if len(usageMetricTags) > 0 {
 			// Ensure we get the limit metric with the same tags as the usage one
 			limitMetrics, err := v.caps.FakeIntake().Client().FilterMetrics("gpu.core.limit", client.WithTags[*aggregator.MetricSeries](usageMetricTags))


### PR DESCRIPTION
### What does this PR do?

Changes the workload tag cache so that any tags built are stored in the cache for subsequent runs. The `TestGetWorkloadTags` has also been fixed to account for this case.

The e2e test has also been fixed to ensure that the `pid:` tag is always present on core usage metrics.

### Motivation

Without this fix, there would be an inconsistency where in the first call to get tags for a missing process we would get some default tags (pid/nspid) but then in subsequent ones we wouldn't get any. It also caused #incident-46337: when `gpu.process.core.usage` was the metric that got the `pid` tags, then `gpu.core.limit` wouldn't get them and therefore we did not find it and failed the test.

### Describe how you validated your changes

Unit tests added to ensure this behavior is covered and working.

### Additional Notes
