### PR TITLE
[EBPF-907] gpu: add support for cuLaunchKernel API call

### DIFF
--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -90,6 +90,51 @@ int BPF_UPROBE(uprobe__cudaLaunchKernel, const void *func, __u64 grid_xy, __u64 
     return 0;
 }
 
+
+SEC("uprobe/cuLaunchKernel")
+int BPF_UPROBE(uprobe__cuLaunchKernel, const void *func, __u32 grid_x, __u32 grid_y, __u32 grid_z, __u32 block_x, __u32 block_y) {
+    cuda_kernel_launch_t launch_data = { 0 };
+    long read_ret = 0;
+    __u64 shared_mem = 0;
+    __u64 stream = 0;
+    __u32 block_z = 0;
+
+    block_z = PT_REGS_USER_PARM7(ctx, read_ret);
+    if (read_ret < 0) {
+        log_debug("cuLaunchKernel: failed to read block_z");
+        return 0;
+    }
+
+    shared_mem = PT_REGS_USER_PARM8(ctx, read_ret);
+    if (read_ret < 0) {
+        log_debug("cuLaunchKernel: failed to read shared_mem");
+        return 0;
+    }
+
+    stream = PT_REGS_USER_PARM9(ctx, read_ret);
+    if (read_ret < 0) {
+        log_debug("cuLaunchKernel: failed to read stream");
+        return 0;
+    }
+
+    launch_data.grid_size.x = grid_x;
+    launch_data.grid_size.y = grid_y;
+    launch_data.grid_size.z = grid_z;
+    launch_data.block_size.x = block_x;
+    launch_data.block_size.y = block_y;
+    launch_data.block_size.z = block_z;
+    launch_data.kernel_addr = (uint64_t)func;
+    launch_data.shared_mem_size = shared_mem;
+    fill_header(&launch_data.header, stream, cuda_kernel_launch);
+
+    log_debug("cuLaunchKernel: EMIT[1/2] pid_tgid=%llu, ts=%llu", launch_data.header.pid_tgid, launch_data.header.ktime_ns);
+    log_debug("cuLaunchKernel: EMIT[2/2] kernel_addr=0x%llx, shared_mem=%llu, stream_id=%llu", launch_data.kernel_addr, launch_data.shared_mem_size, launch_data.header.stream_id);
+
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &launch_data, sizeof(launch_data), get_ringbuf_flags(sizeof(launch_data)));
+
+    return 0;
+}
+
 SEC("uprobe/cudaMalloc")
 int BPF_UPROBE(uprobe__cudaMalloc, void **devPtr, size_t size) {
     __u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -91,6 +91,7 @@ const (
 	setenvProbe                  probeFuncName = "uprobe__setenv"
 	cuStreamSyncProbe            probeFuncName = "uprobe__cuStreamSynchronize"
 	cuStreamSyncRetProbe         probeFuncName = "uretprobe__cuStreamSynchronize"
+	cuLaunchKernelProbe          probeFuncName = "uprobe__cuLaunchKernel"
 )
 
 const ringbufferWakeupSizeConstantName = "ringbuffer_wakeup_size"
@@ -446,6 +447,7 @@ func getCuLibraryAttacherRule() *uprobes.AttachRule {
 				Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cuStreamSyncProbe}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cuStreamSyncRetProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cuLaunchKernelProbe}},
 				},
 			},
 		},

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -8,7 +8,9 @@
 package gpu
 
 import (
+	"encoding/json"
 	"os"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -115,10 +117,10 @@ func (s *probeTestSuite) waitForExpectedCudasampleEvents(probe *Probe, pid int) 
 	require.True(t, ok)
 
 	expectedEvents := map[string]int{
-		ebpf.CudaEventTypeKernelLaunch.String():      2,
+		ebpf.CudaEventTypeKernelLaunch.String():      3,
 		ebpf.CudaEventTypeSetDevice.String():         1,
 		ebpf.CudaEventTypeMemory.String():            2,
-		ebpf.CudaEventTypeSync.String():              3, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize
+		ebpf.CudaEventTypeSync.String():              4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize, cuStreamSynchronize
 		ebpf.CudaEventTypeVisibleDevicesSet.String(): 1,
 		ebpf.CudaEventTypeSyncDevice.String():        2, // cudaDeviceSynchronize, cudaMemcpy
 	}
@@ -174,7 +176,7 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 	require.Equal(t, 2, len(streamPastData.kernels))
 	for i := range 2 {
 		span := streamPastData.kernels[i]
-		require.Equal(t, uint64(1), span.numKernels)
+		require.Equal(t, uint64(2-i), span.numKernels) // first kernel launch has 2 kernels, second has 1
 		require.Equal(t, uint64(1*2*3*4*5*6), span.avgThreadCount)
 		require.Greater(t, span.endKtime, span.startKtime)
 	}
@@ -419,6 +421,143 @@ func BenchmarkProbeEventProcessing(b *testing.B) {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 			_ = cmd.Wait()
+		}
+	}
+}
+
+func assertEventEqual[T any](t *testing.T, expected any, actualMarshaled []byte) {
+	expectedEvent, ok := expected.(*T)
+	require.True(t, ok, "expected event should be pointer to type %T", expectedEvent)
+
+	var actual T
+	require.NoError(t, json.Unmarshal(actualMarshaled, &actual))
+
+	// Get the header from both events using reflection
+	expectedHeader := reflect.ValueOf(*expectedEvent).FieldByName("Header").Interface().(ebpf.CudaEventHeader)
+	actualHeader := reflect.ValueOf(actual).FieldByName("Header").Interface().(ebpf.CudaEventHeader)
+
+	// Only compare type and stream ID, as those are the only values we can
+	// predict
+	require.Equal(t, expectedHeader.Type, actualHeader.Type, "header type mismatch")
+	require.Equal(t, expectedHeader.Stream_id, actualHeader.Stream_id, "header stream ID mismatch")
+
+	// Now set the header in the expected event to the actual header, so that we can compare the rest of the event
+	reflect.ValueOf(expectedEvent).Elem().FieldByName("Header").Set(reflect.ValueOf(actualHeader))
+
+	require.Equal(t, expectedEvent, &actual)
+}
+
+func (s *probeTestSuite) TestDebugCollectorEvents() {
+	t := s.T()
+
+	probe := s.getProbe()
+
+	// Build expected events array based on cudasample.c in order:
+	// Line 33: cudaSetDevice(device) -> CudaEventTypeSetDevice
+	// Line 34: cudaLaunchKernel(...) -> CudaEventTypeKernelLaunch
+	// Line 35: cuLaunchKernel(...) -> CudaEventTypeKernelLaunch
+	// Line 37: cudaMalloc(&ptr, 100) -> CudaEventTypeMemory (alloc)
+	// Line 38: cudaFree(ptr) -> CudaEventTypeMemory (free)
+	// Line 39: cudaStreamSynchronize(stream) -> CudaEventTypeSync
+	// Line 40: cuStreamSynchronize(stream) -> CudaEventTypeSync
+	// Line 45: cudaMemcpy(...) -> CudaEventTypeSyncDevice
+	// Line 48: cudaEventQuery(event) -> CudaEventTypeSync
+	// Line 49: cudaEventSynchronize(event) -> CudaEventTypeSync
+	// Line 53: cudaLaunchKernel(...) -> CudaEventTypeKernelLaunch
+	// Line 55: cudaDeviceSynchronize() -> CudaEventTypeSyncDevice
+	// Line 57: setenv("CUDA_VISIBLE_DEVICES", "42", 1) -> CudaEventTypeVisibleDevicesSet
+	deviceIdx := int32(0) // default device index used by RunSample
+	kernelAddr := uint64(0x1234)
+	allocSize := uint64(100)
+	streamID := uint64(30)
+
+	expectedEvents := []interface{}{
+		&ebpf.CudaSetDeviceEvent{Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeSetDevice), Stream_id: 0}, Device: deviceIdx},
+		&ebpf.CudaKernelLaunch{
+			Header:          ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeKernelLaunch), Stream_id: streamID},
+			Kernel_addr:     kernelAddr,
+			Grid_size:       ebpf.Dim3{X: 1, Y: 2, Z: 3},
+			Block_size:      ebpf.Dim3{X: 4, Y: 5, Z: 6},
+			Shared_mem_size: 10,
+		},
+		&ebpf.CudaKernelLaunch{
+			Header:          ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeKernelLaunch), Stream_id: streamID},
+			Kernel_addr:     kernelAddr,
+			Grid_size:       ebpf.Dim3{X: 1, Y: 2, Z: 3},
+			Block_size:      ebpf.Dim3{X: 4, Y: 5, Z: 6},
+			Shared_mem_size: 10,
+		},
+		&ebpf.CudaMemEvent{
+			Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeMemory), Stream_id: 0},
+			Type:   uint32(ebpf.CudaMemAlloc),
+			Size:   allocSize,
+			Addr:   uint64(0xdeadbeef),
+		},
+		&ebpf.CudaMemEvent{
+			Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeMemory), Stream_id: 0},
+			Type:   uint32(ebpf.CudaMemFree),
+			Addr:   uint64(0xdeadbeef),
+		},
+		&ebpf.CudaSync{Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeSync), Stream_id: streamID}},
+		&ebpf.CudaSync{Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeSync), Stream_id: streamID}},
+		&ebpf.CudaSyncDeviceEvent{Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeSyncDevice), Stream_id: 0}},
+		&ebpf.CudaSync{Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeSync), Stream_id: streamID}},
+		&ebpf.CudaSync{Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeSync), Stream_id: streamID}},
+		&ebpf.CudaKernelLaunch{
+			Header:          ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeKernelLaunch), Stream_id: streamID},
+			Kernel_addr:     kernelAddr,
+			Grid_size:       ebpf.Dim3{X: 1, Y: 2, Z: 3},
+			Block_size:      ebpf.Dim3{X: 4, Y: 5, Z: 6},
+			Shared_mem_size: 10,
+		},
+		&ebpf.CudaSyncDeviceEvent{Header: ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeSyncDevice), Stream_id: 0}},
+		&ebpf.CudaVisibleDevicesSetEvent{
+			Header:  ebpf.CudaEventHeader{Type: uint32(ebpf.CudaEventTypeVisibleDevicesSet), Stream_id: 0},
+			Devices: [256]byte{0x34, 0x32, 0x00}, // "42" as bytes
+		},
+	}
+
+	totalExpectedEvents := len(expectedEvents)
+
+	probe.consumer.debugCollector.enable(totalExpectedEvents * 2) // some margin in case we get extra events
+
+	// Run the CUDA sample
+	cmd, err := testutil.RunSample(t, testutil.CudaSample)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	require.Eventually(t, func() bool {
+		return len(probe.consumer.debugCollector.eventStore) >= totalExpectedEvents
+	}, 10*time.Second, 100*time.Millisecond, "should collect at least %d events", totalExpectedEvents)
+
+	collectedEvents := probe.consumer.debugCollector.eventStore
+	require.Equal(t, len(collectedEvents), totalExpectedEvents, "should collect exactly %d events", totalExpectedEvents)
+
+	// Parse collected events
+	for i, eventBytes := range collectedEvents {
+		expectedEvent := expectedEvents[i]
+
+		// Parse event-specific fields
+		switch expectedEvent.(type) {
+		case *ebpf.CudaKernelLaunch:
+			assertEventEqual[ebpf.CudaKernelLaunch](t, expectedEvent, eventBytes)
+		case *ebpf.CudaMemEvent:
+			assertEventEqual[ebpf.CudaMemEvent](t, expectedEvent, eventBytes)
+		case *ebpf.CudaSetDeviceEvent:
+			assertEventEqual[ebpf.CudaSetDeviceEvent](t, expectedEvent, eventBytes)
+		case *ebpf.CudaSync:
+			assertEventEqual[ebpf.CudaSync](t, expectedEvent, eventBytes)
+		case *ebpf.CudaSyncDeviceEvent:
+			assertEventEqual[ebpf.CudaSyncDeviceEvent](t, expectedEvent, eventBytes)
+		case *ebpf.CudaVisibleDevicesSetEvent:
+			assertEventEqual[ebpf.CudaVisibleDevicesSetEvent](t, expectedEvent, eventBytes)
+		default:
+			require.Fail(t, "unexpected event type: %T", expectedEvent)
 		}
 	}
 }

