### PR TITLE
libyaml: fix default shared lib name

### DIFF
--- a/deps/libyaml.BUILD.bazel
+++ b/deps/libyaml.BUILD.bazel
@@ -45,14 +45,14 @@ cc_library(
 )
 
 cc_shared_library(
-    name = "libyaml_so",
+    name = "yaml",
     deps = [":libyaml"],
     visibility = ["//visibility:public"],
 )
 
 so_symlink(
     name = "lib_files",
-    src = ":libyaml_so",
+    src = ":yaml",
     libname = "libyaml",
     version = VERSION,
 )


### PR DESCRIPTION
### What does this PR do?

Ensure the yaml shared library is named `libyaml.{so|dylib}`

### Motivation

Currently a lib linking with libyaml's cc_shared_library would attempt to load `liblibyaml_so.so` at runtime

### Describe how you validated your changes

### Additional Notes
