### PR TITLE
read datadog.yaml from same dir as system-probe.yaml

### DIFF
--- a/cmd/system-probe/command/command_test.go
+++ b/cmd/system-probe/command/command_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatadogConfPath(t *testing.T) {
+	cases := []struct {
+		params   GlobalParams
+		expected string
+	}{
+		{GlobalParams{}, ""},
+		{GlobalParams{ConfFilePath: "/some/other/dir"}, "/some/other/dir"},
+		{GlobalParams{ConfFilePath: "/some/other/dir/system-probe.yaml"}, "/some/other/dir"},
+		{GlobalParams{ConfFilePath: "/some/other/dir", datadogConfFilePath: "/another/dir"}, "/another/dir"},
+		{GlobalParams{ConfFilePath: "/some/other/dir", datadogConfFilePath: "/another/dir/datadog.yaml"}, "/another/dir/datadog.yaml"},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expected, c.params.DatadogConfFilePath(), "%+v", c.params)
+	}
+}

--- a/cmd/system-probe/command/command_unix_test.go
+++ b/cmd/system-probe/command/command_unix_test.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build unix
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatadogConfPath(t *testing.T) {
+	cases := []struct {
+		params   GlobalParams
+		expected string
+	}{
+		{GlobalParams{}, ""},
+		{GlobalParams{ConfFilePath: "/some/other/dir"}, "/some/other/dir"},
+		{GlobalParams{ConfFilePath: "/some/other/dir/system-probe.yaml"}, "/some/other/dir"},
+		{GlobalParams{ConfFilePath: "/some/other/dir", datadogConfFilePath: "/another/dir"}, "/another/dir"},
+		{GlobalParams{ConfFilePath: "/some/other/dir", datadogConfFilePath: "/another/dir/datadog.yaml"}, "/another/dir/datadog.yaml"},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expected, c.params.DatadogConfFilePath(), "%+v", c.params)
+	}
+}

