### PR TITLE
Disable `perfsprint` linter on test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -260,6 +260,13 @@ linters:
     - path: _test\.go
       linters:
         - errcheck
+    # Exclude perfsprint from test files where performance is not critical
+    - path: _test\.go
+      linters:
+        - perfsprint
+    - path: ^test/
+      linters:
+        - perfsprint
     # disable typecheck in folder where it breaks because of build tags
     - path: "pkg/security/"
       linters: [typecheck]


### PR DESCRIPTION
### What does this PR do?

Disable `perfsprint` linter on test files.

### Motivation

Some rules were considered too strict for files where the performance isn’t critical: https://github.com/DataDog/datadog-agent/pull/43413#discussion_r2571031512

### Describe how you validated your changes

### Additional Notes
