### PR TITLE
AGTMETRICS-385 Add missing configuration keys

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1579,7 +1579,9 @@ func serializer(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("serializer_compressor_kind", DefaultCompressorKind)
 	config.BindEnvAndSetDefault("serializer_zstd_compressor_level", DefaultZstdCompressionLevel)
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.endpoints", []string{})
+	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.sketches.endpoints", []string{})
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.validate", false)
+	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.sketches.validate", false)
 
 	config.BindEnvAndSetDefault("use_v2_api.series", true)
 	// Serializer: allow user to blacklist any kind of payload to be sent


### PR DESCRIPTION
### What does this PR do?

Add configuration keys that are read, but are not initialized.

### Motivation

Avoid warnings about not being able to convert nil to a slice.

### Describe how you validated your changes

- Run the agent with the default configuration.
- Send sketches via dogstatsd.
- Ensure that the following warnings are not produced: ``` failed to get configuration value for key "serializer_experimental_use_v3_api.sketches.endpoints": unable to cast <nil> of type <nil> to []string config key "serializer_experimental_use_v3_api.sketches.validate" is unknown config key "serializer_experimental_use_v3_api.sketches.endpoints" is unknown ```

### Additional Notes

Backport of #43719