### PR TITLE
[Backport 7.74.x] `tests_macos_gitlab_arm64` flakiness: extend `go build` isolation in `pkgconfigusage`

### DIFF
--- a/pkg/linters/components/pkgconfigusage/pkgconfigusage_test.go
+++ b/pkg/linters/components/pkgconfigusage/pkgconfigusage_test.go
@@ -17,6 +17,7 @@ import (
 func TestAll(t *testing.T) {
 	// Set environment variables to prevent go commands from accessing
 	// the module cache concurrently, which can cause timeouts on macOS.
+	t.Setenv("GOCACHE", t.TempDir())
 	t.Setenv("GOPRIVATE", "*")
 	t.Setenv("GOPROXY", "off")
 


### PR DESCRIPTION
**Cherry-picked** from #43773.

### What does this PR do?
Add `GOCACHE` isolation to `TestAll` in `pkg/linters/components/pkgconfigusage` to reduce test timeouts on macOS CI runners.

### Motivation
The test still times out occasionally ([example in `main`](http://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1267508733/viewer#L2040)) after 3 minutes on macOS Gitlab runners when running with `-p 12 -parallel 12`, despite previous tentative fix (#43207) which added `GOPRIVATE=*` and `GOPROXY=off`.

`analysistest.Run` internally runs `go build` commands to verify the Go toolchain works. When multiple tests run concurrently with the same shared `GOCACHE`, they can deadlock in Go's process management layer (see golang/go#59657).

### Changes
Added per-test isolated `GOCACHE` directory using `t.TempDir()`, following the same approach as PR #39687 which fixed a similar timeout issue in `comp/core/secrets/impl/fetch_secret_test.go`.

### Describe how you validated your changes
Verified locally with `go test -v -race -count=20 -parallel 12 -timeout 600s`.

### Additional Notes
Prior art include:
- #39518
- #39687
- #43207
- #43627

:bulb: `-mod=vendor` could be also factored out through a future PR should the problem manifest itself again after the present change is merged.