### PR TITLE
Exclude exit code `36` from `bazel` diagnostics on :window:

### DIFF
--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -57,7 +57,9 @@ set "bazel_exit=!errorlevel!"
 
 :: Diagnostics: dump logs on non-trivial failures (https://bazel.build/run/scripts#exit-codes)
 :: TODO(regis): adjust (probably `== 37`) next time a `cannot connect to Bazel server` error happens (#incident-42947)
-if !bazel_exit! geq 2 (
+set "should_diagnose=1"
+for %%c in (0 1 36) do if !bazel_exit!==%%c set "should_diagnose=0"
+if !should_diagnose!==1 (
   >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !bazel_home! ^(excluding junctions^):
   for /f "delims=" %%d in ('dir /a:d-l /b "!bazel_home!"') do (
     >&2 echo 🟡 [%%d]


### PR DESCRIPTION
### Motivation
Exit code `36` is a [Local Environmental Issue, suspected permanent](https://bazel.build/run/scripts#exit-codes) for which it doesn't make sense to dump verbose diagnostics.

### What does this PR do?
Modify the diagnostic condition to use a maintainable list of excluded codes `(0, 1, 36)` instead of a simple `>= 2` check.