### PR TITLE
[revert][network path] Fix agent hostname from system probe

### DIFF
--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -122,6 +122,12 @@ func (r *Runner) RunTraceroute(ctx context.Context, cfg config.Config) (payload.
 		timeout = cfg.Timeout
 	}
 
+	hname, err := r.hostnameService.Get(ctx)
+	if err != nil {
+		tracerouteRunnerTelemetry.failedRuns.Inc()
+		return payload.NetworkPath{}, err
+	}
+
 	params := traceroute.TracerouteParams{
 		Hostname:              cfg.DestHostname,
 		Port:                  int(cfg.DestPort),
@@ -145,7 +151,7 @@ func (r *Runner) RunTraceroute(ctx context.Context, cfg config.Config) (payload.
 		return payload.NetworkPath{}, err
 	}
 
-	pathResult, err := r.processResults(results, cfg.Protocol, cfg.DestHostname, cfg.DestPort)
+	pathResult, err := r.processResults(results, cfg.Protocol, hname, cfg.DestHostname, cfg.DestPort)
 	if err != nil {
 		tracerouteRunnerTelemetry.failedRuns.Inc()
 		return payload.NetworkPath{}, err
@@ -154,7 +160,7 @@ func (r *Runner) RunTraceroute(ctx context.Context, cfg config.Config) (payload.
 	return pathResult, nil
 }
 
-func (r *Runner) processResults(res *result.Results, protocol payload.Protocol, destinationHost string, destinationPort uint16) (payload.NetworkPath, error) {
+func (r *Runner) processResults(res *result.Results, protocol payload.Protocol, hname string, destinationHost string, destinationPort uint16) (payload.NetworkPath, error) {
 	if res == nil {
 		return payload.NetworkPath{}, nil
 	}
@@ -165,8 +171,11 @@ func (r *Runner) processResults(res *result.Results, protocol payload.Protocol, 
 		Protocol:     protocol,
 		Timestamp:    time.Now().UnixMilli(),
 		Source: payload.NetworkPathSource{
-			NetworkID: r.networkID,
-			PublicIP:  res.Source.PublicIP,
+			Name:        hname,
+			DisplayName: hname,
+			Hostname:    hname,
+			NetworkID:   r.networkID,
+			PublicIP:    res.Source.PublicIP,
 		},
 		Destination: payload.NetworkPathDestination{
 			Hostname: destinationHost,

--- a/pkg/networkpath/traceroute/runner/runner_test.go
+++ b/pkg/networkpath/traceroute/runner/runner_test.go
@@ -39,6 +39,7 @@ func TestProcessResults(t *testing.T) {
 		description      string
 		inputResults     *result.Results
 		protocol         payload.Protocol
+		hname            string
 		destinationHost  string
 		useGatewayLookup bool
 		expected         payload.NetworkPath
@@ -53,6 +54,7 @@ func TestProcessResults(t *testing.T) {
 			description:      "test all fields",
 			useGatewayLookup: false,
 			protocol:         payload.ProtocolUDP,
+			hname:            "test-hostname",
 			destinationHost:  "test-destination-hostname",
 			inputResults: &result.Results{
 				Source: result.Source{
@@ -118,7 +120,10 @@ func TestProcessResults(t *testing.T) {
 				AgentVersion: version.AgentVersion,
 				Protocol:     payload.ProtocolUDP,
 				Source: payload.NetworkPathSource{
-					PublicIP: "1.2.3.4",
+					Hostname:    "test-hostname",
+					Name:        "test-hostname",
+					DisplayName: "test-hostname",
+					PublicIP:    "1.2.3.4",
 				},
 				Destination: payload.NetworkPathDestination{
 					Hostname: "test-destination-hostname",
@@ -178,6 +183,7 @@ func TestProcessResults(t *testing.T) {
 			description:      "successful processing no gateway lookup, did not reach target",
 			useGatewayLookup: false,
 			protocol:         payload.ProtocolUDP,
+			hname:            "test-hostname",
 			destinationHost:  "test-destination-hostname",
 			inputResults: &result.Results{
 				Destination: result.Destination{
@@ -218,7 +224,11 @@ func TestProcessResults(t *testing.T) {
 			expected: payload.NetworkPath{
 				AgentVersion: version.AgentVersion,
 				Protocol:     payload.ProtocolUDP,
-				Source:       payload.NetworkPathSource{},
+				Source: payload.NetworkPathSource{
+					Hostname:    "test-hostname",
+					Name:        "test-hostname",
+					DisplayName: "test-hostname",
+				},
 				Destination: payload.NetworkPathDestination{
 					Hostname: "test-destination-hostname",
 					Port:     33434,
@@ -256,6 +266,7 @@ func TestProcessResults(t *testing.T) {
 			description:      "successful processing with gateway lookup, did not reach target",
 			useGatewayLookup: true,
 			protocol:         payload.ProtocolTCP,
+			hname:            "test-hostname",
 			destinationHost:  "test-destination-hostname",
 			inputResults: &result.Results{
 				Destination: result.Destination{
@@ -297,6 +308,9 @@ func TestProcessResults(t *testing.T) {
 				AgentVersion: version.AgentVersion,
 				Protocol:     payload.ProtocolTCP,
 				Source: payload.NetworkPathSource{
+					Hostname:    "test-hostname",
+					Name:        "test-hostname",
+					DisplayName: "test-hostname",
 					Via: &network.Via{
 						Subnet: network.Subnet{
 							Alias: "test-subnet",
@@ -340,6 +354,7 @@ func TestProcessResults(t *testing.T) {
 			description:      "successful processing with gateway lookup, reached target",
 			useGatewayLookup: true,
 			protocol:         payload.ProtocolUDP,
+			hname:            "test-hostname",
 			destinationHost:  "test-destination-hostname",
 			inputResults: &result.Results{
 				Destination: result.Destination{
@@ -386,6 +401,9 @@ func TestProcessResults(t *testing.T) {
 				AgentVersion: version.AgentVersion,
 				Protocol:     payload.ProtocolUDP,
 				Source: payload.NetworkPathSource{
+					Hostname:    "test-hostname",
+					Name:        "test-hostname",
+					DisplayName: "test-hostname",
 					Via: &network.Via{
 						Subnet: network.Subnet{
 							Alias: "test-subnet",
@@ -452,7 +470,7 @@ func TestProcessResults(t *testing.T) {
 			if test.inputResults != nil {
 				dstPort = uint16(test.inputResults.Destination.Port)
 			}
-			actual, err := runner.processResults(test.inputResults, test.protocol, test.destinationHost, dstPort)
+			actual, err := runner.processResults(test.inputResults, test.protocol, test.hname, test.destinationHost, dstPort)
 			if test.errMsg != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.errMsg)

--- a/pkg/networkpath/traceroute/traceroute.go
+++ b/pkg/networkpath/traceroute/traceroute.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
 
 func getTraceroute(ctx context.Context, sysProbeClient *http.Client, clientID string, cfg config.Config) (payload.NetworkPath, error) {
@@ -27,11 +26,5 @@ func getTraceroute(ctx context.Context, sysProbeClient *http.Client, clientID st
 	if err = json.Unmarshal(resp, &path); err != nil {
 		return payload.NetworkPath{}, fmt.Errorf("error unmarshalling response: %w", err)
 	}
-	agentHostname, err := hostname.Get(context.TODO())
-	if err != nil {
-		return payload.NetworkPath{}, fmt.Errorf("error getting the hostname: %w", err)
-	}
-
-	path.Source.Hostname = agentHostname
 	return path, nil
 }

--- a/pkg/networkpath/traceroute/traceroute_test.go
+++ b/pkg/networkpath/traceroute/traceroute_test.go
@@ -31,9 +31,6 @@ func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestGetTraceroute(t *testing.T) {
-	// Setup config for hostname
-	pkgconfigsetup.Datadog().SetWithoutSource("hostname", "test-agent-hostname")
-
 	expectedDest := payload.NetworkPathDestination{
 		Hostname: "example.com",
 		Port:     80,
@@ -47,9 +44,6 @@ func TestGetTraceroute(t *testing.T) {
 
 	jsonBytes, err := json.Marshal(expectedPath)
 	require.NoError(t, err)
-
-	// Update expectedPath with the expected source hostname
-	expectedPath.Source.Hostname = "test-agent-hostname"
 
 	client := &http.Client{
 		Transport: &mockTransport{


### PR DESCRIPTION
### What does this PR do?

[revert][network path] Fix agent hostname from system probe

Revert of https://github.com/DataDog/datadog-agent/pull/43642

### Motivation

The system-probe is expected to get the correct hostname from core agent via IPC.

### Describe how you validated your changes

### Additional Notes
