### PR TITLE
Adds shared k8s dev environment setup for gadget dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -822,3 +822,5 @@
 
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
+
+/q_branch/                               @scottopell @val06

--- a/q_branch/README.md
+++ b/q_branch/README.md
@@ -1,0 +1,27 @@
+# Gadget K8s Host
+
+Lima VM with a Kind cluster for local Kubernetes development.
+
+## Setup
+
+```bash
+./setup-k8s-host.sh
+```
+
+This creates:
+- Lima VM: `gadget-k8s-host`
+- Kind cluster: `gadget-dev` (1 control-plane + 2 workers)
+- Kubeconfig: `~/.kube/gadget-k8s-host.yaml`
+
+## Usage
+
+```bash
+export KUBECONFIG=~/.kube/gadget-k8s-host.yaml
+kubectl get nodes
+```
+
+## SSH into VM
+
+```bash
+limactl shell gadget-k8s-host
+```

--- a/q_branch/README.md
+++ b/q_branch/README.md
@@ -11,12 +11,12 @@ Lima VM with a Kind cluster for local Kubernetes development.
 This creates:
 - Lima VM: `gadget-k8s-host`
 - Kind cluster: `gadget-dev` (1 control-plane + 2 workers)
-- Kubeconfig: `~/.kube/gadget-k8s-host.yaml`
+- Kubeconfig merged into `~/.kube/config`
 
 ## Usage
 
 ```bash
-export KUBECONFIG=~/.kube/gadget-k8s-host.yaml
+kubectx kind-gadget-dev
 kubectl get nodes
 ```
 
@@ -24,4 +24,16 @@ kubectl get nodes
 
 ```bash
 limactl shell gadget-k8s-host
+```
+
+## Teardown
+
+```bash
+# Delete VM
+limactl delete gadget-k8s-host --force
+
+# Remove kubeconfig entries (context, cluster, and user)
+kubectl config delete-context kind-gadget-dev
+kubectl config delete-cluster kind-gadget-dev
+kubectl config delete-user kind-gadget-dev
 ```

--- a/q_branch/README.md
+++ b/q_branch/README.md
@@ -2,23 +2,41 @@
 
 Lima VM with a Kind cluster for local Kubernetes development.
 
-## Setup
+## One-Time Setup
 
 ```bash
+# Create VM and Kind cluster
 ./setup-k8s-host.sh
+
+# Install Datadog Operator
+limactl shell gadget-k8s-host -- helm install datadog-operator datadog/datadog-operator
 ```
 
 This creates:
 - Lima VM: `gadget-k8s-host`
 - Kind cluster: `gadget-dev` (1 control-plane + 2 workers)
 - Kubeconfig merged into `~/.kube/config`
+- Datadog Operator ready to deploy agents
 
-## Usage
+## Dev Loop
 
 ```bash
-kubectx kind-gadget-dev
-kubectl get nodes
+# 1. Build custom agent image
+dda inv omnibus.build-image
+
+# 2. Load image into Kind (macOS docker → Lima docker → Kind)
+docker tag datadog-agent:local localhost/datadog-agent:local
+docker save localhost/datadog-agent:local | limactl shell gadget-k8s-host -- docker load
+limactl shell gadget-k8s-host -- kind load docker-image localhost/datadog-agent:local --name gadget-dev
+
+# 3. Deploy agent with custom image
+kubectl apply -f test-cluster.yaml --context kind-gadget-dev
+
+# 4. Watch pods come up
+kubectl get pods -w --context kind-gadget-dev
 ```
+
+To redeploy after code changes, repeat steps 1-3.
 
 ## SSH into VM
 

