### PR TITLE
runner: add a watchdog to notify about slow checks

### DIFF
--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -78,7 +78,8 @@ type collectorImpl struct {
 	checks         map[checkid.ID]*middleware.CheckWrapper
 	eventReceivers []collector.EventReceiver
 
-	cancelCheckTimeout time.Duration
+	cancelCheckTimeout     time.Duration
+	watchdogWarningTimeout time.Duration
 
 	m         sync.RWMutex
 	createdAt time.Time
@@ -121,18 +122,19 @@ func newProvides(deps dependencies) provides {
 
 func newCollector(deps dependencies) *collectorImpl {
 	c := &collectorImpl{
-		log:                deps.Log,
-		config:             deps.Config,
-		haAgent:            deps.HaAgent,
-		hostname:           deps.Hostname,
-		senderManager:      deps.SenderManager,
-		metricSerializer:   deps.MetricSerializer,
-		agentTelemetry:     deps.AgentTelemetry,
-		checks:             make(map[checkid.ID]*middleware.CheckWrapper),
-		state:              atomic.NewUint32(stopped),
-		checkInstances:     int64(0),
-		cancelCheckTimeout: deps.Config.GetDuration("check_cancel_timeout"),
-		createdAt:          time.Now(),
+		log:                    deps.Log,
+		config:                 deps.Config,
+		haAgent:                deps.HaAgent,
+		hostname:               deps.Hostname,
+		senderManager:          deps.SenderManager,
+		metricSerializer:       deps.MetricSerializer,
+		agentTelemetry:         deps.AgentTelemetry,
+		checks:                 make(map[checkid.ID]*middleware.CheckWrapper),
+		state:                  atomic.NewUint32(stopped),
+		checkInstances:         int64(0),
+		cancelCheckTimeout:     deps.Config.GetDuration("check_cancel_timeout"),
+		watchdogWarningTimeout: deps.Config.GetDuration("check_watchdog_warning_timeout"),
+		createdAt:              time.Now(),
 	}
 
 	if !deps.Config.GetBool("python_lazy_loading") {

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -125,6 +125,8 @@ func (r *Runner) AddWorker() {
 
 // newWorker adds a new worker running in a separate goroutine
 func (r *Runner) newWorker() (*worker.Worker, error) {
+	watchdogWarningTimeout := pkgconfigsetup.Datadog().GetDuration("check_watchdog_warning_timeout")
+
 	worker, err := worker.NewWorker(
 		r.senderManager,
 		r.haAgent,
@@ -133,6 +135,7 @@ func (r *Runner) newWorker() (*worker.Worker, error) {
 		r.pendingChecksChan,
 		r.checksTracker,
 		r.ShouldAddCheckStats,
+		watchdogWarningTimeout,
 	)
 	if err != nil {
 		log.Errorf("Runner %d was unable to instantiate a worker: %s", r.id, err)

--- a/pkg/collector/worker/worker_test.go
+++ b/pkg/collector/worker/worker_test.go
@@ -148,16 +148,16 @@ func TestWorkerInit(t *testing.T) {
 	mockShouldAddStatsFunc := func(checkid.ID) bool { return true }
 
 	senderManager := aggregator.NewNoOpSenderManager()
-	_, err := NewWorker(senderManager, haagentmock.NewMockHaAgent(), 1, 2, nil, checksTracker, mockShouldAddStatsFunc)
+	_, err := NewWorker(senderManager, haagentmock.NewMockHaAgent(), 1, 2, nil, checksTracker, mockShouldAddStatsFunc, 0)
 	require.NotNil(t, err)
 
-	_, err = NewWorker(senderManager, haagentmock.NewMockHaAgent(), 1, 2, pendingChecksChan, nil, mockShouldAddStatsFunc)
+	_, err = NewWorker(senderManager, haagentmock.NewMockHaAgent(), 1, 2, pendingChecksChan, nil, mockShouldAddStatsFunc, 0)
 	require.NotNil(t, err)
 
-	_, err = NewWorker(senderManager, haagentmock.NewMockHaAgent(), 1, 2, pendingChecksChan, checksTracker, nil)
+	_, err = NewWorker(senderManager, haagentmock.NewMockHaAgent(), 1, 2, pendingChecksChan, checksTracker, nil, 0)
 	require.NotNil(t, err)
 
-	worker, err := NewWorker(senderManager, haagentmock.NewMockHaAgent(), 1, 2, pendingChecksChan, checksTracker, mockShouldAddStatsFunc)
+	worker, err := NewWorker(senderManager, haagentmock.NewMockHaAgent(), 1, 2, pendingChecksChan, checksTracker, mockShouldAddStatsFunc, 0)
 	assert.Nil(t, err)
 	assert.NotNil(t, worker)
 }
@@ -179,7 +179,7 @@ func TestWorkerInitExpvarStats(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 
-			worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 1, idx, pendingChecksChan, checksTracker, mockShouldAddStatsFunc)
+			worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 1, idx, pendingChecksChan, checksTracker, mockShouldAddStatsFunc, 0)
 			assert.Nil(t, err)
 
 			worker.Run()
@@ -201,7 +201,7 @@ func TestWorkerName(t *testing.T) {
 
 	for _, id := range []int{1, 100, 500} {
 		expectedName := fmt.Sprintf("worker_%d", id)
-		worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 1, id, pendingChecksChan, checksTracker, mockShouldAddStatsFunc)
+		worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 1, id, pendingChecksChan, checksTracker, mockShouldAddStatsFunc, 0)
 		assert.Nil(t, err)
 		assert.NotNil(t, worker)
 
@@ -254,7 +254,7 @@ func TestWorker(t *testing.T) {
 	pendingChecksChan <- testCheck1
 	close(pendingChecksChan)
 
-	worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 100, 200, pendingChecksChan, checksTracker, mockShouldAddStatsFunc)
+	worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 100, 200, pendingChecksChan, checksTracker, mockShouldAddStatsFunc, 0)
 	require.Nil(t, err)
 
 	wg.Add(1)
@@ -317,6 +317,7 @@ func TestWorkerUtilizationExpvars(t *testing.T) {
 		func() (sender.Sender, error) { return nil, nil },
 		haagentmock.NewMockHaAgent(),
 		100*time.Millisecond,
+		10*time.Second,
 	)
 	require.Nil(t, err)
 
@@ -390,7 +391,7 @@ func TestWorkerErrorAndWarningHandling(t *testing.T) {
 	}
 	close(pendingChecksChan)
 
-	worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 100, 200, pendingChecksChan, checksTracker, mockShouldAddStatsFunc)
+	worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 100, 200, pendingChecksChan, checksTracker, mockShouldAddStatsFunc, 0)
 	require.Nil(t, err)
 	AssertAsyncWorkerCount(t, 0)
 
@@ -437,7 +438,7 @@ func TestWorkerConcurrentCheckScheduling(t *testing.T) {
 	pendingChecksChan <- testCheck
 	close(pendingChecksChan)
 
-	worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 100, 200, pendingChecksChan, checksTracker, mockShouldAddStatsFunc)
+	worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 100, 200, pendingChecksChan, checksTracker, mockShouldAddStatsFunc, 0)
 	require.Nil(t, err)
 
 	worker.Run()
@@ -493,7 +494,7 @@ func TestWorkerStatsAddition(t *testing.T) {
 	pendingChecksChan <- squelchedStatsCheck
 	close(pendingChecksChan)
 
-	worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 100, 200, pendingChecksChan, checksTracker, shouldAddStatsFunc)
+	worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), 100, 200, pendingChecksChan, checksTracker, shouldAddStatsFunc, 0)
 	require.Nil(t, err)
 
 	worker.Run()
@@ -548,6 +549,7 @@ func TestWorkerServiceCheckSending(t *testing.T) {
 		},
 		haagentmock.NewMockHaAgent(),
 		pollingInterval,
+		10*time.Second,
 	)
 	require.Nil(t, err)
 
