### PR TITLE
[7.72.x] Backport PR #43545 manually with dedicated operator commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.72.3
 	github.com/DataDog/datadog-agent/pkg/version v0.72.3
 	github.com/DataDog/datadog-go/v5 v5.6.0
-	github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f
+	github.com/DataDog/datadog-operator/api v0.0.0-20251127144653-377789bdccd6
 	github.com/DataDog/datadog-traceroute v0.1.29
 	github.com/DataDog/dd-trace-go/v2 v2.0.0
 	github.com/DataDog/ebpf-manager v0.7.14

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f h1:O+Ls4K2v4lQpGum7yYWM3aRZ3vJ/Ibvk/Ma/NqXwtWI=
 github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f/go.mod h1:E+dFku5SVIXDUj6apiBdDAzrUOR3xLz1bMgUOGjRAVQ=
+github.com/DataDog/datadog-operator/api v0.0.0-20251127144653-377789bdccd6 h1:0lNEEntbSbSYGpuwLV/VZoIwApxjyfd9vy1/RFa1pTY=
+github.com/DataDog/datadog-operator/api v0.0.0-20251127144653-377789bdccd6/go.mod h1:E+dFku5SVIXDUj6apiBdDAzrUOR3xLz1bMgUOGjRAVQ=
 github.com/DataDog/datadog-traceroute v0.1.29 h1:l6vQHYORtdoZn3xriLorsHe9QuNja6Sr4JyJ2WDwi3Q=
 github.com/DataDog/datadog-traceroute v0.1.29/go.mod h1:PU0w0AsVMEapWPgaqXEtBuDUlPQGlnHsaADsXVMKMts=
 github.com/DataDog/dd-trace-go/v2 v2.0.0 h1:cHMEzD0Wcgtu+Rec9d1GuVgpIN5f+4vCaNzuFHJ0v+Y=

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -509,7 +509,7 @@ func validateAutoscalerObjectives(spec *datadoghq.DatadogPodAutoscalerSpec) erro
 	for _, objective := range spec.Objectives {
 		switch objective.Type {
 		case datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType:
-			if objective.CustomQueryObjective == nil {
+			if objective.CustomQuery == nil {
 				return fmt.Errorf("Autoscaler objective type is custom query but customQueryObjective is nil")
 			}
 		case datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType:

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -955,7 +955,8 @@ func TestValidateAutoscalerObjectives(t *testing.T) {
 				Fallback: &datadoghq.DatadogFallbackPolicy{
 					Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
 						Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-							{Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType}},
+							{Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType},
+						},
 					},
 				},
 			},
@@ -975,10 +976,10 @@ func TestValidateAutoscalerObjectives(t *testing.T) {
 			spec: datadoghq.DatadogPodAutoscalerSpec{
 				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
 					{
-						Type:                 datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType,
-						CustomQueryObjective: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
-						PodResource:          &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
-						ContainerResource:    nil,
+						Type:              datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType,
+						CustomQuery:       &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
+						PodResource:       &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
+						ContainerResource: nil,
 					},
 				},
 			},
@@ -1007,9 +1008,9 @@ func TestValidateAutoscalerObjectives(t *testing.T) {
 			spec: datadoghq.DatadogPodAutoscalerSpec{
 				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
 					{
-						Type:                 datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
-						PodResource:          &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
-						CustomQueryObjective: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
+						Type:        datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+						PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
+						CustomQuery: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
 					},
 				},
 			},
@@ -1018,9 +1019,9 @@ func TestValidateAutoscalerObjectives(t *testing.T) {
 			spec: datadoghq.DatadogPodAutoscalerSpec{
 				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
 					{
-						Type:                 datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
-						ContainerResource:    &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{},
-						CustomQueryObjective: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
+						Type:              datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+						ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{},
+						CustomQuery:       &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
 					},
 				},
 			},

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
@@ -1550,11 +1550,9 @@ func TestCalculateHorizontalRecommendations(t *testing.T) {
 	}
 	customQueryObjective := datadoghqcommon.DatadogPodAutoscalerObjective{
 		Type: datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType,
-		CustomQueryObjective: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{
-			Query: datadoghqcommon.DatadogPodAutoscalerTimeseriesFormulaRequest{
-				Formulas: []datadoghqcommon.DatadogPodAutoscalerQueryFormula{{
-					Formula: "query1",
-				}},
+		CustomQuery: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{
+			Request: datadoghqcommon.DatadogPodAutoscalerTimeseriesFormulaRequest{
+				Formula: "query1",
 				Queries: []datadoghqcommon.DatadogPodAutoscalerTimeseriesQuery{{
 					Source: datadoghqcommon.DatadogPodAutoscalerMetricsDataSourceMetrics,
 					Name:   "a",

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_string.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_string.go
@@ -196,8 +196,8 @@ func formatObjective(objective *datadoghqcommon.DatadogPodAutoscalerObjective) s
 		_, _ = fmt.Fprintln(&sb, "Container Name:", objective.ContainerResource.Container)
 		formatObjectiveValue(&sb, &objective.ContainerResource.Value)
 	}
-	if objective.CustomQueryObjective != nil {
-		formatObjectiveValue(&sb, &objective.CustomQueryObjective.Value)
+	if objective.CustomQuery != nil {
+		formatObjectiveValue(&sb, &objective.CustomQuery.Value)
 	}
 	return sb.String()
 }


### PR DESCRIPTION
### What does this PR do?

Backport #43545 but with a dedicated commit with only the changes in `datadog-operator`: https://github.com/DataDog/datadog-operator/commit/377789bdccd6b8853a8f276a604c52c66549c597

### Motivation

### Describe how you validated your changes

### Additional Notes
