### PR TITLE
Revert "[gitlab] move install tools after deps fetching from cache"

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -75,7 +75,6 @@
   - export AWS_RETRY_MAX_ATTEMPTS=5
 
 .macos_gitlab:
-  needs: ["go_deps", "go_tools_deps"]
   before_script:
     - !reference [.vault_login]
     - !reference [.aws_retry_config]
@@ -88,6 +87,4 @@
     - !reference [.macos_runner_maintenance]
     - dda inv -- -e rtloader.make
     - dda inv -- -e rtloader.install
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e install-tools

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -5,10 +5,13 @@ include:
 .lint_macos_gitlab:
   stage: lint
   extends: .macos_gitlab
+  needs: ["go_deps", "go_tools_deps"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
   script:
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e linter.go --cpus 12 --debug --timeout 60
   retry: !reference [.retry_only_infra_failure, retry]
 

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -10,10 +10,13 @@ include:
   rules:
     - !reference [.except_disable_unit_tests]
     - !reference [.fast_on_dev_branch_only]
+  needs: ["go_deps", "go_tools_deps"]
   variables:
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
     TEST_OUTPUT_FILE: test_output.json
   script:
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - FAST_TESTS_FLAG=""
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi


### PR DESCRIPTION
Reverts DataDog/datadog-agent#43686

This is breaking `test_kmt_local_setup_macos` o `main`