### PR TITLE
[SBOM] exclude `/var/lib/kubelet/plugins/**/globalmount/**` from host SBOMs

### DIFF
--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -158,6 +158,7 @@ func getDefaultArtifactOption(opts sbom.ScanOptions) artifact.Option {
 			"/var/lib/containers/**",
 			"/var/lib/docker/**",
 			"/var/lib/kubelet/pods/**",
+			"/var/lib/kubelet/plugins/**/globalmount/**",
 			"/var/lib/libvirt/**",
 			"/var/lib/snapd/**",
 			"/var/log/**",


### PR DESCRIPTION
### What does this PR do?

This folder contains some folder that are mounted into pods and containers from for example some CSI kubelet plugins. As such they should not be included in host SBOMs scanned directories.

This is similar to how we exclude `/var/lib/kubelet/pods/**` or `/var/lib/containerd/**` today.

### Motivation

### Describe how you validated your changes

### Additional Notes
