### PR TITLE
[CONTP-1059] Collect feature gate data as part of wlm kube api server collector

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -793,7 +793,7 @@ func (c *WorkloadMetaCollector) handleKubeCapabilities(ev workloadmeta.Event) []
 	kubeCapabilities := ev.Entity.(*workloadmeta.KubeCapabilities)
 
 	tagList := taglist.NewTagList()
-	tagList.AddLow("kube_capabilities_version", kubeCapabilities.Version.String())
+	tagList.AddLow(tags.KubeServerVersion, kubeCapabilities.Version.String())
 
 	low, orch, high, standard := tagList.Compute()
 

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -30,16 +30,17 @@ import (
 const (
 	workloadmetaCollectorName = "workloadmeta"
 
-	staticSource         = workloadmetaCollectorName + "-static"
-	podSource            = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesPod)
-	taskSource           = workloadmetaCollectorName + "-" + string(workloadmeta.KindECSTask)
-	containerSource      = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainer)
-	containerImageSource = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainerImageMetadata)
-	processSource        = workloadmetaCollectorName + "-" + string(workloadmeta.KindProcess)
-	kubeMetadataSource   = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesMetadata)
-	deploymentSource     = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesDeployment)
-	gpuSource            = workloadmetaCollectorName + "-" + string(workloadmeta.KindGPU)
-	crdSource            = workloadmetaCollectorName + "-" + string(workloadmeta.KindCRD)
+	staticSource           = workloadmetaCollectorName + "-static"
+	podSource              = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesPod)
+	taskSource             = workloadmetaCollectorName + "-" + string(workloadmeta.KindECSTask)
+	containerSource        = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainer)
+	containerImageSource   = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainerImageMetadata)
+	processSource          = workloadmetaCollectorName + "-" + string(workloadmeta.KindProcess)
+	kubeMetadataSource     = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesMetadata)
+	deploymentSource       = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesDeployment)
+	gpuSource              = workloadmetaCollectorName + "-" + string(workloadmeta.KindGPU)
+	crdSource              = workloadmetaCollectorName + "-" + string(workloadmeta.KindCRD)
+	kubeCapabilitiesSource = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubeCapabilities)
 
 	clusterTagNamePrefix = tags.KubeClusterName
 )

