### PR TITLE
fix node name in manifest payload

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_terminated.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_terminated.go
@@ -109,9 +109,3 @@ func (c *TerminatedPodCollector) Process(rcfg *collectors.CollectorRunConfig, li
 
 	return result, nil
 }
-
-// GetNodeName is used to get the node name from the resource.
-func (c *TerminatedPodCollector) GetNodeName(_ processors.ProcessorContext, resource interface{}) string {
-	r := resource.(*v1.Pod)
-	return r.Spec.NodeName
-}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_terminated_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_terminated_test.go
@@ -105,10 +105,6 @@ func TestTerminatedPodCollector(t *testing.T) {
 			assert.Len(t, processResult.Result.ManifestMessages, 1)
 			assert.IsType(t, &model.CollectorPod{}, processResult.Result.MetadataMessages[0])
 			assert.IsType(t, &model.CollectorManifest{}, processResult.Result.ManifestMessages[0])
-
-			// Test GetNodeName method
-			nodeName := collector.GetNodeName(nil, pod)
-			assert.Equal(t, "test-node", nodeName)
 		},
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -208,3 +208,9 @@ func (h *PodHandlers) ScrubBeforeMarshalling(ctx processors.ProcessorContext, re
 		redact.ScrubPod(r, pctx.Cfg.Scrubber)
 	}
 }
+
+// GetNodeName is used to get the node name from the resource.
+func (h *PodHandlers) GetNodeName(_ processors.ProcessorContext, resource interface{}) string {
+	r := resource.(*corev1.Pod)
+	return r.Spec.NodeName
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_test.go
@@ -385,6 +385,7 @@ func TestPodProcessor_Process(t *testing.T) {
 	assert.Equal(t, int32(1), manifest1.Type) // K8sPod
 	assert.Equal(t, "v1", manifest1.Version)
 	assert.Equal(t, "json", manifest1.ContentType)
+	assert.Equal(t, "test-node", manifest1.NodeName)
 
 	// Parse the actual manifest content
 	var actualManifestPod corev1.Pod


### PR DESCRIPTION
### What does this PR do?

This bug was introduced by https://github.com/DataDog/datadog-agent/pull/36903 and in this PR we fix empty node name in manifest payload.

We should add GetNodeName to `PodHandlers` instead of `TerminatedPodCollector`

### QA

This fix is covered by `TestPodProcessor_Process`
