### PR TITLE
Bumps lading's minor version

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.29.1
+  version: 0.30.0
 
 target:
 


### PR DESCRIPTION
### What does this PR do?

- bumps lading's minor version to `0.30`

### Motivation

Some of the changes included in this minor version of lading are required to be able to start testing out SMP metal runners (for eBPF).

### Describe how you validated your changes

I will let the regression detector job run and complete.

### Additional Notes

N/A
