### PR TITLE
Add EKS node label as tag

### DIFF
--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -280,7 +280,11 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 				"deployments.apps": pulumi.Map{"x-team": pulumi.String("team")},
 				"pods":             pulumi.Map{"x-parent-type": pulumi.String("domain")},
 				"namespaces":       pulumi.Map{"related_org": pulumi.String("org")},
-				"nodes":            pulumi.Map{"kubernetes.io/os": pulumi.String("os"), "kubernetes.io/arch": pulumi.String("arch")},
+				"nodes": pulumi.Map{
+					"kubernetes.io/os":                  pulumi.String("os"),
+					"kubernetes.io/arch":                pulumi.String("arch"),
+					"eks.amazonaws.com/nodegroup-image": pulumi.String("nodegroup-image"),
+				},
 			},
 			"originDetectionUnified": pulumi.Map{
 				"enabled": pulumi.Bool(true),


### PR DESCRIPTION
### What does this PR do?
Adds the node AMI as a tag

### Motivation
Debugging

### Describe how you validated your changes
Checked that metrics emitted by the EKS cluster included the `nodegroup-image` tag

### Additional Notes
