### PR TITLE
[EBPF-947] gpu: fix detection of gpu.clock_throttle_reasons.none

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -355,7 +355,7 @@ func createStatelessAPIs() []apiCallInfo {
 					"none":                        nvml.ClocksEventReasonNone,
 				} {
 					value := 0.0
-					if reasons&reasonBit != 0 {
+					if reasons&reasonBit != 0 || (reasons == 0 && reasonBit == 0) {
 						value = 1.0
 					}
 					allMetrics = append(allMetrics, Metric{


### PR DESCRIPTION
### What does this PR do?

Because `nvml.ClocksEventReasonNone` is zero, the detection of throttle reasons using a bitmask was failing and we were never detecting "none" as a reason.

### Motivation

https://datadoghq.atlassian.net/browse/EBPF-947

### Describe how you validated your changes

Locally tested in a GPU node.

### Additional Notes
