### PR TITLE
[github] checkout repo before installing dda

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -21,6 +21,9 @@ jobs:
     permissions:
       id-token: write # This is required for getting the required OIDC token from GitHub
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Install dda
         uses: ./.github/actions/install-dda
         with:


### PR DESCRIPTION
### What does this PR do?

Checkout the repo before installing dda through local action

### Motivation

Workflow is currently broken, because we install dda from local repo's action, and I removed the checkout step

### Describe how you validated your changes

### Additional Notes
