### PR TITLE
[CSPM] do not set the env variable on the calling process, but directly on oscap-io

### DIFF
--- a/pkg/compliance/evaluator_xccdf.go
+++ b/pkg/compliance/evaluator_xccdf.go
@@ -93,14 +93,15 @@ func newOSCAPIO(file string) *oscapIO {
 func (p *oscapIO) Run(ctx context.Context) error {
 	defer p.Stop()
 
+	var oscapProbeRoot string
+
 	if env.IsContainerized() {
 		hostRoot := os.Getenv("HOST_ROOT")
 		if hostRoot == "" {
 			hostRoot = "/host"
 		}
 
-		os.Setenv("OSCAP_PROBE_ROOT", hostRoot)
-		defer func() { _ = os.Unsetenv("OSCAP_PROBE_ROOT") }()
+		oscapProbeRoot = hostRoot
 	}
 
 	args := []string{}
@@ -116,6 +117,10 @@ func (p *oscapIO) Run(ctx context.Context) error {
 
 	cmd := exec.CommandContext(ctx, binPath, args...)
 	cmd.Dir = filepath.Dir(p.File)
+	cmd.Env = os.Environ()
+	if oscapProbeRoot != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("OSCAP_PROBE_ROOT=%s", oscapProbeRoot))
+	}
 	p.cmd = cmd
 
 	stdin, err := cmd.StdinPipe()


### PR DESCRIPTION
### What does this PR do?

Instead of setting the env variable on the current process, and taking advantage of the env vars inheritance, let's just put the env variable directly on the oscap process. This also ensures that we are not changing a global state in the process.

### Motivation

### Describe how you validated your changes

### Additional Notes
