### PR TITLE
Add retry logic for some EC2 tests

### DIFF
--- a/pkg/util/ec2/ec2_account_id_test.go
+++ b/pkg/util/ec2/ec2_account_id_test.go
@@ -35,7 +35,7 @@ func TestGetInstanceIdentity(t *testing.T) {
 	conf.SetWithoutSource("ec2_metadata_timeout", 1000)
 
 	assert.EventuallyWithT(
-		t, func(c *assert.CollectT) {
+		t, func(_ *assert.CollectT) {
 			val, err := GetInstanceIdentity(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, "us-east-1", val.Region)

--- a/pkg/util/ec2/ec2_account_id_test.go
+++ b/pkg/util/ec2/ec2_account_id_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,9 +34,13 @@ func TestGetInstanceIdentity(t *testing.T) {
 	conf := configmock.New(t)
 	conf.SetWithoutSource("ec2_metadata_timeout", 1000)
 
-	val, err := GetInstanceIdentity(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, "us-east-1", val.Region)
-	assert.Equal(t, "i-aaaaaaaaaaaaaaaaa", val.InstanceID)
-	assert.Equal(t, "REMOVED", val.AccountID)
+	assert.EventuallyWithT(
+		t, func(c *assert.CollectT) {
+			val, err := GetInstanceIdentity(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, "us-east-1", val.Region)
+			assert.Equal(t, "i-aaaaaaaaaaaaaaaaa", val.InstanceID)
+			assert.Equal(t, "REMOVED", val.AccountID)
+		},
+		10*time.Second, 1*time.Second)
 }

--- a/pkg/util/ec2/tags/ec2_tags_test.go
+++ b/pkg/util/ec2/tags/ec2_tags_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,11 +69,15 @@ func TestGetSecurityCreds(t *testing.T) {
 	conf := configmock.New(t)
 	conf.SetWithoutSource("ec2_metadata_timeout", 1000)
 
-	cred, err := getSecurityCreds(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, "123456", cred.AccessKeyID)
-	assert.Equal(t, "secret access key", cred.SecretAccessKey)
-	assert.Equal(t, "secret token", cred.Token)
+	assert.EventuallyWithT(
+		t, func(c *assert.CollectT) {
+			cred, err := getSecurityCreds(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, "123456", cred.AccessKeyID)
+			assert.Equal(t, "secret access key", cred.SecretAccessKey)
+			assert.Equal(t, "secret token", cred.Token)
+		},
+		10*time.Second, 1*time.Second)
 }
 
 func TestFetchEc2TagsFromIMDS(t *testing.T) {

--- a/pkg/util/ec2/tags/ec2_tags_test.go
+++ b/pkg/util/ec2/tags/ec2_tags_test.go
@@ -70,7 +70,7 @@ func TestGetSecurityCreds(t *testing.T) {
 	conf.SetWithoutSource("ec2_metadata_timeout", 1000)
 
 	assert.EventuallyWithT(
-		t, func(c *assert.CollectT) {
+		t, func(_ *assert.CollectT) {
 			cred, err := getSecurityCreds(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, "123456", cred.AccessKeyID)


### PR DESCRIPTION
### What does this PR do?
This PR adds a simple retry logic for some EC2 tests.

### Motivation
These tests can be flaky for Windows runs on the CI.

### Describe how you validated your changes
Running the units tests.

### Additional Notes
