### PR TITLE
`new-e2e-installer`: decrease `TestInstrumentDockerInactive` flakiness

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -724,7 +724,6 @@ new-e2e-installer:
     FLEET_INSTALL_METHOD: "install_script"
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
     E2E_USE_AWS_PROFILE: "false"
-    MAX_RETRIES_FLAG: "--max-retries=3"
 
 new-e2e-installer-ansible:
   extends: .new_e2e_template


### PR DESCRIPTION
### What does this PR do?
This is to decrease flakiness of `TestInstrumentDockerInactive` that occurs on debian_12, suse_15_4 (x86_64/arm64), and ubuntu_24_04 (x86_64/arm64).

### Motivation
The job as a whole often takes 1+ hour to complete. These 5 test failures add ~3-4 minutes of retry time each, contributing to longer CI feedback loops.

### Additional Notes