### PR TITLE
fix VMSuite etw Flakyness

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -131,6 +131,10 @@ type WindowsProbe struct {
 	// approvers
 	approvers    map[eval.Field][]approver
 	approverLock sync.RWMutex
+
+	// ETW ready signaling for tests
+	etwReady     chan struct{}
+	etwReadyOnce sync.Once
 }
 
 type writeRateLimiterKey struct {
@@ -472,6 +476,11 @@ func (p *WindowsProbe) approve(field eval.Field, eventType string, value string)
 func (p *WindowsProbe) startAuditTracing(ecb etwCallback) error {
 	log.Info("Starting Audit tracing...")
 	err := p.auditSession.StartTracing(func(e *etw.DDEventRecord) {
+		// Signal that ETW is ready on the first event
+		p.etwReadyOnce.Do(func() {
+			close(p.etwReady)
+			log.Info("ETW Audit tracing is now ready (first event received)")
+		})
 
 		switch e.EventHeader.ProviderID {
 
@@ -491,6 +500,11 @@ func (p *WindowsProbe) startAuditTracing(ecb etwCallback) error {
 func (p *WindowsProbe) startFrimTracing(ecb etwCallback) error {
 	log.Info("Starting FRIM tracing...")
 	err := p.frimSession.StartTracing(func(e *etw.DDEventRecord) {
+		// Signal that ETW is ready on the first event
+		p.etwReadyOnce.Do(func() {
+			close(p.etwReady)
+			log.Info("ETW FRIM tracing is now ready (first event received)")
+		})
 		p.stats.totalEtwNotifications++
 		switch e.EventHeader.ProviderID {
 		case etw.DDGUID(p.fileguid):
@@ -946,6 +960,12 @@ func (p *WindowsProbe) Start() error {
 	return p.pm.Start()
 }
 
+// ETWReady returns the channel that is closed when ETW is ready (first event received).
+// This is primarily useful for tests to avoid flaky behavior from ETW startup delays.
+func (p *WindowsProbe) ETWReady() <-chan struct{} {
+	return p.etwReady
+}
+
 func (p *WindowsProbe) handleProcessStart(ev *model.Event, start *procmon.ProcessStartNotification) bool {
 	pid := process.Pid(start.Pid)
 	if pid == 0 {
@@ -1378,6 +1398,8 @@ func initializeWindowsProbe(config *config.Config, opts Opts) (*WindowsProbe, er
 		volumeMap: make(map[string]string),
 
 		writeRateLimiter: writeRateLimiter,
+
+		etwReady: make(chan struct{}),
 
 		processKiller: processKiller,
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -476,11 +476,6 @@ func (p *WindowsProbe) approve(field eval.Field, eventType string, value string)
 func (p *WindowsProbe) startAuditTracing(ecb etwCallback) error {
 	log.Info("Starting Audit tracing...")
 	err := p.auditSession.StartTracing(func(e *etw.DDEventRecord) {
-		// Signal that ETW is ready on the first event
-		p.etwReadyOnce.Do(func() {
-			close(p.etwReady)
-			log.Info("ETW Audit tracing is now ready (first event received)")
-		})
 
 		switch e.EventHeader.ProviderID {
 

--- a/pkg/security/tests/file_windows_test.go
+++ b/pkg/security/tests/file_windows_test.go
@@ -35,9 +35,10 @@ func TestBasicFileTest(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
-	// so wait around for it to start
-	time.Sleep(5 * time.Second)
+	// Wait for ETW to be ready (signaled on first event received)
+	if !test.WaitForETWReady(30 * time.Second) {
+		t.Fatal("Timeout waiting for ETW to be ready")
+	}
 
 	test.RunMultiMode(t, "File test 1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 
@@ -78,9 +79,10 @@ func TestRenameFileEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
-	// so wait around for it to start
-	time.Sleep(5 * time.Second)
+	// Wait for ETW to be ready (signaled on first event received)
+	if !test.WaitForETWReady(30 * time.Second) {
+		t.Fatal("Timeout waiting for ETW to be ready")
+	}
 
 	os.MkdirAll("C:\\Temp", 0755)
 	f, err := os.Create("C:\\Temp\\test.bad")
@@ -115,9 +117,10 @@ func TestDeleteFileEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
-	// so wait around for it to start
-	time.Sleep(5 * time.Second)
+	// Wait for ETW to be ready (signaled on first event received)
+	if !test.WaitForETWReady(30 * time.Second) {
+		t.Fatal("Timeout waiting for ETW to be ready")
+	}
 
 	os.MkdirAll("C:\\Temp", 0755)
 	f, err := os.Create("C:\\Temp\\test.bad")
@@ -151,9 +154,10 @@ func TestWriteFileEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
-	// so wait around for it to start
-	time.Sleep(5 * time.Second)
+	// Wait for ETW to be ready (signaled on first event received)
+	if !test.WaitForETWReady(30 * time.Second) {
+		t.Fatal("Timeout waiting for ETW to be ready")
+	}
 
 	os.MkdirAll("C:\\Temp", 0755)
 	f, err := os.Create("C:\\Temp\\test.bad")
@@ -199,9 +203,10 @@ func TestWriteFileEventWithCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
-	// so wait around for it to start
-	time.Sleep(5 * time.Second)
+	// Wait for ETW to be ready (signaled on first event received)
+	if !test.WaitForETWReady(30 * time.Second) {
+		t.Fatal("Timeout waiting for ETW to be ready")
+	}
 
 	os.MkdirAll("C:\\Temp", 0755)
 	f, err := os.Create("C:\\Temp\\test.bad")

--- a/pkg/security/tests/registry_windows_test.go
+++ b/pkg/security/tests/registry_windows_test.go
@@ -47,9 +47,10 @@ func TestBasicRegistryTestPowershell(t *testing.T) {
 	}
 	defer test.Close()
 
-	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
-	// so wait around for it to start
-	time.Sleep(5 * time.Second)
+	// Wait for ETW to be ready (signaled on first event received)
+	if !test.WaitForETWReady(30 * time.Second) {
+		t.Fatal("Timeout waiting for ETW to be ready")
+	}
 
 	test.RunMultiMode(t, "Test registry with powershell", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		inputargs := []string{
@@ -94,9 +95,10 @@ func TestBasicRegistryTestRegExe(t *testing.T) {
 	}
 	defer test.Close()
 
-	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
-	// so wait around for it to start
-	time.Sleep(5 * time.Second)
+	// Wait for ETW to be ready (signaled on first event received)
+	if !test.WaitForETWReady(30 * time.Second) {
+		t.Fatal("Timeout waiting for ETW to be ready")
+	}
 
 	test.RunMultiMode(t, "Test registry with reg.exe", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		inputargs := []string{
@@ -142,9 +144,10 @@ func TestBasicRegistryTestAPI(t *testing.T) {
 	}
 	defer test.Close()
 
-	// this is kinda hokey.  ETW (which is what FIM is based on) takes an indeterminant amount of time to start up.
-	// so wait around for it to start
-	time.Sleep(5 * time.Second)
+	// Wait for ETW to be ready (signaled on first event received)
+	if !test.WaitForETWReady(30 * time.Second) {
+		t.Fatal("Timeout waiting for ETW to be ready")
+	}
 
 	test.RunMultiMode(t, "Test registry with API", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {


### PR DESCRIPTION
### What does this PR do?
Adds wait for etw to start instead of sleep. This should remove issues with test flaking due to etw starting after event we are looking for happens.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1917

### Describe how you validated your changes
Covered by existing and modified unit tests. Manually trigger VMSuite tests.

### Additional Notes
