### PR TITLE
Only call handle method on multihandler inner handler if enabled

### DIFF
--- a/pkg/util/log/slog/handlers/multi.go
+++ b/pkg/util/log/slog/handlers/multi.go
@@ -32,8 +32,10 @@ func NewMulti(handlers ...slog.Handler) slog.Handler {
 func (h *multi) Handle(ctx context.Context, r slog.Record) error {
 	var errs []error
 	for _, handler := range h.handlers {
-		if err := handler.Handle(ctx, r); err != nil {
-			errs = append(errs, err)
+		if handler.Enabled(ctx, r.Level) {
+			if err := handler.Handle(ctx, r); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 	return errors.Join(errs...)


### PR DESCRIPTION
### What does this PR do?
Update `MultiHandler` to only call a inner handler's `Handle` method if this `Handler` is enabled.  

### Motivation
The [documentation](https://pkg.go.dev/log/slog#Handler) of the `Handle` method explicitly says that the method should only be called when enabled.  
```
// Handle handles the Record.
// It will only be called when Enabled returns true.
```

### Describe how you validated your changes
CI

### Additional Notes