--- a/pkg/gpu/testdata/common_functions.h
+++ b/pkg/gpu/testdata/common_functions.h
@@ -78,4 +78,21 @@ cudaError_t cudaDeviceSynchronize() {
     return 0;
 }
 
+cudaError_t cuLaunchKernel(const void *func, unsigned int grid_x, unsigned int grid_y, unsigned int grid_z, unsigned int block_x, unsigned int block_y, unsigned int block_z, unsigned int shared_mem, void* stream, void ** kernel_params, void ** extra) {
+    (void)func;
+    (void)grid_x;
+    (void)grid_y;
+    (void)grid_z;
+    (void)block_x;
+    (void)block_y;
+    (void)block_z;
+    (void)shared_mem;
+    return 0;
+}
+
+cudaError_t cuStreamSynchronize(cudaStream_t stream) {
+    (void)stream; // Suppress unused parameter warning
+    return 0;
+}
+
 #endif // COMMON_FUNCTIONS_H

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -32,10 +32,12 @@ int main(int argc, char **argv) {
 
     cudaSetDevice(device);
     cudaLaunchKernel((void *)0x1234, (dim3){ 1, 2, 3 }, (dim3){ 4, 5, 6 }, NULL, 10, stream);
+    cuLaunchKernel((void *)0x1234, 1, 2, 3, 4, 5, 6, 10, (void*)stream, NULL, NULL);
     void *ptr;
     cudaMalloc(&ptr, 100);
     cudaFree(ptr);
     cudaStreamSynchronize(stream);
+    cuStreamSynchronize(stream);
 
     // Sleep for 10ms to ensure that there's time separating the first span and next
     // spans
@@ -50,6 +52,7 @@ int main(int argc, char **argv) {
     cudaEventDestroy(event);
 
     cudaLaunchKernel((void *)0x1234, (dim3){ 1, 2, 3 }, (dim3){ 4, 5, 6 }, NULL, 10, stream);
+
     cudaDeviceSynchronize();
 
     setenv("CUDA_VISIBLE_DEVICES", "42", 1);


### PR DESCRIPTION
### What does this PR do?

Adds support for the cuLaunchKernel API call

### Motivation

Some programs we have tested use this API, without this change we don't emit eBPF-based core usage metrics for them.

### Describe how you validated your changes

Unit tests added and manually validated against the target workload

### Additional Notes