@@ -620,6 +622,7 @@ func TestWorkerSenderNil(t *testing.T) {
 		},
 		haagentmock.NewMockHaAgent(),
 		pollingInterval,
+		10*time.Second,
 	)
 	require.Nil(t, err)
 
@@ -662,6 +665,7 @@ func TestWorkerServiceCheckSendingLongRunningTasks(t *testing.T) {
 		},
 		haagentmock.NewMockHaAgent(),
 		pollingInterval,
+		10*time.Second,
 	)
 	require.Nil(t, err)
 
@@ -744,7 +748,7 @@ func TestWorker_HaIntegration(t *testing.T) {
 			haagentcomp, _ := haagentimpl.NewComponent(requires)
 			haagentcomp.Comp.SetLeader(tt.setLeaderValue)
 
-			worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentcomp.Comp, 100, 200, pendingChecksChan, checksTracker, mockShouldAddStatsFunc)
+			worker, err := NewWorker(aggregator.NewNoOpSenderManager(), haagentcomp.Comp, 100, 200, pendingChecksChan, checksTracker, mockShouldAddStatsFunc, 0)
 			require.Nil(t, err)
 
 			wg.Add(1)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1301,6 +1301,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("check_runner_utilization_warning_cooldown", 10*time.Minute)
 	config.BindEnvAndSetDefault("check_system_probe_startup_time", 5*time.Minute)
 	config.BindEnvAndSetDefault("check_system_probe_timeout", 60*time.Second)
+	config.BindEnvAndSetDefault("check_watchdog_warning_timeout", 0*time.Second) // If not zero, the agent will log a warning if a check is running for longer than this timeout
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	// used to override the path where the IPC cert/key files are stored/retrieved
 	config.BindEnvAndSetDefault("ipc_cert_file_path", "")


### PR DESCRIPTION
### What does this PR do?

Adds a watchdog in the workers that will automatically send a log when a check execution is taking more than a defined timeout. By default, this watchdog is disabled.

### Motivation

#**incident-45656,** **the** agent is restarting due to the collector queues being locked up. It is happening on multiple clusters at the same time, so the issue might be a check that's locking up all the workers. 

### Describe how you validated your changes

Added a unit test validating the behavior.

### Additional Notes