### PR TITLE
feat(cluster-agent): Implement MCP Server with Leader Election tool

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1122,6 +1122,7 @@ core,github.com/google/gopacket/afpacket,BSD-3-Clause,"Copyright (c) 2009-2011 A
 core,github.com/google/gopacket/layers,BSD-3-Clause,"Copyright (c) 2009-2011 Andreas Krennmair. All rights reserved. | Copyright (c) 2012 Google, Inc. All rights reserved."
 core,github.com/google/gopacket/pcap,BSD-3-Clause,"Copyright (c) 2009-2011 Andreas Krennmair. All rights reserved. | Copyright (c) 2012 Google, Inc. All rights reserved."
 core,github.com/google/gopacket/pcapgo,BSD-3-Clause,"Copyright (c) 2009-2011 Andreas Krennmair. All rights reserved. | Copyright (c) 2012 Google, Inc. All rights reserved."
+core,github.com/google/jsonschema-go/jsonschema,MIT,Copyright (c) 2025 JSON Schema Go Project Authors
 core,github.com/google/pprof/profile,Apache-2.0,Andrew Hunter <andrewhhunter@gmail.com> | Google Inc. | Hyoun Kyu Cho <netforce@google.com> | Martin Spier <spiermar@gmail.com> | Raul Silvera <rsilvera@google.com> | Taco de Wolff <tacodewolff@gmail.com> | Tipp Moseley <tipp@google.com>
 core,github.com/google/s2a-go,Apache-2.0,Copyright (c) 2020 Google
 core,github.com/google/s2a-go/fallback,Apache-2.0,Copyright (c) 2020 Google
@@ -1367,6 +1368,12 @@ core,github.com/moby/sys/sequential,Apache-2.0,Kir Kolyshkin <kolyshkin@gmail.co
 core,github.com/moby/sys/signal,Apache-2.0,Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
 core,github.com/moby/sys/user,Apache-2.0,Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
 core,github.com/moby/sys/userns,Apache-2.0,Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
+core,github.com/modelcontextprotocol/go-sdk/auth,MIT,Copyright (c) 2025 Go MCP SDK Authors
+core,github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2,MIT,Copyright (c) 2025 Go MCP SDK Authors
+core,github.com/modelcontextprotocol/go-sdk/internal/util,MIT,Copyright (c) 2025 Go MCP SDK Authors
+core,github.com/modelcontextprotocol/go-sdk/internal/xcontext,MIT,Copyright (c) 2025 Go MCP SDK Authors
+core,github.com/modelcontextprotocol/go-sdk/jsonrpc,MIT,Copyright (c) 2025 Go MCP SDK Authors
+core,github.com/modelcontextprotocol/go-sdk/mcp,MIT,Copyright (c) 2025 Go MCP SDK Authors
 core,github.com/modern-go/concurrent,Apache-2.0,Copyright (c) 2018 Tao Wen
 core,github.com/modern-go/reflect2,Apache-2.0,Copyright (c) 2018 Tao Wen
 core,github.com/mohae/deepcopy,MIT,Copyright (c) 2014 Joel
@@ -2135,6 +2142,7 @@ core,github.com/xeipuuv/gojsonschema,Apache-2.0,Copyright 2015 xeipuuv
 core,github.com/xi2/xz,Public Domain,Igor Pavlov <http://7-zip.org/> | Lasse Collin <lasse.collin@tukaani.org> | Michael Cross <https://github.com/xi2>
 core,github.com/xor-gate/ar,MIT,Copyright (c) 2013 Blake Smith <blakesmith0@gmail.com>
 core,github.com/yashtewari/glob-intersection,Apache-2.0,Copyright (c) 2018 Yash Tewari (yashtewari)
