### PR TITLE
pkg/collector/corechecks/cluster/ksm: optimize ownerTags

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -1318,19 +1318,18 @@ func ownerTags(kind, name string) []string {
 		return nil
 	}
 
-	tagList := []string{tagKey + ":" + name}
 	switch kind {
 	case kubernetes.JobKind:
 		if cronjob, _ := kubernetes.ParseCronJobForJob(name); cronjob != "" {
-			return append(tagList, tags.KubeCronjob+":"+cronjob)
+			return []string{tagKey + ":" + name, tags.KubeCronjob + ":" + cronjob}
 		}
 	case kubernetes.ReplicaSetKind:
 		if deployment := kubernetes.ParseDeploymentForReplicaSet(name); deployment != "" {
-			return append(tagList, tags.KubeDeployment+":"+deployment)
+			return []string{tagKey + ":" + name, tags.KubeDeployment + ":" + deployment}
 		}
 	}
 
-	return tagList
+	return []string{tagKey + ":" + name}
 }
 
 // labelsMapperOverride allows overriding the default label mapping for

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -1909,3 +1909,19 @@ func TestOwnerTags(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkOwnerTags(b *testing.B) {
+	b.Run("ReplicaSet", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = ownerTags("ReplicaSet", "foo-6768ddc4d")
+		}
+	})
+
+	b.Run("Job", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = ownerTags("Job", "foo-1627309500")
+		}
+	})
+}

--- a/pkg/util/kubernetes/helpers.go
+++ b/pkg/util/kubernetes/helpers.go
@@ -14,7 +14,7 @@ import (
 // Taken from https://github.com/kow3ns/kubernetes/blob/96067e6d7b24a05a6a68a0d94db622957448b5ab/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L76
 const KubeAllowedEncodeStringAlphaNums = "bcdfghjklmnpqrstvwxz2456789"
 
-// Digits holds the digits used for naming replicasets in kubenetes < 1.8
+// Digits holds the digits used for naming replicasets in kubernetes < 1.8
 const Digits = "1234567890"
 
 // ParseDeploymentForReplicaSet gets the deployment name from a replicaset,
@@ -54,14 +54,9 @@ func ParseCronJobForJob(name string) (string, int) {
 		return "", 0
 	}
 
-	if !stringInRuneset(suffix, Digits) {
-		// Invalid suffix
-		return "", 0
-	}
-
 	id, err := strconv.Atoi(suffix)
 	if err != nil {
-		// Cannot happen because of the test just above
+		// Invalid suffix
 		return "", 0
 	}
 
@@ -94,7 +89,7 @@ func removeKubernetesNameSuffix(name string) string {
 		return ""
 	}
 
-	if !stringInRuneset(suffix, Digits) && !stringInRuneset(suffix, KubeAllowedEncodeStringAlphaNums) {
+	if !stringInRuneset(suffix, KubeAllowedEncodeStringAlphaNums) && !stringInRuneset(suffix, Digits) {
 		// Invalid suffix
 		return ""
 	}


### PR DESCRIPTION
### What does this PR do?

* optimize allocations
* check ReplicaSet name pattern used by modern Kubernetes first
* remove redundant Job index pattern check
  (name can not contain '+', earlier dash index ensures suffix
  does not start with '-' and strconv.Atoi only allows '[0-9]')

```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm
cpu: Apple M4 Max
                        │    HEAD~1    │                HEAD                 │
                        │    sec/op    │   sec/op     vs base                │
OwnerTags/ReplicaSet-16   106.70n ± 1%   80.68n ± 1%  -24.38% (p=0.000 n=10)
OwnerTags/Job-16           96.45n ± 1%   59.68n ± 1%  -38.13% (p=0.000 n=10)
geomean                    101.4n        69.39n       -31.60%

                        │   HEAD~1    │                HEAD                │
                        │    B/op     │    B/op     vs base                │
OwnerTags/ReplicaSet-16   104.00 ± 0%   88.00 ± 0%  -15.38% (p=0.000 n=10)
OwnerTags/Job-16           88.00 ± 0%   72.00 ± 0%  -18.18% (p=0.000 n=10)
geomean                    95.67        79.60       -16.79%

                        │   HEAD~1   │                HEAD                │
                        │ allocs/op  │ allocs/op   vs base                │
OwnerTags/ReplicaSet-16   4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
OwnerTags/Job-16          4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
geomean                   4.000        3.000       -25.00%
```

### Motivation

Follow up on https://github.com/DataDog/datadog-agent/pull/43407

### Describe how you validated your changes

```console
% go test ./pkg/collector/corechecks/cluster/ksm/ ./pkg/util/kubernetes/ -tags=kubeapiserver,test -count=1 
ok      github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm   0.984s
ok      github.com/DataDog/datadog-agent/pkg/util/kubernetes    0.963s
```

### Additional Notes
