### PR TITLE
[CWS] fix event replay

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -124,10 +124,10 @@ func (bfh *BaseFieldHandlers) ResolveHostname(_ *model.Event, _ *model.BaseEvent
 // ResolveSource resolves the source of the event
 func (bfh *BaseFieldHandlers) ResolveSource(ev *model.Event, _ *model.BaseEvent) string {
 	if ev.Source == "" {
-		if ev.IsSnapshotEvent() {
-			ev.Source = "snapshot"
+		if ev.IsEventFromReplay() {
+			ev.Source = model.EventSourceReplay
 		} else {
-			ev.Source = "runtime"
+			ev.Source = model.EventSourceRuntime
 		}
 	}
 	return ev.Source

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -65,8 +65,8 @@ const (
 	// EventFlagsHasActiveActivityDump true if the event has an active activity dump associated to it
 	EventFlagsHasActiveActivityDump
 
-	// EventFlagsIsSnapshot is true if the event is generated from a snapshot
-	EventFlagsIsSnapshot
+	// EventFlagsFromReplay is true if the event is generated from a replay
+	EventFlagsFromReplay
 )
 
 const (
@@ -84,6 +84,16 @@ const (
 	IMDSIBMCloudProvider = "ibm"
 	// IMDSOracleCloudProvider is used to report that the IMDS event is for Oracle
 	IMDSOracleCloudProvider = "oracle"
+)
+
+// EventSource is the source of the event
+type EventSource = string
+
+const (
+	// EventSourceRuntime is used to report that the event is generated from a runtime
+	EventSourceRuntime EventSource = "runtime"
+	// EventSourceReplay is used to report that the event is generated from a replay
+	EventSourceReplay EventSource = "replay"
 )
 
 var (

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -272,9 +272,9 @@ func (e *Event) IsAnomalyDetectionEvent() bool {
 	return e.Flags&EventFlagsAnomalyDetectionEvent > 0
 }
 
-// IsSnapshotEvent returns true if the event is generated from a snapshot replay
-func (e *Event) IsSnapshotEvent() bool {
-	return e.Flags&EventFlagsIsSnapshot > 0
+// IsEventFromReplay returns true if the event is generated from a replay
+func (e *Event) IsEventFromReplay() bool {
+	return e.Flags&EventFlagsFromReplay > 0
 }
 
 // AddToFlags adds a flag to the event

--- a/pkg/security/seclwin/model/consts_common.go
+++ b/pkg/security/seclwin/model/consts_common.go
@@ -65,8 +65,8 @@ const (
 	// EventFlagsHasActiveActivityDump true if the event has an active activity dump associated to it
 	EventFlagsHasActiveActivityDump
 
-	// EventFlagsIsSnapshot is true if the event is generated from a snapshot
-	EventFlagsIsSnapshot
+	// EventFlagsFromReplay is true if the event is generated from a replay
+	EventFlagsFromReplay
 )
 
 const (
@@ -84,6 +84,16 @@ const (
 	IMDSIBMCloudProvider = "ibm"
 	// IMDSOracleCloudProvider is used to report that the IMDS event is for Oracle
 	IMDSOracleCloudProvider = "oracle"
+)
+
+// EventSource is the source of the event
+type EventSource = string
+
+const (
+	// EventSourceRuntime is used to report that the event is generated from a runtime
+	EventSourceRuntime EventSource = "runtime"
+	// EventSourceReplay is used to report that the event is generated from a replay
+	EventSourceReplay EventSource = "replay"
 )
 
 var (

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -272,9 +272,9 @@ func (e *Event) IsAnomalyDetectionEvent() bool {
 	return e.Flags&EventFlagsAnomalyDetectionEvent > 0
 }
 
-// IsSnapshotEvent returns true if the event is generated from a snapshot replay
-func (e *Event) IsSnapshotEvent() bool {
-	return e.Flags&EventFlagsIsSnapshot > 0
+// IsEventFromReplay returns true if the event is generated from a replay
+func (e *Event) IsEventFromReplay() bool {
+	return e.Flags&EventFlagsFromReplay > 0
 }
 
 // AddToFlags adds a flag to the event


### PR DESCRIPTION
### What does this PR do?

Replay the rules on ruleset_loaded on all process nodes and not only on the ones coming from the snapshot. 

```
expression: exec.pid == 170191 && exec.file.path == "/usr/bin/ping" && exec.cgroup.id == "/user.slice/user-1000.slice/user@1000.service/app.slice/vte-spawn-ab86cfc9-a9d6-4efd-a966-19df1f636821.scope" && event.source == "replay"
```

### Motivation

### Describe how you validated your changes

### Additional Notes
