### PR TITLE
Remove ETW HTTP Log Statement

### DIFF
--- a/pkg/network/protocols/http/etw_http_service.go
+++ b/pkg/network/protocols/http/etw_http_service.go
@@ -808,7 +808,6 @@ func httpCallbackOnHTTPRequestTraceTaskDeliver(eventInfo *etw.DDEventRecord) {
 	// Get req/resp conn link
 	httpConnLink, found := getHttpConnLink(eventInfo.EventHeader.ActivityID)
 	if !found {
-		log.Warnf("connlink not found at tracetaskdeliver")
 		return
 	}
 	httpConnLink.opcodes = append(httpConnLink.opcodes, eventInfo.EventHeader.EventDescriptor.ID)


### PR DESCRIPTION
### What does this PR do?
Removes unneeded log statement that was causing issues: [AGENT-15099](https://datadoghq.atlassian.net/browse/AGENT-15099).

### Motivation
https://datadoghq.atlassian.net/browse/AGENT-15099
https://datadoghq.atlassian.net/browse/WINA-2071

### Describe how you validated your changes
Only removes a log statement. Covered by existing tests. 

### Additional Notes


[AGENT-15099]: https://datadoghq.atlassian.net/browse/AGENT-15099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

getHttpConnLink already includes a log message for this result and it's behind a verbose flag
https://github.com/DataDog/datadog-agent/blob/12bfa8acd0e134aae84a5c62753b1776a810c18d/pkg/network/protocols/http/etw_http_service.go#L325-L327