### PR TITLE
[CWS] little fixes on rules set expressions and hash resolver

### DIFF
--- a/pkg/security/generators/accessors/accessors.tmpl
+++ b/pkg/security/generators/accessors/accessors.tmpl
@@ -52,6 +52,24 @@ func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 }
 
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
+	// Handle array index access (e.g., field[0])
+	// This is processed here before the switch to support all array fields
+	baseField, arrayIndex, isArrayAccess, err := eval.ExtractArrayIndexAccess(field)
+	if err != nil {
+		return nil, err
+	}
+
+	if isArrayAccess {
+		// Get the base field evaluator (returns the full array)
+		arrayEvaluator, err := (&Model{}).GetEvaluator(baseField, regID, offset)
+		if err != nil {
+			return nil, err
+		}
+
+		// Wrap it to return only the specific index
+		return eval.WrapEvaluatorWithArrayIndex(arrayEvaluator, arrayIndex, baseField)
+	}
+
 	switch field {
 	{{range $Name, $Field := .Fields}}
 	{{- if $Field.GettersOnly }}

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -82,14 +82,18 @@ type ResolverOpts struct {
 type LRUCacheKey struct {
 	path        string
 	containerID string
-	inode       uint64
-	pathID      uint32
 }
 
 // LRUCacheEntry is the structure used to cache hashes
+// It includes file metadata (inode, mtime, size) to detect if the file has changed
 type LRUCacheEntry struct {
 	state  model.HashState
 	hashes []string
+	// File metadata to detect changes
+	inode  uint64 // file inode
+	pathID uint32 // internal path ID
+	mtime  uint64 // modification time in nanoseconds
+	size   int64  // file size in bytes
 }
 
 // Resolver represents a cache for mountpoints and the corresponding file systems
@@ -199,10 +203,10 @@ type fileUniqKey struct {
 	inode uint64
 }
 
-func getFileInfo(path string) (fs.FileMode, int64, fileUniqKey, error) {
+func getFileInfo(path string) (fs.FileMode, int64, uint64, fileUniqKey, error) {
 	stat, err := utils.UnixStat(path)
 	if err != nil {
-		return 0, 0, fileUniqKey{}, err
+		return 0, 0, 0, fileUniqKey{}, err
 	}
 
 	fkey := fileUniqKey{
@@ -210,7 +214,10 @@ func getFileInfo(path string) (fs.FileMode, int64, fileUniqKey, error) {
 		inode: stat.Ino,
 	}
 
-	return utils.UnixStatModeToGoFileMode(stat.Mode), stat.Size, fkey, nil
+	// Convert mtime to nanoseconds
+	mtime := uint64(stat.Mtim.Sec)*1e9 + uint64(stat.Mtim.Nsec)
+
+	return utils.UnixStatModeToGoFileMode(stat.Mode), stat.Size, mtime, fkey, nil
 }
 
 // HashFileEvent hashes the provided file event
@@ -251,18 +258,10 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, ctrID contain
 	fileKey := LRUCacheKey{
 		path:        file.PathnameStr,
 		containerID: string(ctrID),
-		inode:       file.Inode,
-		pathID:      file.PathKey.PathID,
 	}
-	if resolver.cache != nil {
-		cacheEntry, ok := resolver.cache.Get(fileKey)
-		if ok {
-			file.HashState = cacheEntry.state
-			file.Hashes = cacheEntry.hashes
-			hashResolverTelemetry.hashCacheHit.Inc(eventType.String())
-			return
-		}
-	}
+
+	// Note: we'll check after stat if the cached entry matches the file metadata
+	// This is done later after we get the actual file stats
 
 	// check the rate limiter
 	rateReservation := resolver.limiter.Reserve()
@@ -288,12 +287,13 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, ctrID contain
 		f           *os.File
 		mode        fs.FileMode
 		size        int64
+		mtime       uint64
 		fkey        fileUniqKey
 		failedCache = make(map[fileUniqKey]struct{})
 	)
 	for _, pidCandidate := range rootPIDs {
 		path := utils.ProcRootFilePath(pidCandidate, file.PathnameStr)
-		mode, size, fkey, lastErr = getFileInfo(path)
+		mode, size, mtime, fkey, lastErr = getFileInfo(path)
 		if lastErr != nil {
 			continue
 		}
@@ -358,6 +358,27 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, ctrID contain
 		return
 	}
 
+	// Now that we have the file stats, check if we have a cached entry
+	// and if it matches the current file metadata
+	if resolver.cache != nil {
+		cacheEntry, ok := resolver.cache.Get(fileKey)
+		if ok {
+			// Check if the cached entry matches the current file metadata
+			if cacheEntry.inode == file.Inode &&
+				cacheEntry.pathID == file.PathKey.PathID &&
+				cacheEntry.mtime == mtime &&
+				cacheEntry.size == size {
+				// Cache hit: file hasn't changed
+				file.HashState = cacheEntry.state
+				file.Hashes = cacheEntry.hashes
+				hashResolverTelemetry.hashCacheHit.Inc(eventType.String())
+				rateReservation.Cancel()
+				return
+			}
+			// Cache entry exists but file has changed, we'll recompute and update the entry
+		}
+	}
+
 	var hashers []io.Writer
 	for _, algorithm := range resolver.opts.HashAlgorithms {
 		h := resolver.getHashFunction(algorithm)
@@ -416,11 +437,16 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, ctrID contain
 
 	file.HashState = model.Done
 
-	// cache entry
+	// cache entry with file metadata
+	// This will either create a new entry or update an existing one for the same path
 	if resolver.cache != nil {
 		cacheEntry := &LRUCacheEntry{
 			state:  model.Done,
 			hashes: make([]string, len(file.Hashes)),
+			inode:  file.Inode,
+			pathID: file.PathKey.PathID,
+			mtime:  mtime,
+			size:   size,
 		}
 		copy(cacheEntry.hashes, file.Hashes)
 		resolver.cache.Add(fileKey, cacheEntry)

--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -33,13 +33,14 @@ Comment = ("#" | "//") { "\u0000"…"\uffff"-"\n" } .
 CIDR = IP "/" digit { digit } .
 IP = (ipv4 | ipv6) .
 Variable = "${" (alpha | "_") { "_" | alpha | digit | "." } "}" .
+FieldReference = "%{" (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } "}" .
 Duration = digit { digit } ("m" | "s" | "m" | "h") { "s" } .
 Regexp = "r\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Ident = (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } .
 String = "\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Pattern = "~\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Int = [ "-" | "+" ] digit { digit } .
-Punct = ( "!" | "=" | "<" | ">" | "+" | "-" | "[" | "]" | "(" | ")" | "," | "&" | "|" | "~" | "^" ).
+Punct = ( "!" | "=" | "<" | ">" | "+" | "-" | "[" | "]" | "(" | ")" | "," | "&" | "|" | "~" | "^" | "%" ).
 Whitespace = ( " " | "\t" | "\n" ) { " " | "\t" | "\n" } .
 ipv4 = (digit { digit } "." digit { digit } "." digit { digit } "." digit { digit }) .
 ipv6 = ( [hex { hex }] ":" [hex { hex }] ":" [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }]) .
@@ -247,16 +248,17 @@ type UnaryWithOp struct {
 type Primary struct {
 	Pos lexer.Position
 
-	Ident         *string     `parser:"@Ident"`
-	CIDR          *string     `parser:"| @CIDR"`
-	IP            *string     `parser:"| @IP"`
-	Number        *int        `parser:"| @Int"`
-	Variable      *string     `parser:"| @Variable"`
-	String        *string     `parser:"| @String"`
-	Pattern       *string     `parser:"| @Pattern"`
-	Regexp        *string     `parser:"| @Regexp"`
-	Duration      *int        `parser:"| @Duration"`
-	SubExpression *Expression `parser:"| \"(\" @@ \")\""`
+	Ident          *string     `parser:"@Ident"`
+	CIDR           *string     `parser:"| @CIDR"`
+	IP             *string     `parser:"| @IP"`
+	Number         *int        `parser:"| @Int"`
+	Variable       *string     `parser:"| @Variable"`
+	FieldReference *string     `parser:"| @FieldReference"`
+	String         *string     `parser:"| @String"`
+	Pattern        *string     `parser:"| @Pattern"`
+	Regexp         *string     `parser:"| @Regexp"`
+	Duration       *int        `parser:"| @Duration"`
+	SubExpression  *Expression `parser:"| \"(\" @@ \")\""`
 }
 
 // StringMember describes a String based array member
@@ -280,11 +282,12 @@ type CIDRMember struct {
 type Array struct {
 	Pos lexer.Position
 
-	CIDR          *string        `parser:"@CIDR"`
-	Variable      *string        `parser:"| @Variable"`
-	Ident         *string        `parser:"| @Ident"`
-	StringMembers []StringMember `parser:"| \"[\" @@ { \",\" @@ } \"]\""`
-	CIDRMembers   []CIDRMember   `parser:"| \"[\" @@ { \",\" @@ } \"]\""`
-	Numbers       []int          `parser:"| \"[\" @Int { \",\" @Int } \"]\""`
-	Idents        []string       `parser:"| \"[\" @Ident { \",\" @Ident } \"]\""`
+	CIDR           *string        `parser:"@CIDR"`
+	Variable       *string        `parser:"| @Variable"`
+	FieldReference *string        `parser:"| @FieldReference"`
+	Ident          *string        `parser:"| @Ident"`
+	StringMembers  []StringMember `parser:"| \"[\" @@ { \",\" @@ } \"]\""`
+	CIDRMembers    []CIDRMember   `parser:"| \"[\" @@ { \",\" @@ } \"]\""`
+	Numbers        []int          `parser:"| \"[\" @Int { \",\" @Int } \"]\""`
+	Idents         []string       `parser:"| \"[\" @Ident { \",\" @Ident } \"]\""`
 }

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -282,7 +282,7 @@ func arrayToEvaluator(array *ast.Array, opts *Opts, state *State) (interface{}, 
 		if !ok {
 			return nil, array.Pos, NewError(array.Pos, "invalid variable name '%s'", *array.Variable)
 		}
-		return evaluatorFromVariable(varName, array.Pos, opts, state)
+		return evaluatorFromVariable(varName, array.Pos, opts)
 	} else if array.FieldReference != nil {
 		fieldName, ok := isFieldReferenceName(*array.FieldReference)
 		if !ok {
@@ -389,7 +389,7 @@ func evaluatorFromFieldReference(fieldname string, pos lexer.Position, state *St
 	return evaluator, pos, nil
 }
 
-func evaluatorFromVariable(varname string, pos lexer.Position, opts *Opts, state *State) (interface{}, lexer.Position, error) {
+func evaluatorFromVariable(varname string, pos lexer.Position, opts *Opts) (interface{}, lexer.Position, error) {
 	var variableEvaluator interface{}
 	variable := opts.VariableStore.Get(varname)
 	if variable != nil {
@@ -446,7 +446,7 @@ func stringEvaluatorFromVariable(str string, pos lexer.Position, opts *Opts, sta
 
 	doLoc := func(sub string) error {
 		if varname, ok := isVariableName(sub); ok {
-			evaluator, pos, err := evaluatorFromVariable(varname, pos, opts, state)
+			evaluator, pos, err := evaluatorFromVariable(varname, pos, opts)
 			if err != nil {
 				return err
 			}
@@ -1610,7 +1610,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 				return nil, obj.Pos, NewError(obj.Pos, "internal variable error '%s'", varname)
 			}
 
-			return evaluatorFromVariable(varname, obj.Pos, opts, state)
+			return evaluatorFromVariable(varname, obj.Pos, opts)
 		case obj.FieldReference != nil:
 			fieldname, ok := isFieldReferenceName(*obj.FieldReference)
 			if !ok {

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -22,6 +22,7 @@ const defaultMaxVariables = 100
 
 var (
 	variableRegex         = regexp.MustCompile(`\${[^}]*}`)
+	fieldReferenceRegex   = regexp.MustCompile(`%{[^}]*}`)
 	errAppendNotSupported = errors.New("append is not supported")
 )
 

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -101,6 +101,21 @@ func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	return nil
 }
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
+	// Handle array index access (e.g., field[0])
+	// This is processed here before the switch to support all array fields
+	baseField, arrayIndex, isArrayAccess, err := eval.ExtractArrayIndexAccess(field)
+	if err != nil {
+		return nil, err
+	}
+	if isArrayAccess {
+		// Get the base field evaluator (returns the full array)
+		arrayEvaluator, err := (&Model{}).GetEvaluator(baseField, regID, offset)
+		if err != nil {
+			return nil, err
+		}
+		// Wrap it to return only the specific index
+		return eval.WrapEvaluatorWithArrayIndex(arrayEvaluator, arrayIndex, baseField)
+	}
 	switch field {
 	case "accept.addr.family":
 		return &eval.IntEvaluator{

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -46,6 +46,21 @@ func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	return nil
 }
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
+	// Handle array index access (e.g., field[0])
+	// This is processed here before the switch to support all array fields
+	baseField, arrayIndex, isArrayAccess, err := eval.ExtractArrayIndexAccess(field)
+	if err != nil {
+		return nil, err
+	}
+	if isArrayAccess {
+		// Get the base field evaluator (returns the full array)
+		arrayEvaluator, err := (&Model{}).GetEvaluator(baseField, regID, offset)
+		if err != nil {
+			return nil, err
+		}
+		// Wrap it to return only the specific index
+		return eval.WrapEvaluatorWithArrayIndex(arrayEvaluator, arrayIndex, baseField)
+	}
 	switch field {
 	case "change_permission.new_sd":
 		return &eval.StringEvaluator{

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -2315,6 +2315,49 @@ func TestActionSetVariableValidation(t *testing.T) {
 			t.Errorf("failed to load policy: %s", err)
 		}
 	})
+
+	t.Run("array-field-without-append", func(t *testing.T) {
+		testPolicy := &PolicyDef{
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.file.path == "/tmp/test"`,
+				Actions: []*ActionDefinition{{
+					Set: &SetDefinition{
+						Name:  "var1",
+						Field: "open.file.hashes",
+						Scope: "container",
+					},
+				}},
+			}},
+		}
+
+		if _, err := loadPolicy(t, testPolicy, PolicyLoaderOpts{}); err == nil {
+			t.Error("expected policy to fail to load because open.file.hashes is an array field without append: true")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("array-field-with-append", func(t *testing.T) {
+		testPolicy := &PolicyDef{
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.file.path == "/tmp/test"`,
+				Actions: []*ActionDefinition{{
+					Set: &SetDefinition{
+						Name:   "var1",
+						Field:  "open.file.hashes",
+						Scope:  "container",
+						Append: true,
+					},
+				}},
+			}},
+		}
+
+		if _, err := loadPolicy(t, testPolicy, PolicyLoaderOpts{}); err != nil {
+			t.Errorf("expected policy to load successfully with append: true, got: %v", err)
+		}
+	})
 }
 
 func TestActionSetVariableLength(t *testing.T) {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -456,9 +456,15 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 						}
 					}
 				} else if actionDef.Set.Field != "" {
-					_, kind, goType, _, err := rs.eventCtor().GetFieldMetadata(actionDef.Set.Field)
+					_, kind, goType, isArray, err := rs.eventCtor().GetFieldMetadata(actionDef.Set.Field)
 					if err != nil {
 						errs = multierror.Append(errs, fmt.Errorf("failed to get field '%s': %w", actionDef.Set.Field, err))
+						continue
+					}
+
+					// Check if the field is an array and append is not set
+					if isArray && !actionDef.Set.Append {
+						errs = multierror.Append(errs, fmt.Errorf("field '%s' is an array and can only be used with 'append: yes' in set action for variable '%s'", actionDef.Set.Field, actionDef.Set.Name))
 						continue
 					}
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -27,6 +28,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/utils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/validators"
 )
+
+var (
+	arrayIndexRE = regexp.MustCompile(`^(.+)\[(\d+)\]$`)
+)
+
+// parseArrayFieldAccess parses a field like "open.file.hashes[0]" and returns the base field and index
+func parseArrayFieldAccess(field string) (baseField string, index int, isArray bool) {
+	matches := arrayIndexRE.FindStringSubmatch(field)
+	if len(matches) == 3 {
+		baseField = matches[1]
+		index, _ = strconv.Atoi(matches[2])
+		return baseField, index, true
+	}
+	return field, 0, false
+}
 
 // Rule presents a rule in a ruleset
 type Rule struct {
@@ -433,10 +449,22 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					}
 
 					if actionDef.Set.Field != "" {
-						_, kind, _, fieldIsArray, err := rs.eventCtor().GetFieldMetadata(actionDef.Set.Field)
+						// Check if this is an array access like "field[index]"
+						baseField, _, isArrayAccess := parseArrayFieldAccess(actionDef.Set.Field)
+						fieldToValidate := actionDef.Set.Field
+						if isArrayAccess {
+							fieldToValidate = baseField
+						}
+
+						_, kind, _, fieldIsArray, err := rs.eventCtor().GetFieldMetadata(fieldToValidate)
 						if err != nil {
-							errs = multierror.Append(errs, fmt.Errorf("failed to get field '%s': %w", actionDef.Set.Field, err))
+							errs = multierror.Append(errs, fmt.Errorf("failed to get field '%s': %w", fieldToValidate, err))
 							continue
+						}
+
+						// If accessing array by index, the field is not an array from the variable's perspective
+						if isArrayAccess {
+							fieldIsArray = false
 						}
 
 						var valueIsArray bool
@@ -456,16 +484,32 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 						}
 					}
 				} else if actionDef.Set.Field != "" {
-					_, kind, goType, isArray, err := rs.eventCtor().GetFieldMetadata(actionDef.Set.Field)
+					// Check if this is an array access like "field[index]"
+					baseField, _, isArrayAccess := parseArrayFieldAccess(actionDef.Set.Field)
+					fieldToValidate := actionDef.Set.Field
+					if isArrayAccess {
+						fieldToValidate = baseField
+					}
+
+					_, kind, goType, isArray, err := rs.eventCtor().GetFieldMetadata(fieldToValidate)
 					if err != nil {
-						errs = multierror.Append(errs, fmt.Errorf("failed to get field '%s': %w", actionDef.Set.Field, err))
+						errs = multierror.Append(errs, fmt.Errorf("failed to get field '%s': %w", fieldToValidate, err))
 						continue
 					}
 
-					// Check if the field is an array and append is not set
-					if isArray && !actionDef.Set.Append {
-						errs = multierror.Append(errs, fmt.Errorf("field '%s' is an array and can only be used with 'append: yes' in set action for variable '%s'", actionDef.Set.Field, actionDef.Set.Name))
-						continue
+					// If accessing array by index, validate that the base field is actually an array
+					if isArrayAccess {
+						if !isArray {
+							errs = multierror.Append(errs, fmt.Errorf("field '%s' is not an array, cannot use index access", baseField))
+							continue
+						}
+						// When accessing by index, we treat it as a scalar value (no further validation needed)
+					} else {
+						// Check if the field is an array and append is not set
+						if isArray && !actionDef.Set.Append {
+							errs = multierror.Append(errs, fmt.Errorf("field '%s' is an array and can only be used with 'append: yes' in set action for variable '%s'", actionDef.Set.Field, actionDef.Set.Name))
+							continue
+						}
 					}
 
 					switch kind {
@@ -680,9 +724,18 @@ func (rs *RuleSet) innerAddExpandedRule(parsingContext *ast.ParsingContext, pRul
 					return model.UnknownCategory, fmt.Errorf("failed to compile action expression: %w", err)
 				}
 
-				fieldEventType, _, _, _, err := ev.GetFieldMetadata(field)
+				// Check if this is an array access like "field[index]"
+				baseField, _, isArrayAccess := parseArrayFieldAccess(field)
+
+				// Validate using the base field if this is an array access
+				fieldToValidate := field
+				if isArrayAccess {
+					fieldToValidate = baseField
+				}
+
+				fieldEventType, _, _, _, err := ev.GetFieldMetadata(fieldToValidate)
 				if err != nil {
-					return model.UnknownCategory, fmt.Errorf("failed to get event type for field '%s': %w", field, err)
+					return model.UnknownCategory, fmt.Errorf("failed to get event type for field '%s': %w", fieldToValidate, err)
 				}
 				if fieldEventType != "" && fieldEventType != ruleEventType {
 					return model.UnknownCategory, fmt.Errorf("field '%s' with event type `%s` is not compatible with '%s' rules", field, fieldEventType, ruleEventType)
@@ -697,6 +750,7 @@ func (rs *RuleSet) innerAddExpandedRule(parsingContext *ast.ParsingContext, pRul
 				}
 
 				if _, found := rs.fieldEvaluators[field]; !found {
+					// GetEvaluator now handles array index access automatically
 					evaluator, err := rs.model.GetEvaluator(mappedField, "", 0)
 					if err != nil {
 						return model.UnknownCategory, err

--- a/pkg/security/seclwin/model/accessors_win.go
+++ b/pkg/security/seclwin/model/accessors_win.go
@@ -44,6 +44,21 @@ func (_ *Model) GetFieldRestrictions(field eval.Field) []eval.EventType {
 	return nil
 }
 func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int) (eval.Evaluator, error) {
+	// Handle array index access (e.g., field[0])
+	// This is processed here before the switch to support all array fields
+	baseField, arrayIndex, isArrayAccess, err := eval.ExtractArrayIndexAccess(field)
+	if err != nil {
+		return nil, err
+	}
+	if isArrayAccess {
+		// Get the base field evaluator (returns the full array)
+		arrayEvaluator, err := (&Model{}).GetEvaluator(baseField, regID, offset)
+		if err != nil {
+			return nil, err
+		}
+		// Wrap it to return only the specific index
+		return eval.WrapEvaluatorWithArrayIndex(arrayEvaluator, arrayIndex, baseField)
+	}
 	switch field {
 	case "change_permission.new_sd":
 		return &eval.StringEvaluator{

--- a/pkg/security/tests/variables_test.go
+++ b/pkg/security/tests/variables_test.go
@@ -23,7 +23,7 @@ func TestVariableAnyField(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{{
 		ID: "test_rule_field_variable",
 		// TODO(lebauce): should infer event type from variable usage
-		Expression: `open.file.path != "" && "${open.file.path}:foo" == "{{.Root}}/test-open:foo"`,
+		Expression: `open.file.path != "" && "%{open.file.path}:foo" == "{{.Root}}/test-open:foo"`,
 	}}
 
 	test, err := newTestModule(t, nil, ruleDefs)


### PR DESCRIPTION
### What does this PR do?

It fixes 3 issues, one commit per change:
* fix a panic when we try to assign an array field to a variable (like `field: open.file.hashes`)
* add the possibility to assign an array element (of type bool, string or int only ATM) to a variable (like `field: open.file.hashes[0]`)
* fix the hash resolver to recompute file hashes when a file changed
* make explicit in secl the reference:
* - of a field with `%{field.name}` (new sytax)
* - of a variable with `${scope.variablename}` (same syntax as before)

### Motivation

Be able to monitor file changes

### Describe how you validated your changes

### Additional Notes
