### PR TITLE
[EBPF-956] gpu: fix detection of devices assigned to Docker containers

### DIFF
--- a/pkg/gpu/containers/containers.go
+++ b/pkg/gpu/containers/containers.go
@@ -80,7 +80,7 @@ func getDockerVisibleDevicesEnv(container *workloadmeta.Container) (string, erro
 	// If we have an error (e.g, the agent does not have permissions to inspect
 	// the process environment variables) fall back to the container runtime
 	// data
-	envVar, dockerErr := getDockerVisibleDevicesEnvFromRuntime(container)
+	envVar, dockerErr := inspectDockerDevices(container)
 	if dockerErr == nil {
 		return strings.TrimSpace(envVar), nil
 	}

--- a/pkg/gpu/containers/containers_docker.go
+++ b/pkg/gpu/containers/containers_docker.go
@@ -20,7 +20,7 @@ import (
 )
 
 // getDockerVisibleDevicesEnvFromRuntime returns the value of the NVIDIA_VISIBLE_DEVICES environment variable by
-// inspecting the container data
+// inspecting the container data from the Docker API.
 func getDockerVisibleDevicesEnvFromRuntime(container *workloadmeta.Container) (string, error) {
 	dockerUtil, err := docker.GetDockerUtil()
 	if err != nil {

--- a/pkg/gpu/containers/containers_docker.go
+++ b/pkg/gpu/containers/containers_docker.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux && docker
+//go:build linux && nvml && docker
 
 // Package containers has utilities to work with GPU assignment to containers
 package containers

--- a/pkg/gpu/containers/containers_docker.go
+++ b/pkg/gpu/containers/containers_docker.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && docker
+
+// Package containers has utilities to work with GPU assignment to containers
+package containers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+// getDockerVisibleDevicesEnvFromRuntime returns the value of the NVIDIA_VISIBLE_DEVICES environment variable by
+// inspecting the container data
+func getDockerVisibleDevicesEnvFromRuntime(container *workloadmeta.Container) (string, error) {
+	dockerUtil, err := docker.GetDockerUtil()
+	if err != nil {
+		return "", fmt.Errorf("error getting docker util: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dockerInspectTimeout)
+	defer cancel()
+
+	containerInspect, err := dockerUtil.Inspect(ctx, container.ID, false)
+	if err != nil {
+		return "", fmt.Errorf("error inspecting container %s: %w", container.ID, err)
+	}
+
+	if containerInspect.HostConfig == nil {
+		return "", fmt.Errorf("container %s has no host config", container.ID)
+	}
+
+	for _, device := range containerInspect.HostConfig.Resources.DeviceRequests {
+		for _, capabilityGroup := range device.Capabilities {
+			if slices.Contains(capabilityGroup, "gpu") {
+				numGpus := device.Count
+				if numGpus == -1 {
+					return "all", nil
+				}
+
+				// return 0,1,...numGpus-1 as the assumed visible devices variable,
+				// that's how Docker assigns devices to containers, there's no exclusive
+				// allocation.
+				visibleDevices := make([]string, numGpus)
+				for i := 0; i < numGpus; i++ {
+					visibleDevices[i] = strconv.Itoa(i)
+				}
+				return strings.Join(visibleDevices, ","), nil
+			}
+		}
+	}
+
+	return "", nil
+}

--- a/pkg/gpu/containers/containers_docker.go
+++ b/pkg/gpu/containers/containers_docker.go
@@ -19,9 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
-// getDockerVisibleDevicesEnvFromRuntime returns the value of the NVIDIA_VISIBLE_DEVICES environment variable by
+// inspectDockerDevices returns the value of the NVIDIA_VISIBLE_DEVICES environment variable by
 // inspecting the container data from the Docker API.
-func getDockerVisibleDevicesEnvFromRuntime(container *workloadmeta.Container) (string, error) {
+func inspectDockerDevices(container *workloadmeta.Container) (string, error) {
 	dockerUtil, err := docker.GetDockerUtil()
 	if err != nil {
 		return "", fmt.Errorf("error getting docker util: %w", err)

--- a/pkg/gpu/containers/containers_nodocker.go
+++ b/pkg/gpu/containers/containers_nodocker.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && !docker
+
+// Package containers has utilities to work with GPU assignment to containers
+package containers
+
+import workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+
+func getDockerVisibleDevicesEnvFromRuntime(container *workloadmeta.Container) (string, error) {
+	return "", nil
+}

--- a/pkg/gpu/containers/containers_nodocker.go
+++ b/pkg/gpu/containers/containers_nodocker.go
@@ -10,6 +10,6 @@ package containers
 
 import workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 
-func getDockerVisibleDevicesEnvFromRuntime(_container *workloadmeta.Container) (string, error) {
+func inspectDockerDevices(_container *workloadmeta.Container) (string, error) {
 	return "", nil
 }

--- a/pkg/gpu/containers/containers_nodocker.go
+++ b/pkg/gpu/containers/containers_nodocker.go
@@ -10,6 +10,6 @@ package containers
 
 import workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 
-func getDockerVisibleDevicesEnvFromRuntime(container *workloadmeta.Container) (string, error) {
+func getDockerVisibleDevicesEnvFromRuntime(_container *workloadmeta.Container) (string, error) {
 	return "", nil
 }

--- a/pkg/gpu/containers/containers_nodocker.go
+++ b/pkg/gpu/containers/containers_nodocker.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux && !docker
+//go:build linux && nvml && !docker
 
 // Package containers has utilities to work with GPU assignment to containers
 package containers

--- a/test/new-e2e/tests/gpu/capabilities.go
+++ b/test/new-e2e/tests/gpu/capabilities.go
@@ -63,6 +63,7 @@ type suiteCapabilities interface {
 	RunContainerWorkloadWithGPUs(image string, arguments ...string) (string, error)
 	GetRestartCount(component agentComponent) int
 	CheckWorkloadErrors(containerID string) error
+	ExpectedWorkloadTags() []string
 }
 
 // hostCapabilities is an implementation of suiteCapabilities for the Host environment
@@ -187,6 +188,11 @@ func (c *hostCapabilities) CheckWorkloadErrors(containerID string) error {
 	}
 
 	return nil
+}
+
+// ExpectedWorkloadTags returns tags that are expected to be present on workloads
+func (c *hostCapabilities) ExpectedWorkloadTags() []string {
+	return []string{"container_id", "container_name", "short_image"}
 }
 
 // kubernetesCapabilities is an implementation of suiteCapabilities for the Kubernetes environment
@@ -342,4 +348,9 @@ func (c *kubernetesCapabilities) GetRestartCount(component agentComponent) int {
 	}
 
 	return restartCount
+}
+
+// ExpectedWorkloadTags returns tags that are expected to be present on workloads
+func (c *kubernetesCapabilities) ExpectedWorkloadTags() []string {
+	return []string{"kube_container_name", "pod_name"}
 }

--- a/test/new-e2e/tests/gpu/capabilities.go
+++ b/test/new-e2e/tests/gpu/capabilities.go
@@ -352,5 +352,6 @@ func (c *kubernetesCapabilities) GetRestartCount(component agentComponent) int {
 
 // ExpectedWorkloadTags returns tags that are expected to be present on workloads
 func (c *kubernetesCapabilities) ExpectedWorkloadTags() []string {
-	return []string{"kube_container_name", "pod_name"}
+	// Kubernetes tag support not added yet
+	return nil
 }

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -275,9 +275,9 @@ func (s *gpuK8sSuite) AfterTest(suiteName, testName string) {
 
 // runCudaDockerWorkload runs a CUDA workload in a Docker container and returns the container ID
 func (v *gpuBaseSuite[Env]) runCudaDockerWorkload() string {
-	// Configure some defaults
-	vectorSize := 200000
-	numLoops := 10000000  // Loop extra times to ensure the kernel runs for a bit
+	// Configure some defaults. Big vector size and number of loops to ensure the kernel runs for a bit
+	vectorSize := 2000000
+	numLoops := 10000000
 	waitTimeSeconds := 30 // Give enough time to our monitor to hook the probes and for workloadmeta to detect containers
 	binary := "/usr/local/bin/cuda-basic"
 	args := []string{binary, strconv.Itoa(vectorSize), strconv.Itoa(numLoops), strconv.Itoa(waitTimeSeconds)}

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -456,10 +456,15 @@ func (v *gpuBaseSuite[Env]) TestZZAgentDidNotRestart() {
 	}
 }
 
-func assertMetricsHaveExpectedTagKeys(c *assert.CollectT, metrics []*aggregator.MetricSeries, expectedTagKeys []string, metricName string) {
+func assertMetricsHaveExpectedTagKeys(c *assert.CollectT, metrics []*aggregator.MetricSeries, expectedTagKeys []string, metricName string) bool {
 	smallestMissingTagSet := expectedTagKeys
 
-	assert.Greater(c, len(metrics), 0, "no metrics found")
+	if !assert.Greater(c, len(metrics), 0, "no metric values found for metric %s", metricName) {
+		// Don't follow with the rest of the assertions in the function, but
+		// also don't use require so that the caller of the function can
+		// continue with other assertions.
+		return false
+	}
 
 	missingTags := make(map[string]bool)
 	for _, metric := range metrics {
@@ -490,5 +495,5 @@ func assertMetricsHaveExpectedTagKeys(c *assert.CollectT, metrics []*aggregator.
 		}
 	}
 
-	assert.Empty(c, smallestMissingTagSet, "no metric %s found with expected tag keys %v. The closest tagset we got had the following missing tag keys: %v", metricName, expectedTagKeys, smallestMissingTagSet)
+	return assert.Empty(c, smallestMissingTagSet, "no metric %s found with expected tag keys %v. The closest tagset we got had the following missing tag keys: %v", metricName, expectedTagKeys, smallestMissingTagSet)
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the detection of the devices assigned to Docker containers. Depending on how the agent is running, it might not have permissions to access the `/proc/\<pid>/environ` file and therefore it cannot know the value of the `NVIDIA_VISIBLE_DEVICES` variable. This PR adds a fallback where the check will query the Docker runtime by inspecting the container.

### Motivation

Fix for https://datadoghq.atlassian.net/browse/EBPF-956

### Describe how you validated your changes

Added e2e test code for this specific scenario, including a fix to ensure that the Docker socket is accessible in e2e tests. Part of these tests fulfill https://datadoghq.atlassian.net/browse/EBPF-952 and https://datadoghq.atlassian.net/browse/EBPF-771

### Additional Notes

This PR patches the GPU code only, so that the fix can be backported to 7.74.x with reduced risk. A future PR will ensure that this data is ingested in workloadmeta and used in a generic manner.