### PR TITLE
[EBPF-934] gpu: add changelog for Docker fixes

### DIFF
--- a/releasenotes/notes/gpu-docker-a4e6fed17f5416db.yaml
+++ b/releasenotes/notes/gpu-docker-a4e6fed17f5416db.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    gpu: fixed some bugs with possibly incorrect container/process tags for Docker workloads

--- a/releasenotes/notes/gpu-docker-a4e6fed17f5416db.yaml
+++ b/releasenotes/notes/gpu-docker-a4e6fed17f5416db.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    gpu: fixed some bugs with possibly incorrect container/process tags for Docker workloads
+    GPU: Fixed some bugs that could cause incorrect container/process tags for Docker workloads.


### PR DESCRIPTION
### What does this PR do?

Adds a changelog entry for the different fixes for Docker workloads in GPU monitoring for the 7.74 release.

Related PRs: 
* https://github.com/DataDog/datadog-agent/pull/43225
* https://github.com/DataDog/datadog-agent/pull/43217
* https://github.com/DataDog/datadog-agent/pull/43189

### Motivation

### Describe how you validated your changes

Docs only

### Additional Notes
