### PR TITLE
Refactor Windows Docker container jobs

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -48,6 +48,7 @@
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
   timeout: 60m
 
+# Base template for agent7 windows builds
 .docker_build_agent7_windows_common:
   extends:
     - .docker_build_agent_windows_common
@@ -58,31 +59,28 @@
     ["setup_agent_version", "windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-7*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=${SERVER_BASE_IMAGE} --build-arg BASE_IMAGE_OS='windows nanoserver' --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}"
+    SERVERCORE: ""  # Default to nanoserver (empty), override to "-servercore" for servercore builds
+    # OS_TYPE should be set to "nano" or "core" in the job
+    # OS_DISPLAY_NAME should be "windows nanoserver" or "windows server core"
+    BUILD_ARG: "--build-arg BASE_IMAGE=${SERVER_BASE_IMAGE} --build-arg BASE_IMAGE_OS='${OS_DISPLAY_NAME}' --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=${OS_TYPE}-${VARIANT}"
   retry: 2
 
-.docker_build_agent7_windows_servercore_common:
-  extends:
-    - .docker_build_agent7_windows_common
-  variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=${SERVER_BASE_IMAGE} --build-arg BASE_IMAGE_OS='windows server core' --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}"
-    SERVERCORE: "-servercore"
-
+# Base template for FIPS agent7 windows builds
 .docker_build_fips_agent7_windows_common:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent_windows_common
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   needs:
     ["windows_msi_and_bosh_zip_x64-a7-fips", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-fips-agent-7*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=${SERVER_BASE_IMAGE} --build-arg BASE_IMAGE_OS='windows nanoserver' --build-arg WITH_JMX=${WITH_JMX} --build-arg WITH_FIPS=true --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}-fips"
-
-.docker_build_fips_agent7_windows_servercore_common:
-  extends:
-    - .docker_build_fips_agent7_windows_common
-  variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=${SERVER_BASE_IMAGE} --build-arg BASE_IMAGE_OS='windows server core' --build-arg WITH_JMX=${WITH_JMX} --build-arg WITH_FIPS=true --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}-fips"
-    SERVERCORE: "-servercore"
+    SERVERCORE: ""  # Default to nanoserver (empty), override to "-servercore" for servercore builds
+    # OS_TYPE should be set to "nano" or "core" in the job
+    # OS_DISPLAY_NAME should be "windows nanoserver" or "windows server core"
+    BUILD_ARG: "--build-arg BASE_IMAGE=${SERVER_BASE_IMAGE} --build-arg BASE_IMAGE_OS='${OS_DISPLAY_NAME}' --build-arg WITH_JMX=${WITH_JMX} --build-arg WITH_FIPS=true --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=${OS_TYPE}-${VARIANT}-fips"
+  retry: 2
 
 include:
   - .gitlab/container_build/docker_windows_agent7.yml

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -1,140 +1,76 @@
 ---
