### PR TITLE
DSMON-1152: Send Data Streams messages to their own intake

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -47,11 +47,12 @@ func Module(params Params) fxutil.Module {
 }
 
 const (
-	eventTypeDBMSamples  = "dbm-samples"
-	eventTypeDBMMetrics  = "dbm-metrics"
-	eventTypeDBMActivity = "dbm-activity"
-	eventTypeDBMMetadata = "dbm-metadata"
-	eventTypeDBMHealth   = "dbm-health"
+	eventTypeDBMSamples         = "dbm-samples"
+	eventTypeDBMMetrics         = "dbm-metrics"
+	eventTypeDBMActivity        = "dbm-activity"
+	eventTypeDBMMetadata        = "dbm-metadata"
+	eventTypeDBMHealth          = "dbm-health"
+	eventTypeDataStreamsMessage = "data-streams-message"
 )
 
 func getPassthroughPipelines() []passthroughPipelineDesc {
@@ -264,6 +265,18 @@ func getPassthroughPipelines() []passthroughPipelineDesc {
 			//nolint:misspell
 			// TODO(ECT-4272): event-management-intake does not support batching/array, must send one event at a time
 			useStreamStrategy: true,
+		},
+		{
+			eventType:                     eventTypeDataStreamsMessage,
+			category:                      "Data Streams",
+			contentType:                   logshttp.JSONContentType,
+			endpointsConfigPrefix:         "data_streams.forwarder.",
+			hostnameEndpointPrefix:        "trace.agent.",
+			intakeTrackType:               "data_streams_messages",
+			defaultBatchMaxConcurrentSend: 10,
+			defaultBatchMaxContentSize:    pkgconfigsetup.DefaultBatchMaxContentSize,
+			defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
+			defaultInputChanSize:          pkgconfigsetup.DefaultInputChanSize,
 		},
 	}
 

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -200,12 +200,13 @@ func (l *LogsConfigKeys) taggerWarmupDuration() time.Duration {
 
 func (l *LogsConfigKeys) batchWait() time.Duration {
 	key := l.getConfigKey("batch_wait")
-	batchWait := l.getConfig().GetInt(key)
-	if batchWait < 1 || 10 < batchWait {
-		log.Warnf("Invalid %s: %v should be in [1, 10], fallback on %v", key, batchWait, pkgconfigsetup.DefaultBatchWait)
+	batchWaitFloat := l.getConfig().GetFloat64(key)
+	// Valid range: 0.1 seconds (100ms) to 10 seconds
+	if batchWaitFloat < 0.1 || 10 < batchWaitFloat {
+		log.Warnf("Invalid %s: %v should be in [0.1, 10], fallback on %v", key, batchWaitFloat, pkgconfigsetup.DefaultBatchWait)
 		return pkgconfigsetup.DefaultBatchWait * time.Second
 	}
-	return (time.Duration(batchWait) * time.Second)
+	return time.Duration(batchWaitFloat * float64(time.Second))
 }
 
 func (l *LogsConfigKeys) batchMaxConcurrentSend() int {

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -1131,3 +1131,51 @@ func Test_parseAddressWithScheme(t *testing.T) {
 		})
 	}
 }
