### PR TITLE
replace_prefix: don't trust file extensions

### DIFF
--- a/bazel/rules/replace_prefix.sh
+++ b/bazel/rules/replace_prefix.sh
@@ -28,6 +28,11 @@ for f in "$@"; do
         echo "$f: file not found"
         exit 2
     fi
+    # We don't want to process symlinks but rather the actual file it's pointing to
+    # Otherwise `file $f` would return that it's a symlink, not an elf/mach-o file
+    if [ -L "$f" ]; then
+        f=$(realpath "$f")
+    fi
     case $f in
         *.pc)
             sed -ibak -e "s|^prefix=.*|prefix=$PREFIX|" -e "s|##PREFIX##|$PREFIX|" -e "s|\${EXT_BUILD_DEPS}|$PREFIX|" "$f" && rm -f "${f}bak"


### PR DESCRIPTION
### What does this PR do?

Stop using file extensions to dispatch the needed action

### Motivation

Some projects (looking at you, python3) ship `.so` including on macOS.
Currently we'd attempt to run patchelf for those, which fails because the tool isn't available, and would fail further since the binaries are Mach-o and not ELF

### Describe how you validated your changes

CI

### Additional Notes
