### PR TITLE
[CWS-5293] Fix cgroup-scoped SECL variables not being released

### DIFF
--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -33,6 +33,9 @@ func NewCacheEntry(containerID containerutils.ContainerID, cgroupContext *model.
 		ContainerContext: model.ContainerContext{
 			ContainerID: containerID,
 		},
+		CGroupContext: model.CGroupContext{
+			Releasable: &model.Releasable{},
+		},
 		PIDs: make(map[uint32]bool, 10),
 	}
 

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -106,7 +106,9 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupFS FSInterface) (*Re
 		if value.ContainerContext.Resolved && value.ContainerContext.ContainerID != "" {
 			value.ContainerContext.CallReleaseCallback()
 		}
-		value.CGroupContext.CallReleaseCallback()
+		if value.CGroupContext.Releasable != nil {
+			value.CGroupContext.CallReleaseCallback()
+		}
 		value.Deleted.Store(true)
 
 		cr.NotifyListeners(CGroupDeleted, value)

--- a/pkg/security/resolvers/cgroup/resolver_test.go
+++ b/pkg/security/resolvers/cgroup/resolver_test.go
@@ -57,7 +57,8 @@ func createTestProcess(pid, ppid uint32, containerID containerutils.ContainerID)
 					ContainerID: containerID,
 				},
 				CGroup: model.CGroupContext{
-					CGroupID: "",
+					Releasable: &model.Releasable{},
+					CGroupID:   "",
 					CGroupFile: model.PathKey{
 						Inode:   0,
 						MountID: 0,
@@ -138,7 +139,8 @@ func TestResolvePidCgroupFallback_SuccessFromHistory(t *testing.T) {
 
 	// Add parent cgroup context to cache
 	parentCgroup := &model.CGroupContext{
-		CGroupID: "parent-cgroup-id",
+		Releasable: &model.Releasable{},
+		CGroupID:   "parent-cgroup-id",
 		CGroupFile: model.PathKey{
 			Inode:   parentInode,
 			MountID: 123,

--- a/pkg/security/resolvers/container/resolver.go
+++ b/pkg/security/resolvers/container/resolver.go
@@ -35,7 +35,8 @@ func (cr *Resolver) GetContainerContext(pid uint32) (containerutils.ContainerID,
 	}
 
 	return id, model.CGroupContext{
-		CGroupID: ctx.CGroupID,
+		Releasable: &model.Releasable{},
+		CGroupID:   ctx.CGroupID,
 		CGroupFile: model.PathKey{
 			Inode:   ctx.CGroupFileInode,
 			MountID: ctx.CGroupFileMountID,

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -886,7 +886,8 @@ func TestCGroupContext(t *testing.T) {
 		)
 
 		resolver.UpdateProcessCGroupContext(node.ProcessCacheEntry.Pid, &model.CGroupContext{
-			CGroupID: cgroupID,
+			Releasable: &model.Releasable{},
+			CGroupID:   cgroupID,
 			CGroupFile: model.PathKey{
 				Inode: 4242,
 			},

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -267,6 +267,7 @@ func (r *EBPFResolvers) ResolveCGroupContext(pathKey model.PathKey) (*model.CGro
 	}
 
 	cgroupContext := &model.CGroupContext{
+		Releasable: &model.Releasable{},
 		CGroupID:   containerutils.CGroupID(cgroup),
 		CGroupFile: pathKey,
 	}

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -1075,6 +1075,7 @@ type MutableSECLVariable interface {
 type ScopedVariables struct {
 	scoperName     string
 	scoper         Scoper
+	varsLock       sync.RWMutex
 	vars           map[string]map[string]MutableSECLVariable
 	expirablesLock sync.RWMutex
 	expirables     map[string][]expirableVariable
@@ -1082,12 +1083,16 @@ type ScopedVariables struct {
 
 // Len returns the length of the variable map
 func (v *ScopedVariables) Len() int {
+	v.varsLock.RLock()
+	defer v.varsLock.RUnlock()
 	return len(v.vars)
 }
 
 // NewSECLVariable returns new variable of the type of the specified value
 func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName string, opts VariableOpts) (SECLVariable, error) {
 	getVariable := func(ctx *Context) MutableSECLVariable {
+		v.varsLock.RLock()
+		defer v.varsLock.RUnlock()
 		scope := v.scoper(ctx)
 		if scope == nil {
 			return nil
@@ -1107,6 +1112,8 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 	}
 
 	setVariable := func(ctx *Context, value any) error {
+		v.varsLock.Lock()
+		defer v.varsLock.Unlock()
 		scope := v.scoper(ctx)
 		if scope == nil {
 			return fmt.Errorf("`%s` scoper failed to scope variable '%s'", v.scoperName, name)
@@ -1223,7 +1230,9 @@ func (v *ScopedVariables) CleanupExpiredVariables() {
 
 // ReleaseVariable releases a scoped variable
 func (v *ScopedVariables) ReleaseVariable(key string) {
+	v.varsLock.Lock()
 	delete(v.vars, key)
+	v.varsLock.Unlock()
 	v.expirablesLock.Lock()
 	delete(v.expirables, key)
 	v.expirablesLock.Unlock()
@@ -1232,6 +1241,8 @@ func (v *ScopedVariables) ReleaseVariable(key string) {
 // GetScopedVariables returns all scoped variables that match the given name
 func (v *ScopedVariables) GetScopedVariables(name string) map[string]Variable {
 	variables := make(map[string]Variable)
+	v.varsLock.RLock()
+	defer v.varsLock.RUnlock()
 	for key, vars := range v.vars {
 		for varName, variable := range vars {
 			if varName == name {

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -1059,6 +1059,11 @@ func (v *Variables) CleanupExpiredVariables() {
 	}
 }
 
+// GetScopedVariables returns nothing for global variables
+func (v *Variables) GetScopedVariables(_ string) map[string]Variable {
+	return nil
+}
+
 // MutableSECLVariable describes the interface implemented by mutable SECL variable
 type MutableSECLVariable interface {
 	Variable
@@ -1222,6 +1227,19 @@ func (v *ScopedVariables) ReleaseVariable(key string) {
 	v.expirablesLock.Lock()
 	delete(v.expirables, key)
 	v.expirablesLock.Unlock()
+}
+
+// GetScopedVariables returns all scoped variables that match the given name
+func (v *ScopedVariables) GetScopedVariables(name string) map[string]Variable {
+	variables := make(map[string]Variable)
+	for key, vars := range v.vars {
+		for varName, variable := range vars {
+			if varName == name {
+				variables[key] = variable
+			}
+		}
+	}
+	return variables
 }
 
 // NewScopedVariables returns a new set of scope variables

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -86,7 +86,7 @@ func (r *Releasable) CallReleaseCallback() {
 
 // AppendReleaseCallback sets a callback to be called when the cache entry is released
 func (r *Releasable) AppendReleaseCallback(callback func()) {
-	if callback != nil {
+	if callback != nil && r != nil {
 		r.onReleaseCallbacks = append(r.onReleaseCallbacks, callback)
 	}
 }

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -170,7 +170,7 @@ func (e *Event) GetContainerID() string {
 
 // CGroupContext holds the cgroup context of an event
 type CGroupContext struct {
-	Releasable
+	*Releasable
 	CGroupID      containerutils.CGroupID `field:"id,handler:ResolveCGroupID"` // SECLDoc[id] Definition:`ID of the cgroup`
 	CGroupFile    PathKey                 `field:"file"`
 	CGroupVersion int                     `field:"version,handler:ResolveCGroupVersion"` // SECLDoc[version] Definition:`[Experimental] Version of the cgroup API`

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -17,6 +17,7 @@ import (
 type VariableProvider interface {
 	NewSECLVariable(name string, value interface{}, scope string, opts eval.VariableOpts) (eval.SECLVariable, error)
 	CleanupExpiredVariables()
+	GetScopedVariables(name string) map[string]eval.Variable
 }
 
 // VariableProviderFactory describes a function called to instantiate a variable provider

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1278,3 +1278,12 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalO
 		globalVariables:  eval.NewVariables(),
 	}
 }
+
+// GetScopedVariables returns all scoped variables that match the given name and scope
+func (rs *RuleSet) GetScopedVariables(scope Scope, name string) map[string]eval.Variable {
+	variableProvider, found := rs.scopedVariables[scope]
+	if !found {
+		return nil
+	}
+	return variableProvider.GetScopedVariables(name)
+}

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -86,7 +86,7 @@ func (r *Releasable) CallReleaseCallback() {
 
 // AppendReleaseCallback sets a callback to be called when the cache entry is released
 func (r *Releasable) AppendReleaseCallback(callback func()) {
-	if callback != nil {
+	if callback != nil && r != nil {
 		r.onReleaseCallbacks = append(r.onReleaseCallbacks, callback)
 	}
 }

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -388,6 +388,15 @@ func TestCGroupVariables(t *testing.T) {
 			assertFieldNotEmpty(t, event, "process.cgroup.id", "cgroup id shouldn't be empty")
 
 			test.validateOpenSchema(t, event)
+
+			variables := test.ruleEngine.GetRuleSet().GetScopedVariables(rules.ScopeCGroup, "foo")
+			assert.NotNil(t, variables)
+			assert.Contains(t, variables, event.ProcessContext.Process.CGroup.Hash())
+			variable, ok := variables[event.ProcessContext.Process.CGroup.Hash()]
+			assert.True(t, ok)
+			value, ok := variable.GetValue()
+			assert.True(t, ok)
+			assert.Equal(t, 1, value.(int))
 		})
 
 		test.WaitSignal(t, func() error {
@@ -402,4 +411,9 @@ func TestCGroupVariables(t *testing.T) {
 		})
 	})
 
+	t.Run("cgroup-variables-release", func(t *testing.T) {
+		variables := test.ruleEngine.GetRuleSet().GetScopedVariables(rules.ScopeCGroup, "foo")
+		assert.NotNil(t, variables)
+		assert.Len(t, variables, 0)
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Make it so the Releasable object of a cgroup context is shared between multiple copies of the same cgroup context.  

### Motivation

Fix cgroup-scoped SECL variables not being released.

### Describe how you validated your changes

Added a new `TestCGroupVariablesReleased` test.

### Additional Notes