--- a/comp/core/tagger/common/entity_id_builder.go
+++ b/comp/core/tagger/common/entity_id_builder.go
@@ -35,6 +35,8 @@ func BuildTaggerEntityID(entityID workloadmeta.EntityID) types.EntityID {
 		return types.NewEntityID(types.Kubelet, entityID.ID)
 	case workloadmeta.KindCRD:
 		return types.NewEntityID(types.Crd, entityID.ID)
+	case workloadmeta.KindKubeCapabilities:
+		return types.NewEntityID(types.KubernetesCapabilities, entityID.ID)
 	default:
 		log.Errorf("can't recognize entity %q with kind %q; trying %s://%s as tagger entity",
 			entityID.ID, entityID.Kind, entityID.ID, entityID.Kind)

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -111,6 +111,9 @@ const (
 	// which is either true (dedicated CPUs) or false
 	KubeStaticCPUsTag = "kube_static_cpus"
 
+	// KubeServerVersion is the tag for the Kubernetes server version
+	KubeServerVersion = "kube_server_version"
+
 	// CPURestartPolicy is the tag for the container's CPU restart policy
 	CPURestartPolicy = "cpu_restart_policy"
 	// MemoryRestartPolicy is the tag for the container's memory restart policy

--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -73,6 +73,8 @@ const (
 	KubernetesDeployment EntityIDPrefix = "deployment"
 	// KubernetesMetadata is the prefix `kubernetes_metadata`
 	KubernetesMetadata EntityIDPrefix = "kubernetes_metadata"
+	// KubernetesCapabilities is the prefix `kubernetes_capabilities`
+	KubernetesCapabilities EntityIDPrefix = "kubernetes_capabilities"
 	// KubernetesPodUID is the prefix `kubernetes_pod_uid`
 	KubernetesPodUID EntityIDPrefix = "kubernetes_pod_uid"
 	// Process is the prefix `process`
@@ -102,6 +104,7 @@ func AllPrefixesSet() map[EntityIDPrefix]struct{} {
 		GPU:                    {},
 		Kubelet:                {},
 		Crd:                    {},
+		KubernetesCapabilities: {},
 	}
 }
 

--- a/comp/core/tagger/types/filter_builder_test.go
+++ b/comp/core/tagger/types/filter_builder_test.go
@@ -62,6 +62,7 @@ func TestFilterBuilderOps(t *testing.T) {
 					GPU:                    {},
 					Kubelet:                {},
 					Crd:                    {},
+					KubernetesCapabilities: {},
 				},
 				cardinality: HighCardinality,
 			},

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -256,8 +256,8 @@ func (c *collector) GetTargetCatalog() workloadmeta.AgentType {
 func collectKubeCapabilities(ctx context.Context, apiserverClient *apiserver.APIClient, wlmetaStore workloadmeta.Component) {
 	featureGates, err := common.ClusterFeatureGates(ctx, apiserverClient.Cl.Discovery(), 5*time.Second)
 	if err != nil {
-		log.Warnf("failed to collect cluster feature gates: %v", err)
-		featureGates = make(map[string]common.FeatureGate)
+		log.Infof("Couldn't collect cluster feature gates: %v", err)
+		return
 	}
 
 	wlmFeatureGates := make(map[string]workloadmeta.FeatureGate)
@@ -271,7 +271,8 @@ func collectKubeCapabilities(ctx context.Context, apiserverClient *apiserver.API
 
 	versionInfo, err := common.KubeServerVersion(apiserverClient.Cl.Discovery(), 5*time.Second)
 	if err != nil {
-		log.Warnf("failed to collect cluster version: %v", err)
+		log.Infof("Couldn't collect cluster version: %v", err)
+		return
 	}
 
 	wlmetaStore.Notify([]workloadmeta.CollectorEvent{

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -234,10 +234,9 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 			objectStores = append(objectStores, handlerRegistration)
 		}
 	}
+	go collectKubeCapabilities(ctx, apiserverClient, wlmetaStore)
 
 	go runStartupCheck(ctx, objectStores)
-
-	go collectKubeCapabilities(ctx, apiserverClient, wlmetaStore)
 
 	return nil
 }
@@ -255,7 +254,7 @@ func (c *collector) GetTargetCatalog() workloadmeta.AgentType {
 }
 
 func collectKubeCapabilities(ctx context.Context, apiserverClient *apiserver.APIClient, wlmetaStore workloadmeta.Component) {
-	featureGates, err := common.ClusterFeatureGates(ctx, apiserverClient.Cl.Discovery(), 2*time.Second)
+	featureGates, err := common.ClusterFeatureGates(ctx, apiserverClient.Cl.Discovery(), 5*time.Second)
 	if err != nil {
 		log.Warnf("failed to collect cluster feature gates: %v", err)
 		featureGates = make(map[string]common.FeatureGate)
@@ -270,7 +269,7 @@ func collectKubeCapabilities(ctx context.Context, apiserverClient *apiserver.API
 		}
 	}
 
-	versionInfo, err := common.KubeServerVersion(apiserverClient.Cl.Discovery(), 2*time.Second)
+	versionInfo, err := common.KubeServerVersion(apiserverClient.Cl.Discovery(), 5*time.Second)
 	if err != nil {
 		log.Warnf("failed to collect cluster version: %v", err)
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -254,7 +254,7 @@ func (c *collector) GetTargetCatalog() workloadmeta.AgentType {
 }
 
 func collectKubeCapabilities(ctx context.Context, apiserverClient *apiserver.APIClient, wlmetaStore workloadmeta.Component) {
-	featureGates, err := common.ClusterFeatureGates(ctx, apiserverClient.Cl.Discovery(), 5*time.Second)
+	featureGates, err := common.ClusterFeatureGates(ctx, apiserverClient.Cl.Discovery(), 15*time.Second)
 	if err != nil {
 		log.Infof("Couldn't collect cluster feature gates: %v", err)
 		return
@@ -269,7 +269,7 @@ func collectKubeCapabilities(ctx context.Context, apiserverClient *apiserver.API
 		}
 	}
 
-	versionInfo, err := common.KubeServerVersion(apiserverClient.Cl.Discovery(), 5*time.Second)
+	versionInfo, err := common.KubeServerVersion(apiserverClient.Cl.Discovery(), 15*time.Second)
 	if err != nil {
 		log.Infof("Couldn't collect cluster version: %v", err)
 		return

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -235,6 +235,8 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 		}
 	}
 
+	go runStartupCheck(ctx, objectStores)
+
 	kubeCapEvent := collectKubeCapabilities(ctx, apiserverClient)
 	wlmetaStore.Notify([]workloadmeta.CollectorEvent{
 		{
@@ -243,8 +245,6 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 			Entity: kubeCapEvent.Entity,
 		},
 	})
-
-	go runStartupCheck(ctx, objectStores)
 
 	return nil
 }
@@ -262,7 +262,7 @@ func (c *collector) GetTargetCatalog() workloadmeta.AgentType {
 }
 
 func collectKubeCapabilities(ctx context.Context, apiserverClient *apiserver.APIClient) workloadmeta.Event {
-	featureGates, err := common.ClusterFeatureGates(ctx, apiserverClient.Cl.Discovery())
+	featureGates, err := common.ClusterFeatureGates(ctx, apiserverClient.Cl.Discovery(), 2*time.Second)
 	if err != nil {
 		log.Errorf("failed to get cluster feature gates: %v", err)
 		featureGates = make(map[string]common.FeatureGate)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -237,14 +237,17 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 
 	go runStartupCheck(ctx, objectStores)
 
-	kubeCapEvent := collectKubeCapabilities(ctx, apiserverClient)
-	wlmetaStore.Notify([]workloadmeta.CollectorEvent{
-		{
-			Type:   kubeCapEvent.Type,
-			Source: workloadmeta.SourceKubeAPIServer,
-			Entity: kubeCapEvent.Entity,
-		},
-	})
+	// TODO: kube capability collection could be blocking or fail. Need to investigate how to handle
+	go func() {
+		kubeCapEvent := collectKubeCapabilities(ctx, apiserverClient)
+		wlmetaStore.Notify([]workloadmeta.CollectorEvent{
+			{
+				Type:   kubeCapEvent.Type,
+				Source: workloadmeta.SourceKubeAPIServer,
+				Entity: kubeCapEvent.Entity,
+			},
+		})
+	}()
 
 	return nil
 }

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -67,6 +67,9 @@ type Component interface {
 	// GetKubeletMetrics returns metadata about kubelet metrics.
 	GetKubeletMetrics() (*KubeletMetrics, error)
 
+	// GetKubeCapabilities returns metadata about kubernetes cluster capabilities.
+	GetKubeCapabilities() (*KubeCapabilities, error)
+
 	// GetKubernetesDeployment returns metadata about a Kubernetes deployment. It fetches
 	// the entity with kind KindKubernetesDeployment and the given ID.
 	GetKubernetesDeployment(id string) (*KubernetesDeployment, error)

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -2221,8 +2221,8 @@ func (kc KubeCapabilities) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "Version:", kc.Version)
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Feature Gates:")
-		for name, featureGate := range kc.FeatureGates {
-			_, _ = fmt.Fprintln(&sb, "  ", name, " - ", featureGate)
+		for _, featureGate := range kc.FeatureGates {
+			_, _ = fmt.Fprintln(&sb, "\t", featureGate.Name, ":", featureGate.Enabled)
 		}
 	}
 

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -47,6 +47,7 @@ const (
 	KindKubernetesPod          Kind = "kubernetes_pod"
 	KindKubernetesMetadata     Kind = "kubernetes_metadata"
 	KindKubeletMetrics         Kind = "kubelet_metrics"
+	KindKubeCapabilities       Kind = "kubernetes_capabilities"
 	KindKubernetesDeployment   Kind = "kubernetes_deployment"
 	KindECSTask                Kind = "ecs_task"
 	KindContainerImageMetadata Kind = "container_image_metadata"
@@ -54,7 +55,6 @@ const (
 	KindGPU                    Kind = "gpu"
 	KindKubelet                Kind = "kubelet"
 	KindCRD                    Kind = "crd"
-	KindKubeCapabilities       Kind = "kubernetes_capability"
 )
 
 // Source is the source name of an entity.

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mohae/deepcopy"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 
@@ -53,6 +54,7 @@ const (
 	KindGPU                    Kind = "gpu"
 	KindKubelet                Kind = "kubelet"
 	KindCRD                    Kind = "crd"
+	KindKubeCapabilities       Kind = "kubernetes_capability"
 )
 
 // Source is the source name of an entity.
@@ -222,6 +224,14 @@ const (
 	// KubeletMetricsID is the ID of the workloadmeta KindKubeletMetrics entity.
 	// There can only be one per node.
 	KubeletMetricsID = "kubelet-metrics"
+)
+
+const (
+	// KubeCapabilitiesID is a constant ID used to build workloadmeta kubelet capabilities entities
+	// This does not need to be unique because there can only be one per cluster.
+	KubeCapabilitiesID = "kube-capability-id"
+	// KubeCapabilitiesName is used to name the workloadmeta kubelet capabilities entity
+	KubeCapabilitiesName = "kube-capability"
 )
 
 // Entity represents a single unit of work being done that is of interest to
@@ -2146,6 +2156,75 @@ func (crd CRD) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "Group:", crd.Group)
 	_, _ = fmt.Fprintln(&sb, "Kind:", crd.Kind)
 	_, _ = fmt.Fprintln(&sb, "Version:", crd.Version)
+
+	return sb.String()
+}
+
+// FeatureGateStage represents the maturity level of a Kubernetes feature gate
+type FeatureGateStage string
+
+// FeatureGateStage constants represent the maturity level of a Kubernetes feature gate
+const (
+	StageAlpha      FeatureGateStage = "ALPHA"
+	StageBeta       FeatureGateStage = "BETA"
+	StageGA         FeatureGateStage = "" // StageGA is represented as an empty string
+	StageDeprecated FeatureGateStage = "DEPRECATED"
+)
+
+// FeatureGate represents a single Kubernetes feature gate
+type FeatureGate struct {
+	Name    string
+	Stage   FeatureGateStage
+	Enabled bool
+}
+
+// KubeCapabilities represents the capabilities of a Kubernetes cluster.
+type KubeCapabilities struct {
+	EntityID
+	EntityMeta
+	FeatureGates map[string]FeatureGate
+	Version      *version.Info
+}
+
+var _ Entity = &KubeCapabilities{}
+
+// GetID returns the CRD entity ID
+func (kc KubeCapabilities) GetID() EntityID {
+	return kc.EntityID
+}
+
+// Merge allows the merge of 2 CRD entities
+func (kc *KubeCapabilities) Merge(e Entity) error {
+	otherCrd, ok := e.(*KubeCapabilities)
+	if !ok {
+		return fmt.Errorf("cannot merge CRD type with other type: %T", e)
+	}
+
+	return merge(kc, otherCrd)
+}
+
+// DeepCopy returns a deep copy of the given CRD entity
+func (kc KubeCapabilities) DeepCopy() Entity {
+	copyCrd := deepcopy.Copy(kc).(*KubeCapabilities)
+	return copyCrd
+}
+
+func (kc KubeCapabilities) String(verbose bool) string {
+	var sb strings.Builder
+
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprintln(&sb, kc.EntityID.String(verbose))
+
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprintln(&sb, kc.EntityMeta.String(verbose))
+
+	_, _ = fmt.Fprintln(&sb, "Version:", kc.Version)
+	if verbose {
+		_, _ = fmt.Fprintln(&sb, "Feature Gates:")
+		for name, featureGate := range kc.FeatureGates {
+			_, _ = fmt.Fprintln(&sb, "  ", name, " - ", featureGate)
+		}
+	}
 
 	return sb.String()
 }

--- a/comp/core/workloadmeta/impl/dump.go
+++ b/comp/core/workloadmeta/impl/dump.go
@@ -41,6 +41,8 @@ func (w *workloadmeta) Dump(verbose bool) wmdef.WorkloadDumpResponse {
 			info = e.String(verbose)
 		case *wmdef.CRD:
 			info = e.String(verbose)
+		case *wmdef.KubeCapabilities:
+			info = e.String(verbose)
 		default:
 			return "", fmt.Errorf("unsupported type %T", e)
 		}

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -273,6 +273,17 @@ func (w *workloadmeta) GetKubeletMetrics() (*wmdef.KubeletMetrics, error) {
 	return entity.(*wmdef.KubeletMetrics), nil
 }
 
+func (w *workloadmeta) GetKubeCapabilities() (*wmdef.KubeCapabilities, error) {
+	// There should only be one entity of this kind with the ID used in the
+	// Kubelet collector
+	entity, err := w.getEntityByKind(wmdef.KindKubeCapabilities, wmdef.KubeCapabilitiesID)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*wmdef.KubeCapabilities), nil
+}
+
 // GetProcess implements Store#GetProcess.
 func (w *workloadmeta) GetProcess(pid int32) (*wmdef.Process, error) {
 	id := strconv.Itoa(int(pid))

--- a/pkg/util/kubernetes/apiserver/common/feature_gate.go
+++ b/pkg/util/kubernetes/apiserver/common/feature_gate.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+
 package common
 
 import (

--- a/pkg/util/kubernetes/apiserver/common/feature_gate.go
+++ b/pkg/util/kubernetes/apiserver/common/feature_gate.go
@@ -76,7 +76,7 @@ func parseFeatureGatesFromMetrics(metricsData []byte) (map[string]FeatureGate, e
 }
 
 // ClusterFeatureGates queries the /metrics endpoint and returns feature gates
-func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.DiscoveryInterface, timeout time.Duration) (map[string]FeatureGate, error) {
+func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.DiscoveryInterface, _ time.Duration) (map[string]FeatureGate, error) {
 	if featureGates, found := cache.Cache.Get(featureGatesCacheKey); found {
 		return featureGates.(map[string]FeatureGate), nil
 	}
@@ -85,9 +85,7 @@ func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.Discover
 	err := retrier.SetupRetrier(&retry.Config{
 		Name: "featureGates",
 		AttemptMethod: func() error {
-			timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
-			metricsData, err := discoveryClient.RESTClient().Get().AbsPath(apiServerMetricsPath).DoRaw(timeoutCtx)
+			metricsData, err := discoveryClient.RESTClient().Get().AbsPath(apiServerMetricsPath).DoRaw(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to query /metrics endpoint: %v", err)
 			}

--- a/pkg/util/kubernetes/apiserver/common/feature_gate.go
+++ b/pkg/util/kubernetes/apiserver/common/feature_gate.go
@@ -9,6 +9,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -115,7 +116,7 @@ func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.Discover
 			log.Debugf("Waiting for APIServer, next retry: %v", sleepFor)
 			select {
 			case <-timeoutCtx.Done():
-				return nil, fmt.Errorf("timeout reached while waiting for Kubernetes feature gates")
+				return nil, errors.New("timeout reached while waiting for Kubernetes feature gates")
 			case <-time.After(sleepFor):
 			}
 		}

--- a/pkg/util/kubernetes/apiserver/common/feature_gate.go
+++ b/pkg/util/kubernetes/apiserver/common/feature_gate.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package common
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
+	"k8s.io/client-go/discovery"
+)
+
+const (
+	featureGatesCacheKey = "featureGates"
+
+	// API Server metrics path
+	apiServerMetricsPath = "/metrics"
+)
+
+var (
+	retrier retry.Retrier
+)
+
+// FeatureGate represents a single Kubernetes feature gate
+type FeatureGate struct {
+	Name    string
+	Stage   string
+	Enabled bool
+}
+
+// parseFeatureGatesFromMetrics parses the metrics endpoint, extracting feature gate information
+// Expected format: kubernetes_feature_enabled{name="FeatureName",stage="STAGE"} 1
+func parseFeatureGatesFromMetrics(metricsData []byte) (map[string]FeatureGate, error) {
+	gates := make(map[string]FeatureGate)
+
+	// Regex to parse: kubernetes_feature_enabled{name="SomeFeature",stage="BETA"} 1
+	pattern := regexp.MustCompile(`kubernetes_feature_enabled\{name="([^"]+)",stage="([^"]*)"\}\s+(\d+)`)
+
+	scanner := bufio.NewScanner(strings.NewReader(string(metricsData)))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip comments and non-matching lines
+		if strings.HasPrefix(line, "#") || !strings.Contains(line, "kubernetes_feature_enabled") {
+			continue
+		}
+
+		matches := pattern.FindStringSubmatch(line)
+		if len(matches) == 4 {
+			name := matches[1]
+			stage := matches[2]
+			enabled := matches[3] == "1"
+
+			gates[name] = FeatureGate{
+				Name:    name,
+				Stage:   stage,
+				Enabled: enabled,
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error scanning metrics: %v", err)
+	}
+
+	return gates, nil
+}
+
+// ClusterFeatureGates queries the /metrics endpoint and returns feature gates
+func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.DiscoveryInterface) (map[string]FeatureGate, error) {
+	if featureGates, found := cache.Cache.Get(featureGatesCacheKey); found {
+		return featureGates.(map[string]FeatureGate), nil
+	}
+
+	var featureGates map[string]FeatureGate
+	err := retrier.SetupRetrier(&retry.Config{
+		Name: "featureGates",
+		AttemptMethod: func() error {
+			metricsData, err := discoveryClient.RESTClient().Get().AbsPath(apiServerMetricsPath).DoRaw(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to query /metrics endpoint: %v", err)
+			}
+
+			featureGates, err = parseFeatureGatesFromMetrics(metricsData)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Strategy:          retry.Backoff,
+		InitialRetryDelay: 1 * time.Second,
+		MaxRetryDelay:     2 * time.Minute,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("couldnt setup retrier: %w", err)
+	}
+
+	for {
+		err = retrier.TriggerRetry()
+		switch retrier.RetryStatus() {
+		case retry.OK:
+			cache.Cache.Set(featureGatesCacheKey, featureGates, time.Hour)
+			return featureGates, nil
+		case retry.PermaFail:
+			return nil, err
+		default:
+			sleepFor := retrier.NextRetry().UTC().Sub(time.Now().UTC()) + time.Second
+			log.Debugf("Waiting for APIServer, next retry: %v", sleepFor)
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("timeout reached while waiting for Kubernetes feature gates")
+			case <-time.After(sleepFor):
+			}
+		}
+	}
+}

--- a/pkg/util/kubernetes/apiserver/common/feature_gate.go
+++ b/pkg/util/kubernetes/apiserver/common/feature_gate.go
@@ -104,7 +104,7 @@ func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.Discover
 		case retry.PermaFail:
 			return nil, err
 		default:
-			sleepFor := retrier.NextRetry().UTC().Sub(time.Now().UTC()) + time.Second
+			sleepFor := time.Until(retrier.NextRetry()) + time.Second
 			log.Debugf("Waiting for APIServer, next retry: %v", sleepFor)
 			select {
 			case <-timeoutCtx.Done():

--- a/pkg/util/kubernetes/apiserver/common/feature_gate.go
+++ b/pkg/util/kubernetes/apiserver/common/feature_gate.go
@@ -76,7 +76,7 @@ func parseFeatureGatesFromMetrics(metricsData []byte) (map[string]FeatureGate, e
 }
 
 // ClusterFeatureGates queries the /metrics endpoint and returns feature gates
-func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.DiscoveryInterface) (map[string]FeatureGate, error) {
+func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.DiscoveryInterface, retryTimeout time.Duration) (map[string]FeatureGate, error) {
 	if featureGates, found := cache.Cache.Get(featureGatesCacheKey); found {
 		return featureGates.(map[string]FeatureGate), nil
 	}
@@ -99,7 +99,7 @@ func ClusterFeatureGates(ctx context.Context, discoveryClient discovery.Discover
 		},
 		Strategy:          retry.Backoff,
 		InitialRetryDelay: 1 * time.Second,
-		MaxRetryDelay:     2 * time.Minute,
+		MaxRetryDelay:     retryTimeout,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("couldnt setup retrier: %w", err)

--- a/pkg/util/kubernetes/apiserver/common/feature_gate_test.go
+++ b/pkg/util/kubernetes/apiserver/common/feature_gate_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+
 package common
 
 import (

--- a/pkg/util/kubernetes/apiserver/common/feature_gate_test.go
+++ b/pkg/util/kubernetes/apiserver/common/feature_gate_test.go
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFeatureGatesFromMetrics(t *testing.T) {
+	tests := []struct {
+		name        string
+		metricsData string
+		want        map[string]FeatureGate
+		wantErr     bool
+	}{
+		{
+			name: "single feature gate",
+			metricsData: `# HELP kubernetes_feature_enabled [ALPHA] Feature gate status
+# TYPE kubernetes_feature_enabled gauge
+kubernetes_feature_enabled{name="SomeFeature",stage="ALPHA"} 1
+`,
+			want: map[string]FeatureGate{
+				"SomeFeature": {
+					Name:    "SomeFeature",
+					Stage:   "ALPHA",
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple feature gates",
+			metricsData: `# HELP kubernetes_feature_enabled [ALPHA] Feature gate status
+# TYPE kubernetes_feature_enabled gauge
+kubernetes_feature_enabled{name="FeatureA",stage="ALPHA"} 1
+kubernetes_feature_enabled{name="FeatureB",stage="BETA"} 0
+kubernetes_feature_enabled{name="FeatureC",stage="GA"} 1
+`,
+			want: map[string]FeatureGate{
+				"FeatureA": {
+					Name:    "FeatureA",
+					Stage:   "ALPHA",
+					Enabled: true,
+				},
+				"FeatureB": {
+					Name:    "FeatureB",
+					Stage:   "BETA",
+					Enabled: false,
+				},
+				"FeatureC": {
+					Name:    "FeatureC",
+					Stage:   "GA",
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty stage",
+			metricsData: `kubernetes_feature_enabled{name="NoStageFeature",stage=""} 1
+`,
+			want: map[string]FeatureGate{
+				"NoStageFeature": {
+					Name:    "NoStageFeature",
+					Stage:   "",
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "mixed with comments and other metrics",
+			metricsData: `# HELP some_other_metric Some other metric
+# TYPE some_other_metric gauge
+some_other_metric 42
+# HELP kubernetes_feature_enabled [ALPHA] Feature gate status
+# TYPE kubernetes_feature_enabled gauge
+kubernetes_feature_enabled{name="RealFeature",stage="ALPHA"} 1
+other_metric{label="value"} 123
+`,
+			want: map[string]FeatureGate{
+				"RealFeature": {
+					Name:    "RealFeature",
+					Stage:   "ALPHA",
+					Enabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "empty metrics",
+			metricsData: ``,
+			want:        map[string]FeatureGate{},
+			wantErr:     false,
+		},
+		{
+			name: "only comments",
+			metricsData: `# HELP kubernetes_feature_enabled [ALPHA] Feature gate status
+# TYPE kubernetes_feature_enabled gauge
+`,
+			want:    map[string]FeatureGate{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFeatureGatesFromMetrics([]byte(tt.metricsData))
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/collect-kubernetes-feature-gates-de83b1e488708704.yaml
+++ b/releasenotes/notes/collect-kubernetes-feature-gates-de83b1e488708704.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Collect feature gate and version data as part of kubernetes api server workloadmeta collector.


### PR DESCRIPTION
### What does this PR do?

Adds collection of a `KubeCapabilities` entity containing the kube cluster's api version and enabled/disabled feature gates.

Depends on https://github.com/DataDog/datadog-agent/pull/43299

### Motivation

Collecting more metadata about the k8s cluster will enable future work on implement a kubernetes upgrade readiness check.

### Describe how you validated your changes

1. Added feature gate tests (`feature_gate_test.go`)
2. Validate WLM entity collected.
```
agent workload-list -v
```

<img width="804" height="447" alt="image" src="https://github.com/user-attachments/assets/3327d494-35e1-4bfd-8117-b95a53281f31" />


