### PR TITLE
fix(trace): Update macrobenchmark rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1025,6 +1025,10 @@ workflow:
   - <<: *if_scheduled_main
     when: on_success
 
+.on_scheduled_main_or_release_branch:
+  - if: $DDR_WORKFLOW_ID != null && ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/)
+    when: always
+
 .on_main_or_rc_and_no_skip_e2e:
   - <<: *if_disable_e2e_tests
     when: never

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -7,9 +7,7 @@ variables:
   timeout: 1h
   rules:
     - !reference [.except_coverage_pipeline]
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: always
-    - !reference [.on_scheduled_main]
+    - !reference [.on_scheduled_main_or_release_branch]
     - !reference [.manual]
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $BENCHMARKS_CI_IMAGE


### PR DESCRIPTION
### What does this PR do?
Updates CI rules to ensure macrobenchmark jobs are run on both main and release candidate branches, when the pipeline is scheduled.

### Motivation
RC branches have not triggered these jobs since we changed the scheduling to conductor.

### Describe how you validated your changes
N/A

### Additional Notes
