### PR TITLE
[EXP-131] Fix lifecycle event for ECS

### DIFF
--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -187,7 +187,7 @@ func Factory(store workloadmeta.Component) option.Option[func() check.Check] {
 // sendFargateTaskEvent sends Fargate task lifecycle event at the end of the check
 func (c *Check) sendFargateTaskEvent() {
 	if !pkgconfigsetup.Datadog().GetBool("ecs_task_collection_enabled") ||
-		!env.IsECSFargate() {
+		!env.IsECSSidecarMode(pkgconfigsetup.Datadog()) {
 		return
 	}
 

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -117,7 +117,7 @@ func getECSInstanceMetadata(ctx context.Context) (string, string, string, string
 
 	region, awsAccountID := ParseRegionAndAWSAccountID(ecsInstance.ContainerInstanceARN)
 
-	return awsAccountID, region, ecsInstance.Cluster, ecsInstance.Version, err
+	return awsAccountID, region, ParseClusterName(ecsInstance.Cluster), ecsInstance.Version, err
 }
 
 func getECSTaskMetadata(ctx context.Context) (string, string, string, string, error) {

--- a/releasenotes/notes/managed-instance-lifecycle-event-0e59eea89d0ae201.yaml
+++ b/releasenotes/notes/managed-instance-lifecycle-event-0e59eea89d0ae201.yaml
@@ -1,0 +1,6 @@
+
+---
+
+fixes:
+  - |
+    Send ECS task lifecycle event for ECS Managed Instances when agent is deployed as a sidecar.


### PR DESCRIPTION
### What does this PR do?
Fixes the following bugs for ECS lifecycle events:
- lifecycle events are missing cluster name for EC2. We see this error `Error getting cluster id: invalid cache value: 584647299176:us-west-2:arn:aws:ecs:us-west-2:584647299176:cluster/managed-instances-cluster:33633666-6639-3966-3463-393365366661:`
- lifecycle events are not sent at the end of the agent lifecycle for ECS managed instances when running as a sidecar. 

### Motivation
During QA of https://github.com/DataDog/datadog-agent/pull/43470, we observe that lifecycle events are missing for managed instance launch type. Without the lifecycle event, the task will report as running for up to 15 minutes on the ECS explorer. The lifecycle event ensures that the task is marked as stopped immediately.

Also noticed that we're not getting the cluster ID for EC2 due to not parsing the cluster name from V1 metadata.

### Describe how you validated your changes

Validating ECS Managed Instances:
- Deployed image `datadog/agent:7.74.0-rc.1-full` as a sidecar on ECS Managed Instances. 
- Delete task containing the agent sidecar
- Confirmed logs in internal service that shows we received the lifecycle event from the agent
- Confirmed task is properly marked as stopped
<img width="665" height="64" alt="image" src="https://github.com/user-attachments/assets/b3ac5658-687e-47a6-96e8-b225b834068a" />

Validating ECS EC2:
- Deployed image `datadog/agent:7.74.0-rc.1-full` as a sidecar on ECS EC2
- Delete task running in cluster
- Confirmed logs in internal service that shows we received the lifecycle event from the agent
- Confirmed task is properly marked as stopped
<img width="694" height="75" alt="image" src="https://github.com/user-attachments/assets/b7ec52d9-ead6-435c-af98-bd0aeda2e602" />


### Additional Notes
