### PR TITLE
Remove the `dca_dev_branch` mono-arch job

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -118,17 +118,6 @@ dca_dev_branch:
   rules: !reference [.manual]
   needs:
     - docker_build_cluster_agent_amd64
-  variables:
-    IMG_REGISTRIES: dev
-    IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
-    IMG_DESTINATIONS: cluster-agent-dev:${CI_COMMIT_REF_SLUG}
-
-dca_dev_branch_multiarch:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules: !reference [.manual]
-  needs:
-    - docker_build_cluster_agent_amd64
     - docker_build_cluster_agent_arm64
   variables:
     IMG_REGISTRIES: dev


### PR DESCRIPTION
### What does this PR do?

Remove the `dca_dev_branch` mono-arch job and rename the multiarch one

### Motivation

We have one job `dca_dev_branch` that pushes the amd64 and another one `dca_dev_branch_multiarch` pushing armd64 and arm64. Both are manual on branches. We can simplify our config and keep only the job that pushes both.

### Describe how you validated your changes

### Additional Notes
