### PR TITLE
[EBPF] gpu: mark e2e tests as not allowed to fail

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -968,7 +968,6 @@ new-e2e-gpu:
       - EXTRA_PARAMS: "--run TestGPUHostSuiteUbuntu1804Driver510"
       - EXTRA_PARAMS: "--run TestGPUHostSuiteUbuntu1804Driver430" # This driver is not supported by the agent, but we can check that the agent does not crash. No need to test in k8s this one.
   retry: !reference [.retry_only_infra_failure, retry]
-  allow_failure: true
 
 all-artifacts: # This job is used to collect all artifacts needed in the flake finder pipeline, because we are limited to 5 cross pipelines needs: https://forum.gitlab.com/t/needs-pipeline-job-limit-on-premise/88731
   stage: e2e


### PR DESCRIPTION
### What does this PR do?

Removes the `allow_failure: true` mark from new-e2e-gpu jobs.

### Motivation

#incident-46337 is now solved with [this PR](https://github.com/DataDog/datadog-agent/pull/43578), re-enabling the e2e tests after validating they are working correctly.

### Describe how you validated your changes

### Additional Notes
