### PR TITLE
[SNMP] Fix `remManAddr` snmp indexing

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -355,7 +355,7 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 func buildNetworkTopologyMetadataWithLLDP(deviceID string, store *metadata.Store, interfaces []devicemetadata.InterfaceMetadata) []devicemetadata.TopologyLinkMetadata {
 	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
 
-	remManAddrByLLDPRemIndex := getRemManIPAddrByLLDPRemIndex(store.GetColumnIndexes("lldp_remote_management.interface_id_type"))
+	remManAddrByLLDPRemIndexAndLLDPRemLocalPortNum := getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(store.GetColumnIndexes("lldp_remote_management.interface_id_type"))
 
 	indexes := store.GetColumnIndexes("lldp_remote.interface_id") // using `lldp_remote.interface_id` to get indexes since it's expected to be always present
 	if len(indexes) == 0 {
@@ -403,7 +403,7 @@ func buildNetworkTopologyMetadataWithLLDP(deviceID string, store *metadata.Store
 					Description: store.GetColumnAsString("lldp_remote.device_desc", strIndex),
 					ID:          remoteDeviceID,
 					IDType:      remoteDeviceIDType,
-					IPAddress:   remManAddrByLLDPRemIndex[lldpRemIndex],
+					IPAddress:   remManAddrByLLDPRemIndexAndLLDPRemLocalPortNum[fmt.Sprintf("%s.%s", localPortNum, lldpRemIndex)],
 				},
 				Interface: &devicemetadata.TopologyLinkInterface{
 					ID:          remoteInterfaceID,
@@ -572,7 +572,7 @@ func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) 
 	return interfaceIndexByIDType
 }
 
-func getRemManIPAddrByLLDPRemIndex(remManIndexes []string) map[string]string {
+func getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(remManIndexes []string) map[string]string {
 	remManAddrByRemIndex := make(map[string]string)
 	for _, fullIndex := range remManIndexes {
 		indexElems := strings.Split(fullIndex, ".")
@@ -586,6 +586,7 @@ func getRemManIPAddrByLLDPRemIndex(remManIndexes []string) map[string]string {
 			//      the first elements is the IP type e.g. 4 for IPv4
 			continue
 		}
+		lldpRemLocalPortNum := indexElems[1]
 		lldpRemIndex := indexElems[2]
 		lldpRemManAddrSubtype := indexElems[3]
 		ipAddrType := indexElems[4]
@@ -594,7 +595,7 @@ func getRemManIPAddrByLLDPRemIndex(remManIndexes []string) map[string]string {
 		// We only support IPv4 for the moment
 		// TODO: Support IPv6
 		if lldpRemManAddrSubtype == "1" && ipAddrType == "4" {
-			remManAddrByRemIndex[lldpRemIndex] = strings.Join(lldpRemManAddr, ".")
+			remManAddrByRemIndex[fmt.Sprintf("%s.%s", lldpRemLocalPortNum, lldpRemIndex)] = strings.Join(lldpRemManAddr, ".")
 		}
 	}
 	return remManAddrByRemIndex

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -403,7 +403,7 @@ func buildNetworkTopologyMetadataWithLLDP(deviceID string, store *metadata.Store
 					Description: store.GetColumnAsString("lldp_remote.device_desc", strIndex),
 					ID:          remoteDeviceID,
 					IDType:      remoteDeviceIDType,
-					IPAddress:   remManAddrByLLDPRemIndexAndLLDPRemLocalPortNum[fmt.Sprintf("%s.%s", localPortNum, lldpRemIndex)],
+					IPAddress:   remManAddrByLLDPRemIndexAndLLDPRemLocalPortNum[buildLLDPRemoteKey(localPortNum, lldpRemIndex)],
 				},
 				Interface: &devicemetadata.TopologyLinkInterface{
 					ID:          remoteInterfaceID,
@@ -572,6 +572,10 @@ func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) 
 	return interfaceIndexByIDType
 }
 
+func buildLLDPRemoteKey(localPortNum, lldpRemIndex string) string {
+	return fmt.Sprintf("%s.%s", localPortNum, lldpRemIndex)
+}
+
 func getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(remManIndexes []string) map[string]string {
 	remManAddrByRemIndex := make(map[string]string)
 	for _, fullIndex := range remManIndexes {
@@ -595,7 +599,7 @@ func getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(remManIndexes []string)
 		// We only support IPv4 for the moment
 		// TODO: Support IPv6
 		if lldpRemManAddrSubtype == "1" && ipAddrType == "4" {
-			remManAddrByRemIndex[fmt.Sprintf("%s.%s", lldpRemLocalPortNum, lldpRemIndex)] = strings.Join(lldpRemManAddr, ".")
+			remManAddrByRemIndex[buildLLDPRemoteKey(lldpRemLocalPortNum, lldpRemIndex)] = strings.Join(lldpRemManAddr, ".")
 		}
 	}
 	return remManAddrByRemIndex

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -1131,7 +1131,7 @@ func TestComputeInterfaceStatus(t *testing.T) {
 	}
 }
 
-func Test_getRemManIPAddrByLLDPRemIndex(t *testing.T) {
+func Test_getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(t *testing.T) {
 	indexes := []string{
 		// IPv4
 		"0.102.2.1.4.10.250.0.7",
@@ -1143,10 +1143,10 @@ func Test_getRemManIPAddrByLLDPRemIndex(t *testing.T) {
 		// Invalid
 		"0.102.2.1.4.10.250", // too short, ignored
 	}
-	remManIPAddrByLLDPRemIndex := getRemManIPAddrByLLDPRemIndex(indexes)
+	remManIPAddrByLLDPRemIndex := getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(indexes)
 	expectedResult := map[string]string{
-		"2":  "10.250.0.7",
-		"99": "10.250.0.8",
+		"102.2":  "10.250.0.7",
+		"102.99": "10.250.0.8",
 	}
 	assert.Equal(t, expectedResult, remManIPAddrByLLDPRemIndex)
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -1131,6 +1131,47 @@ func TestComputeInterfaceStatus(t *testing.T) {
 	}
 }
 
+func Test_buildLLDPRemoteKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		localPortNum string
+		lldpRemIndex string
+		expectedKey  string
+	}{
+		{
+			name:         "basic case",
+			localPortNum: "102",
+			lldpRemIndex: "2",
+			expectedKey:  "102.2",
+		},
+		{
+			name:         "different values",
+			localPortNum: "99",
+			lldpRemIndex: "5",
+			expectedKey:  "99.5",
+		},
+		{
+			name:         "single digit values",
+			localPortNum: "1",
+			lldpRemIndex: "1",
+			expectedKey:  "1.1",
+		},
+		{
+			name:         "large values",
+			localPortNum: "10000",
+			lldpRemIndex: "99999",
+			expectedKey:  "10000.99999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildLLDPRemoteKey(tt.localPortNum, tt.lldpRemIndex)
+			assert.Equal(t, tt.expectedKey, result)
+		})
+	}
+}
+
 func Test_getRemManIPAddrByLLDPRemIndexAndLLDPRemLocalPortNum(t *testing.T) {
 	indexes := []string{
 		// IPv4

--- a/releasenotes/notes/snmp-topology-fix-device-ip-collection-dd977939284bb503.yaml
+++ b/releasenotes/notes/snmp-topology-fix-device-ip-collection-dd977939284bb503.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fixed SNMP network topology metadata where LLDP remote device IP addresses could be
+    incorrectly mapped when multiple devices shared the same remote index on different ports.


### PR DESCRIPTION
## What does this PR do?

Fixes the LLDP remote management IP address mapping in SNMP network topology metadata collection.

## Motivation

The `getRemManIPAddrByLLDPRemIndex` function was indexing remote management IP addresses using only the `lldpRemIndex`, which could cause collisions when multiple remote devices share the same remote index on different local ports. This resulted in incorrect IP addresses being assigned to remote devices in topology links.

## Additional Notes

This issue does not appear to affect all vendors. The bug would only manifest when devices report LLDP data in a way that produces overlapping remote indexes across different local ports, which varies by vendor implementation.