### PR TITLE
[CWS/CSPM] make the compliance check CLI use the failable ipc module

### DIFF
--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -65,7 +65,7 @@ func CheckCommand(globalParams *command.GlobalParams) *cobra.Command {
 				secretsfx.Module(),
 				logscompressionfx.Module(),
 				statsd.Module(),
-				ipcfx.ModuleReadOnly(),
+				ipcfx.ModuleInsecure(),
 			)
 		},
 	}

--- a/cmd/system-probe/subcommands/compliance/command.go
+++ b/cmd/system-probe/subcommands/compliance/command.go
@@ -63,7 +63,7 @@ func CheckCommand(_ *command.GlobalParams) *cobra.Command {
 				secretsnoopfx.Module(),
 				logscompressionfx.Module(),
 				statsd.Module(),
-				ipcfx.ModuleReadOnly(),
+				ipcfx.ModuleInsecure(),
 			)
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

This PR allows the `{security-agent,system-probe} compliance check` CLI command to be used even if the core agent is not running. The hostname resolution is not guaranteed to be correct in this case.

### Motivation

### Describe how you validated your changes

### Additional Notes