-docker_build_agent7_windows1809:
-  extends:
-    - .docker_build_agent7_windows_common
-    - .windows_docker_2019
+# All Windows builds: nanoserver and servercore, all variants, with/without JMX
+docker_build_agent7_windows:
+  extends: .docker_build_agent7_windows_common
+  parallel:
+    matrix:
+      # Nanoserver builds
+      - VARIANT: "1809"
+        SERVER_BASE_IMAGE: "mcr.microsoft.com/powershell:lts-nanoserver-1809"
+        WINDOWS_RUNNER: "windows-v2:2019"
+        OS_TYPE: "nano"
+        OS_DISPLAY_NAME: "windows nanoserver"
+        TAG_SUFFIX: ["-7", "-7-jmx"]
+        WITH_JMX: ["false", "true"]
+      - VARIANT: "ltsc2022"
+        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2022"
+        WINDOWS_RUNNER: "windows-v2:2022"
+        OS_TYPE: "nano"
+        OS_DISPLAY_NAME: "windows nanoserver"
+        TAG_SUFFIX: ["-7", "-7-jmx"]
+        WITH_JMX: ["false", "true"]
+      - VARIANT: "ltsc2025"
+        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2025"
+        WINDOWS_RUNNER: "windows-v2:2025"
+        OS_TYPE: "nano"
+        OS_DISPLAY_NAME: "windows nanoserver"
+        TAG_SUFFIX: ["-7", "-7-jmx"]
+        WITH_JMX: ["false", "true"]
+        ALLOW_FAILURE: "true"
+      # Servercore builds
+      - VARIANT: "1809"
+        SERVER_BASE_IMAGE: "mcr.microsoft.com/powershell:windowsservercore-1809"
+        WINDOWS_RUNNER: "windows-v2:2019"
+        OS_TYPE: "core"
+        OS_DISPLAY_NAME: "windows server core"
+        SERVERCORE: "-servercore"
+        TAG_SUFFIX: ["-7", "-7-jmx"]
+        WITH_JMX: ["false", "true"]
+      - VARIANT: "ltsc2022"
+        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022"
+        WINDOWS_RUNNER: "windows-v2:2022"
+        OS_TYPE: "core"
+        OS_DISPLAY_NAME: "windows server core"
+        SERVERCORE: "-servercore"
+        TAG_SUFFIX: ["-7", "-7-jmx"]
+        WITH_JMX: ["false", "true"]
+      - VARIANT: "ltsc2025"
+        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2025"
+        WINDOWS_RUNNER: "windows-v2:2025"
+        OS_TYPE: "core"
+        OS_DISPLAY_NAME: "windows server core"
+        SERVERCORE: "-servercore"
+        TAG_SUFFIX: ["-7", "-7-jmx"]
+        WITH_JMX: ["false", "true"]
+        ALLOW_FAILURE: "true"
+  tags: [$WINDOWS_RUNNER]
+  allow_failure: $ALLOW_FAILURE
   variables:
-    VARIANT: 1809
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:lts-nanoserver-1809
-    TAG_SUFFIX: -7
-    WITH_JMX: "false"
+    OVERRIDE_GIT_STRATEGY: "clone"
 
-docker_build_agent7_windows1809_jmx:
-  extends:
-    - .docker_build_agent7_windows_common
-    - .windows_docker_2019
+# FIPS servercore builds: ltsc2022 only (with/without JMX)
+docker_build_fips_agent7_windows:
+  extends: .docker_build_fips_agent7_windows_common
+  parallel:
+    matrix:
+      - VARIANT: "ltsc2022"
+        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022"
+        WINDOWS_RUNNER: "windows-v2:2022"
+        OS_TYPE: "core"
+        OS_DISPLAY_NAME: "windows server core"
+        SERVERCORE: "-servercore"
+        TAG_SUFFIX: ["-7-fips", "-7-fips-jmx"]
+        WITH_JMX: ["false", "true"]
+  tags: [$WINDOWS_RUNNER]
   variables:
-    VARIANT: 1809
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:lts-nanoserver-1809
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows2022_jmx:
-  extends:
-    - .docker_build_agent7_windows_common
-    - .windows_docker_v2_2022
-  variables:
-    VARIANT: ltsc2022
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows2022:
-  extends:
-    - .docker_build_agent7_windows_common
-    - .windows_docker_v2_2022
-  variables:
-    VARIANT: ltsc2022
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
-docker_build_agent7_windows1809_core:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-    - .windows_docker_2019
-  variables:
-    VARIANT: 1809
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:windowsservercore-1809
-    TAG_SUFFIX: -7
-    WITH_JMX: "false"
-
-docker_build_agent7_windows1809_core_jmx:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-    - .windows_docker_2019
-  variables:
-    VARIANT: 1809
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:windowsservercore-1809
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows2022_core:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-    - .windows_docker_v2_2022
-  variables:
-    VARIANT: ltsc2022
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:windowsservercore-ltsc2022
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
-docker_build_agent7_windows2022_core_jmx:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-    - .windows_docker_v2_2022
-  variables:
-    VARIANT: ltsc2022
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:windowsservercore-ltsc2022
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_fips_agent7_windows2022_core:
-  extends:
-    - .docker_build_fips_agent7_windows_servercore_common
-    - .windows_docker_v2_2022
-  variables:
-    VARIANT: ltsc2022
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:windowsservercore-ltsc2022
-    TAG_SUFFIX: "-7-fips"
-    WITH_JMX: "false"
-
-docker_build_fips_agent7_windows2022_core_jmx:
-  extends:
-    - .docker_build_fips_agent7_windows_servercore_common
-    - .windows_docker_v2_2022
-  variables:
-    VARIANT: ltsc2022
-    SERVER_BASE_IMAGE: mcr.microsoft.com/powershell:windowsservercore-ltsc2022
-    TAG_SUFFIX: -7-fips-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows2025_core:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-    - .windows_docker_2025
-  variables:
-    VARIANT: ltsc2025
-    SERVER_BASE_IMAGE: mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2025
-    TAG_SUFFIX: -7
-    WITH_JMX: "false"
-
-docker_build_agent7_windows2025_core_jmx:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-    - .windows_docker_2025
-  variables:
-    VARIANT: ltsc2025
-    SERVER_BASE_IMAGE: mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2025
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows2025:
-  extends:
-    - .docker_build_agent7_windows_common
-    - .windows_docker_2025
-  variables:
-    VARIANT: ltsc2025
-    SERVER_BASE_IMAGE: mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2025
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
-docker_build_agent7_windows2025_jmx:
-  extends:
-    - .docker_build_agent7_windows_common
-    - .windows_docker_2025
-  variables:
-    VARIANT: ltsc2025
-    SERVER_BASE_IMAGE: mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2025
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
+    OVERRIDE_GIT_STRATEGY: "clone"

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -37,7 +37,6 @@
   WINDOWS_RUNNER: "windows-v2:2025"
   OS_TYPE: "nano"
   OS_DISPLAY_NAME: "windows nanoserver"
