### PR TITLE
[CWS] Use modulo for flags approvers

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/approvers.h
+++ b/pkg/security/ebpf/c/include/helpers/approvers.h
@@ -66,6 +66,16 @@ enum SYSCALL_STATE __attribute__((always_inline)) approve_by_auid(struct syscall
 
     return DISCARDED;
 }
+enum SYSCALL_STATE __attribute__((always_inline)) flag_approver (struct u64_flags_filter_t *filter, u32 type, u64 value) {
+    if (filter == NULL || !filter->is_set) {
+        return DISCARDED;
+    }
+    if (((1 << (value % 64)) & filter->flags) > 0) {
+        monitor_event_approved(type, FLAG_APPROVER_TYPE);
+        return APPROVED;
+    }
+    return DISCARDED;
+}
 
 enum SYSCALL_STATE __attribute__((always_inline)) approve_by_basename(struct dentry *dentry, u64 event_type) {
     struct basename_t basename = {};
@@ -352,16 +362,8 @@ enum SYSCALL_STATE __attribute__((always_inline)) utime_approvers(struct syscall
 enum SYSCALL_STATE __attribute__((always_inline)) bpf_approvers(struct syscall_cache_t *syscall) {
     u32 key = 0;
     struct u64_flags_filter_t *filter = bpf_map_lookup_elem(&bpf_cmd_approvers, &key);
-    if (filter == NULL || !filter->is_set) {
-        return DISCARDED;
-    }
-
-    if (((1 << syscall->bpf.cmd) & filter->flags) > 0) {
-        monitor_event_approved(syscall->type, FLAG_APPROVER_TYPE);
-        return APPROVED;
-    }
-
-    return DISCARDED;
+    u64 cmd = syscall->bpf.cmd;
+    return flag_approver(filter, syscall->type, cmd);
 }
 
 enum SYSCALL_STATE __attribute__((always_inline)) sysctl_approvers(struct syscall_cache_t *syscall) {
@@ -382,31 +384,15 @@ enum SYSCALL_STATE __attribute__((always_inline)) sysctl_approvers(struct syscal
 enum SYSCALL_STATE __attribute__((always_inline)) connect_approvers(struct syscall_cache_t *syscall) {
     u32 key = 0;
     struct u64_flags_filter_t *filter = bpf_map_lookup_elem(&connect_addr_family_approvers, &key);
-    if (filter == NULL || !filter->is_set) {
-        return DISCARDED;
-    }
-
-    if (((1 << syscall->connect.family) & filter->flags) > 0) {
-        monitor_event_approved(syscall->type, FLAG_APPROVER_TYPE);
-        return APPROVED;
-    }
-
-    return DISCARDED;
+    u64 family = syscall->connect.family;
+    return flag_approver(filter, syscall->type, family);
 }
 
 enum SYSCALL_STATE __attribute__((always_inline)) prctl_approvers(struct syscall_cache_t *syscall) {
     u32 key = 0;
     struct u64_flags_filter_t *filter = bpf_map_lookup_elem(&prctl_option_approvers, &key);
-    if (filter == NULL || !filter->is_set) {
-        return DISCARDED;
-    }
-
-    if (((1 << syscall->prctl.option) & filter->flags) > 0) {
-        monitor_event_approved(syscall->type, FLAG_APPROVER_TYPE);
-        return APPROVED;
-    }
-
-    return DISCARDED;
+    u64 option = syscall->prctl.option;
+    return flag_approver(filter, syscall->type, option);
 }
 
 enum SYSCALL_STATE __attribute__((always_inline)) approve_syscall_with_tgid(u32 tgid, struct syscall_cache_t *syscall, enum SYSCALL_STATE (*check_approvers)(struct syscall_cache_t *syscall)) {

--- a/pkg/security/probe/kfilters/approvers.go
+++ b/pkg/security/probe/kfilters/approvers.go
@@ -114,7 +114,7 @@ func getFlagsKFilter(tableName string, flags ...uint32) (kFilter, error) {
 func getEnumsKFilters(tableName string, enums ...uint64) (kFilter, error) {
 	var flags []uint64
 	for _, enum := range enums {
-		flags = append(flags, 1<<enum)
+		flags = append(flags, 1<<(enum%64))
 	}
 	return newKFilterWithUInt64Flags(tableName, flags...)
 }


### PR DESCRIPTION
### What does this PR do?

This PR computes the modulo of the uint64 value used for filtering with approvers, ensuring that the value remains non-zero after the bit-shift operation.

### Motivation

When using flag approvers, we perform a shift operation (1 << x). If the value we want to filter on is greater than or equal to 64, the result becomes 0 due to the overflow of the 64-bit shift.
By applying a modulo operation before shifting, we ensure that the computed filter is always valid and non-zero.

Upsides:
Some values were not added to the approvers, which resulted in a significant increase in the number of events sent to user space. This fix ensures that these values are now correctly handled, reducing unnecessary event volume.

Downside:
This change may allow some events with a value ≥ 64 to be sent to user space even if they are not strictly needed. However, this downside should be negligible compared to the benefits provided by the fix.