### PR TITLE
Allow nghttp2 to export a shared library so that we can link the curl binary dynamically against it.

### DIFF
--- a/deps/nghttp2/nghttp2.BUILD.bazel
+++ b/deps/nghttp2/nghttp2.BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_license//rules:license.bzl", "license")
 
 package(
     default_applicable_licenses = [":license"],
-    default_visibility = ["//visibility:private"],
+    default_visibility = ["//visibility:public"],
 )
 
 license(
@@ -14,9 +14,7 @@ license(
     visibility = ["//visibility:public"],
 )
 
-exports_files([
-    "COPYING",
-])
+SO_VERSION = 14
 
 # This builds only the nghttp2 C library, not the C++ application code.
 # Following the omnibus build configuration which uses:
@@ -47,4 +45,10 @@ cc_library(
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+)
+
+cc_shared_library(
+    name = "nghttp2_shared",
+    shared_lib_name = "nghttp2.so.%s" % SO_VERSION,
+    deps = ["nghttp2"],
 )

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -161,9 +161,9 @@ http_archive(
 
 http_archive(
     name = "nghttp2",
-    build_file = "//deps:nghttp2.BUILD.bazel",
     files = {
-        "config.h": "//deps/nghttp2:config.h",
+        "BUILD.bazel": "//deps:nghttp2/nghttp2.BUILD.bazel",
+        "config.h": "//deps:nghttp2/config.h",
     },
     sha256 = "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb",
     strip_prefix = "nghttp2-1.58.0",


### PR DESCRIPTION
Allow nghttp2 to export a shared library so that we can link the curl binary dynamically against it.

- Use case in the curl PR. https://github.com/DataDog/datadog-agent/pull/42546/

After building curl, we see this.
```
$ ldd bazel-bin/external/+_repo_rules+curl/curl_bin
            linux-vdso.so.1 (0x0000ffffa8c25000)
            libnghttp2.so.14 => /opt/datadog-agent/embedded/lib/libnghttp2.so.14 (0x0000ffff90240000)
            libz.so => /opt/datadog-agent/embedded/lib/libz.so (0x0000ffff90210000)
            libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffff901e0000)
            libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffff90130000)
            libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000ffff90100000)
            librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000ffff900d0000)
            libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff8ff10000)
            /lib/ld-linux-aarch64.so.1 (0x0000ffff9028e000)
```
