### PR TITLE
Fix `fileMutator` reinjecting leftovers from temporary files

### DIFF
--- a/pkg/fleet/installer/packages/apminject/file.go
+++ b/pkg/fleet/installer/packages/apminject/file.go
@@ -61,6 +61,8 @@ func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err e
 		}
 		originalFileExists = false
 	}
+
+	var data []byte
 	if originalFileExists {
 		if err := copyFile(ft.path, ft.pathBackup); err != nil {
 			return nil, fmt.Errorf("could not create backup file %s: %s", ft.pathBackup, err)
@@ -68,11 +70,10 @@ func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err e
 		if err := copyFile(ft.pathBackup, ft.pathTmp); err != nil {
 			return nil, fmt.Errorf("could not create temporary file %s: %s", ft.pathTmp, err)
 		}
-	}
-
-	data, err := os.ReadFile(ft.pathTmp)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("could not read file %s: %s", ft.pathTmp, err)
+		data, err = os.ReadFile(ft.pathTmp)
+		if err != nil {
+			return nil, fmt.Errorf("could not read file %s: %s", ft.pathTmp, err)
+		}
 	}
 
 	res, err := ft.transformContent(ctx, data)
@@ -87,7 +88,6 @@ func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err e
 
 	if err = writeFile(ft.pathTmp, res); err != nil {
 		return nil, fmt.Errorf("could not write file %s: %s", ft.pathTmp, err)
-
 	}
 
 	// validate temporary file if validation function provided


### PR DESCRIPTION
### Motivation
When the original file doesn't exist, `fileMutator.mutate()` still tries to read the corresponding `.datadog.prep` temporary file which, if still present, contains leftover data from a previous operation.

This would cause the transformation to be applied to stale content instead of starting from empty data.

Found by investigating test flakiness in `e2e-installer` job (`TestPackages/apm_inject_*_install_script/TestInstrumentDockerInactive`), but this pollution could occur in production after failed install attempts.

### What does this PR do?
The fix ensures `pathTmp` is only read when `originalFileExists` is `true`,  i.e., only when the current operation created the temporary file.

### Describe how you validated your changes
Added `TestFileTransform_No_original_ignores_leftovers` to verify that a leftover temporary file is properly ignored when the original file doesn't exist.

### Additional Notes
There are error cases where temporary files won't be deleted at all, for instance:
```go
		if err := copyFile(ft.path, ft.pathBackup); err != nil {
			return nil, fmt.Errorf("could not create backup file %s: %s", ft.pathBackup, err)
		}
		if err := copyFile(ft.pathBackup, ft.pathTmp); err != nil {
			return nil, fmt.Errorf("could not create temporary file %s: %s", ft.pathTmp, err)
			// ^ ft.pathBackup would not be removed
		}
```
... which the present change does not address.