### PR TITLE
chore: correct format specifier usage in logs

### DIFF
--- a/comp/metadata/inventoryotel/inventoryotelimpl/inventoryotel.go
+++ b/comp/metadata/inventoryotel/inventoryotelimpl/inventoryotel.go
@@ -150,7 +150,7 @@ func (i *inventoryotel) parseResponseFromJSON(body []byte) (otelMetadata, error)
 func (i *inventoryotel) fetchRemoteOtelConfig(u *url.URL) (otelMetadata, error) {
 	body, err := i.client.Get(u.String(), ipchttp.WithTimeout(httpTO))
 	if err != nil {
-		return nil, i.log.Error("error fetching remote otel config: %w", err)
+		return nil, i.log.Error("error fetching remote otel config:", err)
 	}
 
 	return i.parseResponseFromJSON(body)

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -204,7 +204,7 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 
 	if config.EnableCertCollection {
 		if err := ssluprobes.ValidateSupported(); err != nil {
-			log.Warn("TLS certificate collection is not supported on this kernel. Disabling. Details: %w", err)
+			log.Warnf("TLS certificate collection is not supported on this kernel. Disabling. Details: %s", err)
 			config.EnableCertCollection = false
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Corrects log format specifier usage in logging calls across the codebase. Specifically:
- Removes %w format verb from log.Error() call (format verbs are not supported in log.Error())
- Changes log.Warn() to log.Warnf() to properly support format verbs, and updates %w to %s

### Motivation

log.Error() and log.Warn() don’t support format verbs like %s or %v.
If you need to use format specifiers, you must use log.Errorf() or log.Warnf() instead.

Also, %w is only for wrapping errors, so don’t use it for regular log messages.
Use %s or %v when formatting strings in logs.

### Describe how you validated your changes

- Verified that the code compiles successfully
- Confirmed that logging calls now use appropriate format specifiers for their respective logger methods
- Checked that error messages will be properly formatted at runtime

### Additional Notes

This is a minor code quality improvement that ensures log messages are formatted correctly. No functional behavior changes are introduced.