### PR TITLE
[EBPF] gpu: fix settings source for sp_process_metrics_request_timeout

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/ebpf.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf.go
@@ -31,7 +31,7 @@ type SystemProbeCache struct {
 
 // NewSystemProbeCache creates a new stats cache that connects to system-probe using sysprobeclient.
 func NewSystemProbeCache() *SystemProbeCache {
-	timeout := pkgconfigsetup.SystemProbe().GetDuration("gpu.sp_process_metrics_request_timeout")
+	timeout := pkgconfigsetup.Datadog().GetDuration("gpu.sp_process_metrics_request_timeout")
 	client := sysprobeclient.GetCheckClient(
 		sysprobeclient.WithSocketPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")),
 		sysprobeclient.WithCheckTimeout(timeout),


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug with the retrieval of the sp_process_metrics_request_timeout setting, which was querying SystemProbe config instead of the agent config, where it is defined.

### Motivation

Fix configuration

### Describe how you validated your changes

### Additional Notes