### PR TITLE
Fix typo in TestIPCSecuirityLinuxSuite

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/ipc/ipc_security_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/ipc/ipc_security_nix_test.go
@@ -25,7 +25,7 @@ type ipcSecurityLinuxSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
-func TestIPCSecuirityLinuxSuite(t *testing.T) {
+func TestIPCSecurityLinuxSuite(t *testing.T) {
 	t.Parallel()
 	e2e.Run(t, &ipcSecurityLinuxSuite{}, e2e.WithProvisioner(awshost.Provisioner()))
 }


### PR DESCRIPTION
### What does this PR do?

Rename TestIPCSecuirityLinuxSuite to TestIPCSecurityLinuxSuite
### Motivation

### Describe how you validated your changes

### Additional Notes
