### PR TITLE
[gitlab] move install tools after deps fetching from cache

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -75,6 +75,7 @@
   - export AWS_RETRY_MAX_ATTEMPTS=5
 
 .macos_gitlab:
+  needs: ["go_deps", "go_tools_deps"]
   before_script:
     - !reference [.vault_login]
     - !reference [.aws_retry_config]
@@ -87,4 +88,6 @@
     - !reference [.macos_runner_maintenance]
     - dda inv -- -e rtloader.make
     - dda inv -- -e rtloader.install
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e install-tools

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -5,13 +5,10 @@ include:
 .lint_macos_gitlab:
   stage: lint
   extends: .macos_gitlab
-  needs: ["go_deps", "go_tools_deps"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   script:
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e linter.go --cpus 12 --debug --timeout 60
   retry: !reference [.retry_only_infra_failure, retry]
 

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -10,13 +10,10 @@ include:
   rules:
     - !reference [.except_disable_unit_tests]
     - !reference [.fast_on_dev_branch_only]
-  needs: ["go_deps", "go_tools_deps"]
   variables:
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
     TEST_OUTPUT_FILE: test_output.json
   script:
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - FAST_TESTS_FLAG=""
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi


### PR DESCRIPTION
### What does this PR do?

Move go dependencies fetching from cache to common `macos_gitlab`, before running `dda inv -- -e install-tools` 

### Motivation

We noticed an increase in duration for tests_macos_gitlab_* jobs, spending ~30mins at
```bash
cd internal/tools && go install github.com/frapposelli/wwhrd
```

while it takes 1 second normally.

Examples for [arm64](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1263259501) and [amd64](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1263059822), this last one was cancelled as it reached the timeout. This increased the duration of the mq significantly.

@KevinFairise2 spotted we ran `inv -- install tools` before fetching the go cache, moving the deps fetching to the common `macos_gitlab` job to use it when we install go tools.

### Describe how you validated your changes

Validated through CI, linters and unit tests passing on macOS

### Additional Notes
