### PR TITLE
Add missing dependencies when updating the release.json file

### DIFF
--- a/tasks/libs/releasing/json.py
+++ b/tasks/libs/releasing/json.py
@@ -143,7 +143,7 @@ def _update_release_json_entry(
     print(f"Windows DDNPM's SHA256 is {windows_ddnpm_shasum}")
     print(f"Windows DDPROCMON's SHA256 is {windows_ddprocmon_shasum}")
 
-    new_version_config = OrderedDict()
+    new_version_config = {}
     new_version_config["INTEGRATIONS_CORE_VERSION"] = integrations_version
     new_version_config["OMNIBUS_RUBY_VERSION"] = omnibus_ruby_version
     new_version_config["JMXFETCH_VERSION"] = jmxfetch_version
@@ -156,6 +156,12 @@ def _update_release_json_entry(
     new_version_config["WINDOWS_DDPROCMON_VERSION"] = windows_ddprocmon_version
     new_version_config["WINDOWS_DDPROCMON_SHASUM"] = windows_ddprocmon_shasum
 
+    # TODO Agent Delivery: Check with AMP how we handle ADP in that file during the release process
+    # Add all the other keys from the previous entry that are not explicitly set here
+    for key in release_json[RELEASE_JSON_DEPENDENCIES]:
+        if key not in new_version_config:
+            new_version_config[key] = release_json[RELEASE_JSON_DEPENDENCIES][key]
+
     # Necessary if we want to maintain the JSON order, so that humans don't get confused
     new_release_json = OrderedDict()
 
@@ -164,7 +170,7 @@ def _update_release_json_entry(
         new_release_json[key] = value
 
     # Then update the entry
-    new_release_json[RELEASE_JSON_DEPENDENCIES] = _stringify_config(new_version_config)
+    new_release_json[RELEASE_JSON_DEPENDENCIES] = _stringify_config(OrderedDict(sorted(new_version_config.items())))
 
     return new_release_json
 


### PR DESCRIPTION
### What does this PR do?

Add missing dependencies when updating the release.json file

It also sorts the key alphabetically (other bots are doing the same) so we stay consistent

### Motivation

When new keys are added to the dependencies we need to explicitly set them in the function. If we forget, we loose them. This PR fixes that

### Describe how you validated your changes

### Additional Notes
