### PR TITLE
fix(installer): Add proper fips mode

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -138,7 +138,7 @@ build do
   # Build the installer
   # We do this in the same software definition to avoid redundant copying, as it's based on the same source
   if linux_target? and !heroku_target?
-    command "invoke installer.build --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "invoke installer.build #{fips_args} --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     move 'bin/installer/installer', "#{install_dir}/embedded/bin"
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
@@ -303,6 +303,7 @@ build do
         "#{install_dir}/embedded/bin/process-agent",
         "#{install_dir}/embedded/bin/security-agent",
         "#{install_dir}/embedded/bin/system-probe",
+        "#{install_dir}/embedded/bin/installer",
       ]
 
       symbol = "_Cfunc_go_openssl"

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -325,6 +325,7 @@ build_tags = {
         "trace-agent": TRACE_AGENT_TAGS.union(FIPS_TAGS),
         "cws-instrumentation": CWS_INSTRUMENTATION_TAGS.union(FIPS_TAGS),
         "sbomgen": SBOMGEN_TAGS.union(FIPS_TAGS),
+        "installer": INSTALLER_TAGS.union(FIPS_TAGS),
         # Test setups
         "lint": AGENT_TAGS.union(FIPS_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
         "unit-tests": AGENT_TAGS.union(FIPS_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -12,6 +12,7 @@ from invoke import task
 from tasks.build_tags import (
     compute_build_tags_for_flavor,
 )
+from tasks.flavor import AgentFlavor
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
@@ -34,6 +35,7 @@ def build(
     go_mod="readonly",
     no_strip_binary=True,
     no_cgo=False,
+    fips_mode=False,
 ):
     """
     Build the installer.
@@ -52,14 +54,17 @@ def build(
         )
 
     build_tags = compute_build_tags_for_flavor(
-        build="installer", build_include=build_include, build_exclude=build_exclude
+        build="installer",
+        build_include=build_include,
+        build_exclude=build_exclude,
+        flavor=AgentFlavor.fips if fips_mode else AgentFlavor.base,
     )
 
     installer_bin = INSTALLER_BIN
     if output_bin:
         installer_bin = output_bin
 
-    if no_cgo:
+    if no_cgo and not fips_mode:
         env["CGO_ENABLED"] = "0"
     else:
         env["CGO_ENABLED"] = "1"

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -204,7 +204,7 @@ func (h *Host) WaitForUnitActivating(t *testing.T, units ...string) {
 func (h *Host) WaitForUnitExited(t *testing.T, exitCode int, units ...string) {
 	for _, unit := range units {
 		assert.Eventually(t, func() bool {
-			_, err := h.remote.Execute(fmt.Sprintf("grep -q \"(code=exited, status=%d/\" <(sudo systemctl status %s)", exitCode, unit))
+			_, err := h.remote.Execute(fmt.Sprintf("grep -q -e \"(code=exited, status=%[1]d/\" -e \"(code=exited, status=%[1]d)\" <(sudo systemctl status %[2]s)", exitCode, unit))
 			return err == nil
 		}, time.Second*90, time.Second*2, "unit %s did not exit or exit with expected code. logs: %s", unit, h.remote.MustExecute("sudo journalctl -xeu "+unit))
 	}

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -204,7 +204,7 @@ func (h *Host) WaitForUnitActivating(t *testing.T, units ...string) {
 func (h *Host) WaitForUnitExited(t *testing.T, exitCode int, units ...string) {
 	for _, unit := range units {
 		assert.Eventually(t, func() bool {
-			_, err := h.remote.Execute(fmt.Sprintf("grep -q -e \"(code=exited, status=%[1]d/\" -e \"(code=exited, status=%[1]d)\" <(sudo systemctl status %[2]s)", exitCode, unit))
+			_, err := h.remote.Execute(fmt.Sprintf("systemctl show -p ExecMainCode -p ExecMainStatus %[2]s | xargs | grep -q 'ExecMainCode=1 ExecMainStatus=%[1]d'", exitCode, unit))
 			return err == nil
 		}, time.Second*90, time.Second*2, "unit %s did not exit or exit with expected code. logs: %s", unit, h.remote.MustExecute("sudo journalctl -xeu "+unit))
 	}

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -272,7 +272,7 @@ func (s *packageBaseSuite) Purge() {
 	s.Env().RemoteHost.Execute("sudo datadog-installer purge")
 	s.Env().RemoteHost.Execute("sudo /opt/datadog-packages/datadog-installer/stable/bin/installer/installer purge")
 	s.Env().RemoteHost.Execute("sudo /opt/datadog-packages/datadog-agent/stable/embedded/bin/installer purge")
-	s.Env().RemoteHost.Execute("sudo apt-get remove -y --purge datadog-installer datadog-agent|| sudo yum remove -y datadog-installer datadog-agent || sudo zypper remove -y datadog-installer datadog-agent")
+	s.Env().RemoteHost.Execute("sudo apt-get remove -y --purge datadog-installer datadog-agent datadog-fips-agent || sudo yum remove -y datadog-installer datadog-agent datadog-fips-agent || sudo zypper remove -y datadog-installer datadog-agent datadog-fips-agent")
 	s.Env().RemoteHost.Execute("sudo rm -rf /etc/datadog-agent")
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the `installer` CLI to the supported & tested FIPS binaries

### Motivation
Using the installer in FIPS environments

### Describe how you validated your changes
- E2E test to make sure nothing breaks with the build change
- Automated test for FIPS compliance

### Additional Notes