--- a/cmd/system-probe/command/command_unix_test.go
+++ b/cmd/system-probe/command/command_unix_test.go
@@ -19,10 +19,10 @@ func TestDatadogConfPath(t *testing.T) {
 		expected string
 	}{
 		{GlobalParams{}, ""},
-		{GlobalParams{ConfFilePath: "/some/other/dir"}, "/some/other/dir"},
-		{GlobalParams{ConfFilePath: "/some/other/dir/system-probe.yaml"}, "/some/other/dir"},
-		{GlobalParams{ConfFilePath: "/some/other/dir", datadogConfFilePath: "/another/dir"}, "/another/dir"},
-		{GlobalParams{ConfFilePath: "/some/other/dir", datadogConfFilePath: "/another/dir/datadog.yaml"}, "/another/dir/datadog.yaml"},
+		{GlobalParams{ConfFilePath: "/a/b/c"}, "/a/b/c"},
+		{GlobalParams{ConfFilePath: "/a/b/c/system-probe.yaml"}, "/a/b/c"},
+		{GlobalParams{ConfFilePath: "/a/b/c", datadogConfFilePath: "/x/y"}, "/x/y"},
+		{GlobalParams{ConfFilePath: "/a/b/c", datadogConfFilePath: "/x/y/datadog.yaml"}, "/x/y/datadog.yaml"},
 	}
 
 	for _, c := range cases {

--- a/cmd/system-probe/command/command_windows_test.go
+++ b/cmd/system-probe/command/command_windows_test.go
@@ -17,10 +17,10 @@ func TestDatadogConfPath(t *testing.T) {
 		expected string
 	}{
 		{GlobalParams{}, ""},
-		{GlobalParams{ConfFilePath: "C:\\some\\other\\dir"}, "C:\\some\\other\\dir"},
-		{GlobalParams{ConfFilePath: "C:\\some\\other\\dir\\system-probe.yaml"}, "C:\\some\\other\\dir"},
-		{GlobalParams{ConfFilePath: "C:\\some\\other\\dir", datadogConfFilePath: "C:\\another\\dir"}, "C:\\another\\dir"},
-		{GlobalParams{ConfFilePath: "C:\\some\\other\\dir", datadogConfFilePath: "C:\\another\\dir\\datadog.yaml"}, "C:\\another\\dir\\datadog.yaml"},
+		{GlobalParams{ConfFilePath: "C:\\a\\b\\c"}, "C:\\a\\b\\c"},
+		{GlobalParams{ConfFilePath: "C:\\a\\b\\c\\system-probe.yaml"}, "C:\\a\\b\\c"},
+		{GlobalParams{ConfFilePath: "C:\\a\\b\\c", datadogConfFilePath: "C:\\x\\y"}, "C:\\x\\y"},
+		{GlobalParams{ConfFilePath: "C:\\a\\b\\c", datadogConfFilePath: "C:\\x\\y\\datadog.yaml"}, "C:\\x\\y\\datadog.yaml"},
 	}
 
 	for _, c := range cases {

--- a/cmd/system-probe/command/command_windows_test.go
+++ b/cmd/system-probe/command/command_windows_test.go
@@ -17,10 +17,10 @@ func TestDatadogConfPath(t *testing.T) {
 		expected string
 	}{
 		{GlobalParams{}, ""},
-		{GlobalParams{ConfFilePath: "/some/other/dir"}, "/some/other/dir"},
-		{GlobalParams{ConfFilePath: "/some/other/dir/system-probe.yaml"}, "/some/other/dir"},
-		{GlobalParams{ConfFilePath: "/some/other/dir", datadogConfFilePath: "/another/dir"}, "/another/dir"},
-		{GlobalParams{ConfFilePath: "/some/other/dir", datadogConfFilePath: "/another/dir/datadog.yaml"}, "/another/dir/datadog.yaml"},
+		{GlobalParams{ConfFilePath: "C:\\some\\other\\dir"}, "C:\\some\\other\\dir"},
+		{GlobalParams{ConfFilePath: "C:\\some\\other\\dir\\system-probe.yaml"}, "C:\\some\\other\\dir"},
+		{GlobalParams{ConfFilePath: "C:\\some\\other\\dir", datadogConfFilePath: "C:\\another\\dir"}, "C:\\another\\dir"},
+		{GlobalParams{ConfFilePath: "C:\\some\\other\\dir", datadogConfFilePath: "C:\\another\\dir\\datadog.yaml"}, "C:\\another\\dir\\datadog.yaml"},
 	}
 
 	for _, c := range cases {

--- a/cmd/system-probe/subcommands/compliance/command.go
+++ b/cmd/system-probe/subcommands/compliance/command.go
@@ -39,7 +39,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 // CheckCommand returns the 'compliance check' command
-func CheckCommand(_ *command.GlobalParams) *cobra.Command {
+func CheckCommand(globalParams *command.GlobalParams) *cobra.Command {
 	checkArgs := &cli.CheckParams{}
 
 	cmd := &cobra.Command{
@@ -47,7 +47,7 @@ func CheckCommand(_ *command.GlobalParams) *cobra.Command {
 		Short: "Run compliance check(s)",
 		RunE: func(_ *cobra.Command, args []string) error {
 			bundleParams := core.BundleParams{
-				ConfigParams: config.NewAgentParams(""),
+				ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 				LogParams:    log.ForOneShot(command.LoggerName, "info", true),
 			}
 
@@ -73,7 +73,7 @@ func CheckCommand(_ *command.GlobalParams) *cobra.Command {
 	return cmd
 }
 
-func complianceLoadCommand(_ *command.GlobalParams) *cobra.Command {
+func complianceLoadCommand(globalParams *command.GlobalParams) *cobra.Command {
 	loadArgs := &cli.LoadParams{}
 
 	loadCmd := &cobra.Command{
@@ -85,7 +85,7 @@ func complianceLoadCommand(_ *command.GlobalParams) *cobra.Command {
 			return fxutil.OneShot(cli.RunLoad,
 				fx.Supply(loadArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true),
 				}),
 				core.Bundle(),

--- a/cmd/system-probe/subcommands/config/command.go
+++ b/cmd/system-probe/subcommands/config/command.go
@@ -46,7 +46,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(callback,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams:         config.NewAgentParams(""),
+					ConfigParams:         config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot(command.LoggerName, "off", true),
 				}),

--- a/cmd/system-probe/subcommands/coverage/command.go
+++ b/cmd/system-probe/subcommands/coverage/command.go
@@ -46,7 +46,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(requestCoverage,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams:         config.NewAgentParams(""),
+					ConfigParams:         config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot(command.LoggerName, "off", false),
 				}),

--- a/cmd/system-probe/subcommands/debug/command.go
+++ b/cmd/system-probe/subcommands/debug/command.go
@@ -49,7 +49,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(debugRuntime,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams:         config.NewAgentParams(""),
+					ConfigParams:         config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot(command.LoggerName, "off", false),
 				}),

--- a/cmd/system-probe/subcommands/modrestart/command.go
+++ b/cmd/system-probe/subcommands/modrestart/command.go
@@ -46,7 +46,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(moduleRestart,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams:         config.NewAgentParams(""),
+					ConfigParams:         config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
 					LogParams:            log.ForOneShot(command.LoggerName, "off", false),
 				}),

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -99,7 +99,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Long:  `Runs the system-probe in the foreground`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(run,
-				fx.Supply(config.NewAgentParams("")),
+				fx.Supply(config.NewAgentParams(globalParams.DatadogConfFilePath())),
 				// Force FX to load Datadog configuration before System Probe config.
 				// This is necessary because the 'software_inventory.enabled' setting is defined in the Datadog configuration.
 				// Without this explicit dependency, FX might initialize System Probe's config first, causing pkgconfigsetup.Datadog().GetBool()

--- a/cmd/system-probe/subcommands/runtime/activity_dump.go
+++ b/cmd/system-probe/subcommands/runtime/activity_dump.go
@@ -62,14 +62,14 @@ func activityDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpCmd}
 }
 
-func listCommands(_ *command.GlobalParams) []*cobra.Command {
+func listCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	activityDumpListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "get the list of running activity dumps",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(listActivityDumps,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -92,7 +92,7 @@ func stopCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -145,7 +145,7 @@ func generateDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -223,7 +223,7 @@ func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Comma
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -284,7 +284,7 @@ func diffCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(diffActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -85,7 +85,7 @@ func evalCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(evalRule,
 				fx.Supply(evalArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -118,7 +118,7 @@ func commonCheckPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Co
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -135,14 +135,14 @@ func commonCheckPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Co
 	return []*cobra.Command{commonCheckPoliciesCmd}
 }
 
-func commonReloadPoliciesCommands(_ *command.GlobalParams) []*cobra.Command {
+func commonReloadPoliciesCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	commonReloadPoliciesCmd := &cobra.Command{
 		Use:   "reload",
 		Short: "Reload policies",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -153,14 +153,14 @@ func commonReloadPoliciesCommands(_ *command.GlobalParams) []*cobra.Command {
 }
 
 // nolint: deadcode, unused
-func selfTestCommands(_ *command.GlobalParams) []*cobra.Command {
+func selfTestCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	selfTestCmd := &cobra.Command{
 		Use:   "self-test",
 		Short: "Run runtime self test",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(runRuntimeSelfTest,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -191,7 +191,7 @@ func downloadPolicyCommands(globalParams *command.GlobalParams) []*cobra.Command
 			return fxutil.OneShot(downloadPolicy,
 				fx.Supply(downloadPolicyArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "off", false)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -227,7 +227,7 @@ func processCacheCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(dumpProcessCache,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -266,7 +266,7 @@ func networkNamespaceCommands(globalParams *command.GlobalParams) []*cobra.Comma
 			return fxutil.OneShot(dumpNetworkNamespace,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -285,7 +285,7 @@ func networkNamespaceCommands(globalParams *command.GlobalParams) []*cobra.Comma
 }
 
 //nolint:unused // TODO(SEC) Fix unused linter
-func discardersCommands(_ *command.GlobalParams) []*cobra.Command {
+func discardersCommands(globalParams *command.GlobalParams) []*cobra.Command {
 
 	dumpDiscardersCmd := &cobra.Command{
 		Use:   "dump",
@@ -293,7 +293,7 @@ func discardersCommands(_ *command.GlobalParams) []*cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(dumpDiscarders,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),

--- a/cmd/system-probe/subcommands/runtime/security_profile.go
+++ b/cmd/system-probe/subcommands/runtime/security_profile.go
@@ -61,7 +61,7 @@ func securityProfileShowCommands(globalParams *command.GlobalParams) []*cobra.Co
 			return fxutil.OneShot(showSecurityProfile,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -107,7 +107,7 @@ func listSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 			return fxutil.OneShot(listSecurityProfiles,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),
@@ -221,7 +221,7 @@ func saveSecurityProfileCommands(globalParams *command.GlobalParams) []*cobra.Co
 			return fxutil.OneShot(saveSecurityProfile,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle(),
 				secretsnoopfx.Module(),

--- a/cmd/system-probe/subcommands/usm/shared.go
+++ b/cmd/system-probe/subcommands/usm/shared.go
@@ -33,7 +33,7 @@ func makeOneShotCommand(
 				runFunc,
 				fx.Supply(globalParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(""),
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
 					SysprobeConfigParams: sysconfigimpl.NewParams(
 						sysconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath),
 						sysconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),

--- a/releasenotes/notes/sysprobe-datadog-cfg-path-728640a48d0359a9.yaml
+++ b/releasenotes/notes/sysprobe-datadog-cfg-path-728640a48d0359a9.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    system-probe will now attempt to read `datadog.yaml` from the same directory as `system-probe.yaml`.
+    Previously, system-probe would always use the default configuration directory to read `datadog.yaml`.
+    If you need to specify a different directory for `datadog.yaml`, you may use the `--datadogcfgpath` CLI argument to system-probe.


### PR DESCRIPTION
### What does this PR do?

Changes system-probe to read `datadog.yaml` from the same directory as `system-probe.yaml`, unless explicitly specified otherwise. Adds `--datadogcfgpath` CLI argument to system-probe to allow explicitly specifying the path.

### Motivation

Confusing behavior where `system-probe.yaml` could be read from a different directory from `datadog.yaml`

### Describe how you validated your changes

Added tests

### Additional Notes
