### PR TITLE
Update datadog-traceroute to v0.1.33

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.73.0-rc.5
 	github.com/DataDog/datadog-go/v5 v5.8.1
 	github.com/DataDog/datadog-operator/api v0.0.0-20251127112405-4be7033d5f47
-	github.com/DataDog/datadog-traceroute v0.1.32
+	github.com/DataDog/datadog-traceroute v0.1.33
 	github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251120091008-29f645374bec
 	github.com/DataDog/ebpf-manager v0.7.15
 	github.com/DataDog/go-sqllexer v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/DataDog/datadog-go/v5 v5.8.1 h1:+GOES5W9zpKlhwHptZVW2C0NLVf7ilr7pHkDc
 github.com/DataDog/datadog-go/v5 v5.8.1/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20251127112405-4be7033d5f47 h1:uh2sJ7hctv0J3tRfQDQfauCy6x45Ex/A4RdG4/aEOnk=
 github.com/DataDog/datadog-operator/api v0.0.0-20251127112405-4be7033d5f47/go.mod h1:Mx5FrO5t4VF62KTT77HQDheyfGsbufrrBidd+jScicE=
-github.com/DataDog/datadog-traceroute v0.1.32 h1:kqOAIfr60yNcYGzAlaTFMJsRzxVcDnjsVvPnLjrWVcY=
-github.com/DataDog/datadog-traceroute v0.1.32/go.mod h1:sJBXljUoO4m8mcbOH4DCgwEsdq10a81WBCVw/oc1Nes=
+github.com/DataDog/datadog-traceroute v0.1.33 h1:Wd4NbyIuubSnMMGZ1F0f1ECConVv1VjOa28WViY+rDU=
+github.com/DataDog/datadog-traceroute v0.1.33/go.mod h1:sJBXljUoO4m8mcbOH4DCgwEsdq10a81WBCVw/oc1Nes=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251120091008-29f645374bec h1:Cm7Ksl+mKn9ev56CMpYtUs/rQriT4pmLlgaxzkZ8tXU=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251120091008-29f645374bec/go.mod h1:zMOs5XpXrqK5KMLnQDkwwWKF2yVzN2TQGSrBHgPP+eY=
 github.com/DataDog/ebpf-manager v0.7.15 h1:14PbnvXFQccV3zexENfNuADAxCuwHNori7sK55CP0SU=


### PR DESCRIPTION
### What does this PR do?

Update datadog-traceroute to v0.1.33

### Motivation

### Describe how you validated your changes

### Additional Notes
