### PR TITLE
Propagate `CI` env to further `docker run`s

### DIFF
--- a/.gitlab/deploy_packages/winget.yml
+++ b/.gitlab/deploy_packages/winget.yml
@@ -20,6 +20,7 @@ publish_winget_7_x64:
     - >
       docker run --rm
       -v "$(Get-Location):c:\mnt"
+      -e CI
       -e WINGET_GITHUB_ACCESS_TOKEN=${wingetPat}
       -e GENERAL_ARTIFACTS_CACHE_BUCKET_URL
       ${WINBUILDIMAGE}

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -133,7 +133,7 @@ powershell_script_signing:
       - $WINDOWS_POWERSHELL_DIR
   script:
     - mkdir $WINDOWS_POWERSHELL_DIR
-    - docker run --rm -v "$(Get-Location):c:\mnt" -e AWS_NETWORKING=true -e IS_AWS_CONTAINER=true ${WINBUILDIMAGE} powershell -C "dd-wcs sign \mnt\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1"
+    - docker run --rm -v "$(Get-Location):c:\mnt" -e AWS_NETWORKING=true -e CI -e IS_AWS_CONTAINER=true ${WINBUILDIMAGE} powershell -C "dd-wcs sign \mnt\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1"
     - copy .\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1 $WINDOWS_POWERSHELL_DIR\Install-Datadog.ps1
 
 #

--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -218,6 +218,7 @@ class CompilerImage:
             platform = f"--platform linux/{self.arch.go_arch}"
         res = self.ctx.run(
             f"docker run {platform} -d --restart always --name {self.name} "
+            f"--env=CI "
             f"--mount type=bind,source={get_repo_root()},target={CONTAINER_AGENT_PATH} "
             f"{self.expected_image_name} sleep \"infinity\"",
             warn=True,

--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -218,7 +218,6 @@ class CompilerImage:
             platform = f"--platform linux/{self.arch.go_arch}"
         res = self.ctx.run(
             f"docker run {platform} -d --restart always --name {self.name} "
-            f"--env=CI "
             f"--mount type=bind,source={get_repo_root()},target={CONTAINER_AGENT_PATH} "
             f"{self.expected_image_name} sleep \"infinity\"",
             warn=True,

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -485,6 +485,7 @@ def docker_functional_tests(
     capabilities = ['SYS_ADMIN', 'SYS_RESOURCE', 'SYS_PTRACE', 'NET_ADMIN', 'IPC_LOCK', 'ALL']
 
     cmd = 'docker run --name {container_name} {caps} --privileged -d '
+    cmd += '--env=CI '
     cmd += '-v /dev:/dev '
     cmd += '-v /proc:/host/proc -e HOST_PROC=/host/proc '
     cmd += '-v /etc:/host/etc -e HOST_ETC=/host/etc '


### PR DESCRIPTION
### What does this PR do?
This is a follow-up of #43274 aiming at ensuring the `CI` environment variable is propagated to further docker containers started from CI jobs.

### Motivation
The `CI` variable is a _de facto_ standard set by most CI systems (GitHub Actions, GitLab CI, Travis CI, CircleCI, etc.) to indicate code is running in an automated build environment and used by tools such as (but not limited to):
- `cargo-nextest`: automatically hides progress bar when CI is detected,
- `pipenv`: uses non-interactive defaults,
- `pytest`: adjusts output,
- ...

### Additional Notes
- `-e CI`, `--env CI` and `--env=CI` are all equivalent,
- if `CI` is absent from the host environment, it's not added to the container.