### PR TITLE
Update host-profiler-config.yaml to allow hostname override

### DIFF
--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -17,6 +17,7 @@ processors:
 # infraattributes/default is automatically removed when the Agent Core is not available  
   infraattributes/default:
     cardinality: 2 # HighCardinality
+    allow_hostname_override: true
   cumulativetodelta: {}
 
 exporters:


### PR DESCRIPTION
### What does this PR do?

Set `allow_hostname_override: true` to add the hostname tag to the full host profiler.
`allow_hostname_override` is set by default to `false` because in the context of DDOT, we want to have the hostname where the metrics are created and not the hostname where the collector is running. 
For the full host profiler, profiles come from the same host so using  `allow_hostname_override: true` to add the hostname tag  makes sense.

### Describe how you validated your changes
Tested locally.

### Additional Notes
