### PR TITLE
Target agent-sandbox for local KMT use

### DIFF
--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -236,7 +236,7 @@ def launch_stack(
         x86_ami_id=x86_ami,
         arm_ami_id=arm_ami,
         ssh_key_name=ssh_key_obj['aws_key_name'] if ssh_key_obj is not None else None,
-        infra_env="aws/sandbox",
+        infra_env="aws/agent-sandbox",
         vmconfig=vm_config,
         stack_name=stack,
         local=local,
@@ -269,7 +269,7 @@ def destroy_stack_pulumi(ctx: Context, stack: str, ssh_key: str | None):
         prefix = f"aws-vault exec {AWS_ACCOUNT} -- "
 
     build_start_microvms_binary(ctx)
-    start_cmd = start_microvms_cmd(infra_env="aws/sandbox", stack_name=stack, destroy=True, local=True)
+    start_cmd = start_microvms_cmd(infra_env="aws/agent-sandbox", stack_name=stack, destroy=True, local=True)
     ctx.run(f"{prefix}{start_cmd}", env=env)
 
 

--- a/tasks/kernel_matrix_testing/vars.py
+++ b/tasks/kernel_matrix_testing/vars.py
@@ -6,7 +6,7 @@ from tasks.libs.types.arch import Arch, KMTArchName
 
 KMT_SUPPORTED_ARCHS: list[KMTArchName] = ["x86_64", "arm64"]
 VMCONFIG = "vmconfig.json"
-AWS_ACCOUNT = "sso-sandbox-account-admin"
+AWS_ACCOUNT = "sso-agent-sandbox-account-admin"
 
 
 class KMTPaths:

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -101,8 +101,8 @@ except ImportError:
     tabulate = None
 
 
-X86_AMI_ID_SANDBOX = "ami-0d1f81cfdbd5b0188"
-ARM_AMI_ID_SANDBOX = "ami-02cb18e91afb3777c"
+X86_AMI_ID_SANDBOX = "ami-0ee01fdc00d76ae88"
+ARM_AMI_ID_SANDBOX = "ami-0b200b09727f5cd75"
 DEFAULT_VCPU = "4"
 DEFAULT_MEMORY = "8192"
 

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -42,14 +42,20 @@ const (
 	sandboxSecondaryAz = "subnet-8ee8b1c6"
 	sandboxBackupAz    = "subnet-3f5db45b"
 
-	datadogAgentQAEnv = "aws/agent-qa"
-	sandboxEnv        = "aws/sandbox"
-	ec2TagsEnvVar     = "RESOURCE_TAGS"
+	agentSandboxPrimaryAz   = "subnet-0a15f3482cd3f9820"
+	agentSandboxSecondaryAz = "subnet-091570395d476e9ce"
+	agentSandboxBackupAz    = "subnet-003831c49a10df3dd"
+
+	datadogAgentQAEnv      = "aws/agent-qa"
+	sandboxEnv             = "aws/sandbox"
+	datadogAgentSandboxEnv = "aws/agent-sandbox"
+	ec2TagsEnvVar          = "RESOURCE_TAGS"
 )
 
 var availabilityZones = map[string][]string{
-	datadogAgentQAEnv: {agentQAPrimaryAZ, agentQASecondaryAZ, agentQABackupAZ},
-	sandboxEnv:        {sandboxPrimaryAz, sandboxSecondaryAz, sandboxBackupAz},
+	datadogAgentQAEnv:      {agentQAPrimaryAZ, agentQASecondaryAZ, agentQABackupAZ},
+	sandboxEnv:             {sandboxPrimaryAz, sandboxSecondaryAz, sandboxBackupAz},
+	datadogAgentSandboxEnv: {agentSandboxPrimaryAz, agentSandboxSecondaryAz, agentSandboxBackupAz},
 }
 
 // EnvOpts are the options for the system-probe scenario


### PR DESCRIPTION
### What does this PR do?
This PR targets the datadog-agent-sandbox account for launching ec2 instances for local KMT use. This is in preparation for the deprecation of the `sandbox` account.

### Motivation

### Describe how you validated your changes
QA was manually carried out by running tests on KMT


### Additional Notes
Subsequent PR will remove the sandbox account