+core,github.com/yosida95/uritemplate/v3,BSD-3-Clause,"Copyright (C) 2016, Kohei YOSHIDA <https://yosida95.com/>. All rights reserved"
 core,github.com/youmark/pkcs8,MIT,Copyright (c) 2014 youmark
 core,github.com/yusufpapurcu/wmi,MIT,Copyright (c) 2013 Stack Exchange
 core,github.com/zeebo/xxh3,BSD-2-Clause,"Copyright (c) 2012-2014, Yann Collet | Copyright (c) 2019, Jeff Wendling"

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -156,6 +156,11 @@ func ModifyAPIRouter(f func(*mux.Router)) {
 	f(apiRouter)
 }
 
+// ModifyRootRouter allows to pass in a function to modify the root router used in server
+func ModifyRootRouter(f func(*mux.Router)) {
+	f(router)
+}
+
 // StopServer closes the connection and the server
 // stops listening to new commands.
 func StopServer() {

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -67,6 +67,7 @@ import (
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/appsec"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/mcp"
 
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	metadatarunner "github.com/DataDog/datadog-agent/comp/metadata/runner"
@@ -598,6 +599,17 @@ func start(log log.Component,
 		}
 	} else {
 		pkglog.Info("Admission controller is disabled")
+	}
+
+	if config.GetBool("cluster_agent.mcp.enabled") {
+		// Get MCP configured endpoint
+		mcpEndpoint := config.GetString("cluster_agent.mcp.endpoint")
+		// Register MCP handler on the HTTP metrics server via HTTP
+		mcpHandler := mcp.CreateMCPHandler()
+		http.Handle(mcpEndpoint, mcpHandler)
+		pkglog.Infof("MCP endpoint registered with HTTP metrics server on port %d: %s", metricsPort, mcpEndpoint)
+	} else {
+		pkglog.Debug("MCP server is disabled")
 	}
 
 	pkglog.Infof("All components started. Cluster Agent now running.")

--- a/go.mod
+++ b/go.mod
@@ -978,7 +978,13 @@ require (
 require (
 	github.com/DataDog/datadog-agent/pkg/ssi/testutils v0.0.0-00010101000000-000000000000
 	github.com/go-jose/go-jose/v4 v4.1.3
+	github.com/modelcontextprotocol/go-sdk v1.1.0
 	gitlab.com/gitlab-org/api/client-go v1.8.0
+)
+
+require (
+	github.com/google/jsonschema-go v0.3.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 )
 
 require github.com/aws/aws-sdk-go-v2/service/signin v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -844,6 +844,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -1237,6 +1239,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v1.1.0 h1:Qjayg53dnKC4UZ+792W21e4BpwEZBzwgRW6LrjLWSwA=
+github.com/modelcontextprotocol/go-sdk v1.1.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1849,6 +1853,8 @@ github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7 h1:Vo3q7h44BfmnLQh5SdF
 github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7/go.mod h1:TCWCUPhQU1j7axqROa/VHnlgJGHthAOqJZahg7b/DUc=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=

--- a/pkg/clusteragent/mcp/main.go
+++ b/pkg/clusteragent/mcp/main.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package mcp implements the MCP Server for the Cluster Agent.
+package mcp
+
+import (
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/mcp/tools"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// CreateMCPHandler creates and returns an HTTP handler for MCP endpoints
+func CreateMCPHandler() http.Handler {
+	// Create an MCP server.
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "cluster-agent-mcp-server",
+		Version: "0.0.1",
+	}, nil)
+
+	// Register MCP tools.
+	registerMCPTools(server)
+
+	// Create the streamable HTTP handler.
+	handler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+		return server
+	}, nil)
+
+	log.Infof("MCP server handler created")
+	return handler
+}
+
+// registerMCPTools registers all MCP tools to the given server.
+func registerMCPTools(server *mcp.Server) {
+	// The get_leader tool provides information about the current Cluster Agent leader.
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_leader",
+		Description: "Get information about which Cluster Agent is currently the leader",
+	}, tools.GetLeader)
+}

