### PR TITLE
Reduce check sampler log level from Info to Debug

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -169,7 +169,7 @@ func (cs *CheckSampler) commitSeries(timestamp float64, filterList *utilstrings.
 		if !ok {
 			log.Errorf("Can't resolve context of error '%s': inconsistent context resolver state: context with key '%v' is not tracked", err, ckey)
 		} else {
-			log.Infof("No value returned for check metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags().Join(", "), err)
+			log.Debugf("No value returned for check metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags().Join(", "), err)
 		}
 	}
 	for _, serie := range series {

--- a/releasenotes/notes/Reduce-check-sampler-log-level-from-Info-to-Debug-06a19c3b52dcd6c3.yaml
+++ b/releasenotes/notes/Reduce-check-sampler-log-level-from-Info-to-Debug-06a19c3b52dcd6c3.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Reduced log verbosity in the aggregator by changing the log level from
+    Info to Debug for the message logged when no value is returned for a
+    check metric.


### PR DESCRIPTION
### What does this PR do?
Changes the log level from `Info` to `Debug` for the message logged when no value is returned for a check metric in the aggregator.

### Motivation
The log message `No value returned for check metric...` at Info level creates unnecessary log noise in production environments. A customer's agent flare showed that the log file only contained 12 seconds of logs where the agent produced 7115 log entries, where 7112 (99.9%) were this single message.

### Describe how you validated your changes
CI

### Additional Notes
This only affects logging verbosity and does not change any agent functionality or metric collection behavior.