### PR TITLE
[EBPF-927] gpu: fix names for field metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/fields.go
@@ -89,7 +89,7 @@ func (c *fieldsCollector) Collect() ([]Metric, error) {
 
 	metrics := make([]Metric, 0, len(c.fieldMetrics))
 	for i, val := range fields {
-		name := metricNameToFieldID[i].name
+		name := c.fieldMetrics[i].name
 		if val.NvmlReturn != uint32(nvml.SUCCESS) {
 			err = multierror.Append(err, fmt.Errorf("failed to get field value %s: %s", name, nvml.ErrorString(nvml.Return(val.NvmlReturn))))
 			continue
@@ -103,7 +103,7 @@ func (c *fieldsCollector) Collect() ([]Metric, error) {
 		metrics = append(metrics, Metric{
 			Name:  name,
 			Value: value,
-			Type:  metricNameToFieldID[i].metricType},
+			Type:  c.fieldMetrics[i].metricType},
 		)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fixes the names for the field metrics collector.

### Motivation

Detected initially with https://datadoghq.atlassian.net/browse/EBPF-927.

### Describe how you validated your changes

Checked that the fields are correct when running manually.

### Additional Notes