-  ALLOW_FAILURE: "true"
 
 .windows_ltsc2025_servercore: &windows_ltsc2025_servercore
   VARIANT: "ltsc2025"
@@ -46,7 +45,6 @@
   OS_TYPE: "core"
   OS_DISPLAY_NAME: "windows server core"
   SERVERCORE: "-servercore"
-  ALLOW_FAILURE: "true"
 
 # All Windows builds
 docker_build_agent7_windows:
@@ -96,7 +94,6 @@ docker_build_agent7_windows:
         TAG_SUFFIX: "-7-jmx"
         WITH_JMX: "true"
   tags: [$WINDOWS_RUNNER]
-  allow_failure: $ALLOW_FAILURE
   variables:
     OVERRIDE_GIT_STRATEGY: "clone"
 

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -1,76 +1,116 @@
 ---
-# All Windows builds: nanoserver and servercore, all variants, with/without JMX
+# Base configurations for each Windows variant + OS type combination
+# Change base images here to update all builds
+.windows_1809_nanoserver: &windows_1809_nanoserver
+  VARIANT: "1809"
+  SERVER_BASE_IMAGE: "mcr.microsoft.com/powershell:lts-nanoserver-1809"
+  WINDOWS_RUNNER: "windows-v2:2019"
+  OS_TYPE: "nano"
+  OS_DISPLAY_NAME: "windows nanoserver"
+
+.windows_1809_servercore: &windows_1809_servercore
+  VARIANT: "1809"
+  SERVER_BASE_IMAGE: "mcr.microsoft.com/powershell:windowsservercore-1809"
+  WINDOWS_RUNNER: "windows-v2:2019"
+  OS_TYPE: "core"
+  OS_DISPLAY_NAME: "windows server core"
+  SERVERCORE: "-servercore"
+
+.windows_ltsc2022_nanoserver: &windows_ltsc2022_nanoserver
+  VARIANT: "ltsc2022"
+  SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2022"
+  WINDOWS_RUNNER: "windows-v2:2022"
+  OS_TYPE: "nano"
+  OS_DISPLAY_NAME: "windows nanoserver"
+
+.windows_ltsc2022_servercore: &windows_ltsc2022_servercore
+  VARIANT: "ltsc2022"
+  SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022"
+  WINDOWS_RUNNER: "windows-v2:2022"
+  OS_TYPE: "core"
+  OS_DISPLAY_NAME: "windows server core"
+  SERVERCORE: "-servercore"
+
+.windows_ltsc2025_nanoserver: &windows_ltsc2025_nanoserver
+  VARIANT: "ltsc2025"
+  SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2025"
+  WINDOWS_RUNNER: "windows-v2:2025"
+  OS_TYPE: "nano"
+  OS_DISPLAY_NAME: "windows nanoserver"
+  ALLOW_FAILURE: "true"
+
+.windows_ltsc2025_servercore: &windows_ltsc2025_servercore
+  VARIANT: "ltsc2025"
+  SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2025"
+  WINDOWS_RUNNER: "windows-v2:2025"
+  OS_TYPE: "core"
+  OS_DISPLAY_NAME: "windows server core"
+  SERVERCORE: "-servercore"
+  ALLOW_FAILURE: "true"
+
+# All Windows builds
 docker_build_agent7_windows:
   extends: .docker_build_agent7_windows_common
   parallel:
     matrix:
