### PR TITLE
[CWS] New mount release mechanism

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -32,8 +32,6 @@ int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_
     syscall->exec.file.path_key.mount_id = mount_id;
     set_file_inode(syscall->exec.dentry, &syscall->exec.file, 0);
 
-    inc_mount_ref(mount_id);
-
     // resolve dentry
     syscall->resolver.key = syscall->exec.file.path_key;
     syscall->resolver.dentry = syscall->exec.dentry;

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -333,9 +333,7 @@ int __attribute__((always_inline)) handle_do_exit(ctx_t *ctx) {
         // send the entry to maintain userspace cache
         struct exit_event_t event = {};
         struct proc_cache_t *pc = fill_process_context(&event.process);
-        if (pc) {
-            dec_mount_ref(ctx, pc->entry.executable.path_key.mount_id);
-        }
+
         fill_cgroup_context(pc, &event.cgroup);
         fill_span_context(&event.span);
         event.exit_code = (u32)(u64)CTX_PARM1(ctx);
@@ -772,7 +770,6 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
 
             // inherit the parent cgroup context
             fill_cgroup_context(parent_pc, &pc.cgroup);
-            dec_mount_ref(ctx, parent_pc->entry.executable.path_key.mount_id);
         }
     }
 

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -219,9 +219,6 @@ int __attribute__((always_inline)) _sys_open_ret(void *ctx, struct syscall_cache
         return 0;
     }
 
-    // increase mount ref
-    inc_mount_ref(syscall->open.file.path_key.mount_id);
-
     // check if the syscall was discarded
     if (syscall->state == DISCARDED) {
         return 0;
@@ -329,17 +326,6 @@ int rethook_io_openat2(ctx_t *ctx) {
     }
     syscall->retval = CTX_PARMRET(ctx);
     return _sys_open_ret(ctx, syscall);
-}
-
-HOOK_ENTRY("filp_close")
-int hook_filp_close(ctx_t *ctx) {
-    struct file *file = (struct file *)CTX_PARM1(ctx);
-    u32 mount_id = get_file_mount_id(file);
-    if (mount_id) {
-        dec_mount_ref(ctx, mount_id);
-    }
-
-    return 0;
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/umount.h
+++ b/pkg/security/ebpf/c/include/hooks/umount.h
@@ -42,8 +42,6 @@ int __attribute__((always_inline)) sys_umount_ret(void *ctx, int retval) {
 
     send_event(ctx, EVENT_UMOUNT, event);
 
-    umounted(ctx, mount_id);
-
     return 0;
 }
 
@@ -54,6 +52,22 @@ HOOK_SYSCALL_EXIT(umount) {
 
 TAIL_CALL_TRACEPOINT_FNC(handle_sys_umount_exit, struct tracepoint_raw_syscalls_sys_exit_t *args) {
     return sys_umount_ret(args, args->ret);
+}
+
+HOOK_ENTRY("cleanup_mnt")
+int hook_cleanup_mnt(ctx_t *ctx) {
+    struct mount *mnt = (struct mount *)CTX_PARM1(ctx);
+
+    struct mount_released_event_t event = {};
+    event.mount_id = get_mount_mount_id(mnt);
+    event.mount_id_unique = get_mount_mount_id_unique(mnt);
+
+    bump_mount_discarder_revision(event.mount_id);
+    bump_path_id(event.mount_id);
+
+    send_event(ctx, EVENT_MOUNT_RELEASED, event);
+
+    return 0;
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -65,7 +65,6 @@ BPF_LRU_MAP(cgroup_wait_list, u64, u64, 1) // max entries will be overridden at 
 BPF_LRU_MAP(traced_cgroups_discarded, u64, u8, 512)
 BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(pid_rate_limiters, u32, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
-BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)
 BPF_LRU_MAP(bpf_maps, u32, struct bpf_map_t, 4096)
 BPF_LRU_MAP(bpf_progs, u32, struct bpf_prog_t, 4096)
 BPF_LRU_MAP(tgid_fd_map_id, struct bpf_tgid_fd_t, u32, 4096)

--- a/pkg/security/ebpf/c/include/structs/filesystem.h
+++ b/pkg/security/ebpf/c/include/structs/filesystem.h
@@ -7,11 +7,8 @@
 struct mount_released_event_t {
     struct kevent_t event;
     u32 mount_id;
-};
-
-struct mount_ref_t {
-    u32 umounted;
-    s32 counter;
+    u32 __pad;
+    u64 mount_id_unique;
 };
 
 struct mount_fields_t {

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -232,9 +232,6 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 				hookFunc("hook_io_openat2"),
 				hookFunc("rethook_io_openat2"),
 			}},
-			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_filp_close"),
-			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_terminate_walk"),
 			}},
