### PR TITLE
[CWS] cache the result of `ondemand.name` after resolving

### DIFF
--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -825,7 +825,11 @@ func (fh *EBPFFieldHandlers) ResolveOnDemandName(_ *model.Event, e *model.OnDema
 	if fh.onDemand == nil {
 		return ""
 	}
-	return fh.onDemand.getHookNameFromID(int(e.ID))
+	if len(e.Name) != 0 {
+		return e.Name
+	}
+	e.Name = fh.onDemand.getHookNameFromID(int(e.ID))
+	return e.Name
 }
 
 func resolveOnDemandArgStr(e *model.OnDemandEvent, index int) string {


### PR DESCRIPTION
### What does this PR do?

Make sure to not recompute the ondemand event name for every usage, and instead cache it in the event itself as done for most (all ?) other fields already.

### Motivation

### Describe how you validated your changes

### Additional Notes
