### PR TITLE
[NDMII-3713] Fix profile name key used when accessing the ProfileConfigMap when matching sysObjectIDs

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
@@ -308,6 +308,26 @@ func Test_getProfileForSysObjectID(t *testing.T) {
 			IsUserProfile: true,
 		},
 	}.withNames()
+	mockProfilesWithDifferentNameKeyAndNameDefinition := ProfileConfigMap{
+		"PROFILE1": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Name: "profile1",
+				Metrics: []profiledefinition.MetricsConfig{
+					{Symbol: profiledefinition.SymbolConfig{OID: "1.2.3.4.5", Name: "someMetric"}},
+				},
+				SysObjectIDs: profiledefinition.StringArray{"1.3.6.1.4.1.3375.2.1.3"},
+			},
+			IsUserProfile: true,
+		},
+		"profile2": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Metrics: []profiledefinition.MetricsConfig{
+					{Symbol: profiledefinition.SymbolConfig{OID: "1.2.3.4.5", Name: "someMetric"}},
+				},
+				SysObjectIDs: profiledefinition.StringArray{"1.3.6.1.4.1.3375.2.1.3"},
+			},
+		},
+	}.withNames()
 	tests := []struct {
 		name                string
 		profiles            ProfileConfigMap
@@ -391,6 +411,13 @@ func Test_getProfileForSysObjectID(t *testing.T) {
 			sysObjectID:         "1.3.6.1.4.1.3375.2.1.3",
 			expectedProfileName: "",
 			expectedError:       "has the same sysObjectID (1.3.6.1.4.1.3375.2.1.3) as",
+		},
+		{
+			name:                "different name key and name definition",
+			profiles:            mockProfilesWithDifferentNameKeyAndNameDefinition,
+			sysObjectID:         "1.3.6.1.4.1.3375.2.1.3",
+			expectedProfileName: "profile1",
+			expectedError:       "",
 		},
 	}
 	for _, tt := range tests {

--- a/releasenotes/notes/fix-profile-name-key-e0a7fecc991472d6.yaml
+++ b/releasenotes/notes/fix-profile-name-key-e0a7fecc991472d6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug in SNMP integration where a custom profile sysObjectIDs could conflict with default profiles ones when defining the name field in the custom profile.

--- a/releasenotes/notes/fix-profile-name-key-e0a7fecc991472d6.yaml
+++ b/releasenotes/notes/fix-profile-name-key-e0a7fecc991472d6.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix a bug in SNMP integration where a custom profile sysObjectIDs could conflict with default profiles ones when defining the name field in the custom profile.
+    Fixed a bug in the SNMP integration, where a custom profile's `sysObjectIDs` could conflict with default profiles' when defining the `name` field in the custom profile.


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/AGENT-15013

The support ticket above has a custom running into the error `profile "opengear-console-manager" has the same sysObjectID (1.3.6.1.4.1.25049.1.*) as "opengear-lighthouse"`, while `opengear-console-manager` is a default profiles and `opengear-lighthouse` is their custom profiles. This happens because when we create the `ProfileConfigMap`, we use the filename as a key ([see here](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go#L87)), but when we access it, we use the profile name definition ([see here](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/snmp/internal/profile/profile.go#L74)) which can be overwritten when using the `name` field in the profile yaml.

### Motivation

### Describe how you validated your changes

### Additional Notes
