### PR TITLE
[EBPF-912] gpu: fix leak in kernel span pool

### DIFF
--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -364,6 +364,7 @@ func (sh *StreamHandler) getCurrentKernelSpan(maxTime uint64) *kernelSpan {
 	}
 
 	if span.numKernels == 0 {
+		memPools.kernelSpanPool.Put(span)
 		return nil
 	}
 

--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -450,6 +450,10 @@ func (sh *StreamHandler) getCurrentData(now uint64) *streamSpans {
 	}
 
 	for alloc := range sh.memAllocEvents.ValuesIter() {
+		if alloc.Header.Ktime_ns >= now {
+			continue
+		}
+
 		span := memPools.memorySpanPool.Get()
 		span.startKtime = alloc.Header.Ktime_ns
 		span.endKtime = 0


### PR DESCRIPTION
### What does this PR do?

Fixes a leak in the kernel span pool that happened when no kernel launches matched the time filter. It fixes also a bug in the filter for memory allocations, discovered when making an equivalent test for memory spans.

### Motivation

Ensure all codepaths return spans to the pool correctly.

### Describe how you validated your changes

Added a test to reproduce the test.

### Additional Notes