### PR TITLE
Push the arm64 version of the DCA on main

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -141,9 +141,10 @@ dca_dev_master:
   rules: !reference [.on_main]
   needs:
     - docker_build_cluster_agent_amd64
+    - docker_build_cluster_agent_arm64
   variables:
     IMG_REGISTRIES: dev
-    IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: cluster-agent-dev:master
 
 cws_instrumentation_dev_branch_multiarch:


### PR DESCRIPTION
### What does this PR do?

Push the arm64 version of the DCA on main 

### Motivation

It's missing and some people would like to have it

https://datadoghq.atlassian.net/browse/BARX-1458

### Describe how you validated your changes

### Additional Notes
