### PR TITLE
Add support for batch obfuscating sql statements from python integrations

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -332,7 +332,7 @@ func BatchObfuscateSQL(queriesJSON, opts *C.char, errResult **C.char) *C.char {
 	var sqlOpts sqlConfig
 	if err := json.Unmarshal([]byte(optStr), &sqlOpts); err != nil {
 		log.Errorf("Failed to unmarshal batch obfuscation options: %s", err.Error())
-		*errResult = TrackedCString(fmt.Sprintf("Failed to parse options: %s", err.Error()))
+		*errResult = TrackedCString(err.Error())
 		return nil
 	}
 
@@ -341,7 +341,7 @@ func BatchObfuscateSQL(queriesJSON, opts *C.char, errResult **C.char) *C.char {
 	queriesStr := C.GoString(queriesJSON)
 	if err := json.Unmarshal([]byte(queriesStr), &queries); err != nil {
 		log.Errorf("Failed to unmarshal queries array: %s", err.Error())
-		*errResult = TrackedCString(fmt.Sprintf("Failed to parse queries: %s", err.Error()))
+		*errResult = TrackedCString(err.Error())
 		return nil
 	}
 
@@ -381,7 +381,7 @@ func BatchObfuscateSQL(queriesJSON, opts *C.char, errResult **C.char) *C.char {
 	// Marshal results array to JSON
 	out, err := json.Marshal(results)
 	if err != nil {
-		*errResult = TrackedCString(fmt.Sprintf("Failed to marshal results: %s", err.Error()))
+		*errResult = TrackedCString(err.Error())
 		return nil
 	}
 

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -96,7 +96,7 @@ void SetExternalTags(char *, char *, char **);
 void WritePersistentCache(char *, char *);
 bool TracemallocEnabled();
 char* ObfuscateSQL(char *, char *, char **);
-char* BatchObfuscateSQL(char *, char *, char **);
+char* BatchObfuscateSQL(char **, char *, char **);
 char* ObfuscateSQLExecPlan(char *, bool, char **);
 double getProcessStartTime();
 char* ObfuscateMongoDBString(char *, char **);

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -96,6 +96,7 @@ void SetExternalTags(char *, char *, char **);
 void WritePersistentCache(char *, char *);
 bool TracemallocEnabled();
 char* ObfuscateSQL(char *, char *, char **);
+char* BatchObfuscateSQL(char *, char *, char **);
 char* ObfuscateSQLExecPlan(char *, bool, char **);
 double getProcessStartTime();
 char* ObfuscateMongoDBString(char *, char **);
@@ -115,6 +116,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 	set_read_persistent_cache_cb(rtloader, ReadPersistentCache);
 	set_tracemalloc_enabled_cb(rtloader, TracemallocEnabled);
 	set_obfuscate_sql_cb(rtloader, ObfuscateSQL);
+	set_batch_obfuscate_sql_cb(rtloader, BatchObfuscateSQL);
 	set_obfuscate_sql_exec_plan_cb(rtloader, ObfuscateSQLExecPlan);
 	set_get_process_start_time_cb(rtloader, getProcessStartTime);
 	set_obfuscate_mongodb_string_cb(rtloader, ObfuscateMongoDBString);

--- a/rtloader/common/builtins/datadog_agent.h
+++ b/rtloader/common/builtins/datadog_agent.h
@@ -153,6 +153,7 @@ void _set_set_external_tags_cb(cb_set_external_tags_t);
 void _set_write_persistent_cache_cb(cb_write_persistent_cache_t);
 void _set_read_persistent_cache_cb(cb_read_persistent_cache_t);
 void _set_obfuscate_sql_cb(cb_obfuscate_sql_t);
+void _set_batch_obfuscate_sql_cb(cb_batch_obfuscate_sql_t);
 void _set_obfuscate_sql_exec_plan_cb(cb_obfuscate_sql_exec_plan_t);
 void _set_get_process_start_time_cb(cb_get_process_start_time_t);
 void _set_obfuscate_mongodb_string_cb(cb_obfuscate_mongodb_string_t);

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -633,6 +633,16 @@ DATADOG_AGENT_RTLOADER_API void set_read_persistent_cache_cb(rtloader_t *, cb_re
 */
 DATADOG_AGENT_RTLOADER_API void set_obfuscate_sql_cb(rtloader_t *, cb_obfuscate_sql_t);
 
+/*! \fn void set_batch_obfuscate_sql_cb(rtloader_t *, cb_batch_obfuscate_sql_t)
+    \brief Sets a callback to be used by rtloader to allow batch obfuscating SQL queries.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param object A function pointer with cb_batch_obfuscate_sql_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
+DATADOG_AGENT_RTLOADER_API void set_batch_obfuscate_sql_cb(rtloader_t *, cb_batch_obfuscate_sql_t);
+
 /*! \fn void set_obfuscate_sql_exec_plan_cb(rtloader_t *, cb_obfuscate_sql_exec_plan_t)
     \brief Sets a callback to be used by rtloader to allow retrieving a value for a given
     check instance.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -462,6 +462,14 @@ public:
     */
     virtual void setObfuscateSqlCb(cb_obfuscate_sql_t) = 0;
 
+    //! setBatchObfuscateSqlCb member.
+    /*!
+      \param A cb_batch_obfuscate_sql_t function pointer to the CGO callback.
+
+      This allows us to set the relevant CGO callback that will allow batch obfuscating SQL queries.
+    */
+    virtual void setBatchObfuscateSqlCb(cb_batch_obfuscate_sql_t) = 0;
+
     //! setObfuscateSqlExecPlanCb member.
     /*!
       \param A cb_obfuscate_sql_exec_plan_t function pointer to the CGO callback.

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -137,8 +137,8 @@ typedef void (*cb_write_persistent_cache_t)(char *, char *);
 typedef char *(*cb_read_persistent_cache_t)(char *);
 // (sql_query, options, error_message)
 typedef char *(*cb_obfuscate_sql_t)(char *, char *, char **);
-// (queries_json, options, error_message)
-typedef char *(*cb_batch_obfuscate_sql_t)(char *, char *, char **);
+// (queries, options, error_message)
+typedef char *(*cb_batch_obfuscate_sql_t)(char **, char *, char **);
 // (exec_plan, normalize, error_message)
 typedef char *(*cb_obfuscate_sql_exec_plan_t)(char *, bool, char **);
 // ()

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -137,6 +137,8 @@ typedef void (*cb_write_persistent_cache_t)(char *, char *);
 typedef char *(*cb_read_persistent_cache_t)(char *);
 // (sql_query, options, error_message)
 typedef char *(*cb_obfuscate_sql_t)(char *, char *, char **);
+// (queries_json, options, error_message)
+typedef char *(*cb_batch_obfuscate_sql_t)(char *, char *, char **);
 // (exec_plan, normalize, error_message)
 typedef char *(*cb_obfuscate_sql_exec_plan_t)(char *, bool, char **);
 // ()

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -571,6 +571,11 @@ void set_obfuscate_sql_cb(rtloader_t *rtloader, cb_obfuscate_sql_t cb)
     AS_TYPE(RtLoader, rtloader)->setObfuscateSqlCb(cb);
 }
 
+void set_batch_obfuscate_sql_cb(rtloader_t *rtloader, cb_batch_obfuscate_sql_t cb)
+{
+    AS_TYPE(RtLoader, rtloader)->setBatchObfuscateSqlCb(cb);
+}
+
 void set_obfuscate_sql_exec_plan_cb(rtloader_t *rtloader, cb_obfuscate_sql_exec_plan_t cb)
 {
     AS_TYPE(RtLoader, rtloader)->setObfuscateSqlExecPlanCb(cb);

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -1025,6 +1025,11 @@ void Three::setObfuscateSqlCb(cb_obfuscate_sql_t cb)
     _set_obfuscate_sql_cb(cb);
 }
 
+void Three::setBatchObfuscateSqlCb(cb_batch_obfuscate_sql_t cb)
+{
+    _set_batch_obfuscate_sql_cb(cb);
+}
+
 void Three::setObfuscateSqlExecPlanCb(cb_obfuscate_sql_exec_plan_t cb)
 {
     _set_obfuscate_sql_exec_plan_cb(cb);

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -104,6 +104,7 @@ public:
     void setWritePersistentCacheCb(cb_write_persistent_cache_t);
     void setReadPersistentCacheCb(cb_read_persistent_cache_t);
     void setObfuscateSqlCb(cb_obfuscate_sql_t);
+    void setBatchObfuscateSqlCb(cb_batch_obfuscate_sql_t);
     void setObfuscateSqlExecPlanCb(cb_obfuscate_sql_exec_plan_t);
     void setGetProcessStartTimeCb(cb_get_process_start_time_t);
     void setObfuscateMongoDBStringCb(cb_obfuscate_mongodb_string_t);


### PR DESCRIPTION
### What does this PR do?
Exposes a new `datadog_agent.batch_obfuscate_sql()` function in rtloader which will allow us to pass a Python list of query strings over the CGo bridge. The Python list gets converted into a C string array in the CPython layer and the Cgo bridge get's passed a pointer to the C string array of query strings. There is potential concern here about relying on CPython array pointers on the Golang side, but since this is only accessed serially in a blocking fashion on the Python side and the pointer values are read only and not mutated, we shouldn't have as much concerns about pointer memory corruption issues. 

Running these changes locally with two identical Agent builds, one using the existing `datadog_agent.obfuscate_sql()` and the other using the new `datadog_agent.batch_obfuscate_sql()` show positive signs of improvement. 

_Note this is running two agents locally in containers with checks stripped down so that we're primarly only running one Postgres integration with DBM enabled under default configuration settings and our DB load testing tool running. We'll still need to benchmark and validate performance improvements running in real environments_

The biggest win in local testing comes from a dramatic decrease in memory allocations. This is heavily due to avoiding extra string allocations we're currently forced to make between the Python, CPython, and Go layers today.
<img width="1755" height="760" alt="Screenshot 2025-12-03 at 2 53 29 PM" src="https://github.com/user-attachments/assets/6a7c337c-30a4-4338-9809-34fdbfbbebd6" />

We can also see a drop in cpu utilization solely coming from the affected code paths
<img width="1751" height="783" alt="Screenshot 2025-12-03 at 2 51 58 PM" src="https://github.com/user-attachments/assets/04dd3ce7-c40e-4e5c-835a-51d4b44d223b" />

We do see a slight uptick in memory footprint which looks to mostly be due to json marshaling of larger obfuscated query return payloads. I haven't yet looked dug into memory optimizations that could possibly be made here to wrangle this back down. That will happen before productionizing this change.
<img width="1759" height="811" alt="Screenshot 2025-12-03 at 2 57 18 PM" src="https://github.com/user-attachments/assets/a618414a-d464-47ec-9bc3-b0bfdaf4933d" />


On the Python integration side we're seeing faster collection cycles for both query samples and query metrics with query metrics showing up to 30% improvement in latency in local benchmarking
<img width="1758" height="653" alt="Screenshot 2025-12-03 at 3 13 54 PM" src="https://github.com/user-attachments/assets/74472c64-1a52-4f72-ab41-c9bb3e99fc96" />

### Motivation
Currently all DBM integrations require obfuscating queries on the fly. We're regularly calling `datadog_agent.obfuscate_sql()` tens to thousands of times every couple of seconds for each query individually. 

In each integration there are two code paths that require obfuscating queries
1. query samples collection which runs every 1s and captures all currently running queries to obfuscate. The number of queries obfuscated here depends on the workload but can routinely be 10s to 100s of queries.
2. query metrics collection which runs every 10 seconds by default and captures historic queries. The number of queries captured depends on the configured history size of the relevant database's query history table but often on the order of thousands. For Postgres as an example, the database default is ~5,000 queries when the database has a fully warmed history cache.

In both use cases we're currently calling `datadog_agent.obfuscate_sql()` in a tight loop on each individual query. There's potential savings here by batching queries up and taking less round trips over the FFI bridge.

The proposed changes here could be implemented by all our python based DBM integrations (Postgres, Mysql, SqlServer, MongoDB) and benefit from this core change.

### Describe how you validated your changes

The current benchmarks were performed by building a custom image of the Agent from this branch. Tested against a local running Postgres 17 instance running DBM's benchmark suite with two Agent with identical configurations running against it. One baseline agent using the existing logic, the second agent mounting integrations-core with the following [branch](https://github.com/DataDog/integrations-core/compare/eric.weaver/HD-113-arrays?expand=1) changes to make use of the batching API. 

### Additional Notes
Work that still needs to be done
- Improve error handling when we fail to obfuscate a query. Currently in this POC if any query in the batch fails the full batch fails
- Tune batch sizing. Currently we're naively batching the full result set. We might want to cap and split batch sizes
- Investigate benefits of using `sync.Pool` to manage memory pools for our json marshaling of return values to help allocated memory usage
- Possibly expand support for `obfuscate_mongodb_string` and `obfuscate_sql_exec_plan` if applicable
- Thorough review / cleanup of code change
- Wider benchmarking changes
- Add tests to rtloader for the new functionality
