### PR TITLE
Only check DCE on deploy pipelines for systray

### DIFF
--- a/tasks/systray.py
+++ b/tasks/systray.py
@@ -59,7 +59,7 @@ def build(ctx, debug=False, console=False, rebuild=False, race=False, go_mod="re
         bin_path=os.path.join(BIN_PATH, bin_name("ddtray")),
         ldflags=ldflags,
         env=env,
-        check_deadcode=True,
+        check_deadcode=os.getenv("DEPLOY_AGENT") == "true",
         build_tags=["grpcnotrace"],
     )
 


### PR DESCRIPTION
### What does this PR do?
Only check DCE on deploy pipelines for systray.

### Motivation
We only check this on deploy pipelines for other binaries to reduce CI duration, always enabling this was to ease testing and shouldn't have been merged.

### Describe how you validated your changes
CI

### Additional Notes
