### PR TITLE
`cancel-prev-pipelines`: do retry on HTTP 409 (`Conflict`) errors

### DIFF
--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -33,6 +33,10 @@ from tasks.libs.common.utils import retry_function, running_in_ci
 from tasks.libs.linter.gitlab_exceptions import FailureLevel, SingleGitlabLintFailure
 from tasks.libs.types.types import JobDependency
 
+# Patch python-gitlab to retry 409 errors because the "fix" (https://github.com/python-gitlab/python-gitlab/pull/2326)
+# checks `result.reason` but GitLab sends `Conflict` (HTTP standard) while `Resource lock` is in the response... body!
+gitlab.const.RETRYABLE_TRANSIENT_ERROR_CODES.append(409)
+
 BASE_URL = "https://gitlab.ddbuild.io"
 CONFIG_SPECIAL_OBJECTS = {
     "default",


### PR DESCRIPTION
### Motivation
The python-gitlab fix (python-gitlab/python-gitlab#2326) for 409 Resource lock retries checks `result.reason`, but GitLab sends `Conflict` (standard HTTP reason phrase) while `Resource lock` is in the response body. The check never matches, so retries never happen:
```
$ dda inv -- pipeline.auto-cancel-previous-pipelines
[...]
gitlab.exceptions.GitlabHttpError: 409: 409 Conflict: Resource lock
                                        ^ reason      ^ response body
```
Example: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1262109099

### What does this PR do?
This patch adds HTTP `409` to GitLab's API retriable transient error codes as a lightweight workaround, allowing all 409 errors to be retried when `retry_transient_errors=True` (our case).

### Additional Notes
Will file an issue upstream.