### PR TITLE
[CWS] CLI: share event base process with process event types

### DIFF
--- a/pkg/security/generators/accessors/accessors.tmpl
+++ b/pkg/security/generators/accessors/accessors.tmpl
@@ -313,7 +313,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		mappedField = newField
 	}
 
-	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
+	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") || strings.HasPrefix(mappedField, "exit.") {
 		ev.initProcess()
 	}
 

--- a/pkg/security/secl/model/accessors_helpers.go
+++ b/pkg/security/secl/model/accessors_helpers.go
@@ -41,9 +41,7 @@ func (ev *Event) initProcess() {
 		ev.BaseEvent.ProcessContext.Parent = &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process
 	}
 
-	if ev.Exec.Process == nil {
-		ev.Exec.Process = &Process{}
-	}
+	ev.initProcessEventTypes()
 }
 
 // nolint: unused

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -42004,7 +42004,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	if newField, found := GetDefaultLegacyFields(field); found {
 		mappedField = newField
 	}
-	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
+	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") || strings.HasPrefix(mappedField, "exit.") {
 		ev.initProcess()
 	}
 	switch mappedField {

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -2821,7 +2821,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	if newField, found := GetDefaultLegacyFields(field); found {
 		mappedField = newField
 	}
-	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
+	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") || strings.HasPrefix(mappedField, "exit.") {
 		ev.initProcess()
 	}
 	switch mappedField {

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -242,9 +242,15 @@ func initMember(member reflect.Value, deja map[string]bool) {
 	}
 }
 
+func (e *Event) initProcessEventTypes() {
+	e.Exec.Process = &e.BaseEvent.ProcessContext.Process
+	e.Exit.Process = &e.BaseEvent.ProcessContext.Process
+}
+
 // Init initialize the event
 func (e *Event) Init() {
 	initMember(reflect.ValueOf(e).Elem(), map[string]bool{})
+	e.initProcessEventTypes()
 }
 
 // IsSavedByActivityDumps return whether saved by AD

--- a/pkg/security/seclwin/model/accessors_helpers.go
+++ b/pkg/security/seclwin/model/accessors_helpers.go
@@ -41,9 +41,7 @@ func (ev *Event) initProcess() {
 		ev.BaseEvent.ProcessContext.Parent = &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process
 	}
 
-	if ev.Exec.Process == nil {
-		ev.Exec.Process = &Process{}
-	}
+	ev.initProcessEventTypes()
 }
 
 // nolint: unused

--- a/pkg/security/seclwin/model/accessors_win.go
+++ b/pkg/security/seclwin/model/accessors_win.go
@@ -2819,7 +2819,7 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	if newField, found := GetDefaultLegacyFields(field); found {
 		mappedField = newField
 	}
-	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") {
+	if strings.HasPrefix(mappedField, "process.") || strings.HasPrefix(mappedField, "exec.") || strings.HasPrefix(mappedField, "exit.") {
 		ev.initProcess()
 	}
 	switch mappedField {

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -242,9 +242,15 @@ func initMember(member reflect.Value, deja map[string]bool) {
 	}
 }
 
+func (e *Event) initProcessEventTypes() {
+	e.Exec.Process = &e.BaseEvent.ProcessContext.Process
+	e.Exit.Process = &e.BaseEvent.ProcessContext.Process
+}
+
 // Init initialize the event
 func (e *Event) Init() {
 	initMember(reflect.ValueOf(e).Elem(), map[string]bool{})
+	e.initProcessEventTypes()
 }
 
 // IsSavedByActivityDumps return whether saved by AD


### PR DESCRIPTION
### What does this PR do?

Share the base event process with process event types (exec and exit) when evaluating a rule from the CLI

### Motivation

Otherwise setting the `exec.file.name` field to `"foo"` and evaluating a rule with condition `exec.file.name == ""` would result in a positive match because of this line
https://github.com/DataDog/datadog-agent/blob/13e01c06b0c9424a173308ab9ac037190094f238/pkg/security/secl/model/oo_symlink_unix.go#L48

### Describe how you validated your changes

### Additional Notes
