### PR TITLE
[CWS] Improve documentation for setsockopt fields

### DIFF
--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -2190,17 +2190,17 @@ A setsockopt was executed
 
 | Property | Definition |
 | -------- | ------------- |
-| [`setsockopt.filter_hash`](#setsockopt-filter_hash-doc) | Hash of the socket filter using sha256 |
-| [`setsockopt.filter_instructions`](#setsockopt-filter_instructions-doc) | Filter instructions |
-| [`setsockopt.filter_len`](#setsockopt-filter_len-doc) | Length of the filter |
-| [`setsockopt.is_filter_truncated`](#setsockopt-is_filter_truncated-doc) | Indicates that the filter is truncated |
+| [`setsockopt.filter_hash`](#setsockopt-filter_hash-doc) | Hash of the currently attached filter using sha256. Only available if the optname is `SO_ATTACH_FILTER` |
+| [`setsockopt.filter_instructions`](#setsockopt-filter_instructions-doc) | Instructions of the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER` |
+| [`setsockopt.filter_len`](#setsockopt-filter_len-doc) | Length of the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER` |
+| [`setsockopt.is_filter_truncated`](#setsockopt-is_filter_truncated-doc) | Indicates that the currently attached filter is truncated. Only available if the optname is `SO_ATTACH_FILTER` |
 | [`setsockopt.level`](#setsockopt-level-doc) | Socket level |
 | [`setsockopt.optname`](#setsockopt-optname-doc) | Socket option name |
 | [`setsockopt.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 | [`setsockopt.socket_family`](#setsockopt-socket_family-doc) | Socket family |
 | [`setsockopt.socket_protocol`](#setsockopt-socket_protocol-doc) | Socket protocol |
 | [`setsockopt.socket_type`](#setsockopt-socket_type-doc) | Socket type |
-| [`setsockopt.used_immediates`](#setsockopt-used_immediates-doc) | List of immediate values used in the filter |
+| [`setsockopt.used_immediates`](#setsockopt-used_immediates-doc) | List of immediate values used in the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER` |
 
 ### Event `setuid`
 
@@ -4596,28 +4596,28 @@ Definition: Maximum (hard) limit value
 ### `setsockopt.filter_hash` {#setsockopt-filter_hash-doc}
 Type: string
 
-Definition: Hash of the socket filter using sha256
+Definition: Hash of the currently attached filter using sha256. Only available if the optname is `SO_ATTACH_FILTER`
 
 
 
 ### `setsockopt.filter_instructions` {#setsockopt-filter_instructions-doc}
 Type: string
 
-Definition: Filter instructions
+Definition: Instructions of the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`
 
 
 
 ### `setsockopt.filter_len` {#setsockopt-filter_len-doc}
 Type: int
 
-Definition: Length of the filter
+Definition: Length of the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`
 
 
 
 ### `setsockopt.is_filter_truncated` {#setsockopt-is_filter_truncated-doc}
 Type: bool
 
-Definition: Indicates that the filter is truncated
+Definition: Indicates that the currently attached filter is truncated. Only available if the optname is `SO_ATTACH_FILTER`
 
 
 
@@ -4659,7 +4659,7 @@ Definition: Socket type
 ### `setsockopt.used_immediates` {#setsockopt-used_immediates-doc}
 Type: int
 
-Definition: List of immediate values used in the filter
+Definition: List of immediate values used in the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`
 
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -9197,22 +9197,22 @@
       "properties": [
         {
           "name": "setsockopt.filter_hash",
-          "definition": "Hash of the socket filter using sha256",
+          "definition": "Hash of the currently attached filter using sha256. Only available if the optname is `SO_ATTACH_FILTER`",
           "property_doc_link": "setsockopt-filter_hash-doc"
         },
         {
           "name": "setsockopt.filter_instructions",
-          "definition": "Filter instructions",
+          "definition": "Instructions of the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`",
           "property_doc_link": "setsockopt-filter_instructions-doc"
         },
         {
           "name": "setsockopt.filter_len",
-          "definition": "Length of the filter",
+          "definition": "Length of the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`",
           "property_doc_link": "setsockopt-filter_len-doc"
         },
         {
           "name": "setsockopt.is_filter_truncated",
-          "definition": "Indicates that the filter is truncated",
+          "definition": "Indicates that the currently attached filter is truncated. Only available if the optname is `SO_ATTACH_FILTER`",
           "property_doc_link": "setsockopt-is_filter_truncated-doc"
         },
         {
@@ -9247,7 +9247,7 @@
         },
         {
           "name": "setsockopt.used_immediates",
-          "definition": "List of immediate values used in the filter",
+          "definition": "List of immediate values used in the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`",
           "property_doc_link": "setsockopt-used_immediates-doc"
         }
       ]
@@ -16217,7 +16217,7 @@
       "name": "setsockopt.filter_hash",
       "link": "setsockopt-filter_hash-doc",
       "type": "string",
-      "definition": "Hash of the socket filter using sha256",
+      "definition": "Hash of the currently attached filter using sha256. Only available if the optname is `SO_ATTACH_FILTER`",
       "prefixes": [
         "setsockopt"
       ],
@@ -16229,7 +16229,7 @@
       "name": "setsockopt.filter_instructions",
       "link": "setsockopt-filter_instructions-doc",
       "type": "string",
-      "definition": "Filter instructions",
+      "definition": "Instructions of the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`",
       "prefixes": [
         "setsockopt"
       ],
@@ -16241,7 +16241,7 @@
       "name": "setsockopt.filter_len",
       "link": "setsockopt-filter_len-doc",
       "type": "int",
-      "definition": "Length of the filter",
+      "definition": "Length of the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`",
       "prefixes": [
         "setsockopt"
       ],
@@ -16253,7 +16253,7 @@
       "name": "setsockopt.is_filter_truncated",
       "link": "setsockopt-is_filter_truncated-doc",
       "type": "bool",
-      "definition": "Indicates that the filter is truncated",
+      "definition": "Indicates that the currently attached filter is truncated. Only available if the optname is `SO_ATTACH_FILTER`",
       "prefixes": [
         "setsockopt"
       ],
@@ -16325,7 +16325,7 @@
       "name": "setsockopt.used_immediates",
       "link": "setsockopt-used_immediates-doc",
       "type": "int",
-      "definition": "List of immediate values used in the filter",
+      "definition": "List of immediate values used in the currently attached filter. Only available if the optname is `SO_ATTACH_FILTER`",
       "prefixes": [
         "setsockopt"
       ],

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -1023,16 +1023,16 @@ type SetSockOptEvent struct {
 	SyscallEvent
 	SocketType         uint16 `field:"socket_type"`                                                         // SECLDoc[socket_type] Definition:`Socket type`
 	SocketFamily       uint16 `field:"socket_family"`                                                       // SECLDoc[socket_family] Definition:`Socket family`
-	FilterLen          uint16 `field:"filter_len"`                                                          // SECLDoc[filter_len] Definition:`Length of the filter`
+	FilterLen          uint16 `field:"filter_len"`                                                          // SECLDoc[filter_len] Definition:`Length of the currently attached filter. Only available if the optname is \`SO_ATTACH_FILTER\``
 	SocketProtocol     uint16 `field:"socket_protocol"`                                                     // SECLDoc[socket_protocol] Definition:`Socket protocol`
 	Level              uint32 `field:"level"`                                                               // SECLDoc[level] Definition:`Socket level`
 	OptName            uint32 `field:"optname"`                                                             // SECLDoc[optname] Definition:`Socket option name`
 	SizeToRead         uint32 `field:"-"`                                                                   // Internal field, not exposed to users
-	IsFilterTruncated  bool   `field:"is_filter_truncated"`                                                 // SECLDoc[is_filter_truncated] Definition:`Indicates that the filter is truncated`
+	IsFilterTruncated  bool   `field:"is_filter_truncated"`                                                 // SECLDoc[is_filter_truncated] Definition:`Indicates that the currently attached filter is truncated. Only available if the optname is \`SO_ATTACH_FILTER\``
 	RawFilter          []byte `field:"-"`                                                                   // Internal field, not exposed to users
-	FilterInstructions string `field:"filter_instructions,handler:ResolveSetSockOptFilterInstructions"`     // SECLDoc[filter_instructions] Definition:`Filter instructions`
-	FilterHash         string `field:"filter_hash,handler:ResolveSetSockOptFilterHash:"`                    // SECLDoc[filter_hash] Definition:`Hash of the socket filter using sha256`
-	UsedImmediates     []int  `field:"used_immediates,handler:ResolveSetSockOptUsedImmediates, weight:999"` // SECLDoc[used_immediates] Definition:`List of immediate values used in the filter`
+	FilterInstructions string `field:"filter_instructions,handler:ResolveSetSockOptFilterInstructions"`     // SECLDoc[filter_instructions] Definition:`Instructions of the currently attached filter. Only available if the optname is \`SO_ATTACH_FILTER\``
+	FilterHash         string `field:"filter_hash,handler:ResolveSetSockOptFilterHash:"`                    // SECLDoc[filter_hash] Definition:`Hash of the currently attached filter using sha256. Only available if the optname is \`SO_ATTACH_FILTER\``
+	UsedImmediates     []int  `field:"used_immediates,handler:ResolveSetSockOptUsedImmediates, weight:999"` // SECLDoc[used_immediates] Definition:`List of immediate values used in the currently attached filter. Only available if the optname is \`SO_ATTACH_FILTER\``
 }
 
 // CapabilitiesEvent is used to report capabilities usage


### PR DESCRIPTION
### What does this PR do?
This PR improves the definition of some fields of the setsockopt event type.

### Motivation
Some definitions lacked important information—for example, that certain fields are only present when setsockopt is invoked with specific options or in specific contexts.

### Describe how you validated your changes

### Additional Notes
