### PR TITLE
[CWS] Improve SECL documentation generation

### DIFF
--- a/pkg/security/generators/accessors/doc/doc.go
+++ b/pkg/security/generators/accessors/doc/doc.go
@@ -455,9 +455,15 @@ func extractVersionAndDefinition(evtType *common.EventTypeMetadata) eventTypeInf
 }
 
 var (
-	seclDocRE  = regexp.MustCompile(`SECLDoc\[((?:[a-z0-9_]+\.?)*[a-z0-9_]+)\]\s*Definition:\s*\x60([^\x60]+)\x60\s*(?:Constants:\x60([^\x60]+)\x60\s*)?(?:Example:\s*\x60([^\x60]+)\x60\s*(?:Description:\s*\x60([^\x60]+)\x60\s*)?)*`)
-	examplesRE = regexp.MustCompile(`Example:\s*\x60([^\x60]+)\x60\s*(?:Description:\s*\x60([^\x60]+)\x60\s*)?`)
+	// Pattern explanation: (?:[^\x60\\]|\\.)+ means "one or more of: (non-backtick, non-backslash) OR (backslash followed by any char)"
+	seclDocRE  = regexp.MustCompile(`SECLDoc\[((?:[a-z0-9_]+\.?)*[a-z0-9_]+)\]\s*Definition:\s*\x60((?:[^\x60\\]|\\.)+)\x60\s*(?:Constants:\x60((?:[^\x60\\]|\\.)+)\x60\s*)?(?:Example:\s*\x60((?:[^\x60\\]|\\.)+)\x60\s*(?:Description:\s*\x60((?:[^\x60\\]|\\.)+)\x60\s*)?)*`)
+	examplesRE = regexp.MustCompile(`Example:\s*\x60((?:[^\x60\\]|\\.)+)\x60\s*(?:Description:\s*\x60((?:[^\x60\\]|\\.)+)\x60\s*)?`)
 )
+
+// unescapeBackticks replaces escaped backticks (\`) with actual backticks
+func unescapeBackticks(s string) string {
+	return strings.ReplaceAll(s, "\\`", "`")
+}
 
 func parseSECLDocWithSuffix(comment string, wantedSuffix string) (string, string, []example) {
 	trimmed := strings.TrimSpace(comment)
@@ -469,18 +475,18 @@ func parseSECLDocWithSuffix(comment string, wantedSuffix string) (string, string
 			continue
 		}
 
-		definition := trimmed[match[4]:match[5]]
+		definition := unescapeBackticks(trimmed[match[4]:match[5]])
 		var constants string
 		if match[6] != -1 && match[7] != -1 {
-			constants = trimmed[match[6]:match[7]]
+			constants = unescapeBackticks(trimmed[match[6]:match[7]])
 		}
 
 		var examples []example
 		for _, exampleMatch := range examplesRE.FindAllStringSubmatchIndex(matchedSubString, -1) {
-			expr := matchedSubString[exampleMatch[2]:exampleMatch[3]]
+			expr := unescapeBackticks(matchedSubString[exampleMatch[2]:exampleMatch[3]])
 			var desc string
 			if exampleMatch[4] != -1 && exampleMatch[5] != -1 {
-				desc = matchedSubString[exampleMatch[4]:exampleMatch[5]]
+				desc = unescapeBackticks(matchedSubString[exampleMatch[4]:exampleMatch[5]])
 			}
 			examples = append(examples, example{Expression: expr, Description: desc})
 		}

--- a/pkg/security/secl/model/bpf_maps_generator/gen.go.tmpl
+++ b/pkg/security/secl/model/bpf_maps_generator/gen.go.tmpl
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+// Code generated - DO NOT EDIT.
 
 package {{ .PackageName }}
 

--- a/pkg/security/secl/model/consts_map_names_linux.go
+++ b/pkg/security/secl/model/consts_map_names_linux.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+// Code generated - DO NOT EDIT.
 
 package model
 


### PR DESCRIPTION
### What does this PR do?
- Adds a comment indicating that the file is generated code, for consistency with other templates.
- Allows the use of backticks for Markdown formatting
### Motivation
- This template was missing the generated-code notice found in other similar files, which could create confusion. This PR fixes that by adding the missing comment.
- The backticks are very usefull for Markdown formatting