### PR TITLE
[NTP] Submit metric using GaugeWithTimestamp

### DIFF
--- a/releasenotes/notes/ntp-offset-timestamp-9d637f0aed7aefc1.yaml
+++ b/releasenotes/notes/ntp-offset-timestamp-9d637f0aed7aefc1.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The NTP check now submits the ``ntp.offset`` metric using the timestamp
+    returned by the NTP server rather than the local system clock. This restores
+    the behavior present in Agent v5 and prevents incorrect metric alignment
+    when host clocks are skewed.


### PR DESCRIPTION
### **What does this PR do?**

Restores the original behavior of the NTP check by submitting the `ntp.offset` metric using the timestamp returned by the NTP server instead of the local system clock. The Agent now emits the metric via `GaugeWithTimestamp` using the authoritative NTP response time.

### **Motivation**

In Agent v5, the NTP check used the timestamp provided by the NTP server.
During the v6 rewrite, this behavior was lost and the metric began using the local system time instead.
When the host clock is skewed, this results in incorrectly aligned data in the UI.

This PR restores the correct behavior.

### **Describe how you validated your changes**

* Added comprehensive unit tests using mocked NTP responses, including timestamp propagation.
* Updated resiliency tests to use valid mock NTP packets.
* Ensured that cloud-provider fallback does not interfere with mocked tests.
* Verified that `GaugeWithTimestamp` is called with the NTP server timestamp.

### **Additional Notes**

None.
