### PR TITLE
extract hostname component from core bundle

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -168,6 +169,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					return nil
 				}),
 				core.Bundle(),
+				hostnameimpl.Module(),
 				haagentfx.Module(),
 				logscompressorfx.Module(),
 				metricscompressorfx.Module(),

--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	processCommand "github.com/DataDog/datadog-agent/cmd/process-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
@@ -43,6 +44,7 @@ func getCoreAgentFxOptions(cliParams *check.CliParams, bundleParams core.BundleP
 	return []fx.Option{
 		fx.Supply(cliParams, bundleParams),
 		core.Bundle(),
+		hostnameimpl.Module(),
 		secretsfx.Module(),
 
 		// Provide eventplatformimpl module

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -78,6 +78,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/gui/guiimpl"
 	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobefx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
@@ -397,6 +398,7 @@ func getSharedFxOption() fx.Option {
 			defaultpaths.StreamlogsLogFile,
 		)),
 		core.Bundle(),
+		hostnameimpl.Module(),
 		flareprofiler.Module(),
 		fx.Provide(func(cfg config.Component) flaretypes.Provider {
 			provider := &hostSbom.FlareProvider{

--- a/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
+++ b/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -44,6 +45,7 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 
 	deps := fxutil.Test[testDeps](t, fx.Options(
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		fx.Supply(core.BundleParams{}),
 		demultiplexerimpl.MockModule(),
 		dogstatsd.Bundle(server.Params{Serverless: false}),

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -93,6 +94,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle(),
+				hostnameimpl.Module(),
 				secretsfx.Module(),
 				snmpscanfx.Module(),
 				orchestratorimpl.Module(orchestratorimpl.NewDefaultParams()),
@@ -157,6 +159,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:    log.ForOneShot(command.LoggerName, logLevelDefaultOff.Value(), true)}),
 				core.Bundle(),
+				hostnameimpl.Module(),
 				secretsfx.Module(),
 				orchestratorimpl.Module(orchestratorimpl.NewDefaultParams()),
 				eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),

--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -38,6 +38,7 @@ import (
 	diagnosefx "github.com/DataDog/datadog-agent/comp/core/diagnose/fx"
 	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobefx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -103,6 +104,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					LogParams:    log.ForDaemon(command.LoggerName, "log_file", defaultpaths.DCALogFile),
 				}),
 				core.Bundle(),
+				hostnameimpl.Module(),
 				secretsfx.Module(),
 				forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithResolvers())),
 				demultiplexerimpl.Module(demultiplexerimpl.NewDefaultParams()),

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -40,6 +40,7 @@ import (
 	diagnosefx "github.com/DataDog/datadog-agent/comp/core/diagnose/fx"
 	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobefx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
@@ -154,6 +155,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					LogParams:    log.ForDaemon(command.LoggerName, "log_file", defaultpaths.DCALogFile),
 				}),
 				core.Bundle(),
+				hostnameimpl.Module(),
 				secretsfx.Module(),
 				forwarder.Bundle(defaultforwarder.NewParams(defaultforwarder.WithResolvers(), defaultforwarder.WithDisableAPIKeyChecking())),
 				demultiplexerimpl.Module(demultiplexerimpl.NewDefaultParams()),

