### PR TITLE
Disable dd-trace-go profiler initial log

### DIFF
--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -60,6 +60,7 @@ func Start(settings Settings) error {
 		profiler.WithDeltaProfiles(settings.WithDeltaProfiles),
 		profiler.WithTags(settings.Tags...),
 		profiler.WithAPIKey(""), // to silence the error log about `DD_API_KEY`
+		profiler.WithLogStartup(false),
 	}
 
 	if settings.Socket != "" {


### PR DESCRIPTION
### What does this PR do?
Disable dd-trace-go profiler initial log.

### Motivation
dd-trace-go logger isn't a wrapper on top of the agent's logger, so it doesn't log with the correct format (in particular when JSON logging is enabled).

### Describe how you validated your changes
CI

### Additional Notes