-      # Nanoserver builds
-      - VARIANT: "1809"
-        SERVER_BASE_IMAGE: "mcr.microsoft.com/powershell:lts-nanoserver-1809"
-        WINDOWS_RUNNER: "windows-v2:2019"
-        OS_TYPE: "nano"
-        OS_DISPLAY_NAME: "windows nanoserver"
-        TAG_SUFFIX: ["-7", "-7-jmx"]
-        WITH_JMX: ["false", "true"]
-      - VARIANT: "ltsc2022"
-        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2022"
-        WINDOWS_RUNNER: "windows-v2:2022"
-        OS_TYPE: "nano"
-        OS_DISPLAY_NAME: "windows nanoserver"
-        TAG_SUFFIX: ["-7", "-7-jmx"]
-        WITH_JMX: ["false", "true"]
-      - VARIANT: "ltsc2025"
-        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2025"
-        WINDOWS_RUNNER: "windows-v2:2025"
-        OS_TYPE: "nano"
-        OS_DISPLAY_NAME: "windows nanoserver"
-        TAG_SUFFIX: ["-7", "-7-jmx"]
-        WITH_JMX: ["false", "true"]
-        ALLOW_FAILURE: "true"
-      # Servercore builds
-      - VARIANT: "1809"
-        SERVER_BASE_IMAGE: "mcr.microsoft.com/powershell:windowsservercore-1809"
-        WINDOWS_RUNNER: "windows-v2:2019"
-        OS_TYPE: "core"
-        OS_DISPLAY_NAME: "windows server core"
-        SERVERCORE: "-servercore"
-        TAG_SUFFIX: ["-7", "-7-jmx"]
-        WITH_JMX: ["false", "true"]
-      - VARIANT: "ltsc2022"
-        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022"
-        WINDOWS_RUNNER: "windows-v2:2022"
-        OS_TYPE: "core"
-        OS_DISPLAY_NAME: "windows server core"
-        SERVERCORE: "-servercore"
-        TAG_SUFFIX: ["-7", "-7-jmx"]
-        WITH_JMX: ["false", "true"]
-      - VARIANT: "ltsc2025"
-        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2025"
-        WINDOWS_RUNNER: "windows-v2:2025"
-        OS_TYPE: "core"
-        OS_DISPLAY_NAME: "windows server core"
-        SERVERCORE: "-servercore"
-        TAG_SUFFIX: ["-7", "-7-jmx"]
-        WITH_JMX: ["false", "true"]
-        ALLOW_FAILURE: "true"
+      # 1809 nanoserver
+      - <<: *windows_1809_nanoserver
+        TAG_SUFFIX: "-7"
+        WITH_JMX: "false"
+      - <<: *windows_1809_nanoserver
+        TAG_SUFFIX: "-7-jmx"
+        WITH_JMX: "true"
+      # ltsc2022 nanoserver
+      - <<: *windows_ltsc2022_nanoserver
+        TAG_SUFFIX: "-7"
+        WITH_JMX: "false"
+      - <<: *windows_ltsc2022_nanoserver
+        TAG_SUFFIX: "-7-jmx"
+        WITH_JMX: "true"
+      # ltsc2025 nanoserver
+      - <<: *windows_ltsc2025_nanoserver
+        TAG_SUFFIX: "-7"
+        WITH_JMX: "false"
+      - <<: *windows_ltsc2025_nanoserver
+        TAG_SUFFIX: "-7-jmx"
+        WITH_JMX: "true"
+      # 1809 servercore
+      - <<: *windows_1809_servercore
+        TAG_SUFFIX: "-7"
+        WITH_JMX: "false"
+      - <<: *windows_1809_servercore
+        TAG_SUFFIX: "-7-jmx"
+        WITH_JMX: "true"
+      # ltsc2022 servercore
+      - <<: *windows_ltsc2022_servercore
+        TAG_SUFFIX: "-7"
+        WITH_JMX: "false"
+      - <<: *windows_ltsc2022_servercore
+        TAG_SUFFIX: "-7-jmx"
+        WITH_JMX: "true"
+      # ltsc2025 servercore
+      - <<: *windows_ltsc2025_servercore
+        TAG_SUFFIX: "-7"
+        WITH_JMX: "false"
+      - <<: *windows_ltsc2025_servercore
+        TAG_SUFFIX: "-7-jmx"
+        WITH_JMX: "true"
   tags: [$WINDOWS_RUNNER]
   allow_failure: $ALLOW_FAILURE
   variables:
     OVERRIDE_GIT_STRATEGY: "clone"
 
