### PR TITLE
Fix create_rc_pr workflow to skip PR creation in warning mode

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -3,9 +3,9 @@ name: Create RC PR
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 14 * * 2,4' # Run on Tuesday and Thursday at 14:00 UTC
-    - cron: '0 8 * * 2,4' # Same as above but at 08:00 UTC, to warn agent-integrations team about releasing
-    - cron: '0 9 * * 1' # Run Agent 6 workflow on Monday at 09:00 UTC
+    - cron: "0 14 * * 2,4" # Run on Tuesday and Thursday at 14:00 UTC
+    - cron: "0 8 * * 2,4" # Same as above but at 08:00 UTC, to warn agent-integrations team about releasing
+    - cron: "0 9 * * 1" # Run Agent 6 workflow on Monday at 09:00 UTC
 
 env:
   IS_AGENT6_RELEASE: ${{ github.event.schedule == '0 9 * * 1' }}
@@ -37,7 +37,7 @@ jobs:
       - name: Check previous agent 6 RC status
         if: ${{ env.IS_AGENT6_RELEASE == 'true' }}
         env:
-          DD_SITE: 'datadoghq.com'
+          DD_SITE: "datadoghq.com"
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
         env:
           ATLASSIAN_USERNAME: ${{ secrets.ATLASSIAN_USERNAME }}
           ATLASSIAN_PASSWORD: ${{ secrets.ATLASSIAN_PASSWORD }}
-          SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
           MATRIX: ${{ matrix.value }}
           WARNING: ${{ needs.find_release_branches.outputs.warning }}
         run: |
@@ -110,7 +110,7 @@ jobs:
       - name: Check if agent 6 is in qualification phase
         if: ${{ env.IS_AGENT6_RELEASE == 'true' }}
         env:
-          SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
         run: |
           is_qualification=$(dda inv -- -e release.is-qualification -r 6.53.x --output)
           echo "IS_QUALIFICATION=$is_qualification" >> $GITHUB_ENV
@@ -119,10 +119,10 @@ jobs:
           fi
 
       - name: Create RC PR
-        if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_AGENT6_RELEASE == 'true' && env.IS_QUALIFICATION == 'false') }}
+        if: ${{ needs.find_release_branches.outputs.warning == '' && (steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_AGENT6_RELEASE == 'true' && env.IS_QUALIFICATION == 'false')) }}
         env:
           MATRIX: ${{ matrix.value }}
-          SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           if ${{ env.IS_AGENT6_RELEASE == 'true' }}; then


### PR DESCRIPTION
## What does this PR do?

Fixes the `create_rc_pr.yml` workflow to prevent PR creation during warning mode runs (08:00 UTC on Tue/Thu).

## Motivation

The workflow has three scheduled runs:
- **08:00 UTC (Tue/Thu)**: Warning mode - intended to only notify agent-integrations team
- **14:00 UTC (Tue/Thu)**: Normal mode - create RC PRs for Agent 7
- **09:00 UTC (Mon)**: Agent 6 releases

Currently, the 08:00 warning runs are incorrectly creating PRs when they should only send notifications.

## Describe how to test/QA your changes

The fix adds a condition check to the "Create RC PR" step:
```yaml
if: ${{ needs.find_release_branches.outputs.warning == '' && (...) }}
```

This ensures:
- ✅ 08:00 runs: Warning flag is set (`-w`), condition is false, no PR created
- ✅ 14:00 runs: Warning flag is empty, PRs created normally
- ✅ 09:00 runs: Warning flag is empty, Agent 6 releases proceed normally

To test, you can monitor the next scheduled 08:00 run to verify it doesn't create a PR.

## Possible drawbacks / trade-offs

None - this restores the intended behavior.

## Additional Notes

The `-w` flag is still passed to `release.check-for-changes` during warning runs, which handles sending notifications to the agent-integrations team.