--- a/pkg/clusteragent/mcp/tools/get_leader.go
+++ b/pkg/clusteragent/mcp/tools/get_leader.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package tools implements MCP tools for the Cluster Agent.
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
+)
+
+// LeaderOutput contains information about the current leader
+type LeaderOutput struct {
+	IsLeader          bool   `json:"is_leader" jsonschema:"Whether this instance is the leader"`
+	LeaderName        string `json:"leader_name" jsonschema:"Name/identity of the current leader"`
+	LeaderIP          string `json:"leader_ip,omitempty" jsonschema:"IP address of the leader (empty if this instance is leader)"`
+	AcquiredTime      string `json:"acquired_time,omitempty" jsonschema:"When the leadership was acquired"`
+	RenewedTime       string `json:"renewed_time,omitempty" jsonschema:"When the leadership was last renewed"`
+	LeaderTransitions int    `json:"leader_transitions,omitempty" jsonschema:"Number of leadership changes"`
+	Error             string `json:"error,omitempty" jsonschema:"Error message if leader election information is unavailable"`
+}
+
+// GetLeader returns information about the current Cluster Agent leader
+func GetLeader(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (
+	*mcp.CallToolResult,
+	LeaderOutput,
+	error,
+) {
+	output := LeaderOutput{}
+
+	// Get the leader election engine
+	engine, err := leaderelection.GetLeaderEngine()
+	if err != nil {
+		output.Error = fmt.Sprintf("Leader election not available: %v", err)
+		return nil, output, nil
+	}
+
+	// Check if this instance is the leader
+	output.IsLeader = engine.IsLeader()
+
+	// Get the leader IP
+	leaderIP, err := engine.GetLeaderIP()
+	if err != nil {
+		output.Error = fmt.Sprintf("Failed to get leader IP: %v", err)
+		return nil, output, nil
+	}
+	output.LeaderIP = leaderIP
+
+	// Get detailed leader election record
+	record, err := leaderelection.GetLeaderElectionRecord()
+	if err != nil {
+		output.Error = fmt.Sprintf("Failed to get leader election record: %v", err)
+		return nil, output, nil
+	}
+
+	output.LeaderName = record.HolderIdentity
+	output.AcquiredTime = record.AcquireTime.Format(time.RFC3339)
+	output.RenewedTime = record.RenewTime.Format(time.RFC3339)
+	output.LeaderTransitions = int(record.LeaderTransitions)
+
+	return nil, output, nil
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -556,6 +556,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Datadog cluster agent
 	config.BindEnvAndSetDefault("cluster_agent.enabled", false)
 	config.BindEnvAndSetDefault("cluster_agent.cmd_port", 5005)
+	config.BindEnvAndSetDefault("cluster_agent.mcp.enabled", false)
+	config.BindEnvAndSetDefault("cluster_agent.mcp.endpoint", "/mcp")
 	config.BindEnvAndSetDefault("cluster_agent.allow_legacy_tls", false)
 	config.BindEnvAndSetDefault("cluster_agent.auth_token", "")
 	config.BindEnvAndSetDefault("cluster_agent.url", "")

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -47,11 +47,11 @@ static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 957.95 MiB
   max_on_wire_size: 316.35 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 179.56 MiB
-  max_on_wire_size: 64.14 MiB
+  max_on_disk_size: 181.08 MiB
+  max_on_wire_size: 64.49 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 196.79 MiB
-  max_on_wire_size: 60.69 MiB
+  max_on_disk_size: 198.49 MiB
+  max_on_wire_size: 61.17 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.18 MiB
   max_on_wire_size: 3.33 MiB


### PR DESCRIPTION
## What does this PR do?
Implements a basic MCP (Model Context Protocol) server within the Datadog Cluster Agent that exposes Cluster Agent leadership information through a standardized tool interface.

## Motivation
The MCP server enables external tools and AI assistants to programmatically query cluster agent leadership information through a standardized protocol. This improves observability and debugging capabilities for multi-replica cluster agent deployments where understanding leadership status is crucial for troubleshooting.

### Costs and time

**Using an MCP Server to ask Claude which Cluster Agent pod is the current leader saves roughly 75% in cost and 70% in time.**

Without MCP:
```
╭─── Claude Code v2.0.69 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                    │ Tips for getting started                                                                                      │
│                    Welcome back!                   │ Run /init to create a CLAUDE.md file with instructions for Claude                                             │
│                                                    │ Note: You have launched claude in your home directory. For the best experience, launch it in a project direc… │
│                     * ▐▛███▜▌ *                    │ ───────────────────────────────────────────────────────────────────────────────────────────────────────────── │
│                    * ▝▜█████▛▘ *                   │ Recent activity                                                                                               │
│                     *  ▘▘ ▝▝  *                    │ No recent activity                                                                                            │
│                                                    │                                                                                                               │
│      Sonnet 4.5 · API Usage Billing · Datadog      │                                                                                                               │
│      Staging/Dev                                   │                                                                                                               │
│                 /Users/wassim.dhif                 │                                                                                                               │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

> Which Cluster Agent pod is the current Leader?

⏺ I'll help you find which Cluster Agent pod is the current Leader. Let me check the Kubernetes cluster for Cluster Agent pods and their leader status.

⏺ Bash(kubectl get pods --all-namespaces | grep -i "cluster-agent")
  ⎿  default       datadog-agent-cluster-agent-f95494c47-6ttzg   1/1     Running   0          70s
     default       datadog-agent-cluster-agent-f95494c47-9h9qx   1/1     Running   0          70s
     default       datadog-agent-cluster-agent-f95494c47-bsdxz   1/1     Running   0          70s

⏺ Bash(kubectl get lease -n default | grep -i "cluster-agent")
  ⎿  No resources found in default namespace.

⏺ Bash(kubectl get configmap -n default | grep -i "leader")
  ⎿  datadog-agent-leader-election           0      19h

⏺ Bash(kubectl describe configmap datadog-agent-leader-election -n default)
  ⎿  Name:         datadog-agent-leader-election
     Namespace:    default
     Labels:       <none>
     … +10 lines (ctrl+o to expand)

⏺ Bash(kubectl get configmap datadog-agent-leader-election -n default -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io/leader}' | jq .)
  ⎿  {
       "holderIdentity": "datadog-agent-cluster-agent-f95494c47-bsdxz",
       "leaseDurationSeconds": 60,
     … +6 lines (ctrl+o to expand)

⏺ The current Leader of the Cluster Agent is datadog-agent-cluster-agent-f95494c47-bsdxz.

  Here are the leader election details:
  - Leader Pod: datadog-agent-cluster-agent-f95494c47-bsdxz
  - Acquired Leadership: 2025-12-13T11:28:37Z
  - Last Renewed: 2025-12-13T11:28:52Z
  - Lease Duration: 60 seconds
  - Leader Transitions: 2 (indicating there have been 2 leadership changes)

  The other two Cluster Agent pods (datadog-agent-cluster-agent-f95494c47-6ttzg and datadog-agent-cluster-agent-f95494c47-9h9qx) are running as followers.

> /cost
  ⎿  Total cost:            $0.1346
  ⎿  Total duration (API):  52s
  ⎿  Total duration (wall): 60s
  ⎿  Total code changes:    0 lines added, 0 lines removed
  ⎿  Usage by model:
  ⎿          claude-haiku:  3.0k input, 344 output, 0 cache read, 0 cache write ($0.0047)
  ⎿         claude-sonnet:  931 input, 1.5k output, 166.2k cache read, 14.8k cache write ($0.1299)
  ```
  
  With MCP
  ```
  ╭─── Claude Code v2.0.69 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                    │ Tips for getting started                                                                                      │
│                    Welcome back!                   │ Run /init to create a CLAUDE.md file with instructions for Claude                                             │
│                                                    │ Note: You have launched claude in your home directory. For the best experience, launch it in a project direc… │
│                     * ▐▛███▜▌ *                    │ ───────────────────────────────────────────────────────────────────────────────────────────────────────────── │
│                    * ▝▜█████▛▘ *                   │ Recent activity                                                                                               │
│                     *  ▘▘ ▝▝  *                    │ No recent activity                                                                                            │
│                                                    │                                                                                                               │
│      Sonnet 4.5 · API Usage Billing · Datadog      │                                                                                                               │
│      Staging/Dev                                   │                                                                                                               │
│                 /Users/wassim.dhif                 │                                                                                                               │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

> Which Cluster Agent pod is the current Leader?

⏺ I'll check which Cluster Agent pod is currently the Leader.
  ⎿  {
       "acquired_time": "2025-12-13T11:28:37Z",
       "is_leader": false,
     … +5 lines (ctrl+o to expand)

⏺ The current Cluster Agent Leader is:

  Pod: datadog-agent-cluster-agent-f95494c47-bsdxz
  IP: 10.244.0.6

  Leadership was acquired at 2025-12-13T11:28:37Z and last renewed at 2025-12-13T11:31:22Z. There have been 2 leader transitions so far.

> /cost
  ⎿  Total cost:            $0.0356
  ⎿  Total duration (API):  22s
  ⎿  Total duration (wall): 21s
  ⎿  Total code changes:    0 lines added, 0 lines removed
  ⎿  Usage by model:
  ⎿          claude-haiku:  982 input, 163 output, 0 cache read, 0 cache write ($0.0018)
  ⎿         claude-sonnet:  881 input, 601 output, 70.8k cache read, 233 cache write ($0.0338)
  ```

## Describe how you validated your changes
https://github.com/user-attachments/assets/633bf6c5-a0cc-4fa0-b94c-d0dac4181e2b

Modify the Skaffold configuration with the following:
```
diff --git a/skaffold.yaml b/skaffold.yaml
index bb2f8e83af..e16b59bd5a 100644
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -31,10 +31,18 @@ deploy:
               repository: "{{.IMAGE_REPO_clusteragent}}"
               tag: "{{.IMAGE_TAG_clusteragent}}"
               doNotCheckTag: true
+            env:
+              - name: DD_CLUSTER_AGENT_MCP_ENABLED
+                value: "true"
           clusterCheckRunner.image:
             repository: "{{.IMAGE_REPO_agent}}"
             tag: "{{.IMAGE_TAG_agent}}"
             doNotCheckTag: true
+portForward:
+  - resourceType: deployment
+    resourceName: datadog-agent-cluster-agent
+    port: 5000
+    localPort: 5000  # metrics_port - Metrics & MCP endpoint (/mcp)
 profiles:
   - name: kind
     activation:
```

Start Skaffold
```
dda inv skaffold.create
dda inv skaffold.dev
```

Add Cluster Agent MCP Server
```
claude mcp add --transport http cluster-agent http://localhost:5000/mcp
```

```
➜  datadog-agent-primary git:(dev/wassim.dhif/cluster-agent-mcp-server) ✗ claude

 ▐▛███▜▌   Claude Code v2.0.62
▝▜█████▛▘  Sonnet 4.5 · API Usage Billing
  ▘▘ ▝▝    ~/go/src/github.com/DataDog/datadog-agent/datadog-agent-primary

> Which Cluster Agent pod is the current Leader?

⏺ I'll check which Cluster Agent pod is currently the leader.
  ⎿  {
       "acquired_time": "2025-12-09T17:34:26Z",
       "is_leader": true,
     … +4 lines (ctrl+o to expand)

⏺ The current Cluster Agent leader is:

  datadog-agent-cluster-agent-7bcb87bfbd-phr4f

  Additional details:
  - Acquired leadership: 2025-12-09 at 17:34:26 UTC
  - Last renewed: 2025-12-09 at 17:53:12 UTC
  - Leader transitions: 11
  - Status: Active leader
```

## Additional Notes
* No changelog was created, as the current Leader Election tool is only used for testing purposes. Future changelogs will be added once other tool implementations are in place.
* No authentication method has been implemented for this PoC.
* Currently using the Metrics Server endpoint, as it isn’t behind TLS and self-signed certificates do not work with Claude.