### PR TITLE
Versa topology

### DIFF
--- a/pkg/collector/corechecks/network-devices/versa/client/client.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client.go
@@ -350,7 +350,6 @@ func (client *Client) GetInterfaces(tenantName string) ([]Interface, error) {
 
 // GetTopology retrieves topology data for for a specific appliance and tenant
 func (client *Client) GetTopology(applianceName string) ([]Neighbor, error) {
-	log.Tracef("Getting topology metadata for appliance: %s", applianceName)
 
 	if applianceName == "" {
 		return nil, fmt.Errorf("applianceName cannot be empty")

--- a/pkg/collector/corechecks/network-devices/versa/client/client.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client.go
@@ -349,13 +349,15 @@ func (client *Client) GetInterfaces(tenantName string) ([]Interface, error) {
 }
 
 // GetTopology retrieves topology data for for a specific appliance and tenant
-func (client *Client) GetTopology(applianceName string, tenantName string) ([]Neighbor, error) {
+func (client *Client) GetTopology(applianceName string) ([]Neighbor, error) {
+	log.Tracef("Getting topology metadata for appliance: %s", applianceName)
+
 	if applianceName == "" {
 		return nil, fmt.Errorf("applianceName cannot be empty")
 	}
-	if tenantName == "" {
-		return nil, fmt.Errorf("tenantName cannot be empty")
-	}
+	// if tenantName == "" {
+	// 	return nil, fmt.Errorf("tenantName cannot be empty")
+	// }
 
 	// params := map[string]string{
 	// 	"tenantName": tenantName,
@@ -372,7 +374,38 @@ func (client *Client) GetTopology(applianceName string, tenantName string) ([]Ne
 	// 	return nil, errors.New("failed to get topology: returned nil")
 	// }
 
-	return []Neighbor{}, nil
+	return []Neighbor{
+		Neighbor{
+			SystemName: "Mock System Name",
+			SystemDescription: "Mock System Description",
+			ChassisID: "1",
+			DeviceIDType: "chassisID",
+			IPAddress: "10.0.0.1",
+			PortID: "1",
+			PortIDType: "portID",
+			PortDescription: "Port Description 1",
+		},
+		Neighbor{
+			SystemName: "Mock System Name 2",
+			SystemDescription: "Mock System Description 2",
+			ChassisID: "2",
+			DeviceIDType: "chassisID",
+			IPAddress: "10.0.0.2",
+			PortID: "2",
+			PortIDType: "portID",
+			PortDescription: "Port Description 2",
+		},
+		Neighbor{
+			SystemName: "Mock System Name 3",
+			SystemDescription: "Mock System Description 3",
+			ChassisID: "3",
+			DeviceIDType: "chassisID",
+			IPAddress: "10.0.0.3",
+			PortID: "3",
+			PortIDType: "portID",
+			PortDescription: "Port Description 3",
+		},
+	}, nil
 }
 
 // GetInterfaceMetrics retrieves interface metrics for a specific appliance and tenant using pagination

--- a/pkg/collector/corechecks/network-devices/versa/client/client.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client.go
@@ -349,31 +349,31 @@ func (client *Client) GetInterfaces(tenantName string) ([]Interface, error) {
 }
 
 // GetTopology retrieves topology data for for a specific appliance andtenant
-func (client *Client) GetTopology(applianceName string, tenantName string) ([]Topology, error) {
-	if applianceName == "" {
-		return nil, fmt.Errorf("applianceName cannot be empty")
-	}
-	if tenantName == "" {
-		return nil, fmt.Errorf("tenantName cannot be empty")
-	}
+// func (client *Client) GetTopology(applianceName string, tenantName string) ([]Topology, error) {
+// 	if applianceName == "" {
+// 		return nil, fmt.Errorf("applianceName cannot be empty")
+// 	}
+// 	if tenantName == "" {
+// 		return nil, fmt.Errorf("tenantName cannot be empty")
+// 	}
 
-	params := map[string]string{
-		"tenantName": tenantName,
-	}
+// 	params := map[string]string{
+// 		"tenantName": tenantName,
+// 	}
 
-	lldpPath := "command=lldp/neighbor/detail/interface-detail"
-	path := fmt.Sprintf("/vnms/dashboard/appliance/%s/live?uuid=%s&%s", applianceName, applianceUUID, lldpPath)
+// 	lldpPath := "command=lldp/neighbor/detail/interface-detail"
+// 	path := fmt.Sprintf("/vnms/dashboard/appliance/%s/live?uuid=%s&%s", applianceName, applianceUUID, lldpPath)
 
-	resp, err := get[InterfaceListResponse](client, path, params, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get interfaces: %v", err)
-	}
-	if resp == nil {
-		return nil, errors.New("failed to get interfaces: returned nil")
-	}
+// 	resp, err := get[InterfaceListResponse](client, path, params, false)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to get interfaces: %v", err)
+// 	}
+// 	if resp == nil {
+// 		return nil, errors.New("failed to get interfaces: returned nil")
+// 	}
 
-	return resp.List.Value, nil
-}
+// 	return resp.List.Value, nil
+// }
 
 // GetInterfaceMetrics retrieves interface metrics for a specific appliance and tenant using pagination
 func (client *Client) GetInterfaceMetrics(applianceName string, tenantName string) ([]InterfaceMetrics, error) {

--- a/pkg/collector/corechecks/network-devices/versa/client/client.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client.go
@@ -348,32 +348,32 @@ func (client *Client) GetInterfaces(tenantName string) ([]Interface, error) {
 	return resp.List.Value, nil
 }
 
-// GetTopology retrieves topology data for for a specific appliance andtenant
-// func (client *Client) GetTopology(applianceName string, tenantName string) ([]Topology, error) {
-// 	if applianceName == "" {
-// 		return nil, fmt.Errorf("applianceName cannot be empty")
-// 	}
-// 	if tenantName == "" {
-// 		return nil, fmt.Errorf("tenantName cannot be empty")
-// 	}
+// GetTopology retrieves topology data for for a specific appliance and tenant
+func (client *Client) GetTopology(applianceName string, tenantName string) ([]Neighbor, error) {
+	if applianceName == "" {
+		return nil, fmt.Errorf("applianceName cannot be empty")
+	}
+	if tenantName == "" {
+		return nil, fmt.Errorf("tenantName cannot be empty")
+	}
 
-// 	params := map[string]string{
-// 		"tenantName": tenantName,
-// 	}
+	// params := map[string]string{
+	// 	"tenantName": tenantName,
+	// }
 
-// 	lldpPath := "command=lldp/neighbor/detail/interface-detail"
-// 	path := fmt.Sprintf("/vnms/dashboard/appliance/%s/live?uuid=%s&%s", applianceName, applianceUUID, lldpPath)
+	// command := 'lldp/neighbor/detail/interface-detail'
+	// path := fmt.Sprintf("/vnms/dashboard/appliance/%s/live?uuid=%s&command%s", applianceName, UUID, command)
 
-// 	resp, err := get[InterfaceListResponse](client, path, params, false)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to get interfaces: %v", err)
-// 	}
-// 	if resp == nil {
-// 		return nil, errors.New("failed to get interfaces: returned nil")
-// 	}
+	// resp, err := get[LldpNeighborInterfaceDetailResponse](client, path, params, false)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to get topology: %v", err)
+	// }
+	// if resp == nil {
+	// 	return nil, errors.New("failed to get topology: returned nil")
+	// }
 
-// 	return resp.List.Value, nil
-// }
+	return []Neighbor{}, nil
+}
 
 // GetInterfaceMetrics retrieves interface metrics for a specific appliance and tenant using pagination
 func (client *Client) GetInterfaceMetrics(applianceName string, tenantName string) ([]InterfaceMetrics, error) {

--- a/pkg/collector/corechecks/network-devices/versa/client/client.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client.go
@@ -348,6 +348,33 @@ func (client *Client) GetInterfaces(tenantName string) ([]Interface, error) {
 	return resp.List.Value, nil
 }
 
+// GetTopology retrieves topology data for for a specific appliance andtenant
+func (client *Client) GetTopology(applianceName string, tenantName string) ([]Topology, error) {
+	if applianceName == "" {
+		return nil, fmt.Errorf("applianceName cannot be empty")
+	}
+	if tenantName == "" {
+		return nil, fmt.Errorf("tenantName cannot be empty")
+	}
+
+	params := map[string]string{
+		"tenantName": tenantName,
+	}
+
+	lldpPath := "command=lldp/neighbor/detail/interface-detail"
+	path := fmt.Sprintf("/vnms/dashboard/appliance/%s/live?uuid=%s&%s", applianceName, applianceUUID, lldpPath)
+
+	resp, err := get[InterfaceListResponse](client, path, params, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get interfaces: %v", err)
+	}
+	if resp == nil {
+		return nil, errors.New("failed to get interfaces: returned nil")
+	}
+
+	return resp.List.Value, nil
+}
+
 // GetInterfaceMetrics retrieves interface metrics for a specific appliance and tenant using pagination
 func (client *Client) GetInterfaceMetrics(applianceName string, tenantName string) ([]InterfaceMetrics, error) {
 	if applianceName == "" {

--- a/pkg/collector/corechecks/network-devices/versa/client/client_test.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client_test.go
@@ -370,6 +370,27 @@ func TestGetDirectorStatus(t *testing.T) {
 	require.Equal(t, expectedDirectorStatus, actualDirectorStatus)
 }
 
+func TestGetTopology(t *testing.T) {
+	expectedTopology := []Neighbor{
+		{
+			
+		},
+	}
+
+	server := SetupMockAPIServer()
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	actualTopology, err := client.GetTopology("test-branch-2B")
+	require.NoError(t, err)
+
+	// Check contents
+	require.Equal(t, expectedTopology, actualTopology)
+
+}
+
 func TestGetSLAMetrics(t *testing.T) {
 	expectedSLAMetrics := []SLAMetrics{
 		{

--- a/pkg/collector/corechecks/network-devices/versa/client/types.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/types.go
@@ -547,6 +547,7 @@ type AnalyticsInterfaceMetrics struct {
 type LldpNeighborInterfaceDetailResponse struct {
 }
 
+// Neighbor encapsulates metadata for a Versa neighbor device
 type Neighbor struct {
 	SystemName string
 	SystemDescription string

--- a/pkg/collector/corechecks/network-devices/versa/client/types.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/types.go
@@ -542,3 +542,18 @@ type AnalyticsInterfaceMetrics struct {
 	BandwidthTx float64
 	Bandwidth   float64
 }
+
+// LldpNeighborInterfaceDetailResponse /versa/ncs-services/vnms/dashboard/appliance/<applianceName>/live?uuid=<UUID>&command=lldp/neighbor/detail/interface-detail
+type LldpNeighborInterfaceDetailResponse struct {
+}
+
+type Neighbor struct {
+	SystemName string
+	SystemDescription string
+	ChassisID string
+	DeviceIDType string
+	IPAddress string
+	PortID string
+	PortIDType string
+	PortDescription string
+}

--- a/pkg/collector/corechecks/network-devices/versa/payload/topology.go
+++ b/pkg/collector/corechecks/network-devices/versa/payload/topology.go
@@ -2,8 +2,11 @@
 package payload
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/versa/client"
 	devicemetadata "github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+	"fmt"
+
 )
 
 // GetDeviceMetadataFromAppliances process devices API payloads to build metadata
@@ -11,76 +14,89 @@ func GetTopologyMetadata(namespace string, deviceNameToIPMap map[string]string, 
 
 	var links []devicemetadata.TopologyLinkMetadata
 
+	// Iterate over all appliances, build topology for each device
 	for _, device := range appliances {
+
 		device_id := buildDeviceID(namespace, device.IPAddress)
 
-		// Build topology data for the local device, and the remote device that is connected
-		local = generate_local_side(device_id, device_name: device.Name, device_description: device.Description, device_ip: device.IPAddress)
-		remote = generate_remote_side()
+		// Will have to iterate over all connections, building links for each
+		RemoteSystemName:=""
+		RemoteSystemDescription:=""
+		id:=""
+		idType:=""
+		RemoteIpAddress:=""
+		RemotePortId:=""
+		RemotePortDescription:=""
 
-		newLink := TopologyLinkMetadata{
-			id=generate_topology_link_id(local_device_id, local_port_id, remote_port_id),
-            source_type="",
-            integration="versa",
-            local=local
-            remote=remote
-		}
-		links = append(links, newLink)
+		local := generate_local_side(device_id, "")
+		remote := generate_remote_side(
+            RemoteSystemName,
+            RemoteSystemDescription,
+            id,
+            idType,
+            RemoteIpAddress,
+            RemotePortId,
+            RemotePortDescription,
+        )
+
+        link := devicemetadata.TopologyLinkMetadata{
+            ID: generate_topology_link_id(device_id, "", RemotePortId),
+            SourceType: "lldp",
+            Integration: "versa",
+            Local: &local,
+            Remote: &remote,
+        }
+
+		links = append(links, link)
 	}
 
 	return links, nil
 }
 
-func generate_local_side(local_device_id string, ) {
-	return TopologyLinkSide{
-        device=TopologyLinkDevice(dd_id=device_id),
-        interface=TopologyLinkInterface{
-            dd_id=generate_interface_dd_id(),
-            id=,
-            id_type="",
-		}
-		}
+func generate_local_side(device_id string, local_port_id string) devicemetadata.TopologyLinkSide {
+    return devicemetadata.TopologyLinkSide{
+        Device: &devicemetadata.TopologyLinkDevice{
+            DDID: device_id,
+        },
+        Interface: &devicemetadata.TopologyLinkInterface{
+            DDID: generate_interface_dd_id(),
+            ID: local_port_id,
+            IDType: "",
+        },
+    }
 }
 
-func generate_remote_side() {
-	// Check if the device is monitored by Datadog, if it is, can use a DD ID
-	remote_device_dd_id = None
-    if remote_device:
-        remote_device_dd_id = remote_device.serial
-
-    return TopologyLinkSide(
-        device=TopologyLinkDevice(
-            dd_id=remote_device_dd_id,
-            name=sys_name,
-            description=sys_desc,
-            id=id,
-            id_type=id_type,
-            ip_address=ip_addr,
-        ),
-        interface=generate_remote_interface(remote_device, port_id, port_desc)
+func generate_remote_side(sys_name string, sys_desc string, id string, id_type string, ip_addr string, port_id string, port_desc string) devicemetadata.TopologyLinkSide {
+    return devicemetadata.TopologyLinkSide{
+        Device: &devicemetadata.TopologyLinkDevice{
+            DDID: generate_device_dd_id(),
+            Name: sys_name,
+            Description: sys_desc,
+            ID: id,
+            IDType: id_type,
+            IPAddress: ip_addr,
+        },
+        Interface: generate_remote_interface(remote_device, port_id, port_desc),
+	}
 }
 
-func generate_remote_interface(remote_device client.Device, port_id string, port_desc string) {
-	
-	remote_interface = TopologyLinkInterface{id=f"Port {port_id}", id_type="interface_name", description=port_desc}
-    
-	if remote_device:
-        remote_interface_dd_id, ok = generate_interface_dd_id()
 
-        if ok:
-            remote_interface = TopologyLinkInterface{dd_id=remote_interface_dd_id}
-        else:
-            remote_interface = TopologyLinkInterface{id=, id_type=""}
-
-    return remote_interface
-}
-
-// generate_interface_dd_id returns the Datadog ID for the interface, error indicates the interface does not resolve to device that is monitored by Datadog
-func generate_interface_dd_id() (id string, error) {
-
-	return nil, errors.New("Not a Datadog monitored device")
+func generate_remote_interface(port_id string, port_desc string) *devicemetadata.TopologyLinkInterface {
+	remote_interface := devicemetadata.TopologyLinkInterface{
+		DDID: generate_interface_dd_id(),
+		ID: port_id,
+		IDType: "interface_name",
+		Description: port_desc,
+	}
+	return &remote_interface
 }
 
 func generate_topology_link_id(local_device_id string, local_port_id string, remote_port_id string) string {
-	return f"{local_device_id}:{local_port_id}.{remote_port_id}"
+    //Generate the topology link ID according to NDM format
+    return fmt.Sprintf("%s:%s.%s", local_device_id, local_port_id, remote_port_id)
+}
+
+func generate_interface_dd_id() string {
+    //Generate the device's interface ID if possible (Datadog monitored device and interface)
+    return ""
 }

--- a/pkg/collector/corechecks/network-devices/versa/payload/topology.go
+++ b/pkg/collector/corechecks/network-devices/versa/payload/topology.go
@@ -7,12 +7,9 @@
 package payload
 
 import (
-
+	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/versa/client"
 	devicemetadata "github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
-	"fmt"
-
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
 // GetTopologyMetadata process a list of device neighbors into topology links
@@ -26,66 +23,66 @@ func GetTopologyMetadata(namespace string, deviceNameToIPMap map[string]string, 
 		// Will have to iterate over/unpack all of the connections to the current device
 
 		// Collect the data needed to build the links
-		localDeviceId := buildDeviceID(namespace, device.IPAddress)
-		localPortId:=""
-		localPortIdType:=""
+		localDeviceID := buildDeviceID(namespace, device.IPAddress)
+		localPortID := ""
+		localPortIDType := ""
 
 		var remoteLink *devicemetadata.TopologyLinkSide
 
-		if datadogDevice(neighbor.SystemName, neighbor.IPAddress, deviceNameToIPMap){ //if the remote device is monitored by Datadog, create remote structs with DDIDs
+		if datadogDevice(neighbor.SystemName, neighbor.IPAddress, deviceNameToIPMap) { //if the remote device is monitored by Datadog, create remote structs with DDIDs
 			remoteDeviceDDID := buildDeviceID(namespace, neighbor.IPAddress)
-			remoteInterfaceDDID := generate_interface_dd_id()
+			remoteInterfaceDDID := generateInterfaceDDID()
 
 			remoteLink = &devicemetadata.TopologyLinkSide{
 				Device: &devicemetadata.TopologyLinkDevice{
-					DDID: remoteDeviceDDID,
-					Name: neighbor.SystemName,
+					DDID:        remoteDeviceDDID,
+					Name:        neighbor.SystemName,
 					Description: neighbor.SystemDescription,
-					ID: neighbor.ChassisID,
-					IDType: neighbor.DeviceIDType,
-					IPAddress: neighbor.IPAddress,
+					ID:          neighbor.ChassisID,
+					IDType:      neighbor.DeviceIDType,
+					IPAddress:   neighbor.IPAddress,
 				},
 				Interface: &devicemetadata.TopologyLinkInterface{
-					DDID: remoteInterfaceDDID,
-					ID: neighbor.PortID,
-					IDType: neighbor.PortIDType,
+					DDID:        remoteInterfaceDDID,
+					ID:          neighbor.PortID,
+					IDType:      neighbor.PortIDType,
 					Description: neighbor.PortDescription,
 				},
 			}
 		} else { //if the remote device is not monitored by Datadog, create remote structs without DDIDs
 			remoteLink = &devicemetadata.TopologyLinkSide{
 				Device: &devicemetadata.TopologyLinkDevice{
-					Name: neighbor.SystemName,
+					Name:        neighbor.SystemName,
 					Description: neighbor.SystemDescription,
-					ID: neighbor.ChassisID,
-					IDType: neighbor.DeviceIDType,
-					IPAddress: neighbor.IPAddress,
+					ID:          neighbor.ChassisID,
+					IDType:      neighbor.DeviceIDType,
+					IPAddress:   neighbor.IPAddress,
 				},
 				Interface: &devicemetadata.TopologyLinkInterface{
-					ID: neighbor.PortID,
-					IDType: neighbor.PortIDType,
+					ID:          neighbor.PortID,
+					IDType:      neighbor.PortIDType,
 					Description: neighbor.PortDescription,
 				},
 			}
 		}
 
 		// create the link
-        link := devicemetadata.TopologyLinkMetadata{
-            ID: generate_topology_link_id(localDeviceId, localPortId, neighbor.PortID),
-            SourceType: "lldp",
-            Integration: "versa",
-            Local: &devicemetadata.TopologyLinkSide{
+		link := devicemetadata.TopologyLinkMetadata{
+			ID:          generateTopologyLinkID(localDeviceID, localPortID, neighbor.PortID),
+			SourceType:  "lldp",
+			Integration: "versa",
+			Local: &devicemetadata.TopologyLinkSide{
 				Device: &devicemetadata.TopologyLinkDevice{
-					DDID: localDeviceId,
+					DDID: localDeviceID,
 				},
 				Interface: &devicemetadata.TopologyLinkInterface{
-					DDID: generate_interface_dd_id(),
-					ID: localPortId,
-					IDType: localPortIdType,
+					DDID:   generateInterfaceDDID(),
+					ID:     localPortID,
+					IDType: localPortIDType,
 				},
 			},
-            Remote: remoteLink,
-        }
+			Remote: remoteLink,
+		}
 
 		links = append(links, link)
 	}
@@ -93,22 +90,22 @@ func GetTopologyMetadata(namespace string, deviceNameToIPMap map[string]string, 
 	return links, nil
 }
 
-func generate_topology_link_id(local_device_id string, local_port_id string, remote_port_id string) string {
-    //Generate the topology link ID according to NDM format
-    return fmt.Sprintf("%s:%s.%s", local_device_id, local_port_id, remote_port_id)
+func generateTopologyLinkID(localDeviceID string, localPortID string, remotePortID string) string {
+	//Generate the topology link ID according to NDM format
+	return fmt.Sprintf("%s:%s.%s", localDeviceID, localPortID, remotePortID)
 }
 
 func datadogDevice(deviceName string, deviceIP string, deviceNameToIDMap map[string]string) bool {
-    //Check if the device is monitored by Datadog
+	//Check if the device is monitored by Datadog
 	if mappedIP, ok := deviceNameToIDMap[deviceName]; ok {
 		if mappedIP == deviceIP {
 			return true
 		}
 	}
-    return false
+	return false
 }
 
-func generate_interface_dd_id() string {
-    //Generate the device's interface ID if possible (Datadog monitored device and interface)
-    return ""
+func generateInterfaceDDID() string {
+	//Generate the device's interface ID if possible (Datadog monitored device and interface)
+	return ""
 }

--- a/pkg/collector/corechecks/network-devices/versa/payload/topology.go
+++ b/pkg/collector/corechecks/network-devices/versa/payload/topology.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 // Package payload implement processing of Versa api responses
 package payload
 
@@ -12,8 +17,6 @@ import (
 
 // GetTopologyMetadata process a list of device neighbors into topology links
 func GetTopologyMetadata(namespace string, deviceNameToIPMap map[string]string, device client.Appliance, neighbors []client.Neighbor) ([]devicemetadata.TopologyLinkMetadata, error) {
-
-	log.Tracef("Getting topology links for device: %s", device.Name)
 
 	var links []devicemetadata.TopologyLinkMetadata
 

--- a/pkg/collector/corechecks/network-devices/versa/payload/topology.go
+++ b/pkg/collector/corechecks/network-devices/versa/payload/topology.go
@@ -1,0 +1,89 @@
+// Package payload implement processing of Versa api responses
+package payload
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	devicemetadata "github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+)
+
+// GetDeviceMetadataFromAppliances process devices API payloads to build metadata
+func GetTopologyMetadata() ([]devicemetadata.TopologyLinkMetadata, error) {
+	log.Tracef("GetTopologyMetadata called")
+	return []devicemetadata.TopologyLinkMetadata{}, nil
+}
+
+
+// func buildNetworkTopologyMetadataWithLLDP(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata) []devicemetadata.TopologyLinkMetadata {
+// 	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
+
+// 	remManAddrByLLDPRemIndex := getRemManIPAddrByLLDPRemIndex(store.GetColumnIndexes("lldp_remote_management.interface_id_type"))
+
+// 	indexes := store.GetColumnIndexes("lldp_remote.interface_id") // using `lldp_remote.interface_id` to get indexes since it's expected to be always present
+// 	if len(indexes) == 0 {
+// 		log.Debugf("Unable to build links metadata: no lldp_remote indexes found")
+// 		return nil
+// 	}
+// 	sort.Strings(indexes)
+// 	var links []devicemetadata.TopologyLinkMetadata
+// 	for _, strIndex := range indexes {
+// 		indexElems := strings.Split(strIndex, ".")
+
+// 		// The lldpRemEntry index is composed of those 3 elements separate by `.`: lldpRemTimeMark, lldpRemLocalPortNum, lldpRemIndex
+// 		if len(indexElems) != 3 {
+// 			log.Debugf("Expected 3 index elements, but got %d, index=`%s`", len(indexElems), strIndex)
+// 			continue
+// 		}
+// 		// TODO: Handle TimeMark at indexElems[0] if needed later
+// 		//       See https://www.rfc-editor.org/rfc/rfc2021
+
+// 		localPortNum := indexElems[1]
+// 		lldpRemIndex := indexElems[2]
+
+// 		remoteDeviceIDType := lldp.ChassisIDSubtypeMap[store.GetColumnAsString("lldp_remote.chassis_id_type", strIndex)]
+// 		remoteDeviceID := formatID(remoteDeviceIDType, store, "lldp_remote.chassis_id", strIndex)
+
+// 		remoteInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_remote.interface_id_type", strIndex)]
+// 		remoteInterfaceID := formatID(remoteInterfaceIDType, store, "lldp_remote.interface_id", strIndex)
+
+// 		localInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_local.interface_id_type", localPortNum)]
+// 		localInterfaceID := formatID(localInterfaceIDType, store, "lldp_local.interface_id", localPortNum)
+
+// 		resolvedLocalInterfaceID := resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
+
+// 		// remEntryUniqueID: The combination of localPortNum and lldpRemIndex is expected to be unique for each entry in
+// 		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it can change often.
+// 		remEntryUniqueID := localPortNum + "." + lldpRemIndex
+
+// 		newLink := devicemetadata.TopologyLinkMetadata{
+// 			ID:          deviceID + ":" + remEntryUniqueID,
+// 			SourceType:  topologyLinkSourceTypeLLDP,
+// 			Integration: common.SnmpIntegrationName,
+// 			Remote: &devicemetadata.TopologyLinkSide{
+// 				Device: &devicemetadata.TopologyLinkDevice{
+// 					Name:        store.GetColumnAsString("lldp_remote.device_name", strIndex),
+// 					Description: store.GetColumnAsString("lldp_remote.device_desc", strIndex),
+// 					ID:          remoteDeviceID,
+// 					IDType:      remoteDeviceIDType,
+// 					IPAddress:   remManAddrByLLDPRemIndex[lldpRemIndex],
+// 				},
+// 				Interface: &devicemetadata.TopologyLinkInterface{
+// 					ID:          remoteInterfaceID,
+// 					IDType:      remoteInterfaceIDType,
+// 					Description: store.GetColumnAsString("lldp_remote.interface_desc", strIndex),
+// 				},
+// 			},
+// 			Local: &devicemetadata.TopologyLinkSide{
+// 				Interface: &devicemetadata.TopologyLinkInterface{
+// 					DDID:   resolvedLocalInterfaceID,
+// 					ID:     localInterfaceID,
+// 					IDType: localInterfaceIDType,
+// 				},
+// 				Device: &devicemetadata.TopologyLinkDevice{
+// 					DDID: deviceID,
+// 				},
+// 			},
+// 		}
+// 		links = append(links, newLink)
+// 	}
+// 	return links
+// }

--- a/pkg/collector/corechecks/network-devices/versa/payload/topology.go
+++ b/pkg/collector/corechecks/network-devices/versa/payload/topology.go
@@ -6,84 +6,164 @@ import (
 	devicemetadata "github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 )
 
-// GetDeviceMetadataFromAppliances process devices API payloads to build metadata
-func GetTopologyMetadata() ([]devicemetadata.TopologyLinkMetadata, error) {
-	log.Tracef("GetTopologyMetadata called")
-	return []devicemetadata.TopologyLinkMetadata{}, nil
-}
-
-
-// func buildNetworkTopologyMetadataWithLLDP(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata) []devicemetadata.TopologyLinkMetadata {
-// 	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
-
-// 	remManAddrByLLDPRemIndex := getRemManIPAddrByLLDPRemIndex(store.GetColumnIndexes("lldp_remote_management.interface_id_type"))
-
-// 	indexes := store.GetColumnIndexes("lldp_remote.interface_id") // using `lldp_remote.interface_id` to get indexes since it's expected to be always present
-// 	if len(indexes) == 0 {
-// 		log.Debugf("Unable to build links metadata: no lldp_remote indexes found")
+// func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata) []devicemetadata.TopologyLinkMetadata {
+// 	if store == nil {
+// 		// it's expected that the value store is nil if we can't reach the device
+// 		// in that case, we just return a nil slice.
 // 		return nil
 // 	}
-// 	sort.Strings(indexes)
-// 	var links []devicemetadata.TopologyLinkMetadata
-// 	for _, strIndex := range indexes {
-// 		indexElems := strings.Split(strIndex, ".")
 
-// 		// The lldpRemEntry index is composed of those 3 elements separate by `.`: lldpRemTimeMark, lldpRemLocalPortNum, lldpRemIndex
-// 		if len(indexElems) != 3 {
-// 			log.Debugf("Expected 3 index elements, but got %d, index=`%s`", len(indexElems), strIndex)
-// 			continue
-// 		}
-// 		// TODO: Handle TimeMark at indexElems[0] if needed later
-// 		//       See https://www.rfc-editor.org/rfc/rfc2021
-
-// 		localPortNum := indexElems[1]
-// 		lldpRemIndex := indexElems[2]
-
-// 		remoteDeviceIDType := lldp.ChassisIDSubtypeMap[store.GetColumnAsString("lldp_remote.chassis_id_type", strIndex)]
-// 		remoteDeviceID := formatID(remoteDeviceIDType, store, "lldp_remote.chassis_id", strIndex)
-
-// 		remoteInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_remote.interface_id_type", strIndex)]
-// 		remoteInterfaceID := formatID(remoteInterfaceIDType, store, "lldp_remote.interface_id", strIndex)
-
-// 		localInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_local.interface_id_type", localPortNum)]
-// 		localInterfaceID := formatID(localInterfaceIDType, store, "lldp_local.interface_id", localPortNum)
-
-// 		resolvedLocalInterfaceID := resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
-
-// 		// remEntryUniqueID: The combination of localPortNum and lldpRemIndex is expected to be unique for each entry in
-// 		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it can change often.
-// 		remEntryUniqueID := localPortNum + "." + lldpRemIndex
-
-// 		newLink := devicemetadata.TopologyLinkMetadata{
-// 			ID:          deviceID + ":" + remEntryUniqueID,
-// 			SourceType:  topologyLinkSourceTypeLLDP,
-// 			Integration: common.SnmpIntegrationName,
-// 			Remote: &devicemetadata.TopologyLinkSide{
-// 				Device: &devicemetadata.TopologyLinkDevice{
-// 					Name:        store.GetColumnAsString("lldp_remote.device_name", strIndex),
-// 					Description: store.GetColumnAsString("lldp_remote.device_desc", strIndex),
-// 					ID:          remoteDeviceID,
-// 					IDType:      remoteDeviceIDType,
-// 					IPAddress:   remManAddrByLLDPRemIndex[lldpRemIndex],
-// 				},
-// 				Interface: &devicemetadata.TopologyLinkInterface{
-// 					ID:          remoteInterfaceID,
-// 					IDType:      remoteInterfaceIDType,
-// 					Description: store.GetColumnAsString("lldp_remote.interface_desc", strIndex),
-// 				},
-// 			},
-// 			Local: &devicemetadata.TopologyLinkSide{
-// 				Interface: &devicemetadata.TopologyLinkInterface{
-// 					DDID:   resolvedLocalInterfaceID,
-// 					ID:     localInterfaceID,
-// 					IDType: localInterfaceIDType,
-// 				},
-// 				Device: &devicemetadata.TopologyLinkDevice{
-// 					DDID: deviceID,
-// 				},
-// 			},
-// 		}
-// 		links = append(links, newLink)
+// 	links := buildNetworkTopologyMetadataWithLLDP(deviceID, store, interfaces)
+// 	if len(links) == 0 {
+// 		links = buildNetworkTopologyMetadataWithCDP(deviceID, store, interfaces)
 // 	}
 // 	return links
 // }
+
+// GetDeviceMetadataFromAppliances process devices API payloads to build metadata
+func GetTopologyMetadata(namespace string, deviceNameToIPMap map[string]string, ifaces []client.Interface) ([]devicemetadata.TopologyLinkMetadata, error) {
+	log.Tracef("GetTopologyMetadata called")
+	return []devicemetadata.TopologyLinkMetadata{}, nil
+
+	var links []devicemetadata.TopologyLinkMetadata
+
+	for _, strIndex := range indexes {
+		indexElems := strings.Split(strIndex, ".")
+
+		// The lldpRemEntry index is composed of those 3 elements separate by `.`: lldpRemTimeMark, lldpRemLocalPortNum, lldpRemIndex
+		if len(indexElems) != 3 {
+			log.Debugf("Expected 3 index elements, but got %d, index=`%s`", len(indexElems), strIndex)
+			continue
+		}
+		// TODO: Handle TimeMark at indexElems[0] if needed later
+		//       See https://www.rfc-editor.org/rfc/rfc2021
+
+		localPortNum := indexElems[1]
+		lldpRemIndex := indexElems[2]
+
+		remoteDeviceIDType := lldp.ChassisIDSubtypeMap[store.GetColumnAsString("lldp_remote.chassis_id_type", strIndex)]
+		remoteDeviceID := formatID(remoteDeviceIDType, store, "lldp_remote.chassis_id", strIndex)
+
+		remoteInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_remote.interface_id_type", strIndex)]
+		remoteInterfaceID := formatID(remoteInterfaceIDType, store, "lldp_remote.interface_id", strIndex)
+
+		localInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_local.interface_id_type", localPortNum)]
+		localInterfaceID := formatID(localInterfaceIDType, store, "lldp_local.interface_id", localPortNum)
+
+		resolvedLocalInterfaceID := resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
+
+		// remEntryUniqueID: The combination of localPortNum and lldpRemIndex is expected to be unique for each entry in
+		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it can change often.
+		remEntryUniqueID := localPortNum + "." + lldpRemIndex
+
+		newLink := devicemetadata.TopologyLinkMetadata{
+			ID:          deviceID + ":" + remEntryUniqueID,
+			SourceType:  topologyLinkSourceTypeLLDP,
+			Integration: common.SnmpIntegrationName,
+			Remote: &devicemetadata.TopologyLinkSide{
+				Device: &devicemetadata.TopologyLinkDevice{
+					Name:        store.GetColumnAsString("lldp_remote.device_name", strIndex),
+					Description: store.GetColumnAsString("lldp_remote.device_desc", strIndex),
+					ID:          remoteDeviceID,
+					IDType:      remoteDeviceIDType,
+					IPAddress:   remManAddrByLLDPRemIndex[lldpRemIndex],
+				},
+				Interface: &devicemetadata.TopologyLinkInterface{
+					ID:          remoteInterfaceID,
+					IDType:      remoteInterfaceIDType,
+					Description: store.GetColumnAsString("lldp_remote.interface_desc", strIndex),
+				},
+			},
+			Local: &devicemetadata.TopologyLinkSide{
+				Interface: &devicemetadata.TopologyLinkInterface{
+					DDID:   resolvedLocalInterfaceID,
+					ID:     localInterfaceID,
+					IDType: localInterfaceIDType,
+				},
+				Device: &devicemetadata.TopologyLinkDevice{
+					DDID: deviceID,
+				},
+			},
+		}
+		links = append(links, newLink)
+	}
+	return links
+}
+
+
+func doInFuncAbove(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata) []devicemetadata.TopologyLinkMetadata {
+
+	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
+
+	remManAddrByLLDPRemIndex := getRemManIPAddrByLLDPRemIndex(store.GetColumnIndexes("lldp_remote_management.interface_id_type"))
+
+	indexes := store.GetColumnIndexes("lldp_remote.interface_id") // using `lldp_remote.interface_id` to get indexes since it's expected to be always present
+	if len(indexes) == 0 {
+		log.Debugf("Unable to build links metadata: no lldp_remote indexes found")
+		return nil
+	}
+	sort.Strings(indexes)
+	var links []devicemetadata.TopologyLinkMetadata
+
+	for _, strIndex := range indexes {
+		indexElems := strings.Split(strIndex, ".")
+
+		// The lldpRemEntry index is composed of those 3 elements separate by `.`: lldpRemTimeMark, lldpRemLocalPortNum, lldpRemIndex
+		if len(indexElems) != 3 {
+			log.Debugf("Expected 3 index elements, but got %d, index=`%s`", len(indexElems), strIndex)
+			continue
+		}
+		// TODO: Handle TimeMark at indexElems[0] if needed later
+		//       See https://www.rfc-editor.org/rfc/rfc2021
+
+		localPortNum := indexElems[1]
+		lldpRemIndex := indexElems[2]
+
+		remoteDeviceIDType := lldp.ChassisIDSubtypeMap[store.GetColumnAsString("lldp_remote.chassis_id_type", strIndex)]
+		remoteDeviceID := formatID(remoteDeviceIDType, store, "lldp_remote.chassis_id", strIndex)
+
+		remoteInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_remote.interface_id_type", strIndex)]
+		remoteInterfaceID := formatID(remoteInterfaceIDType, store, "lldp_remote.interface_id", strIndex)
+
+		localInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_local.interface_id_type", localPortNum)]
+		localInterfaceID := formatID(localInterfaceIDType, store, "lldp_local.interface_id", localPortNum)
+
+		resolvedLocalInterfaceID := resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
+
+		// remEntryUniqueID: The combination of localPortNum and lldpRemIndex is expected to be unique for each entry in
+		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it can change often.
+		remEntryUniqueID := localPortNum + "." + lldpRemIndex
+
+		newLink := devicemetadata.TopologyLinkMetadata{
+			ID:          deviceID + ":" + remEntryUniqueID,
+			SourceType:  topologyLinkSourceTypeLLDP,
+			Integration: common.SnmpIntegrationName,
+			Remote: &devicemetadata.TopologyLinkSide{
+				Device: &devicemetadata.TopologyLinkDevice{
+					Name:        store.GetColumnAsString("lldp_remote.device_name", strIndex),
+					Description: store.GetColumnAsString("lldp_remote.device_desc", strIndex),
+					ID:          remoteDeviceID,
+					IDType:      remoteDeviceIDType,
+					IPAddress:   remManAddrByLLDPRemIndex[lldpRemIndex],
+				},
+				Interface: &devicemetadata.TopologyLinkInterface{
+					ID:          remoteInterfaceID,
+					IDType:      remoteInterfaceIDType,
+					Description: store.GetColumnAsString("lldp_remote.interface_desc", strIndex),
+				},
+			},
+			Local: &devicemetadata.TopologyLinkSide{
+				Interface: &devicemetadata.TopologyLinkInterface{
+					DDID:   resolvedLocalInterfaceID,
+					ID:     localInterfaceID,
+					IDType: localInterfaceIDType,
+				},
+				Device: &devicemetadata.TopologyLinkDevice{
+					DDID: deviceID,
+				},
+			},
+		}
+		links = append(links, newLink)
+	}
+	return links
+}

--- a/pkg/collector/corechecks/network-devices/versa/report/metadata.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/metadata.go
@@ -21,10 +21,7 @@ var TimeNow = time.Now
 // SendMetadata send Versa device, interface and IP Address metadata
 func (s *Sender) SendMetadata(devices []devicemetadata.DeviceMetadata, interfaces []devicemetadata.InterfaceMetadata, ipAddresses []devicemetadata.IPAddressMetadata, topologyLinks []devicemetadata.TopologyLinkMetadata) {
 	collectionTime := TimeNow()
-	if len(topologyLinks) >= 0 {
-		log.Tracef("topology links recieved in SendMetadata")
-	}
-	metadataPayloads := devicemetadata.BatchPayloads(integrations.Versa, s.namespace, "", collectionTime, devicemetadata.PayloadMetadataBatchSize, devices, interfaces, ipAddresses, nil, nil, nil, nil)
+	metadataPayloads := devicemetadata.BatchPayloads(integrations.Versa, s.namespace, "", collectionTime, devicemetadata.PayloadMetadataBatchSize, devices, interfaces, ipAddresses, topologyLinks, nil, nil, nil)
 	for _, payload := range metadataPayloads {
 		payloadBytes, err := json.Marshal(payload)
 		if err != nil {

--- a/pkg/collector/corechecks/network-devices/versa/report/metadata.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/metadata.go
@@ -19,8 +19,11 @@ import (
 var TimeNow = time.Now
 
 // SendMetadata send Versa device, interface and IP Address metadata
-func (s *Sender) SendMetadata(devices []devicemetadata.DeviceMetadata, interfaces []devicemetadata.InterfaceMetadata, ipAddresses []devicemetadata.IPAddressMetadata) {
+func (s *Sender) SendMetadata(devices []devicemetadata.DeviceMetadata, interfaces []devicemetadata.InterfaceMetadata, ipAddresses []devicemetadata.IPAddressMetadata, topologyLinks []devicemetadata.TopologyLinkMetadata) {
 	collectionTime := TimeNow()
+	if len(topologyLinks) >= 0 {
+		log.Tracef("topology links recieved in SendMetadata")
+	}
 	metadataPayloads := devicemetadata.BatchPayloads(integrations.Versa, s.namespace, "", collectionTime, devicemetadata.PayloadMetadataBatchSize, devices, interfaces, ipAddresses, nil, nil, nil, nil)
 	for _, payload := range metadataPayloads {
 		payloadBytes, err := json.Marshal(payload)

--- a/pkg/collector/corechecks/network-devices/versa/versa.go
+++ b/pkg/collector/corechecks/network-devices/versa/versa.go
@@ -203,20 +203,26 @@ func (v *VersaCheck) Run() error {
 		log.Tracef("interfaces are as follows: %+v", interfaceMetadata)
 	}
 
-	// UPDATE HERE TO GET TOPOLOGY METADATA
+	
 	var topologyMetadata []devicemetadata.TopologyLinkMetadata
 	log.Infof("SendTopologyMetadata config value: %v", *v.config.SendTopologyMetadata)
 
 	// Get topology link metadata
 	if *v.config.SendTopologyMetadata {
-		var err error
-		topologyMetadata, err = payload.GetTopologyMetadata(v.config.Namespace, deviceNameToIDMap, appliances)
-		if err != nil {
-			if len(topologyMetadata) == 0 {
-				log.Errorf("failed to parse all topology metadata: %v", err)
-			} else {
-				log.Errorf("partial failure in parsing topology metadata: %v", err)
-			}
+		for _, device := range appliances {
+
+			neighbors, err := c.GetTopology(device.Name, device.OwnerOrg)
+			deviceTopologyMetadata, err := payload.GetTopologyMetadata(v.config.Namespace, deviceNameToIDMap, device, neighbors)
+			
+			if err != nil {
+				if len(deviceTopologyMetadata) == 0 {
+					log.Errorf("failed to parse all topology metadata: %v", err)
+				} else {
+					log.Errorf("partial failure in parsing topology metadata: %v", err)
+				}
+
+			topologyMetadata = append(topologyMetadata, deviceTopologyMetadata...)
+		}
 		}
 
 		log.Tracef("topology metadata is as follows:")

--- a/pkg/collector/corechecks/network-devices/versa/versa.go
+++ b/pkg/collector/corechecks/network-devices/versa/versa.go
@@ -210,7 +210,7 @@ func (v *VersaCheck) Run() error {
 	// Get topology link metadata
 	if *v.config.SendTopologyMetadata {
 		var err error
-		topologyMetadata, err = payload.GetTopologyMetadata(v.config.Namespace, deviceNameToIDMap, interfaces)
+		topologyMetadata, err = payload.GetTopologyMetadata(v.config.Namespace, deviceNameToIDMap, appliances)
 		if err != nil {
 			if len(topologyMetadata) == 0 {
 				log.Errorf("failed to parse all topology metadata: %v", err)
@@ -219,7 +219,14 @@ func (v *VersaCheck) Run() error {
 			}
 		}
 
-		log.Tracef("topology metadata is as follows: %+v", topologyMetadata)
+		log.Tracef("topology metadata is as follows:")
+		for _, link := range topologyMetadata {
+			log.Tracef("link: %+v", link)
+			log.Tracef("local: %+v", link.Local.Device)
+			log.Tracef("remote: %+v", link.Remote.Device)
+			log.Tracef("local interface: %+v", link.Local.Interface)
+			log.Tracef("remote interface: %+v", link.Remote.Interface)
+		}
 	}
 
 	// UPDATE HERE TO GET TOPOLOGY METADATA

--- a/pkg/collector/corechecks/network-devices/versa/versa.go
+++ b/pkg/collector/corechecks/network-devices/versa/versa.go
@@ -206,11 +206,11 @@ func (v *VersaCheck) Run() error {
 	// UPDATE HERE TO GET TOPOLOGY METADATA
 	var topologyMetadata []devicemetadata.TopologyLinkMetadata
 	log.Infof("SendTopologyMetadata config value: %v", *v.config.SendTopologyMetadata)
-	
+
 	// Get topology link metadata
 	if *v.config.SendTopologyMetadata {
 		var err error
-		topologyMetadata, err = payload.GetTopologyMetadata()
+		topologyMetadata, err = payload.GetTopologyMetadata(v.config.Namespace, deviceNameToIDMap, interfaces)
 		if err != nil {
 			if len(topologyMetadata) == 0 {
 				log.Errorf("failed to parse all topology metadata: %v", err)


### PR DESCRIPTION
### What does this PR do?

**Added a new configuration option to emit topology data for Versa devices**
`send_topology_metadata: true` can be set in `dev/dist/conf.d/versa.d/conf.yaml`

### Motivation

### Describe how you validated your changes

### Additional Notes
<details>
<summary> local testing commands</summary>

`dda inv -e agent.build`

`./bin/agent/agent run -c ./bin/agent/dist/datadog.yaml`
</details>