+
+func (suite *ConfigTestSuite) TestBatchWaitSubsecondValues() {
+	suite.config.SetWithoutSource("api_key", "123")
+
+	// Test with 0.1 seconds (100ms)
+	suite.config.SetWithoutSource("logs_config.batch_wait", 0.1)
+
+	logsConfig := NewLogsConfigKeys("logs_config.", suite.config)
+	endpoints, err := BuildHTTPEndpointsWithConfig(suite.config, logsConfig, "http-intake.logs.", "test-track", "test-proto", "test-source")
+
+	suite.Nil(err)
+	suite.Equal(100*time.Millisecond, endpoints.BatchWait, "BatchWait should be 100ms")
+
+	// Test with 0.5 seconds (500ms)
+	suite.config.SetWithoutSource("logs_config.batch_wait", 0.5)
+	endpoints, err = BuildHTTPEndpointsWithConfig(suite.config, logsConfig, "http-intake.logs.", "test-track", "test-proto", "test-source")
+
+	suite.Nil(err)
+	suite.Equal(500*time.Millisecond, endpoints.BatchWait, "BatchWait should be 500ms")
+
+	// Test with 1.5 seconds
+	suite.config.SetWithoutSource("logs_config.batch_wait", 1.5)
+	endpoints, err = BuildHTTPEndpointsWithConfig(suite.config, logsConfig, "http-intake.logs.", "test-track", "test-proto", "test-source")
+
+	suite.Nil(err)
+	suite.Equal(1500*time.Millisecond, endpoints.BatchWait, "BatchWait should be 1.5 seconds")
+
+	// Test with integer value for backwards compatibility
+	suite.config.SetWithoutSource("logs_config.batch_wait", 5)
+	endpoints, err = BuildHTTPEndpointsWithConfig(suite.config, logsConfig, "http-intake.logs.", "test-track", "test-proto", "test-source")
+
+	suite.Nil(err)
+	suite.Equal(5*time.Second, endpoints.BatchWait, "BatchWait should be 5 seconds (integer value)")
+
+	// Test with value below minimum (should fallback to default)
+	suite.config.SetWithoutSource("logs_config.batch_wait", 0.05) // 50ms, below 100ms minimum
+	endpoints, err = BuildHTTPEndpointsWithConfig(suite.config, logsConfig, "http-intake.logs.", "test-track", "test-proto", "test-source")
+
+	suite.Nil(err)
+	suite.Equal(pkgconfigsetup.DefaultBatchWait*time.Second, endpoints.BatchWait, "BatchWait should fallback to default for too-small values")
+
+	// Test with value above maximum (should fallback to default)
+	suite.config.SetWithoutSource("logs_config.batch_wait", 15) // Above 10 second maximum
+	endpoints, err = BuildHTTPEndpointsWithConfig(suite.config, logsConfig, "http-intake.logs.", "test-track", "test-proto", "test-source")
+
+	suite.Nil(err)
+	suite.Equal(pkgconfigsetup.DefaultBatchWait*time.Second, endpoints.BatchWait, "BatchWait should fallback to default for too-large values")
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1859,6 +1859,9 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("database_monitoring.autodiscovery.rds.tags", []string{"datadoghq.com/scrape:true"})
 	config.BindEnvAndSetDefault("database_monitoring.autodiscovery.rds.dbm_tag", "datadoghq.com/dbm:true")
 
+	bindEnvAndSetLogsConfigKeys(config, "data_streams.forwarder.")
+	config.BindEnvAndSetDefault("data_streams.forwarder.batch_wait", 0.1) // 100ms for low-latency forwarding
+
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -333,6 +333,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 		// this can happen when the method or the url are valid.
 		return err
 	}
+
 	req.Header.Set("DD-API-KEY", d.endpoint.GetAPIKey())
 	req.Header.Set("Content-Type", d.contentType)
 	req.Header.Set("User-Agent", "datadog-agent/"+version.AgentVersion)

--- a/releasenotes/notes/add-data-streams-messages-endpoint-605040a0ca074213.yaml
+++ b/releasenotes/notes/add-data-streams-messages-endpoint-605040a0ca074213.yaml
@@ -1,0 +1,2 @@
+features:
+  - Add new Data Streams intake for Kafka messages


### PR DESCRIPTION
### What does this PR do?

Adds new intake connections for Data Streams.
Integrations can now send data to data streams backend.

The events from the integration are sent as a result of an action in the UI (
Click: retrieve messages
Wait
See messages show up in the UI)

So low latency is critical. That's why I reduce batch wait to 100ms.

### Motivation

Send Kafka messages to Datadog backend, and control their storage & access.

### Describe how you validated your changes

### Additional Notes


Connectivity tests fails because intake PR is not yet merged due to code freeze.
