### PR TITLE
Only retry KMT setup on infra failure

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -136,6 +136,7 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   needs: ["go_deps", "go_tools_deps", "go_e2e_deps"]
   tags: ["arch:amd64", "specific:true"]
+  retry: !reference [.retry_only_infra_failure]
   variables:
     AWS_REGION: us-east-1
     STACK_DIR: $CI_PROJECT_DIR/stack.dir

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -136,7 +136,7 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   needs: ["go_deps", "go_tools_deps", "go_e2e_deps"]
   tags: ["arch:amd64", "specific:true"]
-  retry: !reference [.retry_only_infra_failure]
+  retry: !reference [.retry_only_infra_failure, retry]
   variables:
     AWS_REGION: us-east-1
     STACK_DIR: $CI_PROJECT_DIR/stack.dir


### PR DESCRIPTION
### What does this PR do?
This PR only retries KMT setup job on infra failure. Retries on job script failure are not supported by the KMT framework.

### Motivation

### Describe how you validated your changes
Changes exercised by existing jobs.

### Additional Notes
