### PR TITLE
Fix DD_PKG_GITLAB_URL to include full API path

### DIFF
--- a/.gitlab/trigger_release/agent.yml
+++ b/.gitlab/trigger_release/agent.yml
@@ -19,7 +19,7 @@
     # Set DD_PKG_GITLAB_URL for nightly builds to use staging artifact gateway
     - |
       if [ "$BUCKET_BRANCH" = "nightly" ] || [ "$BUCKET_BRANCH" = "oldnightly" ]; then
-        export DD_PKG_GITLAB_URL="https://artifact-gateway.us1.staging.dog"
+        export DD_PKG_GITLAB_URL="https://artifact-gateway.us1.staging.dog/internal/artifact-gateway/api/v4"
         echo "Using staging artifact gateway: $DD_PKG_GITLAB_URL"
       fi
     - |-

--- a/.gitlab/trigger_release/installer.yml
+++ b/.gitlab/trigger_release/installer.yml
@@ -21,7 +21,7 @@
     # Set DD_PKG_GITLAB_URL for nightly builds to use staging artifact gateway
     - |
       if [ "$BUCKET_BRANCH" = "nightly" ] || [ "$BUCKET_BRANCH" = "oldnightly" ]; then
-        export DD_PKG_GITLAB_URL="https://artifact-gateway.us1.staging.dog"
+        export DD_PKG_GITLAB_URL="https://artifact-gateway.us1.staging.dog/internal/artifact-gateway/api/v4"
         echo "Using staging artifact gateway: $DD_PKG_GITLAB_URL"
       fi
     - |-


### PR DESCRIPTION
### What does this PR do?

Fixes the DD_PKG_GITLAB_URL variable to use the correct artifact gateway URL with the full API path for nightly builds.

### Motivation

A recent merge introduced the dd-pkg variable for the GitLab URL, but it used an incomplete URL. The correct URL should be `https://artifact-gateway.us1.staging.dog/internal/artifact-gateway/api/v4` instead of `https://artifact-gateway.us1.staging.dog`.

### Describe how you validated your changes

- Updated `.gitlab/trigger_release/agent.yml` to use the correct URL
- Updated `.gitlab/trigger_release/installer.yml` to use the correct URL
- Changes will be validated by nightly build pipelines using the updated URL

### Additional Notes

This affects only nightly and oldnightly builds that use the staging artifact gateway.