### PR TITLE
Remove irrelevant operations from Agent docker build

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -154,8 +154,7 @@ COPY install_info etc/datadog-agent/
 #   - jmxfetch on nojmx build
 
 RUN --mount=from=artifacts,target=/artifacts \
- find /artifacts -maxdepth 1 -type f -name "datadog-*-$TARGETARCH.tar.xz" ! -name "$DD_AGENT_ARTIFACT" -exec rm {} \; \
- && find /artifacts -maxdepth 1 -name "${DD_AGENT_ARTIFACT}" -exec tar xvf {} -C . \; \
+ find /artifacts -maxdepth 1 -name "${DD_AGENT_ARTIFACT}" -exec tar xvf {} -C . \; \
  && rm -rf usr etc/init lib \
     go/ \
     opt/datadog-agent/embedded/bin/installer \

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -136,8 +136,6 @@ ARG TARGETARCH
 ARG WITH_JMX
 
 ARG DD_AGENT_ARTIFACT=datadog-agent*-$TARGETARCH.tar.xz
-# copy everything - globbing with args wont work
-COPY ${DD_AGENT_ARTIFACT} /
 WORKDIR /output
 
 # Configuration:


### PR DESCRIPTION
### What does this PR do?

It removes a copy and a removal that are no longer relevant. 
- The artifact that we attempt to `COPY` is not really used, and when not `DD_AGENT_ARTIFACT` has no wildcard in it, the build fails if the file doesn't actually exist (found by @scottopell in https://github.com/DataDog/datadog-agent/pull/43692#discussion_r2586270965).
- The removal of artifacts is irrelevant, and a leftover from a time where the "artifact selection" was slightly different. As it was, it wasn't really doing anything useful, as we're targeting `DD_AGENT_ARTIFACT` anyways.

### Motivation

Mainly prompted by https://github.com/DataDog/datadog-agent/pull/43692#discussion_r2586270965. The COPY specifically is a leftover from https://github.com/DataDog/datadog-agent/pull/37208, where we changed to getting the artifacts via a named build context instead of the default one. The `find ... exec rm` could've probably been cleaned up much earlier.

### Describe how you validated your changes

Passing CI.

### Additional Notes
