### PR TITLE
Use a split writer to write to all outputs in slog logger

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1272,7 +1272,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("log_to_console", true)
 	config.BindEnvAndSetDefault("log_format_rfc3339", false)
 	config.BindEnvAndSetDefault("log_all_goroutines_when_unhealthy", false)
-	config.BindEnvAndSetDefault("log_use_slog", false)
+	config.BindEnvAndSetDefault("log_use_slog", true)
 	config.BindEnvAndSetDefault("logging_frequency", int64(500))
 	config.BindEnvAndSetDefault("disable_file_logging", false)
 	config.BindEnvAndSetDefault("syslog_uri", "")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1272,7 +1272,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("log_to_console", true)
 	config.BindEnvAndSetDefault("log_format_rfc3339", false)
 	config.BindEnvAndSetDefault("log_all_goroutines_when_unhealthy", false)
-	config.BindEnvAndSetDefault("log_use_slog", true)
+	config.BindEnvAndSetDefault("log_use_slog", false)
 	config.BindEnvAndSetDefault("logging_frequency", int64(500))
 	config.BindEnvAndSetDefault("disable_file_logging", false)
 	config.BindEnvAndSetDefault("syslog_uri", "")

--- a/pkg/util/log/setup/internal/seelog/seelog_config.go
+++ b/pkg/util/log/setup/internal/seelog/seelog_config.go
@@ -130,7 +130,7 @@ func (c *Config) SlogLogger() (types.LoggerInterface, error) {
 		if c.format == "json" {
 			formatter = c.jsonFormatter
 		}
-		handlerList = append(handlerList, handlers.NewFormat(formatter, io.MultiWriter(writers...)))
+		handlerList = append(handlerList, handlers.NewFormat(formatter, newSplitWriter(writers...)))
 	}
 
 	// syslog handler (formatter + writer)

--- a/pkg/util/log/setup/internal/seelog/split_writer.go
+++ b/pkg/util/log/setup/internal/seelog/split_writer.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package seelog
+
+import (
+	"errors"
+	"io"
+)
+
+// splitWriter writes to multiple writers, without stopping on the first error like io.MultiWriter does
+type splitWriter struct {
+	writers []io.Writer
+}
+
+// newSplitWriter returns a writer which writes to all the writers
+func newSplitWriter(writers ...io.Writer) io.Writer {
+	if len(writers) == 1 {
+		return writers[0]
+	}
+	return &splitWriter{writers: writers}
+}
+
+// Write writes to all the writers, joining the errors if any
+//
+// It returns the minimum number of bytes written
+func (w *splitWriter) Write(p []byte) (n int, err error) {
+	var errs []error
+	minN := len(p)
+	for _, writer := range w.writers {
+		n, err := writer.Write(p)
+		if err != nil {
+			errs = append(errs, err)
+			minN = min(minN, n)
+		}
+	}
+
+	return minN, errors.Join(errs...)
+}

--- a/pkg/util/log/setup/internal/seelog/split_writer_test.go
+++ b/pkg/util/log/setup/internal/seelog/split_writer_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package seelog
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitWriter_SuccessWriter(t *testing.T) {
+	var buf1, buf2 bytes.Buffer
+
+	writer := newSplitWriter(&buf1, &buf2)
+	n, err := writer.Write([]byte("test"))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, "test", buf1.String())
+	assert.Equal(t, "test", buf2.String())
+}
+
+func TestSplitWriter_FailingWriter(t *testing.T) {
+	var buf bytes.Buffer
+	err0 := errors.New("failing writer")
+	failingWriter := newFailingWriter(0, err0)
+
+	writer := newSplitWriter(failingWriter, &buf)
+	n, err := writer.Write([]byte("test"))
+	assert.ErrorIs(t, err, err0)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, "test", buf.String())
+}
+
+func TestSplitWriter_FailingWriters(t *testing.T) {
+	err1 := errors.New("failing writer1")
+	failingWriter1 := newFailingWriter(1, err1)
+	err2 := errors.New("failing writer2")
+	failingWriter2 := newFailingWriter(2, err2)
+
+	writer := newSplitWriter(failingWriter1, failingWriter2)
+	n, err := writer.Write([]byte("test"))
+	assert.ErrorIs(t, err, err1)
+	assert.ErrorIs(t, err, err2)
+	assert.Equal(t, 1, n)
+}
+
+func TestSingleWriter(t *testing.T) {
+	var buf bytes.Buffer
+	writer := newSplitWriter(&buf)
+	assert.Same(t, writer, &buf)
+
+	n, err := writer.Write([]byte("test"))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, "test", buf.String())
+}
+
+type failingWriter struct {
+	n   int
+	err error
+}
+
+func newFailingWriter(n int, err error) io.Writer {
+	return &failingWriter{n: n, err: err}
+}
+
+func (w *failingWriter) Write([]byte) (n int, err error) {
+	return w.n, w.err
+}


### PR DESCRIPTION
### What does this PR do?
Use a `splitWriter` instead of `io.MultiWriter` to write to the different output streams in the slog logger.
`splitWriter` always writes to all inner `io.Writer`, instead of stopping on the first error like `io.MultiWriter` does.

### Motivation
We don't want to stop logging if there is an error on one of the streams.
In particular on Windows the agent service has its standard outputs closed, which makes writing to `Stdout` fail, which prevents writing to the log file.

### Describe how you validated your changes
CI

### Additional Notes