-# FIPS servercore builds: ltsc2022 only (with/without JMX)
+# FIPS builds: ltsc2022 only (with/without JMX)
 docker_build_fips_agent7_windows:
   extends: .docker_build_fips_agent7_windows_common
   parallel:
     matrix:
-      - VARIANT: "ltsc2022"
-        SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022"
-        WINDOWS_RUNNER: "windows-v2:2022"
-        OS_TYPE: "core"
-        OS_DISPLAY_NAME: "windows server core"
-        SERVERCORE: "-servercore"
-        TAG_SUFFIX: ["-7-fips", "-7-fips-jmx"]
-        WITH_JMX: ["false", "true"]
+      - <<: *windows_ltsc2022_servercore
+        TAG_SUFFIX: "-7-fips"
+        WITH_JMX: "false"
+      - <<: *windows_ltsc2022_servercore
+        TAG_SUFFIX: "-7-fips-jmx"
+        WITH_JMX: "true"
   tags: [$WINDOWS_RUNNER]
   variables:
     OVERRIDE_GIT_STRATEGY: "clone"

--- a/.gitlab/dev_container_deploy/docker_windows.yml
+++ b/.gitlab/dev_container_deploy/docker_windows.yml
@@ -6,18 +6,7 @@ include:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   needs:
-    - docker_build_agent7_windows1809
-    - docker_build_agent7_windows1809_jmx
-    - docker_build_agent7_windows1809_core
-    - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows2022
-    - docker_build_agent7_windows2022_jmx
-    - docker_build_agent7_windows2022_core
-    - docker_build_agent7_windows2022_core_jmx
-    - docker_build_agent7_windows2025
-    - docker_build_agent7_windows2025_jmx
-    - docker_build_agent7_windows2025_core
-    - docker_build_agent7_windows2025_core_jmx
+    - docker_build_agent7_windows
   variables:
     IMG_REGISTRIES: dev
   parallel:
@@ -100,8 +89,7 @@ dev_nightly-a7-windows:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   needs:
-    - docker_build_fips_agent7_windows2022_core
-    - docker_build_fips_agent7_windows2022_core_jmx
+    - docker_build_fips_agent7_windows
   variables:
     IMG_REGISTRIES: dev
   # Only publish ltsc2022 servercore for now, that's all that's used by the integrations testing

--- a/.gitlab/dev_container_deploy/e2e.yml
+++ b/.gitlab/dev_container_deploy/e2e.yml
@@ -10,8 +10,7 @@ qa_agent:
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64
-    - docker_build_agent7_windows1809
-    - docker_build_agent7_windows2022
+    - docker_build_agent7_windows
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-winltsc2022-amd64
@@ -27,7 +26,7 @@ qa_agent_fips:
   needs:
     - docker_build_fips_agent7
     - docker_build_fips_agent7_arm64
-    - docker_build_fips_agent7_windows2022_core
+    - docker_build_fips_agent7_windows
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-winltsc2022-servercore-amd64
@@ -43,8 +42,7 @@ qa_agent_jmx:
   needs:
     - docker_build_agent7_jmx
     - docker_build_agent7_jmx_arm64
-    - docker_build_agent7_windows1809_jmx
-    - docker_build_agent7_windows2022_jmx
+    - docker_build_agent7_windows
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-winltsc2022-amd64
@@ -60,7 +58,7 @@ qa_agent_fips_jmx:
   needs:
     - docker_build_fips_agent7_jmx
     - docker_build_fips_agent7_arm64_jmx
