### PR TITLE
Enable `bazel --remote_local_fallback`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,6 +31,7 @@ common:windows --noexperimental_convenience_symlinks --shell_executable=C:/tools
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
 common:cache --remote_cache=grpc://bazel-buildbarn-frontend.ddbuild.io:443
 common:cache --remote_instance_name=remote-caching/datadog-agent
+common:cache --remote_local_fallback  # best-effort on transient connection errors (no such host)
 common:cache --remote_retries=1
 common:cache --remote_timeout=60
 


### PR DESCRIPTION
### Motivation
`bazel` started exiting on exit code `39`:
> Blobs required by Bazel are evicted from Remote Cache.


This is caused by (hopefully) transient:
```
io.grpc.StatusRuntimeException: UNAVAILABLE: Shard 2: connection error: desc = "transport: Error while dialing: dial tcp: lookup buildbarn-storage-2.buildbarn-storage.buildbarn.local-cluster.local-dc.fabric.dog on 169.254.20.10:53: no such host"
```