--- a/cmd/host-profiler/subcommands/run/command.go
+++ b/cmd/host-profiler/subcommands/run/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/host-profiler/globalparams"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
@@ -73,6 +74,7 @@ func runHostProfilerCommand(ctx context.Context, cliParams *cliParams) error {
 	if cliParams.GlobalParams.CoreConfPath != "" {
 		opts = append(opts,
 			core.Bundle(),
+			hostnameimpl.Module(),
 			fx.Supply(core.BundleParams{
 				ConfigParams: config.NewAgentParams(cliParams.GlobalParams.CoreConfPath),
 				LogParams:    log.ForDaemon(command.LoggerName, "log_file", setup.DefaultHostProfilerLogFile),

--- a/cmd/installer/subcommands/daemon/api.go
+++ b/cmd/installer/subcommands/daemon/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/installer/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
@@ -191,6 +192,7 @@ func experimentFxWrapper(f interface{}, params *cliParams) error {
 			LogParams:            log.ForOneShot("INSTALLER", "off", true),
 		}),
 		core.Bundle(),
+		hostnameimpl.Module(),
 		secretsfx.Module(),
 		fx.Supply(params),
 		localapiclientimpl.Module(),

--- a/cmd/installer/subcommands/daemon/run.go
+++ b/cmd/installer/subcommands/daemon/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/installer/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
@@ -51,6 +52,7 @@ func getCommonFxOption(global *command.GlobalParams) fx.Option {
 			LogParams:            log.ForDaemon("INSTALLER", "installer.log_file", pkgconfigsetup.DefaultUpdaterLogFile),
 		}),
 		core.Bundle(),
+		hostnameimpl.Module(),
 		secretsfx.Module(),
 		fx.Supply(&rcservice.Params{
 			Options: []service.Option{

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	fxinstrumentation "github.com/DataDog/datadog-agent/comp/core/fxinstrumentation/fx"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	logcomp "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -130,6 +131,7 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 
 		// Provide core components
 		core.Bundle(),
+		hostnameimpl.Module(),
 		secretsfx.Module(),
 
 		// Provide process agent bundle so fx knows where to find components

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -39,6 +40,7 @@ func getProcessAgentFxOptions(cliParams *processchecks.CliParams, bundleParams c
 	return []fx.Option{
 		fx.Supply(cliParams, bundleParams),
 		core.Bundle(),
+		hostnameimpl.Module(),
 		secretsfx.Module(),
 
 		// Provide eventplatformimpl module

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	fxinstrumentation "github.com/DataDog/datadog-agent/comp/core/fxinstrumentation/fx"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -100,6 +101,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					LogParams:            log.ForDaemon(command.LoggerName, "security_agent.log_file", pkgconfigsetup.DefaultSecurityAgentLogFile),
 				}),
 				core.Bundle(),
+				hostnameimpl.Module(),
 				statsd.Module(),
 				secretsfx.Module(),
 				// workloadmeta setup

--- a/cmd/systray/command/command.go
+++ b/cmd/systray/command/command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	diagnosefx "github.com/DataDog/datadog-agent/comp/core/diagnose/fx"
 	"github.com/DataDog/datadog-agent/comp/core/flare"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
@@ -98,6 +99,7 @@ func MakeCommand() *cobra.Command {
 					LogParams:    logParams,
 				}),
 				core.Bundle(),
+				hostnameimpl.Module(),
 				// flare
 				flare.Module(flare.NewParams(
 					defaultpaths.GetDistPath(),

--- a/comp/aggregator/bundle_test.go
+++ b/comp/aggregator/bundle_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/fx-noop"
@@ -27,6 +28,7 @@ import (
 func TestBundleDependencies(t *testing.T) {
 	fxutil.TestBundle(t, Bundle(demultiplexerimpl.Params{}),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		defaultforwarder.MockModule(),
 		orchestratorForwarderImpl.MockModule(),
 		eventplatformimpl.MockModule(),

--- a/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer_mock_test.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer_mock_test.go
@@ -12,6 +12,7 @@ import (
 
 	demultiplexerComp "github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -21,6 +22,7 @@ import (
 func TestSetDefaultSender(t *testing.T) {
 	mock := fxutil.Test[demultiplexerComp.Mock](t, MockModule(),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		defaultforwarder.MockModule())
 
 	sender := &mocksender.MockSender{}

--- a/comp/aggregator/demultiplexer/demultiplexerimpl/status_test.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/status_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	"github.com/DataDog/datadog-agent/comp/core/status"
@@ -63,6 +64,7 @@ func TestStatusOutPut(t *testing.T) {
 
 	deps := fxutil.Test[dependencies](t, fx.Options(
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
 		defaultforwarder.MockModule(),
 		haagentmock.Module(),

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logfx "github.com/DataDog/datadog-agent/comp/core/log/fx"
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
@@ -38,7 +37,6 @@ func Bundle() fxutil.BundleOptions {
 		fx.Provide(func(params BundleParams) sysprobeconfigimpl.Params { return params.SysprobeConfigParams }),
 		sysprobeconfigimpl.Module(),
 		telemetryimpl.Module(),
-		hostnameimpl.Module(),
 		pidimpl.Module(), // You must supply pidimpl.NewParams in order to use it
 	)
 }

--- a/comp/core/bundle_mock.go
+++ b/comp/core/bundle_mock.go
@@ -21,7 +21,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
@@ -40,7 +39,6 @@ func makeMockBundle(logParams, logger fx.Option) fxutil.BundleOptions {
 		fx.Provide(func(params BundleParams) sysprobeconfigimpl.Params { return params.SysprobeConfigParams }),
 		sysprobeconfigimpl.MockModule(),
 		telemetryimpl.MockModule(),
-		hostnameimpl.MockModule(),
 	)
 }
 

--- a/comp/metadata/bundle_test.go
+++ b/comp/metadata/bundle_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -25,7 +26,9 @@ import (
 )
 
 func TestBundleDependencies(t *testing.T) {
-	fxutil.TestBundle(t, Bundle(), core.MockBundle(),
+	fxutil.TestBundle(t, Bundle(),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		fx.Supply(option.None[runnerimpl.MetadataProvider]()),
 		fx.Provide(func() serializer.MetricSerializer { return nil }),
 		collectorimpl.MockModule(),

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
@@ -139,6 +139,7 @@ func TestGetPayload(t *testing.T) {
 			}),
 			collectorimpl.MockModule(),
 			core.MockBundle(),
+			hostnameimpl.MockModule(),
 			workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		)
 
@@ -161,6 +162,7 @@ func TestGetPayload(t *testing.T) {
 			t,
 			logsBundle.MockBundle(),
 			core.MockBundle(),
+			hostnameimpl.MockModule(),
 			inventoryagentimpl.MockModule(),
 			logscompression.MockModule(),
 			workloadmetafxmock.MockModule(workloadmeta.NewParams()),

--- a/comp/ndmtmp/bundle_test.go
+++ b/comp/ndmtmp/bundle_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
@@ -25,6 +26,7 @@ func TestBundleDependencies(t *testing.T) {
 		defaultforwarder.MockModule(),
 		eventplatformimpl.MockModule(),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 	)
 }
 

--- a/comp/netflow/server/server_test.go
+++ b/comp/netflow/server/server_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder/forwarderimpl"
 	rdnsquerierfxmock "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
@@ -68,6 +69,7 @@ var testOptions = fx.Options(
 	demultiplexerimpl.MockModule(),
 	defaultforwarder.MockModule(),
 	core.MockBundle(),
+	hostnameimpl.MockModule(),
 	rdnsquerierfxmock.MockModule(),
 	fx.Invoke(func(lc fx.Lifecycle, c Component) {
 		// Set the internal flush frequency to a small number so tests don't take forever

--- a/comp/networkpath/bundle_test.go
+++ b/comp/networkpath/bundle_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
 	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
@@ -21,6 +22,7 @@ import (
 func TestBundleDependencies(t *testing.T) {
 	fxutil.TestBundle(t, Bundle(),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		eventplatformimpl.MockModule(),
 		rdnsquerier.MockModule(),
 		logscompression.MockModule(),

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -52,6 +52,7 @@ func TestBundleDependencies(t *testing.T) {
 		fx.Supply(mockCoreBundleParams),
 		fx.Provide(func() types.CheckComponent { return nil }),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
 		coreStatusImpl.Module(),

--- a/comp/snmpscan/impl/snmpscan_test.go
+++ b/comp/snmpscan/impl/snmpscan_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
@@ -28,7 +29,7 @@ type deps struct {
 }
 
 func TestSnmpScanComp(t *testing.T) {
-	testDeps := fxutil.Test[deps](t, eventplatformimpl.MockModule(), logscomp.MockModule(), core.MockBundle())
+	testDeps := fxutil.Test[deps](t, eventplatformimpl.MockModule(), logscomp.MockModule(), core.MockBundle(), hostnameimpl.MockModule())
 	deps := Requires{
 		Logger:        logmock.New(t),
 		EventPlatform: testDeps.EventPlatform,

--- a/comp/updater/updater/updaterimpl/updater_test.go
+++ b/comp/updater/updater/updaterimpl/updater_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -31,6 +32,7 @@ func (m *mockLifecycle) Append(_ fx.Hook) {}
 func TestUpdaterWithoutRemoteConfig(t *testing.T) {
 	deps := fxutil.Test[testDependencies](t, fx.Options(
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		fx.Supply(core.BundleParams{}),
 		fx.Supply(option.None[rcservice.Component]()),
 		Module(),

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -827,6 +828,7 @@ func createAggrDeps(t *testing.T) aggregatorDeps {
 		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
 		defaultforwarder.MockModule(),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		logscompressionmock.MockModule(),
 		metricscompressionmock.MockModule(),
 		haagentmock.Module())

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
@@ -48,7 +49,7 @@ func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 	// For some reasons using InitAggregator[WithInterval] doesn't fix the problem,
 	// but this do.
 	mockConfig := configmock.New(b)
-	deps := fxutil.Test[benchmarkDeps](b, core.MockBundle())
+	deps := fxutil.Test[benchmarkDeps](b, core.MockBundle(), hostnameimpl.MockModule())
 	taggerComponent := taggerfxmock.SetupFakeTagger(b)
 	resolver, _ := resolver.NewSingleDomainResolvers(map[string][]utils.APIKeys{"hello": {utils.NewAPIKeys("", "world")}})
 	forwarderOpts := forwarder.NewOptionsWithResolvers(mockConfig, deps.Log, resolver)

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -121,6 +122,7 @@ func TestDemuxNoAggOptionIsDisabledByDefault(t *testing.T) {
 		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
 		defaultforwarder.MockModule(),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		haagentmock.Module(),
 		logscompression.MockModule(),
 		metricscompression.MockModule())
@@ -179,6 +181,7 @@ func createDemultiplexerAgentTestDeps(t *testing.T) DemultiplexerAgentTestDeps {
 		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
 		defaultforwarder.MockModule(),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		orchestratorimpl.MockModule(),
 		eventplatformimpl.MockModule(),
 		logscompression.MockModule(),

--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -287,6 +288,7 @@ func createDemuxDepsWithOrchestratorFwd(
 		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
 		defaultforwarder.MockModule(),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		orchestratorForwarderImpl.Module(orchestratorParams),
 		eventplatformimpl.Module(eventPlatformParams),
 		eventplatformreceiverimpl.Module(),

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
@@ -86,7 +87,7 @@ type SenderTestDeps struct {
 func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 	// this test not using anything global
 	// -
-	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle())
+	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle(), hostnameimpl.MockModule())
 	demux := testDemux(deps.Log, deps.Hostname)
 	aggregatorInstance := demux.Aggregator()
 	go aggregatorInstance.run()
@@ -106,7 +107,7 @@ func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 	// this test not using anything global
 	// -
-	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle())
+	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle(), hostnameimpl.MockModule())
 	demux := testDemux(deps.Log, deps.Hostname)
 
 	aggregatorInstance := demux.Aggregator()
@@ -136,7 +137,7 @@ func TestGetSenderWithSameIDsReturnsSameSender(t *testing.T) {
 	// this test not using anything global
 	// -
 
-	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle())
+	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle(), hostnameimpl.MockModule())
 	demux := testDemux(deps.Log, deps.Hostname)
 	aggregatorInstance := demux.Aggregator()
 	go aggregatorInstance.run()
@@ -159,7 +160,7 @@ func TestDestroySender(t *testing.T) {
 	// this test not using anything global
 	// -
 
-	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle())
+	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle(), hostnameimpl.MockModule())
 	demux := testDemux(deps.Log, deps.Hostname)
 	aggregatorInstance := demux.Aggregator()
 	go aggregatorInstance.run()
@@ -189,7 +190,7 @@ func TestGetAndSetSender(t *testing.T) {
 	// this test not using anything global
 	// -
 
-	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle())
+	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle(), hostnameimpl.MockModule())
 	demux := testDemux(deps.Log, deps.Hostname)
 
 	itemChan := make(chan senderItem, 10)
@@ -212,7 +213,7 @@ func TestGetSenderDefaultHostname(t *testing.T) {
 	// this test not using anything global
 	// -
 
-	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle())
+	deps := fxutil.Test[SenderTestDeps](t, core.MockBundle(), hostnameimpl.MockModule())
 	demux := testDemux(deps.Log, deps.Hostname)
 	aggregatorInstance := demux.Aggregator()
 	go aggregatorInstance.run()

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -38,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -164,6 +165,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 					LogParams:            log.ForOneShot(globalParams.LoggerName, "off", true),
 				}),
 				core.Bundle(),
+				hostnameimpl.Module(),
 				secretsfx.Module(),
 
 				// workloadmeta setup

--- a/pkg/cli/subcommands/processchecks/command_test.go
+++ b/pkg/cli/subcommands/processchecks/command_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
@@ -54,6 +55,7 @@ func TestCommand(t *testing.T) {
 	fxutil.Test[ipc.Component](t,
 		ipcfx.ModuleReadWrite(),
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 	)
 
 	// closely mirrors what the agents would use, but with mock modules where possible
@@ -61,6 +63,7 @@ func TestCommand(t *testing.T) {
 		return []fx.Option{
 			fx.Supply(cliParams, bundleParams),
 			core.Bundle(),
+			hostnameimpl.Module(),
 			secretsfx.Module(),
 
 			workloadmetafxmock.MockModule(workloadmeta.NewParams()),

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
@@ -38,7 +39,7 @@ type deps struct {
 }
 
 func createDeps(t *testing.T) deps {
-	return fxutil.Test[deps](t, demultiplexerimpl.MockModule(), defaultforwarder.MockModule(), core.MockBundle())
+	return fxutil.Test[deps](t, demultiplexerimpl.MockModule(), defaultforwarder.MockModule(), core.MockBundle(), hostnameimpl.MockModule())
 }
 
 // mockTimeNow mocks time.Now

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
 	snmpscanmanagermock "github.com/DataDog/datadog-agent/comp/snmpscanmanager/mock"
@@ -52,7 +53,7 @@ type deps struct {
 }
 
 func createDeps(t *testing.T) deps {
-	return fxutil.Test[deps](t, demultiplexerimpl.MockModule(), defaultforwarder.MockModule(), core.MockBundle())
+	return fxutil.Test[deps](t, demultiplexerimpl.MockModule(), defaultforwarder.MockModule(), core.MockBundle(), hostnameimpl.MockModule())
 }
 
 func Test_Run_simpleCase(t *testing.T) {

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -66,6 +67,7 @@ func processCheckWithMocks(t *testing.T) (*ProcessCheck, *mocks.Probe, workloadm
 
 	mockWLM := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 	))
 
@@ -99,6 +101,7 @@ func mockContainerProvider(t *testing.T) proccontainers.ContainerProvider {
 	// Workload meta + tagger
 	metadataProvider := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
+		hostnameimpl.MockModule(),
 		fx.Supply(context.Background()),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 	))
@@ -518,7 +521,7 @@ func TestProcessWithNoCommandline(t *testing.T) {
 	useWindowsServiceName := true
 	useImprovedAlgorithm := false
 	serviceExtractor := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
-	taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), taggerfxmock.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), hostnameimpl.MockModule(), taggerfxmock.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	procs := fmtProcesses(procutil.NewDefaultDataScrubber(), disallowList, procMap, procMap, nil, syst2, syst1, lastRun, nil, false, serviceExtractor, nil, taggerMock, now)
 	assert.Len(t, procs, 1)
 
@@ -684,7 +687,7 @@ func TestProcessTaggerIntegration(t *testing.T) {
 	}
 
 	// Create tagger mock and configure it to return specific tags for our test processes
-	taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), taggerfxmock.MockModule(),
+	taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), hostnameimpl.MockModule(), taggerfxmock.MockModule(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 
 	// Set up expected tags for process 1234

--- a/pkg/process/runner/runner_test.go
+++ b/pkg/process/runner/runner_test.go
@@ -17,6 +17,7 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
@@ -35,10 +36,10 @@ func TestUpdateRTStatus(t *testing.T) {
 
 	// Mock IPC component to provide TLS credentials
 	ipcMock := ipcmock.New(t)
-	taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), taggerfxmock.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), hostnameimpl.MockModule(), taggerfxmock.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 
 	assert := assert.New(t)
-	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), hostnameimpl.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	c, err := NewRunner(cfg, nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck(cfg, cfg, wmeta, nil, &statsd.NoOpClient{}, ipcMock.GetTLSServerConfig(), taggerMock)}, nil)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
@@ -77,8 +78,8 @@ func TestUpdateRTInterval(t *testing.T) {
 	assert := assert.New(t)
 	// Mock IPC component to provide TLS credentials
 	ipcMock := ipcmock.New(t)
-	taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), taggerfxmock.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
-	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), hostnameimpl.MockModule(), taggerfxmock.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), hostnameimpl.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	c, err := NewRunner(configmock.New(t), nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck(cfg, cfg, wmeta, nil, &statsd.NoOpClient{}, ipcMock.GetTLSServerConfig(), taggerMock)}, nil)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
@@ -138,7 +139,7 @@ func TestDisableRealTimeProcessCheck(t *testing.T) {
 			disableRealtime: false,
 		},
 	}
-	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), hostnameimpl.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig := configmock.New(t)
@@ -148,7 +149,7 @@ func TestDisableRealTimeProcessCheck(t *testing.T) {
 			ipcMock := ipcmock.New(t)
 
 			assert := assert.New(t)
-			taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), taggerfxmock.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+			taggerMock := fxutil.Test[taggermock.Mock](t, core.MockBundle(), hostnameimpl.MockModule(), taggerfxmock.MockModule(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 			expectedChecks := []checks.Check{checks.NewProcessCheck(mockConfig, mockConfig, wmeta, nil, &statsd.NoOpClient{}, ipcMock.GetTLSServerConfig(), taggerMock)}
 
 			c, err := NewRunner(mockConfig, nil, &checks.HostInfo{}, expectedChecks, nil)


### PR DESCRIPTION
### What does this PR do?

The core bundle provides the most important fx modules, modules that are obvious and used by most sub-agents like the config, the logger, some telemetry etc.

The hostname component is not obvious on the other hand because there is actually 2 implementations: the local one and the remote one, and the local one should really only be used in the core agent because it's the only sub-agent that as all the build tags (related to cloud providers and container runtimes) necessary to resolve the correct hostname, other agents should really use the remote component, especially since it guarantees that you have the same one as the core agent.

This PR extracts the hostname component from the core bundle, replaces all needing call sites with an explicit call to the local module, to preserve the exact same behavior as today.

No functional change intended.

### Motivation

Being able to use "core.Bundle + remote hostname component" in the security agent.

### Describe how you validated your changes

All fx calls have tests (this is enforced by a linter rule) ensuring the fx tree is providing all components, so CI should be enough for this.

### Additional Notes
