### PR TITLE
dyninst/procsubscribe: expose debug info for tracked processes

### DIFF
--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -295,6 +295,24 @@ func (m *Module) Register(router *module.Router) error {
 			},
 		),
 	)
+	// Handler for printing debug information about the known Go processes with
+	// the Datadog tracer. These processes are watched for Remote Config updates
+	// related to Dynamic Instrumentation.
+	router.HandleFunc(
+		"/debug/goprocs",
+		utils.WithConcurrencyLimit(
+			utils.DefaultMaxConcurrentRequests,
+			func(w http.ResponseWriter, _ *http.Request) {
+				if m.shutdown.realDependencies.procSubscriber == nil {
+					utils.WriteAsJSON(w, nil, utils.PrettyPrint)
+					return
+				}
+
+				report := m.shutdown.realDependencies.procSubscriber.GetReport()
+				utils.WriteAsJSON(w, report, utils.PrettyPrint)
+			},
+		),
+	)
 	return nil
 }
 

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -255,7 +255,7 @@ func makeRealDependencies(
 		return ret, fmt.Errorf("error getting monotonic time: %w", err)
 	}
 	ret.dispatcher = dispatcher.NewDispatcher(ret.loader.OutputReader())
-	ret.procSubscriber = procsubscribe.NewRemoteConfigProcessSubscriber(
+	ret.procSubscriber = procsubscribe.NewSubscriber(
 		remoteConfigSubscriber,
 	)
 

--- a/pkg/dyninst/procsubscribe/procscan/scanner.go
+++ b/pkg/dyninst/procsubscribe/procscan/scanner.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io/fs"
 	"iter"
+	"sync"
 	"syscall"
 	"time"
 
@@ -32,7 +33,7 @@ type ProcessID uint32
 // at least startDelay. Processes that exit before startDelay are never
 // analyzed.
 //
-// Thread-safety: not thread-safe, use from a single goroutine only.
+// Thread-safety: Scan is not thread-safe, use from a single goroutine only.
 type Scanner struct {
 
 	// startDelay is how long a process must be alive before analysis.
@@ -44,8 +45,11 @@ type Scanner struct {
 	// nowTicks returns the current time in ticks since boot.
 	nowTicks func() (ticks, error)
 
-	// live tracks discovered processes that have been reported as live.
-	live *btree.BTreeG[uint32]
+	mu struct {
+		sync.Mutex
+		// live tracks discovered processes that have been reported as live.
+		live *btree.BTreeG[uint32]
+	}
 
 	// listPids returns an iterator over all PIDs in the system.
 	listPids func() iter.Seq2[uint32, error]
@@ -102,15 +106,16 @@ func newScanner(
 	tracerMetadataReader func(pid int32) (tracermetadata.TracerMetadata, error),
 	resolveExecutable func(pid int32) (process.Executable, error),
 ) *Scanner {
-	return &Scanner{
+	s := &Scanner{
 		startDelay:           startDelay,
 		nowTicks:             nowTicks,
 		listPids:             listPids,
 		readStartTime:        readStartTime,
 		tracerMetadataReader: tracerMetadataReader,
 		resolveExecutable:    resolveExecutable,
-		live:                 btree.NewG(16, cmp.Less[uint32]),
 	}
+	s.mu.live = btree.NewG(16, cmp.Less[uint32])
+	return s
 }
 
 // DiscoveredProcess represents a newly discovered process that should be
@@ -169,7 +174,10 @@ func (p *Scanner) Scan() (
 
 	// Clone the live set. Processes still alive will be removed from this
 	// clone. Whatever remains has exited.
-	noLongerLive := p.live.Clone()
+	p.mu.Lock()
+	noLongerLive := p.mu.live.Clone()
+	p.mu.Unlock()
+
 	var ret []DiscoveredProcess
 
 	for pid, err := range p.listPids() {
@@ -207,7 +215,6 @@ func (p *Scanner) Scan() (
 			continue
 		}
 
-		p.live.ReplaceOrInsert(pid)
 		ret = append(ret, DiscoveredProcess{
 			PID:            pid,
 			StartTimeTicks: uint64(startTime),
@@ -219,11 +226,30 @@ func (p *Scanner) Scan() (
 	removed = make([]ProcessID, 0, noLongerLive.Len())
 	noLongerLive.Ascend(func(pid uint32) bool {
 		removed = append(removed, ProcessID(pid))
-		p.live.Delete(pid)
+		p.mu.live.Delete(pid)
 		return true
 	})
 	noLongerLive.Clear(true)
 
+	p.mu.Lock()
+	for _, newProc := range ret {
+		p.mu.live.ReplaceOrInsert(newProc.PID)
+	}
+	p.mu.Unlock()
+
 	p.lastWatermark = nextWatermark
 	return ret, removed, nil
+}
+
+// LiveProcesses returns the list of processes that were alive as of the last
+// call to Scan. This can be called concurrently with Scan.
+func (p *Scanner) LiveProcesses() []ProcessID {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ret := make([]ProcessID, 0, p.mu.live.Len())
+	p.mu.live.Ascend(func(pid uint32) bool {
+		ret = append(ret, ProcessID(pid))
+		return true
+	})
+	return ret
 }

--- a/pkg/dyninst/procsubscribe/procscan/scanner_test.go
+++ b/pkg/dyninst/procsubscribe/procscan/scanner_test.go
@@ -374,8 +374,10 @@ type scanOutput struct {
 func (ts *scannerTestState) cloneState(
 	includeStartDelay bool,
 ) *scannerStateSnapshot {
+	ts.scanner.mu.Lock()
+	defer ts.scanner.mu.Unlock()
 	live := make([]int32, 0)
-	ts.scanner.live.Ascend(func(pid uint32) bool {
+	ts.scanner.mu.live.Ascend(func(pid uint32) bool {
 		live = append(live, int32(pid))
 		return true
 	})

--- a/pkg/dyninst/procsubscribe/remote_config.go
+++ b/pkg/dyninst/procsubscribe/remote_config.go
@@ -398,6 +398,82 @@ func (s *Subscriber) runConnectedStream(
 	return <-errCh
 }
 
+// ProcessReport contains information about a Go process that has been detected
+// and is being monitored for Dynamic Instrumentation updates.
+type ProcessReport struct {
+	RuntimeID    string             `json:"runtime_id"`
+	ProcessID    int32              `json:"process_id"`
+	Executable   process.Executable `json:"executable"`
+	SymDBEnabled bool               `json:"symdb_enabled"`
+	Probes       []ProbeInfo        `json:"probes"`
+	// ProcessAlive is set if the procscan.Scanner reports the process as alive.
+	// This should be true, except for races between the report and the Scanner
+	// recently figuring out that a process is dead.
+	ProcessAlive bool `json:"process_alive"`
+}
+
+// ProbeInfo contains information about a probe for the ProcessReport.
+type ProbeInfo struct {
+	ID      string `json:"id"`
+	Version int    `json:"version"`
+}
+
+// Report is a snapshot of the current state of the subscriber.
+type Report struct {
+	// Processes contains the state for all the currently tracked processes.
+	Processes []ProcessReport `json:"processes"`
+	// ProcessesNotTracked contains the PIDs of processes known to the scanner
+	// that are not tracked. This should be empty, except for to race conditions
+	// between producing this report and the scanner discovering new processes
+	// that have not been added to the tracked set yet.
+	ProcessesNotTracked []int32 `json:"processes_not_tracked"`
+}
+
+// GetReport returns a snapshot of the current state of the subscriber.
+func (s *Subscriber) GetReport() Report {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	liveProcs := map[int32]struct{}{}
+	if scanner, ok := s.scanner.(*procscan.Scanner); ok {
+		procs := scanner.LiveProcesses()
+		for _, proc := range procs {
+			liveProcs[int32(proc)] = struct{}{}
+		}
+	}
+
+	var ret Report
+	for _, entry := range s.mu.state.tracked {
+		pid := entry.Info.ProcessID.PID
+		_, alive := liveProcs[pid]
+		pr := ProcessReport{
+			RuntimeID:    entry.runtimeID,
+			ProcessID:    pid,
+			Executable:   entry.Executable,
+			SymDBEnabled: entry.symdbEnabled,
+			ProcessAlive: alive,
+		}
+		for _, probe := range entry.probesByPath {
+			pr.Probes = append(pr.Probes, ProbeInfo{
+				ID:      probe.GetID(),
+				Version: probe.GetVersion(),
+			})
+		}
+		ret.Processes = append(ret.Processes, pr)
+	}
+	// Look for processes known to the scanner that are not tracked. There
+	// should be no such processes, modulo race conditions between producing
+	// this report and the scanner discovering new processes that have not been
+	// added to the tracked set yet.
+	for pid := range liveProcs {
+		_, ok := s.mu.state.pidToRuntime[pid]
+		if ok {
+			continue
+		}
+		ret.ProcessesNotTracked = append(ret.ProcessesNotTracked, pid)
+	}
+	return ret
+}
+
 type parsedRemoteConfigUpdate struct {
 	probes        map[string]ir.ProbeDefinition
 	haveSymdbFile bool

--- a/pkg/dyninst/procsubscribe/remote_config.go
+++ b/pkg/dyninst/procsubscribe/remote_config.go
@@ -116,9 +116,9 @@ type optionFunc func(*config)
 
 func (f optionFunc) apply(c *config) { f(c) }
 
-// NewRemoteConfigProcessSubscriber creates a ProcessSubscriber that sources
-// updates directly from Remote Config.
-func NewRemoteConfigProcessSubscriber(
+// NewSubscriber creates a Subscriber that sources updates directly from Remote
+// Config.
+func NewSubscriber(
 	client RemoteConfigSubscriber,
 	opts ...Option,
 ) *Subscriber {

--- a/pkg/dyninst/procsubscribe/remote_config_test.go
+++ b/pkg/dyninst/procsubscribe/remote_config_test.go
@@ -168,7 +168,7 @@ func TestRemoteConfigProcessSubscriberTracksUpdatesAndRemovals(t *testing.T) {
 
 	waitRequests := make(waitRequestChan)
 	streams, remoteSub := runFakeAgentSecureServer(t)
-	subscriber := procsubscribe.NewRemoteConfigProcessSubscriber(
+	subscriber := procsubscribe.NewSubscriber(
 		remoteSub,
 		procsubscribe.WithProcessScanner(scanner),
 		procsubscribe.WithClock(mockClock),
@@ -319,7 +319,7 @@ func TestRetrackAfterNewStream(t *testing.T) {
 	}
 
 	streams, remoteSub := runFakeAgentSecureServer(t)
-	subscriber := procsubscribe.NewRemoteConfigProcessSubscriber(
+	subscriber := procsubscribe.NewSubscriber(
 		remoteSub,
 		procsubscribe.WithProcessScanner(scanner),
 		procsubscribe.WithClock(mockClock),
@@ -394,7 +394,7 @@ func TestRemoteConfigSymDBUpdates(t *testing.T) {
 	}
 
 	streams, remoteSub := runFakeAgentSecureServer(t)
-	subscriber := procsubscribe.NewRemoteConfigProcessSubscriber(
+	subscriber := procsubscribe.NewSubscriber(
 		remoteSub,
 		procsubscribe.WithProcessScanner(scanner),
 		procsubscribe.WithClock(mockClock),
@@ -512,7 +512,7 @@ func TestContainerAndGitInfoParsing(t *testing.T) {
 	}
 
 	streams, remoteSub := runFakeAgentSecureServer(t)
-	subscriber := procsubscribe.NewRemoteConfigProcessSubscriber(
+	subscriber := procsubscribe.NewSubscriber(
 		remoteSub,
 		procsubscribe.WithProcessScanner(scanner),
 		procsubscribe.WithClock(mockClock),
@@ -576,7 +576,7 @@ func TestExponentialBackoffUpToMaxDelayForNewStream(t *testing.T) {
 	mockClock := clock.NewMock()
 	streams, remoteSub := runFakeAgentSecureServer(t)
 	waitRequests := make(waitRequestChan)
-	subscriber := procsubscribe.NewRemoteConfigProcessSubscriber(
+	subscriber := procsubscribe.NewSubscriber(
 		remoteSub,
 		procsubscribe.WithProcessScanner(scanner),
 		procsubscribe.WithClock(mockClock),
@@ -635,7 +635,7 @@ func TestSymDBStatePreservedWhenNotInMatchedConfigs(t *testing.T) {
 	}
 
 	streams, remoteSub := runFakeAgentSecureServer(t)
-	subscriber := procsubscribe.NewRemoteConfigProcessSubscriber(
+	subscriber := procsubscribe.NewSubscriber(
 		remoteSub,
 		procsubscribe.WithProcessScanner(scanner),
 		procsubscribe.WithClock(mockClock),


### PR DESCRIPTION
This patch adds a debug endpoint /dynamic_instrumentation/debug/goprocs
(to be accessed through `system-probe debug dynamic_instrumentation
goprocs) that lists information about Go processes that are "tracked"
(i.e. the remote config module in the core agent was told to route
updates for the respective runtime ID to the system-probe), as well as
other processes that have been detected on the box. The two sets should
be the same, but we appear to have a bug that I'm trying to track down.