### PR TITLE
Temporarily disable the deploy_latest_rc_only job

### DIFF
--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -1,14 +1,15 @@
 # deploy mutable image tags stage
 # Contains jobs which deploy Agent 7 related mutable image tags to the registries. That means - not uploading the image, but only creating the tags.
 
-deploy_latest_rc_only:
-  stage: deploy_mutable_image_tags
-  tags: ["arch:amd64", "specific:true"]
-  rules:
-    !reference [.on_deploy_rc]
-  needs: []
-  script:
-    - ./tools/ci/check_latest_rc.sh
+# https://github.com/DataDog/datadog-agent/pull/43846
+#deploy_latest_rc_only:
+#  stage: deploy_mutable_image_tags
+#  tags: ["arch:amd64", "specific:true"]
+#  rules:
+#    !reference [.on_deploy_rc]
+#  needs: []
+#  script:
+#    - ./tools/ci/check_latest_rc.sh
 
 .deploy_mutable_image_tags_base:
   extends: .docker_publish_job_definition
@@ -40,8 +41,9 @@ deploy_mutable_image_tags-a7-rc:
   needs:
     - job: deploy_containers-a7
       artifacts: false
-    - job: deploy_latest_rc_only
-      artifacts: false
+# https://github.com/DataDog/datadog-agent/pull/43846
+#    - job: deploy_latest_rc_only
+#      artifacts: false
   parallel:
     matrix:
       - SUFFIX:
@@ -59,8 +61,9 @@ deploy_mutable_image_tags-a7-win-only-rc:
   needs:
     - job: deploy_containers-a7-win-only
       artifacts: false
-    - job: deploy_latest_rc_only
-      artifacts: false
+# https://github.com/DataDog/datadog-agent/pull/43846
+#    - job: deploy_latest_rc_only
+#      artifacts: false
   parallel:
     matrix:
       - SUFFIX:
@@ -84,8 +87,9 @@ deploy_mutable_image_tags-a7-full-rc:
   needs:
     - job: deploy_containers-a7-full
       artifacts: false
-    - job: deploy_latest_rc_only
-      artifacts: false
+# https://github.com/DataDog/datadog-agent/pull/43846
+#    - job: deploy_latest_rc_only
+#      artifacts: false
   parallel:
     matrix:
       - SUFFIX: ["-full"]
@@ -97,8 +101,9 @@ deploy_mutable_image_tags-a7-fips-rc:
   needs:
     - job: deploy_containers-a7-fips
       artifacts: false
-    - job: deploy_latest_rc_only
-      artifacts: false
+# https://github.com/DataDog/datadog-agent/pull/43846
+#    - job: deploy_latest_rc_only
+#      artifacts: false
   parallel:
     matrix:
       - SUFFIX:


### PR DESCRIPTION
### What does this PR do?

Temporarily disable the deploy_latest_rc_only job

### Motivation

- That job [started to fail](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1271823201) all of a sudden (it seems). Disabling it for now so we can push mutable tags to docker hub for release candidates
- We'll bring it back once we find the issue, this job is not vital 

### Describe how you validated your changes

### Additional Notes
