### PR TITLE
ci(labels): Improve label management

### DIFF
--- a/.github/chainguard/self.assign-issue.label-issue.sts.yaml
+++ b/.github/chainguard/self.assign-issue.label-issue.sts.yaml
@@ -12,3 +12,4 @@ claim_pattern:
 permissions:
   contents: read
   issues: write
+  members: read

--- a/.github/workflows/check_issue_status.yml
+++ b/.github/workflows/check_issue_status.yml
@@ -4,6 +4,12 @@ name: Check if datadog commented an issue
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to check'
+        required: true
+        type: number
 
 jobs:
   check_comment:
@@ -16,10 +22,13 @@ jobs:
         with:
           result-encoding: string
           script: |
+            const issueNumber = context.eventName === 'issue_comment'
+              ? context.issue.number
+              : parseInt(inputs.issue_number);
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number
+              issue_number: issueNumber
             });
             let commented = "false";
             for (const comment of comments.data) {
@@ -46,17 +55,20 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
+            const issueNumber = context.eventName === 'issue_comment'
+              ? context.issue.number
+              : parseInt(inputs.issue_number);
             const labels = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number
+              issue_number: issueNumber
             });
             for (const label of labels.data) {
               if (label.name === 'pending') {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: context.issue.number,
+                  issue_number: issueNumber,
                   name: label.name
                 });
               }

--- a/.github/workflows/check_issue_status.yml
+++ b/.github/workflows/check_issue_status.yml
@@ -15,16 +15,27 @@ jobs:
   check_comment:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request == null
+    permissions:
+      id-token: write # Required for OIDC token
+    environment:
+      name: main
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.assign-issue.label-issue
+
       - name: Check if there is a comment from a datadog member
         id: datadog-comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
           result-encoding: string
           script: |
             const issueNumber = context.eventName === 'issue_comment'
               ? context.issue.number
-              : parseInt(inputs.issue_number);
+              : parseInt(context.payload.inputs.issue_number);
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -54,10 +65,11 @@ jobs:
         if: steps.datadog-comment.outputs.result == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const issueNumber = context.eventName === 'issue_comment'
               ? context.issue.number
-              : parseInt(inputs.issue_number);
+              : parseInt(context.payload.inputs.issue_number);
             const labels = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -72,4 +84,35 @@ jobs:
                   name: label.name
                 });
               }
+            }
+      - name: Remove the team/triage label if another team label exists
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
+          script: |
+            const issueNumber = context.eventName === 'issue_comment'
+              ? context.issue.number
+              : parseInt(context.payload.inputs.issue_number);
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            let hasTeamLabel = false;
+            let hasTriageLabel = false;
+            for (const label of labels.data) {
+              if (label.name === 'team/triage') {
+                hasTriageLabel = true;
+              } else if (label.name.startsWith('team/')) {
+                hasTeamLabel = true;
+              }
+            }
+            if (hasTriageLabel && hasTeamLabel) {
+              // Remove only 'team/triage' label, let others be
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: 'team/triage'
+              });
             }

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -202,17 +202,13 @@ def assign_team_label(_, pr_id=-1):
 
     # Check for 'team/' labels
     labels = gh.get_pr_labels(pr_id)
-    has_triage = False
     has_team = False
     for label in labels:
         if label.startswith('team/'):
             if label != 'team/triage':
                 has_team = True
             else:
-                has_triage = True
-
-    if has_triage:
-        _remove_pr_label(gh, pr_id, 'team/triage')
+                _remove_pr_label(gh, pr_id, 'team/triage')
 
     if has_team:
         return

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -194,11 +194,16 @@ def assign_team_label(_, pr_id=-1):
     from tasks.libs.ciproviders.github_api import GithubAPI
 
     gh = GithubAPI('DataDog/datadog-agent')
+    # Fetch the team first, and early return if no team is found
+    teams = _get_teams(gh.get_pr_files(pr_id))
+    if teams == []:
+        print('No team found')
+        return
 
+    # Check for 'team/' labels
     labels = gh.get_pr_labels(pr_id)
     has_triage = False
     has_team = False
-
     for label in labels:
         if label.startswith('team/'):
             if label != 'team/triage':
@@ -208,15 +213,9 @@ def assign_team_label(_, pr_id=-1):
 
     if has_triage:
         _remove_pr_label(gh, pr_id, 'team/triage')
+
     if has_team:
         return
-
-    # Find team
-    teams = _get_teams(gh.get_pr_files(pr_id))
-    if teams == []:
-        print('No team found')
-        return
-
     _assign_pr_team_labels(gh, pr_id, teams)
 
 

--- a/tasks/unit_tests/github_tasks_tests.py
+++ b/tasks/unit_tests/github_tasks_tests.py
@@ -141,6 +141,12 @@ class TestAssignTeamLabelMock(unittest.TestCase):
 
         self.make_test(changed_files, expected_labels, pr_labels=['team/triage', 'team/team-a'])
 
+    def test_no_remove_triage_label(self):
+        changed_files = ['idonotexist']
+        expected_labels = ['team/triage']
+
+        self.make_test(changed_files, expected_labels, pr_labels=['team/triage'])
+
 
 class TestExtractQADescriptionFromPR(unittest.TestCase):
     def test_extract_qa_description(self):


### PR DESCRIPTION
### What does this PR do?
- Issue labels
  - Use an `octo-sts` token to remove the `pending` label on issues. The `check_issue_status` workflow was not working because `GITHUB_TOKEN` did not have access to org members.
  - Add the possibility to trigger this workflow manually.
  - Remove the `team/triage` label if another `team/label` exists.
- Pull Request labels:
  - Always set a `team/` label to every PR. This is relates to https://github.com/DataDog/ddqa/pull/142. `ddqa` issue creation does not use these labels anymore, but the `qa/` labels.
  - Remove the `team/triage` if already present

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-1127
https://datadoghq.atlassian.net/browse/ACIX-1079


### Describe how you validated your changes
Unit tests

