### PR TITLE
[CWS] Fix bug with the listmount snapshotter

### DIFF
--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -203,7 +203,7 @@ func collectUniqueMountNSFDs(procfs string) ([]int, error) {
 		}
 
 		ino, err := getInodeNumFromLink(linkTarget)
-		
+
 		if err != nil {
 			continue
 		}

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -196,7 +196,14 @@ func collectUniqueMountNSFDs(procfs string) ([]int, error) {
 			continue
 		}
 		p := filepath.Join(procfs, pid, "ns", "mnt")
-		ino, err := getInodeNumFromLink(p)
+
+		linkTarget, err := os.Readlink(p)
+		if err != nil {
+			continue
+		}
+
+		ino, err := getInodeNumFromLink(linkTarget)
+		
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
### What does this PR do?

* The link of `/proc/<pid>/ns/mnt` wasn't being read and for this reason, system-probe wasn't obtaining a valid namespace inode number when snapshotting mounts using listmount. This PR fixes the problem.
* This was causing `TestMountSnapshotListmount` fail in some cases
