### PR TITLE
[Backport 7.74.x] Add empty needs and tags to the deploy_latest_rc_only job

### DIFF
--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -3,9 +3,10 @@
 
 deploy_latest_rc_only:
   stage: deploy_mutable_image_tags
+  tags: ["arch:amd64", "specific:true"]
   rules:
     !reference [.on_deploy_rc]
-  dependencies: []
+  needs: []
   script:
     - ./tools/ci/check_latest_rc.sh
 


### PR DESCRIPTION
Backport 3babb048b9be9c5cf5ab6e282947545544136fb5 from #43717.

___

### What does this PR do?

Add empty needs and tags to the `deploy_latest_rc_only` job.

### Motivation

We want this job to run even if one of the jobs in the previous stage failed, as most of them are unrelated.Additionally - for this job to run we need to add tags so the proper runner can be selected.

This PR is meant to unblock this mechanism, but we probably should revisit it as it depends on intentionally failing the job to skip the other ones which sounds like a bad pattern.
