### PR TITLE
[CWS] remove sbom related `SetKnown` call since it's no longer needed

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -84,8 +84,6 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.
 	cfg.BindEnvAndSetDefault("sbom.scan_queue.base_backoff", "5m")
 	cfg.BindEnvAndSetDefault("sbom.scan_queue.max_backoff", "1h")
-	// those configs are used by the core agent path, but are not used by the system probe
-	cfg.SetKnown("sbom.container_image.overlayfs_direct_scan") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 
 	// Auto exit configuration
 	cfg.BindEnvAndSetDefault("auto_exit.validation_period", 60)


### PR DESCRIPTION
### What does this PR do?

Since https://github.com/DataDog/datadog-agent/pull/40934, the trivy based SBOM scanner is no longer used in the system-probe. As such there is no need for this `SetKnown` call since the option is no longer read by the system-probe at all.

In addition to that, main config flags are automatically `SetKnown` to the system-probe to prevent spurious error logs, so this call was never really useful in the first place.

### Motivation

### Describe how you validated your changes

### Additional Notes
