### PR TITLE
[ABLD-46] Create individual files for ship source offers.

### DIFF
--- a/compliance/BUILD.bazel
+++ b/compliance/BUILD.bazel
@@ -13,12 +13,12 @@ py_binary(
 )
 
 # Gather the licenses for dependencies that not built by omnibus any more.
-# The target is a temporary hack. In the future, it should becomg //pkg:agent.
+# The target is a temporary hack. In the future, it should become //distrib:agent.
 license_csv(
     name = "licenses",
     csv_out = "licenses.csv",
     licenses_dir = "licenses_dir",
-    offers_out = "sources.txt",
+    offers_dir = "sources_dir",
     tags = ["manual"],
     target = "//deps:all_deps",
 )
@@ -57,10 +57,33 @@ pkg_files(
     srcs = [":license_dir_stripped"],
 )
 
+# Turn the copied offers into a target we can feed to other rules.
+filegroup(
+    name = "copied_offer_dir",
+    srcs = [":licenses"],
+    output_group = "offers",
+)
+
+# This silliness is to strip the directory name of the offer
+# TreeArtifact.
+filter_directory(
+    name = "offer_dir_stripped",
+    src = ":copied_offer_dir",
+    outdir_name = "sources",
+    strip_prefix = ".",
+)
+
+# You would expect that filter_directory returns something usuable to pkg_* rules.
+# It does not, so we have to wrap it.
+pkg_files(
+    name = "offer_copies",
+    srcs = [":offer_dir_stripped"],
+)
+
 pkg_install(
     name = "install_licenses",
     srcs = [
         ":license_copies",
-        ":source_offers",
+        ":offer_copies",
     ],
 )

--- a/compliance/gather_licenses.py
+++ b/compliance/gather_licenses.py
@@ -54,7 +54,7 @@ import csv
 import json
 import os
 
-_DEBUG = 1
+_DEBUG = 0
 
 from tasks.licenses import find_copyright_in_text
 
@@ -91,7 +91,7 @@ class AttrUsage:
     def __init__(self):
         self.licenses = {}
         self.attribute_kinds = {}
-        self.offers = []
+        self.offers = {}
 
     def set_kinds(self, attribute_kinds):
         self.attribute_kinds = attribute_kinds
@@ -159,7 +159,7 @@ class AttrUsage:
 
     def process_source_offer(self, purl=None):
         package = (purl.split("?")[0]).split("/")[-1]
-        self.offers.append(
+        self.offers[package] = (
             f"This package ships {package}\nContact Datadog Support (http://docs.datadoghq.com/help/) to request the sources of this software.\n"
         )
 
@@ -168,8 +168,9 @@ def main():
     parser = argparse.ArgumentParser(description="Helper for gathering third party license information.")
     parser.add_argument("--target", help="The target we are processing.")
     parser.add_argument("--csv_out", help="The CSV style output file.")
+    parser.add_argument("--licenses_dir", help="Directory to copy license texts to.")
+    parser.add_argument("--offers_dir", help="Directory to write 'ship source' offers to.")
     parser.add_argument("--offers_out", help="File to write 'ship source' offers to.")
-    parser.add_argument("--licenses_dir", help="Directory to copy license tesxt to.")
     parser.add_argument("--usage_map", required=True, help="The changes output file, mandatory.")
     parser.add_argument("--kinds", required=True, help="JSON file mapping file paths to their kinds, mandatory.")
     parser.add_argument("--metadata", action='append', help="path to a metadata bundle")
@@ -207,9 +208,19 @@ def main():
             for license in licenses:
                 csv_writer.writerow(license)
 
+    if options.offers_dir:
+        for package in attrs.offers:
+            short_package = package.split("@")[0]  #  foo@version => foo
+            os.mkdir(os.path.join(options.offers_dir, short_package))
+            copy_to = os.path.join(options.offers_dir, short_package, "offer.txt")
+            if _DEBUG > 1:
+                print(f"writing {copy_to}")
+            with open(copy_to, "w", encoding="UTF-8") as out:
+                out.write(attrs.offers[package])
+
     if options.offers_out:
         with open(options.offers_out, "w", encoding="UTF-8") as out:
-            out.write("\n".join(attrs.offers))
+            out.write("\n".join(attrs.offers.values()))
 
     if options.licenses_dir:
         for origin, data in attrs.licenses.items():


### PR DESCRIPTION
This change extends licenses_csv to be able to create individual offer files for each package. This is in addition to the previous capability to emit all the offers into a single file. Single files are the way we have previously done this, so the current default is that legacy technique. As a low priority effort, I'll be advocating to condense them to a single file, so both output styles co-exist.

### Sample
```
$ bazel run -- //compliance:install_licenses --destdir=/tmp/xi
$ find /tmp/xi
/tmp/xi
/tmp/xi/LICENSES
/tmp/xi/LICENSES/xz-COPYING.0BSD
/tmp/xi/LICENSES/-COPYING.LGPL
/tmp/xi/LICENSES/zlib-LICENSE
/tmp/xi/LICENSES/libffi-LICENSE
/tmp/xi/LICENSES/bzip2-LICENSE
/tmp/xi/LICENSES/nghttp2-COPYING
/tmp/xi/sources
/tmp/xi/sources/acl
/tmp/xi/sources/acl/offer.txt
/tmp/xi/sources/attr
/tmp/xi/sources/attr/offer.txt
$ cat /tmp/xi/sources/attr/offer.txt
This package ships attr@2.5.1
Contact Datadog Support (http://docs.datadoghq.com/help/) to request the sources of this software.
```