### PR TITLE
[Backport 7.74.x] [CWS] Add vsock support for event socket

### DIFF
--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -21,6 +21,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/system/socket"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/mdlayher/vsock"
@@ -236,13 +237,13 @@ func (c *RuntimeSecurityEventClient) Close() {
 func NewRuntimeSecurityEventClient() (*RuntimeSecurityEventClient, error) {
 	socketPath := pkgconfigsetup.Datadog().GetString("runtime_security_config.socket")
 
-	family := socket.GetFamilyAddress(socketPath)
+	family, addr := socket.GetSocketAddress(socketPath)
 	if family == "unix" {
 		if runtime.GOOS == "windows" {
 			return nil, fmt.Errorf("unix sockets are not supported on Windows")
 		}
 
-		socketPath = fmt.Sprintf("unix://%s", socketPath)
+		socketPath = fmt.Sprintf("unix://%s", addr)
 	}
 
 	opts := []grpc.DialOption{
@@ -257,7 +258,12 @@ func NewRuntimeSecurityEventClient() (*RuntimeSecurityEventClient, error) {
 	}
 
 	if family == "vsock" {
-		cmdPort, parseErr := strconv.Atoi(socketPath)
+		_, sPort, err := net.SplitHostPort(socketPath)
+		if err != nil {
+			return nil, err
+		}
+
+		cmdPort, parseErr := strconv.Atoi(sPort)
 		if parseErr != nil {
 			return nil, fmt.Errorf("invalid vsock socket path '%s'", socketPath)
 		}
@@ -267,6 +273,7 @@ func NewRuntimeSecurityEventClient() (*RuntimeSecurityEventClient, error) {
 		}
 
 		opts = append(opts, grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			log.Infof("Dialing vsock socket on CID %d and port %d", vsock.Host, cmdPort)
 			return vsock.Dial(vsock.Host, uint32(cmdPort), &vsock.Config{})
 		}))
 	}

--- a/pkg/security/module/client.go
+++ b/pkg/security/module/client.go
@@ -143,6 +143,7 @@ func NewSecurityAgentAPIClient(cfg *config.RuntimeSecurityConfig) (*SecurityAgen
 		return nil, errors.New("runtime_security_config.socket must be set, events will not be sent to the security agent")
 	}
 
+	seclog.Infof("connecting to security agent via socket: %s", cfg.SocketPath)
 	family, socketPath := socket.GetSocketAddress(cfg.SocketPath)
 	if family == "unix" {
 		if runtime.GOOS == "windows" {
@@ -163,6 +164,7 @@ func NewSecurityAgentAPIClient(cfg *config.RuntimeSecurityConfig) (*SecurityAgen
 		}),
 	}
 
+	seclog.Infof("using socket family '%s' and path '%s' to connect to security agent", family, socketPath)
 	if family == "vsock" {
 		cmdPort, parseErr := strconv.Atoi(socketPath)
 		if parseErr != nil {
@@ -173,6 +175,7 @@ func NewSecurityAgentAPIClient(cfg *config.RuntimeSecurityConfig) (*SecurityAgen
 			return nil, fmt.Errorf("invalid port '%s' for vsock", cfg.SocketPath)
 		}
 
+		socketPath = "passthrough:target"
 		opts = append(opts, grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
 			return vsock.Dial(vsock.Host, uint32(cmdPort), &vsock.Config{})
 		}))

--- a/pkg/security/utils/grpc/grpc.go
+++ b/pkg/security/utils/grpc/grpc.go
@@ -67,7 +67,8 @@ func (g *Server) Start() error {
 			return fmt.Errorf("invalid port '%s' for vsock", g.address)
 		}
 
-		ln, err = vsock.Listen(uint32(port), &vsock.Config{})
+		seclog.Infof("starting runtime security agent gRPC server on vsock port %d with host context", port)
+		ln, err = vsock.ListenContextID(vsock.Host, uint32(port), &vsock.Config{})
 	} else {
 		ln, err = net.Listen(g.family, g.address)
 	}


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/commit/19002ad3e94467409a48e019578f39e5f1370a4f from https://github.com/DataDog/datadog-agent/pull/43563.

---

### What does this PR do?

Fix socket parsing when using vsock

### Motivation

The parsing of the socket path used in vsock mode was wrong
and caused vsock not be used for system-probe.

### Describe how you validated your changes

### Additional Notes