--- a/q_branch/README.md
+++ b/q_branch/README.md
@@ -21,6 +21,10 @@ This creates:
 ## Dev Loop
 
 ```bash
+
+# 0. Ensure docker desktop is running and the lima VM is started
+limactl start gadget-k8s-host
+
 # 1. Build and load image into Kind
 dda inv omnibus.docker-build && docker save localhost/datadog-agent:local | limactl shell gadget-k8s-host -- docker load && limactl shell gadget-k8s-host -- kind load docker-image localhost/datadog-agent:local --name gadget-dev
 

--- a/q_branch/gadget-k8s-host.lima.yaml
+++ b/q_branch/gadget-k8s-host.lima.yaml
@@ -57,7 +57,11 @@ provision:
       # Helm
       curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
-      # Datadog helm repo (as root, available to all users)
+  # Datadog helm repo for lima user
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux
       helm repo add datadog https://helm.datadoghq.com
       helm repo update
 

--- a/q_branch/gadget-k8s-host.lima.yaml
+++ b/q_branch/gadget-k8s-host.lima.yaml
@@ -1,0 +1,67 @@
+minimumLimaVersion: "1.0.0"
+
+images:
+- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
+cpus: 6
+memory: 12GiB
+disk: 80GiB
+
+ssh:
+  localPort: 0
+
+# Port forwarding for Kind API server (6443) and NodePorts
+portForwards:
+  - guestPort: 6443
+    hostPort: 6443
+  - guestPortRange: [30000, 30100]
+    hostPortRange: [30000, 30100]
+
+mounts: []
+
+provision:
+  # System packages + Docker CE + k8s tools
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux
+      export DEBIAN_FRONTEND=noninteractive
+
+      apt-get update
+      apt-get install -y \
+        build-essential ca-certificates curl gnupg lsb-release \
+        git wget rsync jq stress-ng
+
+      # Docker CE
+      install -m 0755 -d /etc/apt/keyrings
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+      chmod a+r /etc/apt/keyrings/docker.gpg
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+      apt-get update
+      apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+      usermod -aG docker lima
+      systemctl enable docker
+      systemctl start docker
+
+      # kubectl
+      curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
+      apt-get update
+      apt-get install -y kubectl
+
+      # Kind
+      curl -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-$(dpkg --print-architecture)"
+      chmod +x /usr/local/bin/kind
+
+      # Helm
+      curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      # Datadog helm repo (as root, available to all users)
+      helm repo add datadog https://helm.datadoghq.com
+      helm repo update
+
+message: |
+  Tools installed: docker, kubectl, kind, helm
+
+  Run setup-k8s-host.sh to create the Kind cluster and configure kubectl.

--- a/q_branch/gadget-k8s-host.lima.yaml
+++ b/q_branch/gadget-k8s-host.lima.yaml
@@ -1,5 +1,12 @@
 minimumLimaVersion: "1.0.0"
 
+# Software versions - update these to keep tools current
+# Check latest: https://github.com/kubernetes-sigs/kind/releases
+#               https://kubernetes.io/releases/
+env:
+  KIND_VERSION: "v0.27.0"
+  KUBECTL_VERSION: "v1.32"
+
 images:
 - location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
   arch: "aarch64"
@@ -45,13 +52,13 @@ provision:
       systemctl start docker
 
       # kubectl
-      curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-      echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
+      curl -fsSL "https://pkgs.k8s.io/core:/stable:/${KUBECTL_VERSION}/deb/Release.key" | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBECTL_VERSION}/deb/ /" > /etc/apt/sources.list.d/kubernetes.list
       apt-get update
       apt-get install -y kubectl
 
       # Kind
-      curl -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-$(dpkg --print-architecture)"
+      curl -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-$(dpkg --print-architecture)"
       chmod +x /usr/local/bin/kind
 
       # Helm

--- a/q_branch/test-cluster.yaml
+++ b/q_branch/test-cluster.yaml
@@ -1,0 +1,46 @@
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    clusterName: gadget-k8s-dev
+    kubelet:
+      tlsVerify: false
+    credentials:
+      apiKey: a00000001
+      appKey: a00000001
+  override:
+    nodeAgent:
+      image:
+        # localhost/ prefix required - operator prepends default registry without it
+        name: localhost/datadog-agent:local
+        pullPolicy: Never
+  features:
+    logCollection:
+      enabled: true
+    liveProcessCollection:
+      enabled: true
+    liveContainerCollection:
+      enabled: true
+    processDiscovery:
+      enabled: true
+    oomKill:
+      enabled: true
+    tcpQueueLength:
+      enabled: true
+    ebpfCheck:
+      enabled: true
+    apm:
+      enabled: true
+    cspm:
+      enabled: true
+    cws:
+      enabled: true
+    npm:
+      enabled: true
+    usm:
+      enabled: true
+    dogstatsd:
+      unixDomainSocketConfig:
+        enabled: true

--- a/q_branch/test-cluster.yaml
+++ b/q_branch/test-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: datadog
 spec:
   global:
-    clusterName: gadget-k8s-dev
+    clusterName: gadget-dev
     kubelet:
       tlsVerify: false
     credentials:

--- a/q_branch/test-cluster.yaml
+++ b/q_branch/test-cluster.yaml
@@ -8,8 +8,8 @@ spec:
     kubelet:
       tlsVerify: false
     credentials:
-      apiKey: a00000001
-      appKey: a00000001
+      apiKey: '00000000000000000000000000000000'
+      appKey: '00000000000000000000000000000000'
   override:
     nodeAgent:
       image:


### PR DESCRIPTION
### What does this PR do?

Adds a local Kubernetes development environment using Lima VM + Kind cluster for testing the Datadog Agent with custom-built images.

Key Files:
- `setup-k8s-host.sh` - One-time setup script that creates the VM and cluster
- `gadget-k8s-host.lima.yaml` - Lima VM configuration with Docker, kubectl, Kind, and Helm pre-installed
- `test-cluster.yaml` - DatadogAgent CR configured for local image testing

### Motivation

Provide a shared local development workflow for testing Agent changes in a real Kubernetes environment without needing remote infrastructure.
A tight dev loop is the goal:

1. Build custom agent image (`dda inv omnibus.docker-build`)
2. Load image into Kind cluster
3. Deploy with the Datadog Operator
4. Iterate

### Describe how you validated your changes

- Created Lima VM and Kind cluster from scratch (and deleted, and recreated)
- Installed Datadog Operator via Helm
- Built and loaded a custom agent image
- Deployed DatadogAgent CR and verified pods started with the custom image

### Additional Notes

- Kubeconfig is automatically merged into `~/.kube/config` so `kubectx`/`kubectl` discover the cluster
- The `localhost/` prefix on the image name is required due to how the Datadog Operator handles image registry defaults (see comment in test-cluster.yaml)
- VM requires ~12GB RAM and 80GB disk space
