### PR TITLE
fix(mypy): Use the correct syntax for f-string

### DIFF
--- a/tasks/libs/common/feature_flags.py
+++ b/tasks/libs/common/feature_flags.py
@@ -12,19 +12,19 @@ def is_enabled(ctx: Context, feature: str, verbose: bool = False) -> bool:  # no
     """
     Performs a dda feature flag check and returns whether a feature is enabled or not.
     """
-    verbose = verbose or os.getenv("VERBOSE_FEATURE_FLAGS")
+    verbose = verbose or bool(os.getenv("VERBOSE_FEATURE_FLAGS"))
 
     try:
         res = ctx.run(f'dda self feature {feature}', hide=True)
         enabled = res.stdout.strip() == 'True'
     except Exception:
         if verbose:
-            print(f'[{color_message('Warning', Color.BLUE)}] Failed to get feature flag {feature}', file=sys.stderr)
+            print(f'[{color_message("Warning", Color.BLUE)}] Failed to get feature flag {feature}', file=sys.stderr)
         enabled = False
 
     if enabled or verbose:
         print(
-            f'[{color_message('Feature', Color.BLUE)}] {color_message(feature, Color.BOLD)} is {color_message("enabled", Color.GREEN) if enabled else color_message("disabled", Color.RED)}',
+            f'[{color_message("Feature", Color.BLUE)}] {color_message(feature, Color.BOLD)} is {color_message("enabled", Color.GREEN) if enabled else color_message("disabled", Color.RED)}',
             file=sys.stderr,
         )
 


### PR DESCRIPTION
### What does this PR do?
- Use the correct syntax for f-string (use `'` within `"` or the opposite, but we must alternate)
- Align type (force the os.gentenv to be a `bool`)

### Motivation
Pass my pre-commit locally :)

### Describe how you validated your changes
Local execution

### Additional Notes
