### PR TITLE
Adds optimized-for-local-dev omnibus docker build invoke task

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -4,6 +4,7 @@
 # Copyright 2016-present Datadog, Inc.
 require "./lib/ostools.rb"
 require "./lib/project_helpers.rb"
+require "./lib/omnibus/packagers/tarball.rb"
 flavor = ENV['AGENT_FLAVOR']
 output_config_dir = ENV["OUTPUT_CONFIG_DIR"]
 
@@ -210,9 +211,14 @@ package :msi do
 end
 
 package :xz do
-  skip_packager (!do_build && !BUILD_OCIRU) || heroku_target?
+  skip_packager (!do_build && !BUILD_OCIRU) || heroku_target? || (ENV["COMPRESS_PACKAGE"] == "false")
   compression_threads COMPRESSION_THREADS
   compression_level COMPRESSION_LEVEL
+end
+
+# Uncompressed tar for faster local builds (skip the slow XZ compression)
+package :tarball do
+  skip_packager !(ENV["COMPRESS_PACKAGE"] == "false")
 end
 
 # ------------------------------------

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -211,14 +211,14 @@ package :msi do
 end
 
 package :xz do
-  skip_packager (!do_build && !BUILD_OCIRU) || heroku_target? || (ENV["COMPRESS_PACKAGE"] == "false")
+  skip_packager (!do_build && !BUILD_OCIRU) || heroku_target? || (ENV["SKIP_PKG_COMPRESSION"] == "true")
   compression_threads COMPRESSION_THREADS
   compression_level COMPRESSION_LEVEL
 end
 
 # Uncompressed tar for faster local builds (skip the slow XZ compression)
 package :tarball do
-  skip_packager !(ENV["COMPRESS_PACKAGE"] == "false")
+  skip_packager !(ENV["SKIP_PKG_COMPRESSION"] == "true")
 end
 
 # ------------------------------------

--- a/omnibus/config/projects/ddot.rb
+++ b/omnibus/config/projects/ddot.rb
@@ -4,6 +4,7 @@
 # Copyright 2016-present Datadog, Inc.
 require "./lib/ostools.rb"
 require "./lib/project_helpers.rb"
+require "./lib/omnibus/packagers/tarball.rb"
 
 name 'ddot'
 if fips_mode?
@@ -167,9 +168,14 @@ package :msi do
 end
 
 package :xz do
-  skip_packager do_package
+  skip_packager do_package || (ENV["COMPRESS_PACKAGE"] == "false")
   compression_threads COMPRESSION_THREADS
   compression_level COMPRESSION_LEVEL
+end
+
+# Uncompressed tar for faster local builds (skip the slow XZ compression)
+package :tarball do
+  skip_packager !(ENV["COMPRESS_PACKAGE"] == "false")
 end
 
 # all flavors use the same package scripts

--- a/omnibus/config/projects/ddot.rb
+++ b/omnibus/config/projects/ddot.rb
@@ -168,14 +168,14 @@ package :msi do
 end
 
 package :xz do
-  skip_packager do_package || (ENV["COMPRESS_PACKAGE"] == "false")
+  skip_packager do_package || (ENV["SKIP_PKG_COMPRESSION"] == "true")
   compression_threads COMPRESSION_THREADS
   compression_level COMPRESSION_LEVEL
 end
 
 # Uncompressed tar for faster local builds (skip the slow XZ compression)
 package :tarball do
-  skip_packager !(ENV["COMPRESS_PACKAGE"] == "false")
+  skip_packager !(ENV["SKIP_PKG_COMPRESSION"] == "true")
 end
 
 # all flavors use the same package scripts

--- a/omnibus/lib/omnibus/packagers/tarball.rb
+++ b/omnibus/lib/omnibus/packagers/tarball.rb
@@ -42,16 +42,15 @@ module Omnibus
       "#{project.package_name}#{debug ? "-dbg" : ""}-#{project.build_version}-#{project.build_iteration}-#{safe_architecture}.tar"
     end
 
-    def safe_architecture(val = NULL)
-      val = shellout!("uname --processor").stdout.strip
+    def safe_architecture
+      raw = shellout!("uname --processor").stdout.strip
 
-      val = case val
-            when "x86_64", "x64", "amd64" then "amd64"
-            when "arm64", "aarch64" then "arm64"
-            when "armv7l" then "arm"
-            else raise ArgumentError, "Unknown architecture '#{val}'"
-            end
-      val
+      case raw
+      when "x86_64", "x64", "amd64" then "amd64"
+      when "arm64", "aarch64" then "arm64"
+      when "armv7l" then "arm"
+      else raise ArgumentError, "Unknown architecture '#{raw}'"
+      end
     end
   end
 

