### PR TITLE
Don't fail builds when non-critical actions fail

### DIFF
--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -343,9 +343,12 @@ def build(
                     ctx.run(f"{aws_cmd} s3 cp --only-show-errors {bundle_path} {git_cache_url}")
                     bundle_dir.cleanup()
             elif ctx.run(f"git -C {omnibus_cache_dir} tag -l").stdout != cache_state:
-                send_cache_mutation_event(
-                    ctx, os.environ.get('CI_PIPELINE_ID'), remote_cache_name, os.environ.get('CI_JOB_ID')
-                )
+                try:
+                    send_cache_mutation_event(
+                        ctx, os.environ.get('CI_PIPELINE_ID'), remote_cache_name, os.environ.get('CI_JOB_ID')
+                    )
+                except Exception as e:
+                    print("Failed to send cache mutation event:", e)
 
     # Output duration information for different steps
     print("Build component timing:")
@@ -354,7 +357,10 @@ def build(
         if name in durations:
             print(f"{name}: {durations[name].duration}")
 
-    send_build_metrics(ctx, durations['Omnibus'].duration)
+    try:
+        send_build_metrics(ctx, durations['Omnibus'].duration)
+    except Exception as e:
+        print("Failed to send metrics:", e)
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Wrap metric and event sending calls on omnibus build task in try-except's to avoid failing (and retrying) builds when those non-critical actions fail in any way.

### Motivation

Failures such as https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1260394723#L1801, where we have occasional failures to retrieve API keys from SSM. It doesn't happen with a huge frequency ([logs](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%22Command%3A%20%27aws.exe%20ssm%20get-parameter%20--region%20us-east-1%20--name%20ci.datadog-agent.datadog_api_key_org2%20--with-decryption%20--query%20%5C%22Parameter.Value%5C%22%20--out%20text%27%20%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1761667449131&to_ts=1764259449131&live=true)), but it still makes no sense to fail a build job when the build succeeded, even if we failed to send some sort of telemetry.

The culprit being usually this call to `get_dd_api_key` here: https://github.com/DataDog/datadog-agent/blob/01bb62da4dc0e147ab2cb6beca9910bbd9f300f7/tasks/libs/common/omnibus.py#L303

### Describe how you validated your changes

If CI passes, there should be no harm in this, and we should be able to observe its effects over the coming days.

### Additional Notes

I'm avoiding spending to much time in doing this cleanly because this is code that we expect to get rid of not too far in the future, so, on the basis of cost-effort merits, I'm deliberately:

- Not adding tests.
- Not taking care of cleaning up the flow of code (for example, there's other places where errors result in something being printed and just continuing).
- Not looking into better, more up-to-date ways to send this telemetry (assuming they exist).
