### PR TITLE
[Cloud Run Jobs] Remove high cardinality tags from enhanced metrics

### DIFF
--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -63,7 +63,6 @@ func (c *CloudRunJobs) GetTags() map[string]string {
 	taskAttemptVal := os.Getenv(cloudRunTaskAttemptEnvVar)
 	taskCountVal := os.Getenv(cloudRunTaskCountEnvVar)
 
-	// TODO: remove high cardinality tags and include them only in logs/traces.
 	if jobNameVal != "" {
 		tags[cloudRunJobNamespace+jobNameTag] = jobNameVal
 		tags[jobNameTag] = jobNameVal

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -33,13 +33,15 @@ const (
 
 const (
 	cloudRunJobNamespace = "gcrj."
-	jobNameTag           = "job_name"
-	executionNameTag     = "execution_name"
-	taskIndexTag         = "task_index"
-	taskAttemptTag       = "task_attempt"
-	taskCountTag         = "task_count"
-	resourceNameTag      = "resource_name"
 	cloudRunJobsPrefix   = "gcp.run.job"
+	// Low cardinality (include with metrics)
+	jobNameTag      = "job_name"
+	resourceNameTag = "resource_name"
+	// High cardinality (avoid adding to metrics)
+	executionNameTag = "execution_name"
+	taskIndexTag     = "task_index"
+	taskAttemptTag   = "task_attempt"
+	taskCountTag     = "task_count" // not really high cardinality, but not necessary for metrics
 )
 
 // CloudRunJobs has helper functions for getting Google Cloud Run data

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -22,6 +22,15 @@ const (
 	enableBackendTraceStatsEnvVar = "DD_SERVERLESS_INIT_ENABLE_BACKEND_TRACE_STATS"
 )
 
+// highCardinalityTags is a set of tag keys that should be excluded from metrics
+var highCardinalityTags = map[string]struct{}{
+	"container_id":       {},
+	"gcr.container_id":   {},
+	"gcrfx.container_id": {},
+	"replica_name":       {},
+	"aca.replica.name":   {},
+}
+
 // TagPair contains a pair of tag key and value
 //
 //nolint:revive // TODO(SERV) Fix revive linter
@@ -78,11 +87,7 @@ func GetBaseTagsMapWithMetadata(metadata map[string]string, versionMode string) 
 func WithoutHighCardinalityTags(tags map[string]string) map[string]string {
 	newTags := make(map[string]string, len(tags))
 	for k, v := range tags {
-		if k != "container_id" &&
-			k != "gcr.container_id" &&
-			k != "gcrfx.container_id" &&
-			k != "replica_name" &&
-			k != "aca.replica.name" {
+		if _, isHighCardinality := highCardinalityTags[k]; !isHighCardinality {
 			newTags[k] = v
 		}
 	}

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -24,11 +24,15 @@ const (
 
 // highCardinalityTags is a set of tag keys that should be excluded from metrics
 var highCardinalityTags = map[string]struct{}{
-	"container_id":       {},
-	"gcr.container_id":   {},
-	"gcrfx.container_id": {},
-	"replica_name":       {},
-	"aca.replica.name":   {},
+	"container_id":        {},
+	"gcr.container_id":    {},
+	"gcrfx.container_id":  {},
+	"replica_name":        {},
+	"aca.replica.name":    {},
+	"gcrj.execution_name": {},
+	"gcrj.task_index":     {},
+	"gcrj.task_attempt":   {},
+	"gcrj.task_count":     {},
 }
 
 // TagPair contains a pair of tag key and value

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -105,7 +105,16 @@ func TestDdTags(t *testing.T) {
 }
 
 func TestWithoutHighCardinalityTags(t *testing.T) {
-	tags := map[string]string{"key1": "value1", "key2": "value2", "container_id": "abc", "replica_name": "abc"}
+	tags := map[string]string{
+		"key1":                "value1",
+		"key2":                "value2",
+		"container_id":        "abc",
+		"replica_name":        "abc",
+		"gcrj.execution_name": "exec-123",
+		"gcrj.task_index":     "0",
+		"gcrj.task_attempt":   "1",
+		"gcrj.task_count":     "10",
+	}
 	filteredTags := WithoutHighCardinalityTags(tags)
 	assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, filteredTags)
 }


### PR DESCRIPTION
### What does this PR do?

This is a temporary fix to remove high cardinality tags from Cloud Run Jobs enhanced metrics.
A more thorough refactor will be done in a future PR (https://github.com/DataDog/datadog-agent/pull/43370)

High cardinality removed:
<img width="400" height="393" alt="Screenshot 2025-12-04 at 2 11 05 PM" src="https://github.com/user-attachments/assets/0d002d7f-5d58-448d-ae24-8a9c62bf5849" />

Low cardinality still exists:
<img width="400" height="382" alt="Screenshot 2025-12-04 at 2 11 39 PM" src="https://github.com/user-attachments/assets/076e73c6-769b-4f11-b023-b2579905a9c7" />

### Motivation

Cost savings

### Describe how you validated your changes

Manually with a real Cloud Run Job

### Additional Notes

No changelog because Cloud Run Jobs support is not officially released yet.