--- a/omnibus/lib/omnibus/packagers/tarball.rb
+++ b/omnibus/lib/omnibus/packagers/tarball.rb
@@ -1,0 +1,66 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+# Custom tarball packager for creating uncompressed tar archives.
+# This is useful for local development builds where compression time
+# is not worth the disk space savings.
+
+require "pathname"
+
+module Omnibus
+  class Packager::Tarball < Packager::Base
+    id :tarball
+
+    setup do
+    end
+
+    build do
+      out_file = windows_safe_path(Config.package_dir, package_name)
+      input_paths = ["#{windows_safe_path(project.install_dir)}/*"] + project.extra_package_files
+      cmd = <<-EOH.split.join(" ").squeeze(" ").strip
+        tar -cf
+        #{out_file}
+        #{input_paths.join(" ")}
+      EOH
+      shellout!(cmd)
+
+      if debug_build?
+        out_file = windows_safe_path(Config.package_dir, package_name(true))
+        cmd = <<-EOH.split.join(" ").squeeze(" ").strip
+          tar -cf
+          #{out_file}
+          #{debug_package_paths.map { |dir| File.join(install_dir, dir) }.join(' ')}
+        EOH
+        shellout!(cmd)
+      end
+    end
+
+    # @see Base#package_name
+    def package_name(debug = false)
+      "#{project.package_name}#{debug ? "-dbg" : ""}-#{project.build_version}-#{project.build_iteration}-#{safe_architecture}.tar"
+    end
+
+    def safe_architecture(val = NULL)
+      val = shellout!("uname --processor").stdout.strip
+
+      val = case val
+            when "x86_64", "x64", "amd64" then "amd64"
+            when "arm64", "aarch64" then "arm64"
+            when "armv7l" then "arm"
+            else raise ArgumentError, "Unknown architecture '#{val}'"
+            end
+      val
+    end
+  end
+
+  # Register Tarball packager for all Linux platforms
+  # The skip_packager logic in the project files controls when it's actually used
+  Packager::PLATFORM_PACKAGER_MAP.each do |platform, packagers|
+    next unless packagers.is_a?(Array)
+    next if packagers.include?(Packager::Tarball)
+    # Add Tarball to platforms that have XZ
+    packagers << Packager::Tarball if packagers.include?(Packager::XZ)
+  end
+end

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -19,7 +19,7 @@ ENV_PASSHTROUGH = {
     'CI': "dda and `bazel` rely on this to be able to tell whether they're running on CI and adapt behavior",
     'DD_CC': 'Points at c compiler',
     'DD_CXX': 'Points at c++ compiler',
-    'COMPRESS_PACKAGE': 'Whether to compress the package with XZ (set to false for faster local builds)',
+    'SKIP_PKG_COMPRESSION': 'Skip package XZ compression (set to true for faster local builds)',
     'DD_CMAKE_TOOLCHAIN': 'Points at cmake toolchain',
     'DDA_NO_DYNAMIC_DEPS': 'Variable affecting dda behavior',
     'E2E_COVERAGE_PIPELINE': 'Used to do a special build of the agent to generate coverage data',

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -19,6 +19,7 @@ ENV_PASSHTROUGH = {
     'CI': "dda and `bazel` rely on this to be able to tell whether they're running on CI and adapt behavior",
     'DD_CC': 'Points at c compiler',
     'DD_CXX': 'Points at c++ compiler',
+    'COMPRESS_PACKAGE': 'Whether to compress the package with XZ (set to false for faster local builds)',
     'DD_CMAKE_TOOLCHAIN': 'Points at cmake toolchain',
     'DDA_NO_DYNAMIC_DEPS': 'Variable affecting dda behavior',
     'E2E_COVERAGE_PIPELINE': 'Used to do a special build of the agent to generate coverage data',

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -541,6 +541,15 @@ def docker_build(
     """
     Build the Agent inside a Docker container and create a runnable Docker image.
 
+    This is ideal for local development when you want production-like builds without
+    setting up a local omnibus/Ruby environment. It handles Docker Desktop VirtioFS
+    quirks and uses the same buildimages as CI.
+
+    Related tasks:
+    - omnibus.build: For CI pipelines or when you have local omnibus/Ruby setup
+    - agent.image-build: Creates Docker image from existing omnibus deb package
+    - agent.hacky-dev-image-build: Quick iteration with locally-built binaries (not omnibus)
+
     This task:
     1. Runs the omnibus build inside a Docker container (with caching)
     2. Creates a Docker image from the build output

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -743,17 +743,7 @@ def docker_build(
         f"Dockerfiles/agent"
     )
 
-    # Create empty placeholder to satisfy Dockerfile line 140's COPY instruction.
-    # The actual extraction uses --mount from artifacts context (line 158), so
-    # line 140's COPY is dead code - we just need the file to exist.
-    dockerfile_dir = os.path.join(os.getcwd(), "Dockerfiles", "agent")
-    temp_tarball_path = os.path.join(dockerfile_dir, artifact_name)
-    try:
-        open(temp_tarball_path, 'w').close()  # Create 0-byte file
-        ctx.run(docker_build_cmd)
-    finally:
-        if os.path.exists(temp_tarball_path):
-            os.unlink(temp_tarball_path)
+    ctx.run(docker_build_cmd)
 
     # Print clear usage instructions
     print("\n" + "=" * 60)

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -653,7 +653,7 @@ def docker_build(
         "-e GIT_CONFIG_KEY_0=safe.directory",
         "-e GIT_CONFIG_VALUE_0=/go/src/github.com/DataDog/datadog-agent",
         # Skip XZ compression - faster for local dev, use omnibus.build for CI
-        "-e COMPRESS_PACKAGE=false",
+        "-e SKIP_PKG_COMPRESSION=true",
     ]
 
     # Build volume mounts (note: /opt/datadog-agent is a symlink created in build_cmd)
@@ -704,7 +704,7 @@ def docker_build(
 
     artifacts_dir = os.path.join(omnibus_dir, "pkg")
 
-    # Find the uncompressed tarball (we always set COMPRESS_PACKAGE=false)
+    # Find the uncompressed tarball (we always set SKIP_PKG_COMPRESSION=true)
     tar_pattern = os.path.join(artifacts_dir, f"datadog-agent-*-{arch}.tar")
     tar_files = sorted(glob.glob(tar_pattern), key=os.path.getmtime, reverse=True)
 

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -605,12 +605,6 @@ def docker_build(
     for d in [omnibus_dir, git_cache_dir, opt_dir, gems_dir, go_mod_dir, go_build_dir]:
         os.makedirs(d, exist_ok=True)
 
-    # Initialize git cache directory if needed
-    git_dir = os.path.join(git_cache_dir, ".git")
-    if not os.path.exists(git_dir):
-        print(f"Initializing git cache in {git_cache_dir}")
-        ctx.run(f"git -C {git_cache_dir} init")
-
     # Get current working directory (repo root)
     repo_root = os.getcwd()
 

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -523,7 +523,7 @@ def _packages_from_deb_metadata(lines: Iterator[str]) -> Iterator[DebPackageInfo
         'cache-dir': "Base directory for caches (default: ~/.omnibus-docker-cache)",
         'workers': "Number of parallel workers for compression and builds (default: 8)",
         'build-image': "Docker build image to use (default: uses version from .gitlab-ci.yml)",
-        'tag': "Tag for the built Docker image (default: datadog-agent:local)",
+        'tag': "Tag for the built Docker image (default: localhost/datadog-agent:local)",
     }
 )
 def docker_build(
@@ -532,7 +532,7 @@ def docker_build(
     cache_dir=None,
     workers=8,
     build_image=None,
-    tag="datadog-agent:local",
+    tag="localhost/datadog-agent:local",
 ):
     """
     Build the Agent inside a Docker container and create a runnable Docker image.


### PR DESCRIPTION
## Summary
- Adds a single invoke task that builds the Agent inside Docker and produces a runnable Docker image
- Optimized for local development: uses uncompressed tarball output by default (skips slow XZ compression)
- Aware of `workspaces` dir mount conventions and leverages them for caches.
- Caches everything for fast incremental rebuilds (~21GB cache: go modules, go build cache, omnibus sources, gems)

## Usage

```bash
# Build Agent and create Docker image (default tag: datadog-agent:local)
dda inv omnibus.docker-build

# Custom image tag
dda inv omnibus.docker-build --tag=my-agent:dev

# Build with XZ compression (like CI, slower)
dda inv omnibus.docker-build --compress
```

## What it does

1. Runs omnibus build inside `datadog/agent-buildimages-linux` container
2. Mounts persistent cache volumes for fast incremental builds
3. Produces uncompressed tarball (faster than XZ)
4. Builds Docker image from tarball using `Dockerfiles/agent/Dockerfile`
5. Loads image into local Docker daemon
6. Prints clear run instructions

## Test plan
- [x] Run `dda inv omnibus.docker-build` with warm cache
- [x] Run `docker run --rm datadog-agent:local agent version`
- [ ] Verify `--tag` flag works

