### PR TITLE
Remove duplicated jobs in the final build pipeline to push cws-instrumentation images

### DIFF
--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -13,13 +13,8 @@
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}"
 
-# will push the `7.xx.y-rc.z` tags
-deploy_containers-cws-instrumentation-rc-versioned:
+deploy_containers-cws-instrumentation:
   extends: .deploy_containers-cws-instrumentation-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
   needs: []
 
-# will push the `7.xx.y` tags
-deploy_containers-cws-instrumentation-final-versioned:
-  extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_manual_final]

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_mutable_tags.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_mutable_tags.yml
@@ -13,7 +13,7 @@ deploy_mutable_cws_instrumentation_tags-rc:
   extends: .deploy_mutable_cws_instrumentation_tags-base
   rules: !reference [.on_deploy_rc]
   needs:
-    - job: deploy_containers-cws-instrumentation-rc-versioned
+    - job: deploy_containers-cws-instrumentation
       artifacts: false
   variables:
     IMG_NEW_TAGS: rc
@@ -22,7 +22,7 @@ deploy_mutable_cws_instrumentation_tags-latest:
   extends: .deploy_mutable_cws_instrumentation_tags-base
   rules: !reference [.on_deploy_manual_final]
   needs:
-    - job: deploy_containers-cws-instrumentation-final-versioned
+    - job: deploy_containers-cws-instrumentation
       artifacts: false
   variables:
     IMG_NEW_TAGS: latest


### PR DESCRIPTION
### What does this PR do?

Remove duplicated jobs in the final build pipeline to push cws-instrumentation images

### Motivation

In #incident-46391 we noticed we have two jobs to do the exact same thing: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/84348286. That's because of `on_deploy_manual_auto_on_rc` that also adds it to final build pipelines as manual, on top of the one added with `deploy_containers-cws-instrumentation-final-versioned`. It's not breaking anything, it's just doing the exact same thing so I'm removing one of them to simplify the config.

We have the exact same setup for other images, example with DCA here https://github.com/DataDog/datadog-agent/blob/06759987c1cb242a2ce699e29108326b7d80c432/.gitlab/deploy_dca/deploy_dca.yml#L17-L20

### Describe how you validated your changes

### Additional Notes
