### PR TITLE
dyninst/procsubscribe: fix tracking of dead processes

### DIFF
--- a/pkg/dyninst/procsubscribe/procscan/scanner.go
+++ b/pkg/dyninst/procsubscribe/procscan/scanner.go
@@ -219,6 +219,7 @@ func (p *Scanner) Scan() (
 	removed = make([]ProcessID, 0, noLongerLive.Len())
 	noLongerLive.Ascend(func(pid uint32) bool {
 		removed = append(removed, ProcessID(pid))
+		p.live.Delete(pid)
 		return true
 	})
 	noLongerLive.Clear(true)

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/process_exit.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/process_exit.yaml
@@ -46,4 +46,3 @@ removed: [1001]
 state:
   current_time: 300
   last_watermark: 200
-  live: [1001]


### PR DESCRIPTION
We were not removing dead processes from the scanner's set of known processes, which caused them to be reported as removed repeatedly. This, in turn, caused the system-probe to ask the core agent's RC module to stop tracking those PIDs over and over.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
