### PR TITLE
[CSPM] apply `component/system-probe` on compliance changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,7 @@ component/system-probe:
   - any-glob-to-any-file:
     - pkg/collector/corechecks/ebpf/** #ebpf-platform (oomkill and tcp_queue_length)
     - pkg/collector/corechecks/servicediscovery/module/** # usm
+    - pkg/compliance/** # compliance monitoring (cspm)
     - pkg/ebpf/** # ebpf-platform (ebpf_manager)
     - pkg/eventmonitor/** # cws (new event monitor component)
     - pkg/network/** # npm and usm


### PR DESCRIPTION
### What does this PR do?

Some of this code is soon going to run in the system-probe depending on configuration. Since this label is used to track system-probe changes in nightly builds, we should include the compliance code in it.

### Motivation

### Describe how you validated your changes

### Additional Notes
