### PR TITLE
Fix typo in `apt-disable-unattended-upgrades` script

### DIFF
--- a/test/e2e-framework/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/test/e2e-framework/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -7,7 +7,7 @@ sudo systemctl disable unattended-upgrades.service || true
 sudo systemctl stop unattended-upgrades.service || true
 
 sudo systemctl disable apt-daily.service || true
-sudo systemctl disable apt-daily.time || true
+sudo systemctl disable apt-daily.timer || true
 sudo systemctl stop apt-daily.service || true
 sudo systemctl stop apt-daily.timer || true
 


### PR DESCRIPTION
### What does this PR do?
Fixes a typo in `apt-disable-unattended-upgrades.sh` where `apt-daily.time` should be `apt-daily.timer`.

### Motivation
The script attempts to disable `apt-daily.timer` but incorrectly references `apt-daily.time`, which doesn't exist.
This causes the `systemd disable` command to fail ~silently `(|| true`) and leaves the timer enabled, potentially causing APT lock conflicts during E2E test provisioning.