### PR TITLE
`new-e2e-containers`: decrease `periodic_refresh_seconds`

### DIFF
--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -367,7 +367,7 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 					"init_config":    map[string]any{},
 					"instances": []map[string]any{
 						{
-							"periodic_refresh_seconds": 300, // To have at least one refresh per test
+							"periodic_refresh_seconds": 60, // To have at least one refresh per test
 						},
 					},
 				})),
@@ -376,7 +376,7 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 					"init_config":    map[string]any{},
 					"instances": []map[string]any{
 						{
-							"periodic_refresh_seconds": 300, // To have at least one refresh per test
+							"periodic_refresh_seconds": 60, // To have at least one refresh per test
 						},
 					},
 				})),


### PR DESCRIPTION
### What does this PR do?
Reduce the `periodic_refresh_seconds` configuration from **5 minutes** to **1 minute** for `container_image` and `sbom` checks in Kubernetes e2e tests.

### Motivation
The `new-e2e-containers` job experiences intermittent flakiness where `TestContainerImage` times out after **2 minutes** waiting for container image metadata to appear in the fakeintake, for example:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1265289895:
    `TestContainerImage` times out at exactly 120s,
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1265289897:
    `TestContainerImage` times out at 120s, while `TestContainerLifecycleEvents` passes,
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1265410663:
    the other way around, i.e. `TestContainerLifecycleEvents` fails but `TestContainerImage` passes in 0.04s when images are already available.

The cause is likely a timing issue: when the `container_image` check starts, it subscribes only to new events (`EventTypeSet`).
If container images already exist in `workloadmeta` before the check subscribes, it won't receive events for them and must wait for the periodic refresh to report them.

The previous test configuration used **300s** (matching the production default), but this is incompatible with the test's **120s**-timeout.
The proposed change reduces this to **60s** (the minimum allowed value per `periodicRefreshSecondsValueRange`), ensuring images are collected within ~90s maximum (60s refresh + 30s aggregation buffer from `new_images_max_latency_seconds`), well within the test's timeout.

### Additional Notes
The 300s value was introduced in #41937 when `test-infra-definitions` was merged into `datadog-agent`.
At that time, the comment already expressed the intention "To have at least one refresh per test", but this assumed tests would run for 5+ minutes. The `new-e2e-containers` tests complete much faster, making this value not (or no longer) suitable.

Production uses the same 300s default, which is appropriate for long-running agents that need to balance reporting freshness with backend load.
Tests, however, need faster feedback and can use the minimum value (60s) without concern for backend load since they use a local fakeintake.