-    - docker_build_fips_agent7_windows2022_core_jmx
+    - docker_build_fips_agent7_windows
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-winltsc2022-servercore-amd64

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -17,21 +17,7 @@ internal_kubernetes_deploy_experimental:
       artifacts: false
     - job: publish_internal_dca_container_image
       artifacts: false
-    - job: docker_build_agent7_windows1809
-      artifacts: false
-    - job: docker_build_agent7_windows2022
-      artifacts: false
-    - job: docker_build_agent7_windows1809_jmx
-      artifacts: false
-    - job: docker_build_agent7_windows2022_jmx
-      artifacts: false
-    - job: docker_build_agent7_windows1809_core
-      artifacts: false
-    - job: docker_build_agent7_windows2022_core
-      artifacts: false
-    - job: docker_build_agent7_windows1809_core_jmx
-      artifacts: false
-    - job: docker_build_agent7_windows2022_core_jmx
+    - job: docker_build_agent7_windows
       artifacts: false
     - job: k8s-e2e-main # Currently only require container Argo workflow
       artifacts: false


### PR DESCRIPTION
### What does this PR do?
This PR refactors the Windows docker container builds to avoid repetition (using a matrix template), and to update the Windows server base images to use updated images instead of un-maintained ones.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2059

### Describe how you validated your changes
The CI should pass and individual images can be queried with `crane`

```
❯ for tag in py3-win py3-jmx-win py3-win-servercore py3-jmx-win-servercore py3-win-ltsc2019 py3-jmx-win-ltsc2019 py3-win-servercore-ltsc2019 py3-jmx-win-servercore-ltsc2019 py3-win-ltsc2022 py3-jmx-win-ltsc2022 py3-win-servercore-ltsc2022 py3-jmx-win-servercore-ltsc2022 py3-win-ltsc2025 py3-jmx-win-ltsc2025 py3-win-servercore-ltsc2025 py3-jmx-win-servercore-ltsc2025 py3-fips-win-servercore-ltsc2022 py3-fips-jmx-win-servercore-ltsc2022; do manifest=$(crane manifest docker.io/datadog/agent-dev:julien-lebot-update-windows-docker-images-$tag 2>&1); if echo "$manifest" | grep -q "schemaVersion"; then versions=$(echo "$manifest" | jq -r '.manifests[].platform."os.version"' | paste -sd, -); echo "✓ $tag: OK (windows $versions)"; else echo "✓ $tag: MISSING"; fi; done

✓ py3-win: OK (windows 10.0.17763.5696,10.0.20348.4405,10.0.26100.7171)
✓ py3-jmx-win: OK (windows 10.0.17763.5696,10.0.20348.4405,10.0.26100.7171)
✓ py3-win-servercore: OK (windows 10.0.17763.1697,10.0.20348.4405,10.0.26100.7171)
✓ py3-jmx-win-servercore: OK (windows 10.0.17763.1697,10.0.20348.4405,10.0.26100.7171)
✓ py3-win-ltsc2019: OK (windows 10.0.17763.5696)
✓ py3-jmx-win-ltsc2019: OK (windows 10.0.17763.5696)
✓ py3-win-servercore-ltsc2019: OK (windows 10.0.17763.1697)
✓ py3-jmx-win-servercore-ltsc2019: OK (windows 10.0.17763.1697)
✓ py3-win-ltsc2022: OK (windows 10.0.20348.4405)
✓ py3-jmx-win-ltsc2022: OK (windows 10.0.20348.4405)
✓ py3-win-servercore-ltsc2022: OK (windows 10.0.20348.4405)
✓ py3-jmx-win-servercore-ltsc2022: OK (windows 10.0.20348.4405)
✓ py3-win-ltsc2025: OK (windows 10.0.26100.7171)
✓ py3-jmx-win-ltsc2025: OK (windows 10.0.26100.7171)
✓ py3-win-servercore-ltsc2025: OK (windows 10.0.26100.7171)
✓ py3-jmx-win-servercore-ltsc2025: OK (windows 10.0.26100.7171)
✓ py3-fips-win-servercore-ltsc2022: OK (windows 10.0.20348.4405)
✓ py3-fips-jmx-win-servercore-ltsc2022: OK (windows 10.0.20348.4405)
```

### Additional Notes
Due to the matrix template, the Windows Server 2025 jobs are now not allowed to fail. This should be fine because moving forward we want Windows Server 2025 runners.

