### PR TITLE
[AGENTRUN] Disable RemoteAgentRegistry by default

### DIFF
--- a/comp/core/remoteagentregistry/impl/registry_test.go
+++ b/comp/core/remoteagentregistry/impl/registry_test.go
@@ -112,6 +112,9 @@ func TestDisabled(t *testing.T) {
 func buildComponent(t *testing.T) (Provides, *compdef.TestLifecycle, config.Component, telemetry.Component, ipc.Component) {
 	config := configmock.New(t)
 
+	// enable the remote agent registry
+	config.SetWithoutSource("remote_agent_registry.enabled", true)
+
 	provides, lc, telemetry, ipc := buildComponentWithConfig(t, config)
 	return provides, lc, config, telemetry, ipc
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1207,7 +1207,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.rate_limiter.recovery_interval", time.Duration(0))
 
 	// Remote agents
-	config.BindEnvAndSetDefault("remote_agent_registry.enabled", true)
+	config.BindEnvAndSetDefault("remote_agent_registry.enabled", false)
 	config.BindEnvAndSetDefault("remote_agent_registry.idle_timeout", time.Duration(30*time.Second))
 	config.BindEnvAndSetDefault("remote_agent_registry.query_timeout", time.Duration(3*time.Second))
 	config.BindEnvAndSetDefault("remote_agent_registry.recommended_refresh_interval", time.Duration(10*time.Second))


### PR DESCRIPTION
### What does this PR do?

Disables the Remote Agent Registry (RAR) feature by default by changing the `remote_agent_registry.enabled` configuration default from `true` to `false`.

### Motivation

The remoteAgent components where introducing some memory overhead that needs to be investigated before being enabled by default.

### Describe how you validated your changes
CI is green.