### PR TITLE
Collect all go runtime metrics in prometheus except godebug ones

### DIFF
--- a/comp/core/telemetry/telemetryimpl/telemetry.go
+++ b/comp/core/telemetry/telemetryimpl/telemetry.go
@@ -53,7 +53,7 @@ type dependencies struct {
 func newRegistry() *prometheus.Registry {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	reg.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsGC, collectors.MetricsMemory, collectors.MetricsScheduler)))
+	reg.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll), collectors.WithoutGoCollectorRuntimeMetrics(collectors.MetricsDebug.Matcher)))
 	return reg
 }
 

--- a/comp/core/telemetry/telemetryimpl/telemetry_test.go
+++ b/comp/core/telemetry/telemetryimpl/telemetry_test.go
@@ -131,6 +131,10 @@ func TestGoMetrics(t *testing.T) {
 	assert.Contains(t, metricNames, "go_sched_goroutines_goroutines")
 	assert.Contains(t, metricNames, "go_threads")
 	assert.Contains(t, metricNames, "go_gc_duration_seconds")
+	assert.Contains(t, metricNames, "go_cgo_go_to_c_calls_calls_total")
+	assert.Contains(t, metricNames, "go_cpu_classes_gc_mark_assist_cpu_seconds_total")
+	assert.Contains(t, metricNames, "go_sync_mutex_wait_total_seconds_total")
+	assert.NotContains(t, metricNames, "go_godebug_non_default_behavior_execerrdot_events_total")
 }
 
 func TestGatherText(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Collect all go runtime metrics in prometheus except godebug ones.
Those metrics will appear in flares and be emitted when using a prometheus check configured to collect agent prometheus metrics.

### Motivation
Add a few missing ones, eg. `go_cgo_go_to_c_calls_calls_total`, `go_sync_mutex_wait_total_seconds_total`, and various ones around cpu.
Also automatically get the new categories.

### Describe how you validated your changes
Updated unit tests.

### Additional Notes
See https://pkg.go.dev/runtime/metrics for all the available metrics.