### PR TITLE
[ABLD-300] Unplug `bazel` from GitLab caches on macOS

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -35,6 +35,11 @@
   variables:
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
 
+.bazel:defs:cache:macos:
+  extends: .bazel:defs
+  variables:
+    XDG_CACHE_HOME: "$RUNNER_TEMP_PROJECT_DIR"
+
 .bazel:defs:cache:persistent:
   extends: .bazel:defs
   variables:
@@ -54,11 +59,11 @@
   tags: [ "k8s-persistent:arm64", "specific:true" ]
 
 .bazel:runner:macos-amd64:
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:macos
   tags: [ "macos:sonoma-amd64", "specific:true" ]
 
 .bazel:runner:macos-arm64:
-  extends: .bazel:defs:cache:ephemeral
+  extends: .bazel:defs:cache:macos
   tags: [ "macos:sonoma-arm64", "specific:true" ]
 
 .bazel:runner:windows-amd64:

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -22,7 +22,7 @@
     mkdir -p $GOMODCACHE
 
 .agent_dmg:
-  extends: .bazel:defs:cache:omnibus-transition
+  extends: .bazel:defs:cache:macos
   stage: package_build
   needs: ["go_mod_tidy_check"]
   rules:
@@ -46,6 +46,8 @@
     NOTARIZATION_ATTEMPTS: 3
     NOTARIZATION_WAIT_TIME: 15s
   timeout: 2h
+  cache:
+    - !reference [.cache_omnibus_ruby_deps, cache]
   before_script:
     # Since there is no virtualization on the macOS runners, we need to unmount the Agent dmg volume to avoid conflicts
     - sudo umount /Volumes/Agent || true

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -5,13 +5,14 @@ include:
 .tests_macos_gitlab:
   stage: source_test
   extends:
-    - .unit_test_base
+    - .bazel:defs:cache:macos
     - .macos_gitlab
   rules:
     - !reference [.except_disable_unit_tests]
     - !reference [.fast_on_dev_branch_only]
   needs: ["go_deps", "go_tools_deps"]
   variables:
+    FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
     TEST_OUTPUT_FILE: test_output.json
   script:
     - !reference [.retrieve_linux_go_deps]


### PR DESCRIPTION
### What does this PR do?
Introduce `.bazel:defs:cache:macos` (similar to `.bazel:defs:cache:windows`) cache configuration and migrate macOS jobs to use runner-specific cache locations instead of GitLab distributed cache.

### Motivation
macOS runners use persistent temporary directories (`$RUNNER_TEMP_PROJECT_DIR`) that survive across pipeline runs on the same runner. Using GitLab's distributed cache (`.bazel:defs:cache:ephemeral` with `$CI_PROJECT_DIR/.cache`) was suboptimal -if not wrong- because:
1. macOS runners don't benefit from distributed cache across different machines,
2. the runner's temporary directory provides better locality and persistence,
3. cache configurations suitable for ephemeral containers shouldn't apply to macOS runners.

### Additional Notes
`.agent_dmg` jobs:
- replaced `.bazel:defs:cache:omnibus-transition` with `.bazel:defs:cache:macos`,
- ... but restored `cache: - !reference [.cache_omnibus_ruby_deps, cache]` previously inherited from `.bazel:defs:cache:omnibus-transition`.

`.tests_macos_gitlab` jobs:
- replaced `.unit_test_base` (ephemeral cache) with `.bazel:defs:cache:macos`,
- ... but preserved `FLAKY_PATTERNS_CONFIG` variable previously inherited from `.unit_test_base`.