### PR TITLE
Bump Python version to 3.13.10

### DIFF
--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -1,6 +1,6 @@
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
 
-PYTHON_VERSION = "3.13.7"
+PYTHON_VERSION = "3.13.10"
 
 http_archive(
     name = "cpython",
@@ -12,7 +12,7 @@ http_archive(
     patches = [
         "//deps/cpython:0001-customize-windows-build-script.patch",
     ],
-    sha256 = "6c9d80839cfa20024f34d9a6dd31ae2a9cd97ff5e980e969209746037a5153b2",
+    sha256 = "de5930852e95ba8c17b56548e04648470356ac47f7506014664f8f510d7bd61b",
     strip_prefix = "Python-{}".format(PYTHON_VERSION),
     url = "https://python.org/ftp/python/{0}/Python-{0}.tgz".format(PYTHON_VERSION),
 )

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,6 +1,6 @@
 name "python3"
 
-default_version "3.13.7"
+default_version "3.13.10"
 
 unless windows?
   dependency "libffi"
@@ -13,7 +13,7 @@ end
 dependency "openssl3"
 
 source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-       :sha256 => "6c9d80839cfa20024f34d9a6dd31ae2a9cd97ff5e980e969209746037a5153b2"
+       :sha256 => "de5930852e95ba8c17b56548e04648470356ac47f7506014664f8f510d7bd61b"
 
 relative_path "Python-#{version}"
 
@@ -77,7 +77,7 @@ build do
 
     # This is not necessarily the version we built, but the version
     # the Python build system expects.
-    openssl_version = "3.0.16.2"
+    openssl_version = "3.0.18"
     python_arch = "amd64"
 
     mkdir "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\include"

--- a/releasenotes/notes/Bump-embedded-Python-to-3.13.10-b9237ff233367fc6.yaml
+++ b/releasenotes/notes/Bump-embedded-Python-to-3.13.10-b9237ff233367fc6.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+- |
+    The Agent's embedded Python has been upgraded from 3.13.7 to 3.13.10

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -223,7 +223,7 @@ const (
 	ExpectedPythonVersion2 = "2.7.18"
 	// ExpectedPythonVersion3 is the expected python 3 version
 	// Bump this version when the version in omnibus/config/software/python3.rb changes
-	ExpectedPythonVersion3 = "3.13.7"
+	ExpectedPythonVersion3 = "3.13.10"
 	// ExpectedUnloadedPython is the status value for uninitialized lazy loaded python runtime
 	ExpectedUnloadedPython = "unused"
 )


### PR DESCRIPTION
### What does this PR do?
Bumps the embedded python version to 3.13.10 to in order to address a CVE

### Motivation
https://datadoghq.atlassian.net/browse/VULN-12843

### Describe how you validated your changes

### Additional Notes
