### PR TITLE
Remove deprecated SetKnown usages in trace-agent cleanups old config

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -203,7 +203,7 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 		pkgconfig.Set("remote_configuration.enabled", false, pkgconfigmodel.SourceFile)
 	}
 
-	if pkgconfig.Get("apm_config.features") == nil {
+	if !pkgconfig.IsConfigured("apm_config.features") {
 		apmConfigFeatures := []string{}
 		if !ddfg.OperationAndResourceNameV2FeatureGate.IsEnabled() {
 			apmConfigFeatures = append(apmConfigFeatures, "disable_operation_and_resource_name_logic_v2")

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -320,7 +320,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if core.IsSet("apm_config.max_remote_traces_per_second") {
 		c.MaxRemoteTPS = core.GetFloat64("apm_config.max_remote_traces_per_second")
 	}
-	if k := "apm_config.features"; core.IsSet(k) {
+	if k := "apm_config.features"; core.IsConfigured(k) {
 		feats := core.GetStringSlice(k)
 		for _, f := range feats {
 			c.Features[f] = struct{}{}
@@ -685,7 +685,7 @@ func loadDeprecatedValues(c *config.AgentConfig) error {
 	if cfg.IsSet("apm_config.receiver_timeout") {
 		c.ReceiverTimeout = cfg.GetInt("apm_config.receiver_timeout")
 	}
-	if cfg.IsSet("apm_config.watchdog_check_delay") {
+	if cfg.IsConfigured("apm_config.watchdog_check_delay") {
 		d := time.Duration(cfg.GetInt("apm_config.watchdog_check_delay"))
 		c.WatchdogInterval = d * time.Second
 	}

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -274,7 +274,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		c.PeerTags = core.GetStringSlice("apm_config.peer_tags")
 	}
 
-	if core.IsSet("apm_config.extra_sample_rate") {
+	if core.IsConfigured("apm_config.extra_sample_rate") {
 		c.ExtraSampleRate = core.GetFloat64("apm_config.extra_sample_rate")
 	}
 	if core.IsSet("apm_config.max_events_per_second") {
@@ -474,20 +474,20 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	c.Obfuscation.Cache.Enabled = pkgconfigsetup.Datadog().GetBool("apm_config.obfuscation.cache.enabled")
 	c.Obfuscation.Cache.MaxSize = pkgconfigsetup.Datadog().GetInt64("apm_config.obfuscation.cache.max_size")
 
-	if core.IsSet("apm_config.filter_tags.require") {
+	if core.IsConfigured("apm_config.filter_tags.require") {
 		tags := core.GetStringSlice("apm_config.filter_tags.require")
 		for _, tag := range tags {
 			c.RequireTags = append(c.RequireTags, splitTag(tag))
 		}
 	}
-	if core.IsSet("apm_config.filter_tags.reject") {
+	if core.IsConfigured("apm_config.filter_tags.reject") {
 		tags := core.GetStringSlice("apm_config.filter_tags.reject")
 		for _, tag := range tags {
 			c.RejectTags = append(c.RejectTags, splitTag(tag))
 		}
 	}
 
-	if pkgconfigsetup.Datadog().IsSet("apm_config.filter_tags_regex.require") {
+	if pkgconfigsetup.Datadog().IsConfigured("apm_config.filter_tags_regex.require") {
 		tags := pkgconfigsetup.Datadog().GetStringSlice("apm_config.filter_tags_regex.require")
 		for _, tag := range tags {
 			splitTag := splitTagRegex(tag)
@@ -498,7 +498,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 			c.RequireTagsRegex = append(c.RequireTagsRegex, splitTag)
 		}
 	}
-	if pkgconfigsetup.Datadog().IsSet("apm_config.filter_tags_regex.reject") {
+	if pkgconfigsetup.Datadog().IsConfigured("apm_config.filter_tags_regex.reject") {
 		tags := pkgconfigsetup.Datadog().GetStringSlice("apm_config.filter_tags_regex.reject")
 		for _, tag := range tags {
 			splitTag := splitTagRegex(tag)
@@ -529,12 +529,12 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		// Default of 4 was chosen through experimentation, but may not be the optimal value.
 		c.MaxSenderRetries = 4
 	}
-	if core.IsSet("apm_config.sync_flushing") {
+	if core.IsConfigured("apm_config.sync_flushing") {
 		c.SynchronousFlushing = core.GetBool("apm_config.sync_flushing")
 	}
 
 	// undocumented deprecated
-	if core.IsSet("apm_config.analyzed_rate_by_service") {
+	if core.IsConfigured("apm_config.analyzed_rate_by_service") {
 		rateByService := make(map[string]float64)
 		cfg := pkgconfigsetup.Datadog()
 		if err := structure.UnmarshalKey(cfg, "apm_config.analyzed_rate_by_service", &rateByService); err != nil {
@@ -565,7 +565,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	}
 
 	// undocumented
-	if core.IsSet("apm_config.dd_agent_bin") {
+	if core.IsConfigured("apm_config.dd_agent_bin") {
 		c.DDAgentBin = core.GetString("apm_config.dd_agent_bin")
 	}
 
@@ -678,7 +678,7 @@ func loadDeprecatedValues(c *config.AgentConfig) error {
 		log.Warn("apm_config.api_key is deprecated. Use core api_key instead")
 		c.Endpoints[0].APIKey = utils.SanitizeAPIKey(cfg.GetString("apm_config.api_key"))
 	}
-	if cfg.IsSet("apm_config.bucket_size_seconds") {
+	if cfg.IsConfigured("apm_config.bucket_size_seconds") {
 		d := time.Duration(cfg.GetInt("apm_config.bucket_size_seconds"))
 		c.BucketInterval = d * time.Second
 	}

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -48,24 +48,18 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.obfuscation.memcached.keep_command", false, "DD_APM_OBFUSCATION_MEMCACHED_KEEP_COMMAND")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.cache.enabled", true, "DD_APM_OBFUSCATION_CACHE_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.cache.max_size", 5000000, "DD_APM_OBFUSCATION_CACHE_MAX_SIZE")
-	config.SetKnown("apm_config.filter_tags.require")             //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.filter_tags.reject")              //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.filter_tags_regex.require")       //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.filter_tags_regex.reject")        //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.extra_sample_rate")               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.dd_agent_bin")                    //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.trace_writer.connection_limit")   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.trace_writer.queue_size")         //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.service_writer.connection_limit") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.service_writer.queue_size")       //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.stats_writer.connection_limit")   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.stats_writer.queue_size")         //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.analyzed_rate_by_service")        //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.bucket_size_seconds")             //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.watchdog_check_delay")            //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.sync_flushing")                   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.features")                        //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.SetKnown("apm_config.max_catalog_entries")             //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("apm_config.extra_sample_rate", 0.0)
+	config.BindEnvAndSetDefault("apm_config.dd_agent_bin", "")
+	config.BindEnvAndSetDefault("apm_config.trace_writer.connection_limit", 0)
+	config.BindEnvAndSetDefault("apm_config.trace_writer.queue_size", 0)
+	config.BindEnvAndSetDefault("apm_config.stats_writer.connection_limit", 0)
+	config.BindEnvAndSetDefault("apm_config.stats_writer.queue_size", 0)
+	config.BindEnvAndSetDefault("apm_config.analyzed_rate_by_service", map[string]float64{})
+	config.BindEnvAndSetDefault("apm_config.bucket_size_seconds", 10)
+	config.BindEnvAndSetDefault("apm_config.watchdog_check_delay", 0)
+	config.BindEnvAndSetDefault("apm_config.sync_flushing", false, "DD_APM_SYNC_FLUSHING")
+	config.BindEnvAndSetDefault("apm_config.features", []string{}, "DD_APM_FEATURES")
+	config.BindEnvAndSetDefault("apm_config.max_catalog_entries", 0)
 
 	bindVectorOptions(config, Traces)
 
@@ -160,11 +154,10 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	})
 	config.BindEnvAndSetDefault("apm_config.receiver_socket", defaultReceiverSocket, "DD_APM_RECEIVER_SOCKET")
 	config.BindEnv("apm_config.windows_pipe_name", "DD_APM_WINDOWS_PIPE_NAME")                                                 //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.sync_flushing", "DD_APM_SYNC_FLUSHING")                                                         //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.filter_tags.require", "DD_APM_FILTER_TAGS_REQUIRE")                                             //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.filter_tags.reject", "DD_APM_FILTER_TAGS_REJECT")                                               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.filter_tags_regex.reject", "DD_APM_FILTER_TAGS_REGEX_REJECT")                                   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.filter_tags_regex.require", "DD_APM_FILTER_TAGS_REGEX_REQUIRE")                                 //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("apm_config.filter_tags.require", []string{}, "DD_APM_FILTER_TAGS_REQUIRE")                    //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("apm_config.filter_tags.reject", []string{}, "DD_APM_FILTER_TAGS_REJECT")                      //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("apm_config.filter_tags_regex.reject", []string{}, "DD_APM_FILTER_TAGS_REGEX_REJECT")          //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("apm_config.filter_tags_regex.require", []string{}, "DD_APM_FILTER_TAGS_REGEX_REQUIRE")        //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnv("apm_config.internal_profiling.enabled", "DD_APM_INTERNAL_PROFILING_ENABLED")                               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnv("apm_config.debugger_dd_url", "DD_APM_DEBUGGER_DD_URL")                                                     //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnv("apm_config.debugger_api_key", "DD_APM_DEBUGGER_API_KEY")                                                   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
@@ -190,7 +183,6 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.enable_v1_trace_endpoint", false, "DD_APM_ENABLE_V1_TRACE_ENDPOINT")
 	config.BindEnvAndSetDefault("apm_config.send_all_internal_stats", false, "DD_APM_SEND_ALL_INTERNAL_STATS")
 	config.BindEnvAndSetDefault("apm_config.enable_container_tags_buffer", true, "DD_APM_ENABLE_CONTAINER_TAGS_BUFFER")
-	config.BindEnv("apm_config.features", "DD_APM_FEATURES") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.ParseEnvAsStringSlice("apm_config.features", func(s string) []string {
 		// Either commas or spaces can be used as separators.
 		// Comma takes precedence as it was the only supported separator in the past.

--- a/releasenotes/notes/updateTraceAgentConfig-da54345210ef820a.yaml
+++ b/releasenotes/notes/updateTraceAgentConfig-da54345210ef820a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    APM: Removed unused configuration options `apm_config.service_writer.queue_size`, and `apm_config.service_writer.connection_limit`. These options were already ignored.


### PR DESCRIPTION
### What does this PR do?
Primarily remove all usages of the deprecated `SetKnown` function. In doing this I happened upon two config options that are completely unused so I removed those.

### Motivation
SetKnown has been deprecated in favor of providing defaults with types so the config package can better manage a config schema

### Describe how you validated your changes
Unit tests here should cover these configurations, and using IsConfigured in place of (the also deprecated) `IsSet` ensures the same behavior as before.

### Additional Notes
