### PR TITLE
[otlp/metrics] Add EncodeSliceMetadataAsTags option

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
@@ -106,6 +106,10 @@ func newFactoryForAgentWithType(
 	default:
 		options = append(options, otlpmetrics.WithOTelPrefix())
 	}
+	if featuregates.AttributeSliceMultiTagExportingFeatureGate.IsEnabled() {
+		fmt.Println("Adding WithEncodeSliceMetadataAsTags from AttributeSliceMultiTagExportingFeatureGate")
+		options = append(options, otlpmetrics.WithEncodeSliceMetadataAsTags())
+	}
 
 	f := &factory{
 		s:            s,
@@ -150,6 +154,10 @@ func NewFactoryForOSSExporter(typ component.Type, statsIn chan []byte) exp.Facto
 		// old gate, no action needed
 	default:
 		options = append(options, otlpmetrics.WithRemapping())
+	}
+	if featuregates.AttributeSliceMultiTagExportingFeatureGate.IsEnabled() {
+		fmt.Println("Adding WithEncodeSliceMetadataAsTags from AttributeSliceMultiTagExportingFeatureGate")
+		options = append(options, otlpmetrics.WithEncodeSliceMetadataAsTags())
 	}
 
 	f := &factory{

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
@@ -107,7 +107,6 @@ func newFactoryForAgentWithType(
 		options = append(options, otlpmetrics.WithOTelPrefix())
 	}
 	if featuregates.AttributeSliceMultiTagExportingFeatureGate.IsEnabled() {
-		fmt.Println("Adding WithEncodeSliceMetadataAsTags from AttributeSliceMultiTagExportingFeatureGate")
 		options = append(options, otlpmetrics.WithEncodeSliceMetadataAsTags())
 	}
 
@@ -156,7 +155,6 @@ func NewFactoryForOSSExporter(typ component.Type, statsIn chan []byte) exp.Facto
 		options = append(options, otlpmetrics.WithRemapping())
 	}
 	if featuregates.AttributeSliceMultiTagExportingFeatureGate.IsEnabled() {
-		fmt.Println("Adding WithEncodeSliceMetadataAsTags from AttributeSliceMultiTagExportingFeatureGate")
 		options = append(options, otlpmetrics.WithEncodeSliceMetadataAsTags())
 	}
 

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/config.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/config.go
@@ -30,6 +30,7 @@ type translatorConfig struct {
 	InstrumentationLibraryMetadataAsTags bool
 	InstrumentationScopeMetadataAsTags   bool
 	InferDeltaInterval                   bool
+	EncodeSliceMetadataAsTags            bool
 
 	originProduct OriginProduct
 
@@ -246,6 +247,16 @@ func WithInitialCumulMonoValueMode(mode InitialCumulMonoValueMode) TranslatorOpt
 func WithInferDeltaInterval() TranslatorOption {
 	return func(t *translatorConfig) error {
 		t.InferDeltaInterval = true
+		return nil
+	}
+}
+
+// WithEncodeSliceMetadataAsTags converts slice attributes into multiple tags.
+// By default slice attributes are converted to a JSON-ish string (e.g. `{"key1": ["val1", "val2"]} → `["key1:[\"val1\",\"val2\"]"]`).
+// This option converts slice attributes into multiple tags (e.g. `{"key1": ["val1", "val2"]} → `["key1:val1","key1:val2"]`).
+func WithEncodeSliceMetadataAsTags() TranslatorOption {
+	return func(t *translatorConfig) error {
+		t.EncodeSliceMetadataAsTags = true
 		return nil
 	}
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go
@@ -55,7 +55,7 @@ func (m *defaultMapper) MapNumberMetrics(
 	dt DataType,
 	slice pmetric.NumberDataPointSlice,
 ) {
-	mapNumberMetrics(ctx, consumer, dims, dt, slice, m.logger, m.cfg.InferDeltaInterval)
+	mapNumberMetrics(ctx, consumer, dims, dt, slice, m.logger, m.cfg.InferDeltaInterval, m.cfg.EncodeSliceMetadataAsTags)
 }
 
 // MapHistogramMetrics maps double histogram metrics slices to Datadog metrics
@@ -87,7 +87,7 @@ func (m *defaultMapper) MapHistogramMetrics(
 
 		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
-		pointDims := dims.WithAttributeMap(p.Attributes())
+		pointDims := dims.WithAttributeMap(p.Attributes(), m.cfg.EncodeSliceMetadataAsTags)
 
 		histInfo := histogramInfo{ok: true}
 
@@ -172,7 +172,7 @@ func (m *defaultMapper) MapSummaryMetrics(
 
 		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
-		pointDims := dims.WithAttributeMap(p.Attributes())
+		pointDims := dims.WithAttributeMap(p.Attributes(), m.cfg.EncodeSliceMetadataAsTags)
 
 		// treat count as a cumulative monotonic metric
 		// and sum as a non-monotonic metric
@@ -239,7 +239,7 @@ func (m *defaultMapper) MapExponentialHistogramMetrics(
 		p := slice.At(i)
 		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
-		pointDims := dims.WithAttributeMap(p.Attributes())
+		pointDims := dims.WithAttributeMap(p.Attributes(), m.cfg.EncodeSliceMetadataAsTags)
 
 		histInfo := histogramInfo{ok: true}
 

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/dimensions_test.go
@@ -27,12 +27,20 @@ func TestWithAttributeMap(t *testing.T) {
 		"key1": "val1",
 		"key2": "val2",
 		"key3": "",
+		"key4": int64(1),
 	})
+	key5Slice := attributes.PutEmptySlice("key5")
+	key5Slice.AppendEmpty().SetStr("val51")
+	key5Slice.AppendEmpty().SetStr("val52")
 
 	dims := Dimensions{}
 	assert.ElementsMatch(t,
-		dims.WithAttributeMap(attributes).tags,
-		[...]string{"key1:val1", "key2:val2", "key3:n/a"},
+		dims.WithAttributeMap(attributes, false).tags,
+		[...]string{"key1:val1", "key2:val2", "key3:n/a", "key4:1", "key5:[\"val51\",\"val52\"]"},
+	)
+	assert.ElementsMatch(t,
+		dims.WithAttributeMap(attributes, true).tags,
+		[...]string{"key1:val1", "key2:val2", "key3:n/a", "key4:1", "key5:val51", "key5:val52"},
 	)
 }
 
@@ -115,7 +123,7 @@ func TestAllFieldsAreCopied(t *testing.T) {
 	newDims := dims.
 		AddTags("tagThree:c").
 		WithSuffix("suffix").
-		WithAttributeMap(attributes)
+		WithAttributeMap(attributes, true)
 
 	assert.Equal(t, "example.name.suffix", newDims.Name())
 	assert.Equal(t, "hostname", newDims.Host())

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/lossless_mapper.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/lossless_mapper.go
@@ -35,7 +35,7 @@ func newLossLessMapper(cfg translatorConfig, logger *zap.Logger) mapper {
 
 // MapNumberMetrics maps number datapoints to Datadog metrics.
 func (m *lossLessMapper) MapNumberMetrics(ctx context.Context, consumer Consumer, dims *Dimensions, dt DataType, slice pmetric.NumberDataPointSlice) {
-	mapNumberMetrics(ctx, consumer, dims, dt, slice, m.logger, m.cfg.InferDeltaInterval)
+	mapNumberMetrics(ctx, consumer, dims, dt, slice, m.logger, m.cfg.InferDeltaInterval, m.cfg.EncodeSliceMetadataAsTags)
 }
 
 // mapNumberMetrics maps number datapoints into Datadog metrics.
@@ -48,6 +48,7 @@ func mapNumberMetrics(
 	slice pmetric.NumberDataPointSlice,
 	logger *zap.Logger,
 	inferInterval bool,
+	encodeSliceMetadataAsTags bool,
 ) {
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
@@ -56,7 +57,7 @@ func mapNumberMetrics(
 			continue
 		}
 
-		pointDims := dims.WithAttributeMap(p.Attributes())
+		pointDims := dims.WithAttributeMap(p.Attributes(), encodeSliceMetadataAsTags)
 		var val float64
 		switch p.ValueType() {
 		case pmetric.NumberDataPointValueTypeDouble:
@@ -90,7 +91,7 @@ func (m *lossLessMapper) MapSummaryMetrics(ctx context.Context, consumer Consume
 		}
 
 		ts := uint64(p.Timestamp())
-		pointDims := dims.WithAttributeMap(p.Attributes())
+		pointDims := dims.WithAttributeMap(p.Attributes(), m.cfg.EncodeSliceMetadataAsTags)
 
 		// Emit count as a Gauge (raw value, no delta conversion)
 		countDims := pointDims.WithSuffix("count")

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go
@@ -300,7 +300,7 @@ func (t *defaultTranslator) mapNumberMonotonicMetrics(
 
 		ts := uint64(p.Timestamp())
 		startTs := uint64(p.StartTimestamp())
-		pointDims := dims.WithAttributeMap(p.Attributes())
+		pointDims := dims.WithAttributeMap(p.Attributes(), t.cfg.EncodeSliceMetadataAsTags)
 
 		var val float64
 		switch p.ValueType() {

--- a/releasenotes/notes/otlp-slice-tag-conversion-e866af8958e1f76c.yaml
+++ b/releasenotes/notes/otlp-slice-tag-conversion-e866af8958e1f76c.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The OpenTelemetry exporter can now serialize slice attributes
+    as multiple Datadog tags (instead of converting the slice to a
+    single JSON-esque tag).


### PR DESCRIPTION
### What does this PR do?

Currently, when converting OpenTelemetry attributes to Datadog tags, all attribute values are converted as-is to strings. For simple types (strings, ints, etc) this works as expected, but OpenTelemetry also supports [more complex types](https://opentelemetry.io/docs/specs/otel/common/#anyvalue) as attribute values. Array values in particular are a useful attribute value type, as both OpenTelemetry (e.g. [`container.image.repo_digests`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/container/)) and Datadog (e.g. [`kube_service`](https://docs.datadoghq.com/containers/kubernetes/tag/)) support having multiple values on the same key for the same data point. To support these cases, this change gives the OTLP `Translator` the ability to covert top-level array attribute values into multiple Datadog tags (instead of a single tag formatted like a JSON array).

### Motivation

This has been a particular pain point when using the OpenTelemetry collector's [`datadogexporter`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter) plugin to ingest metrics into Datadog. The collector plugin depends on the `opentelemetry-mapping-go` package updated in this change. By exposing this new setting, metrics sent from the collector can more fully use Datadog's rich tag slicing feature with OpenTelemetry-based metrics.

### Describe how you validated your changes

Unit tests test that both the old behaviour still works as expected. I also built a version of the OpenTelemetry Collector that uses this change, and it exports metrics with the expected tags.