@@ -257,6 +254,7 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 				hookFunc("hook_clone_mnt"),
 				hookFunc("rethook_clone_mnt"),
 				hookFunc("hook_mnt_change_mountpoint"),
+				hookFunc("hook_cleanup_mnt"),
 			}},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("rethook_alloc_vfsmnt"),

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -57,6 +57,12 @@ func getMountProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_cleanup_mnt",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_mnt_change_mountpoint",
 			},
 		},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -69,12 +69,6 @@ func getOpenProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "hook_filp_close",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_terminate_walk",
 			},
 		},

--- a/pkg/security/resolvers/dentry/resolver.go
+++ b/pkg/security/resolvers/dentry/resolver.go
@@ -174,8 +174,8 @@ func (dr *Resolver) sendERPCStats() error {
 	return dr.bufferSelector.Put(ebpf.BufferSelectorERPCMonitorKey, dr.activeERPCStatsBuffer)
 }
 
-// DelCacheEntries removes all the entries belonging to a mountID
-func (dr *Resolver) DelCacheEntries(mountID uint32) {
+// DelCacheEntriesForMountID removes all the entries belonging to a mountID
+func (dr *Resolver) DelCacheEntriesForMountID(mountID uint32) {
 	dr.cache.RemoveKey1(mountID)
 }
 

--- a/pkg/security/resolvers/mount/interface.go
+++ b/pkg/security/resolvers/mount/interface.go
@@ -16,13 +16,13 @@ import (
 type ResolverInterface interface {
 	IsMountIDValid(mountID uint32) (bool, error)
 	SyncCache() error
-	Delete(mountID uint32) error
+	Delete(mountID uint32, mountIDUnique uint64) error
 	ResolveFilesystem(mountID uint32, pid uint32) (string, error)
 	Insert(m model.Mount) error
 	InsertMoved(m model.Mount) error
 	ResolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
 	ResolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
-	ResolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error)
+	ResolveMount(mountID uint32, pid uint32, useRedemptionAndSync bool) (*model.Mount, model.MountSource, model.MountOrigin, error)
 	SendStats() error
 	ToJSON() ([]byte, error)
 }

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -203,7 +203,6 @@ func collectUniqueMountNSFDs(procfs string) ([]int, error) {
 		}
 
 		ino, err := getInodeNumFromLink(linkTarget)
-
 		if err != nil {
 			continue
 		}

--- a/pkg/security/resolvers/mount/no_op_resolver.go
+++ b/pkg/security/resolvers/mount/no_op_resolver.go
@@ -39,7 +39,7 @@ func (mr *NoOpResolver) SyncCacheFromListMount() error {
 }
 
 // Delete a mount from the cache
-func (mr *NoOpResolver) Delete(_ uint32) error {
+func (mr *NoOpResolver) Delete(_ uint32, _ uint64) error {
 	return nil
 }
 
@@ -64,7 +64,7 @@ func (mr *NoOpResolver) ResolveMountPath(_ uint32, _ uint32) (string, model.Moun
 }
 
 // ResolveMount returns the mount
-func (mr *NoOpResolver) ResolveMount(_ uint32, _ uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMount(_ uint32, _ uint32, _ bool) (*model.Mount, model.MountSource, model.MountOrigin, error) {
 	return nil, model.MountSourceUnknown, model.MountOriginUnknown, errors.New("not available")
 }
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -34,7 +34,7 @@ import (
 const (
 	numAllowedMountIDsToResolvePerPeriod = 5
 	fallbackLimiterPeriod                = time.Second
-	redemptionTime                       = 2 * time.Second
+	redemptionTime                       = 20 * time.Second
 	// should be enough to handle most of in-queue mounts waiting to be deleted
 	openQueuePreAllocSize = 32
 	// mounts LRU limit: 100000 mounts

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -34,7 +34,7 @@ import (
 const (
 	numAllowedMountIDsToResolvePerPeriod = 5
 	fallbackLimiterPeriod                = time.Second
-	redemptionTime                       = 20 * time.Second
+	redemptionTime                       = 2 * time.Second
 	// should be enough to handle most of in-queue mounts waiting to be deleted
 	openQueuePreAllocSize = 32
 	// mounts LRU limit: 100000 mounts

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -419,7 +419,7 @@ func TestMountResolver(t *testing.T) {
 					mr.insert(&evt.mount.Mount, false)
 				}
 				if evt.umount != nil {
-					mount, _, _, err := mr.ResolveMount(evt.umount.MountID, pid)
+					mount, _, _, err := mr.ResolveMount(evt.umount.MountID, pid, true)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -53,7 +53,7 @@ func (r *Resolver) ResolveMountAttributes(e *model.FileEvent, pidCtx *model.PIDC
 		return nil
 	}
 
-	mnt, _, _, err := r.mountResolver.ResolveMount(e.MountID, pidCtx.Pid)
+	mnt, _, _, err := r.mountResolver.ResolveMount(e.MountID, pidCtx.Pid, true)
 	if err != nil {
 		return fmt.Errorf("attribute resolution error: %w", err)
 	}

--- a/pkg/security/secl/model/consts_map_names_linux.go
+++ b/pkg/security/secl/model/consts_map_names_linux.go
@@ -66,7 +66,6 @@ var bpfMapNames = []string{
 	"memfd_tracking",
 	"mmap_flags_appr",
 	"mmap_protection",
-	"mount_ref",
 	"mprotect_req_pr",
 	"mprotect_vm_pro",
 	"netdevice_looku",

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -853,6 +853,7 @@ func deepCopyMount(fieldToCopy Mount) Mount {
 func deepCopyMountReleasedEvent(fieldToCopy MountReleasedEvent) MountReleasedEvent {
 	copied := MountReleasedEvent{}
 	copied.MountID = fieldToCopy.MountID
+	copied.MountIDUnique = fieldToCopy.MountIDUnique
 	return copied
 }
 func deepCopyNetDeviceEvent(fieldToCopy NetDeviceEvent) NetDeviceEvent {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -517,7 +517,8 @@ type InvalidateDentryEvent struct {
 
 // MountReleasedEvent defines a mount released event
 type MountReleasedEvent struct {
-	MountID uint32
+	MountID       uint32
+	MountIDUnique uint64
 }
 
 // LinkEvent represents a link event

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -719,13 +719,14 @@ func UnmarshalBinary(data []byte, binaryUnmarshalers ...BinaryUnmarshaler) (int,
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *MountReleasedEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 4 {
+	if len(data) < 16 {
 		return 0, ErrNotEnoughData
 	}
 
 	e.MountID = binary.NativeEndian.Uint32(data[0:4])
+	e.MountIDUnique = binary.NativeEndian.Uint64(data[8:16])
 
-	return 8, nil
+	return 16, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -363,7 +363,7 @@ func testMountSnapshot(t *testing.T) {
 	checkSnapshotAndModelMatch := func(mntInfo *mountinfo.Info) {
 		dev := utils.Mkdev(uint32(mntInfo.Major), uint32(mntInfo.Minor))
 
-		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid)
+		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid, true)
 		if err != nil {
 			t.Error(err)
 			return

--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -92,7 +92,7 @@ func TestMoveMount(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
+			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0, true)
 			assert.Equal(t, err, nil)
 			assert.Equal(t, submountDir, mountPtr.Path, "Wrong mountpoint path")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
@@ -253,13 +253,13 @@ func TestMoveMountRecursiveNoPropagation(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
+			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0, true)
 			assert.Equal(t, err, nil, "Error resolving mount")
 			assert.Equal(t, len(mount.Children), 2, "Wrong number of child mounts")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
 
 			for _, childMountID := range mount.Children {
-				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(childMountID, 0)
+				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(childMountID, 0, true)
 				assert.Equal(t, err, nil, "Error resolving child mount")
 				assert.True(t, strings.HasPrefix(child.Path, te.submountDirDst), "Path wasn't updated")
 			}

--- a/pkg/security/tests/umount_test.go
+++ b/pkg/security/tests/umount_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+import (
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TmpMountAtLegacyAPI(dir string) error {
+	return unix.Mount("", dir, "tmpfs", 0, "size=1M")
+}
+
+func TestUmount(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	test, err := newTestModule(t, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	mountDir := t.TempDir()
+	err = TmpMountAtLegacyAPI(mountDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mountID, err := getMountID(mountDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
+
+	if !ok {
+		t.Skip("not supported")
+	}
+
+	time.Sleep(1 * time.Second)
+
+	mnt, _, _, err := p.Resolvers.MountResolver.ResolveMount(mountID, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mnt == nil {
+		t.Fatal("nil mount")
+	}
+
+	assert.Equal(t, "tmpfs", mnt.FSType)
+
+	err = unix.Unmount(mountDir, syscall.MNT_DETACH)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// Resolve the mount after detaching, without using redemption or reloading. Should return nil
+	mnt, _, _, err = p.Resolvers.MountResolver.ResolveMount(mountID, 0, false)
+	if err == nil {
+		t.Fatal("No error")
+	}
+	if mnt != nil {
+		t.Fatal("mount not nil")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

* Uses the `cleanup_mnt` hook instead of a reference counter to determine when a mount is finally released
* If available, use unique mount id to double-check if we're deleting the correct mount
* Tweak: Make LRU remove from redemption if an expired entry is found


### Motivation

Makes the mechanism simpler and closer to the true state

### Describe how you validated your changes

Functional testing, deploying on a cluster