### PR TITLE
`new-e2e-installer-ansible`: skip Python2 tests earlier

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -220,18 +220,15 @@ func (s *packageBaseSuite) RunInstallScript(params ...string) {
 		err := s.RunInstallScriptWithError(params...)
 		require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stdout.log || true"), s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stderr.log || true"))
 	case InstallMethodAnsible:
+		if (s.os.Flavor == e2eos.AmazonLinux && s.os.Version == e2eos.AmazonLinux2.Version) ||
+			(s.os.Flavor == e2eos.CentOS && s.os.Version == e2eos.CentOS7.Version) {
+			s.T().Skip("Ansible doesn't install support Python2 anymore")
+		}
 		// Install ansible then install the agent
 		var ansiblePrefix string
 		for i := 0; i < 3; i++ {
-			var err error
 			ansiblePrefix = s.installAnsible(s.os)
-			if (s.os.Flavor == e2eos.AmazonLinux && s.os.Version == e2eos.AmazonLinux2.Version) ||
-				(s.os.Flavor == e2eos.CentOS && s.os.Version == e2eos.CentOS7.Version) {
-				s.T().Skip("Ansible doesn't install support Python2 anymore")
-			} else {
-				_, err = s.Env().RemoteHost.Execute(ansiblePrefix + "ansible-galaxy collection install -vvv datadog.dd")
-			}
-			if err == nil {
+			if _, err := s.Env().RemoteHost.Execute(ansiblePrefix + "ansible-galaxy collection install -vvv datadog.dd"); err == nil {
 				break
 			}
 			if i == 2 {


### PR DESCRIPTION
### What does this PR do?
This change moves the Python2 compatibility check before the Ansible installation, allowing non applicable tests to skip instantly.

### Motivation
The `new-e2e-installer-ansible` job frequently takes more than 1h50min to complete, examples:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1263220186
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1263583985 (timeout)

Currently, tests for Python2-only systems (AmazonLinux2 and CentOS7) install Ansible before checking if they should be skipped. This wastes ~2 minutes per test installing Ansible and its dependencies, only to skip immediately after.

This would spare something like 30 minutes from the above example runs.