### PR TITLE
`new-e2e-containers`: fix `EnableStringUnmarshal` to support YAML

### DIFF
--- a/comp/core/workloadfilter/catalog/filter_config.go
+++ b/comp/core/workloadfilter/catalog/filter_config.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/impl/parse"
@@ -130,25 +128,9 @@ func (fc *FilterConfig) GetLegacyContainerExclude() []string {
 func loadCELConfig(cfg config.Component) ([]workloadfilter.RuleBundle, error) {
 	var celConfig []workloadfilter.RuleBundle
 
-	// First try the standard UnmarshalKey method (input defined in datadog.yaml)
-	err := structure.UnmarshalKey(cfg, "cel_workload_exclude", &celConfig)
-	if err == nil {
-		return celConfig, nil
-	}
-
-	// Fallback: try to get raw value and unmarshal manually
-	rawValue := cfg.GetString("cel_workload_exclude")
-	if rawValue == "" {
-		return nil, nil
-	}
-
-	// handles both yaml and json input
-	err = yaml.Unmarshal([]byte(rawValue), &celConfig)
-	if err == nil {
-		return celConfig, nil
-	}
-
-	return nil, err
+	// UnmarshalKey with EnableStringUnmarshal handles both YAML and JSON from env vars
+	err := structure.UnmarshalKey(cfg, "cel_workload_exclude", &celConfig, structure.EnableStringUnmarshal)
+	return celConfig, err
 }
 
 // String returns a simple string representation of the FilterConfig

--- a/comp/core/workloadfilter/catalog/filter_config_test.go
+++ b/comp/core/workloadfilter/catalog/filter_config_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNewFilterConfig_CELFallback(t *testing.T) {
-	t.Run("successful unmarshal - no fallback needed", func(t *testing.T) {
+	t.Run("successful unmarshal", func(t *testing.T) {
 
 		mockConfig := configmock.New(t)
 
@@ -40,7 +40,7 @@ func TestNewFilterConfig_CELFallback(t *testing.T) {
 		assert.Contains(t, filterConfig.CELProductRules, workloadfilter.ProductMetrics)
 	})
 
-	t.Run("unmarshal fails but YAML string fallback succeeds", func(t *testing.T) {
+	t.Run("unmarshal YAML string succeeds", func(t *testing.T) {
 		mockConfig := configmock.New(t)
 
 		// Set up YAML string like what would come from configuration files
@@ -69,7 +69,7 @@ func TestNewFilterConfig_CELFallback(t *testing.T) {
 		assert.Equal(t, "service.name == 'yaml-service'", serviceRules)
 	})
 
-	t.Run("unmarshal fails but JSON string fallback succeeds", func(t *testing.T) {
+	t.Run("unmarshal JSON string succeeds", func(t *testing.T) {
 		mockConfig := configmock.New(t)
 		jsonConfig := `[
 			{
@@ -97,7 +97,7 @@ func TestNewFilterConfig_CELFallback(t *testing.T) {
 		assert.Equal(t, "service.name == 'test-service'", serviceRules)
 	})
 
-	t.Run("both unmarshal and fallback fail", func(t *testing.T) {
+	t.Run("unmarshal invalid string fails", func(t *testing.T) {
 		mockConfig := configmock.New(t)
 		mockConfig.SetWithoutSource("cel_workload_exclude", "invalid string data")
 

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -57,14 +57,14 @@ type Endpoint struct {
 	// wrongly update an endpoint when an API key is linked to multuple endpoints.
 	additionalEndpointsIdx int
 
-	Host                    string `mapstructure:"host" json:"host"`
+	Host                    string `mapstructure:"host" json:"host" yaml:"host"`
 	Port                    int
-	PathPrefix              string `mapstructure:"path_prefix" json:"path_prefix"`
-	UseCompression          bool   `mapstructure:"use_compression" json:"use_compression"`
-	CompressionKind         string `mapstructure:"compression_kind" json:"compression_kind"`
-	CompressionLevel        int    `mapstructure:"compression_level" json:"compression_level"`
+	PathPrefix              string `mapstructure:"path_prefix" json:"path_prefix" yaml:"path_prefix"`
+	UseCompression          bool   `mapstructure:"use_compression" json:"use_compression" yaml:"use_compression"`
+	CompressionKind         string `mapstructure:"compression_kind" json:"compression_kind" yaml:"compression_kind"`
+	CompressionLevel        int    `mapstructure:"compression_level" json:"compression_level" yaml:"compression_level"`
 	ProxyAddress            string
-	IsMRF                   bool `mapstructure:"-" json:"-"`
+	IsMRF                   bool `mapstructure:"-" json:"-" yaml:"-"`
 	ConnectionResetInterval time.Duration
 
 	BackoffFactor    float64
@@ -79,14 +79,14 @@ type Endpoint struct {
 	Origin    IntakeOrigin
 }
 
-// unmarshalEndpoint is used to load additional endpoints from the configuration which stored as JSON/mapstructure.
+// unmarshalEndpoint is used to load additional endpoints from the configuration which stored as JSON/YAML/mapstructure.
 // A different type is used than Endpoint since we want some fields to be private in Endpoint (APIKey, IsReliable, ...).
 type unmarshalEndpoint struct {
-	APIKey     string `mapstructure:"api_key" json:"api_key"`
-	IsReliable *bool  `mapstructure:"is_reliable" json:"is_reliable"`
-	UseSSL     *bool  `mapstructure:"use_ssl" json:"use_ssl"`
+	APIKey     string `mapstructure:"api_key" json:"api_key" yaml:"api_key"`
+	IsReliable *bool  `mapstructure:"is_reliable" json:"is_reliable" yaml:"is_reliable"`
+	UseSSL     *bool  `mapstructure:"use_ssl" json:"use_ssl" yaml:"use_ssl"`
 
-	Endpoint `mapstructure:",squash"`
+	Endpoint `mapstructure:",squash" yaml:",inline"`
 }
 
 // EndpointCompressionOptions is the compression options for the endpoint

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -145,12 +145,12 @@ type AutoMultilineSample struct {
 	// MatchThreshold is the ratio of tokens that must match between the sample and the log message to consider it a match.
 	// From a user perspective, this is how similar the log has to be to the sample to be considered a match.
 	// Optional - Default value is 0.75.
-	MatchThreshold *float64 `mapstructure:"match_threshold,omitempty" json:"match_threshold,omitempty"`
+	MatchThreshold *float64 `mapstructure:"match_threshold,omitempty" json:"match_threshold,omitempty" yaml:"match_threshold,omitempty"`
 	// Regex is a pattern used to aggregate logs. NOTE that you can use either a sample or a regex, but not both.
-	Regex string `mapstructure:"regex,omitempty" json:"regex,omitempty"`
+	Regex string `mapstructure:"regex,omitempty" json:"regex,omitempty" yaml:"regex,omitempty"`
 	// Label is the label to apply to the log message if it matches the sample.
 	// Optional - Default value is "start_group".
-	Label *string `mapstructure:"label,omitempty" json:"label,omitempty"`
+	Label *string `mapstructure:"label,omitempty" json:"label,omitempty" yaml:"label,omitempty"`
 }
 
 // StringSliceField is a custom type for unmarshalling comma-separated string values or typical yaml fields into a slice of strings.

--- a/pkg/config/structure/go.mod
+++ b/pkg/config/structure/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/spf13/cast v1.10.0
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -36,7 +37,6 @@ require (
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -7,10 +7,10 @@
 package structure
 
 import (
-	"encoding/json"
 	"reflect"
 
 	mapstructure "github.com/go-viper/mapstructure/v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/config/helper"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -40,7 +40,7 @@ var ErrorUnused UnmarshalKeyOption = func(fs *featureSet) {
 	fs.errorUnused = true
 }
 
-// EnableStringUnmarshal allows UnmarshalKey to handle stringified json and Unmarshal it
+// EnableStringUnmarshal allows UnmarshalKey to handle stringified YAML (including JSON) and Unmarshal it
 var EnableStringUnmarshal UnmarshalKeyOption = func(fs *featureSet) {
 	fs.stringUnmarshal = true
 }
@@ -86,7 +86,7 @@ func UnmarshalKey(cfg model.Reader, key string, target interface{}, opts ...Unma
 			if str == "" {
 				return nil
 			}
-			return json.Unmarshal([]byte(str), &target)
+			return yaml.Unmarshal([]byte(str), target)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?
This fixes the `TestK8SCELFilteringSuite` E2E test failure where `DD_CEL_WORKLOAD_EXCLUDE` contained YAML that failed to parse with:
```
failed to parse 'cel_workload_exclude' filters. Provided value:
        - products: ["global"]
          rules:
            containers:
            - container.name == "redis"
            - container.pod.namespace == "filtered-ns"
        Error: invalid character ' ' in numeric literal
```
([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1274680134#L536))

### Motivation
`EnableStringUnmarshal` was only parsing JSON, causing failures when Kubernetes environment variables contained YAML format. Since YAML is a superset of JSON, we can use `yaml.Unmarshal` to handle both formats.

The `DD_CEL_WORKLOAD_EXCLUDE` configuration was introduced in PR #43203 and tested in PR #43003. PR #43677 attempted to use `EnableStringUnmarshal` for parsing this config, but was reverted in PR #43887 due to the JSON-only limitation.
This commit addresses the root cause and reintroduces the changes from PR #43677.

### Describe how you validated your changes
New test covering both YAML as well as the earlier JSON.