### PR TITLE
ensure system-probe config is adjusted at runtime

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -121,7 +121,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// settings for system-probe in general
 	cfg.BindEnvAndSetDefault(join(spNS, "enabled"), false, "DD_SYSTEM_PROBE_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "external"), false, "DD_SYSTEM_PROBE_EXTERNAL")
-	cfg.SetKnown(join(spNS, "adjusted")) //nolint:forbidigo // runtime setting only
+	cfg.SetDefault(join(spNS, "adjusted"), false)
 
 	cfg.BindEnvAndSetDefault(join(spNS, "sysprobe_socket"), DefaultSystemProbeAddress, "DD_SYSPROBE_SOCKET")
 	cfg.BindEnvAndSetDefault(join(spNS, "max_conns_per_message"), defaultConnsMessageBatchSize)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -121,7 +121,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// settings for system-probe in general
 	cfg.BindEnvAndSetDefault(join(spNS, "enabled"), false, "DD_SYSTEM_PROBE_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "external"), false, "DD_SYSTEM_PROBE_EXTERNAL")
-	cfg.SetKnown(join(spNS, "adjusted")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.SetKnown(join(spNS, "adjusted")) //nolint:forbidigo // runtime setting only
 
 	cfg.BindEnvAndSetDefault(join(spNS, "sysprobe_socket"), DefaultSystemProbeAddress, "DD_SYSPROBE_SOCKET")
 	cfg.BindEnvAndSetDefault(join(spNS, "max_conns_per_message"), defaultConnsMessageBatchSize)

--- a/pkg/system-probe/config/adjust.go
+++ b/pkg/system-probe/config/adjust.go
@@ -21,7 +21,7 @@ var adjustMtx sync.Mutex
 func Adjust(cfg model.Config) {
 	adjustMtx.Lock()
 	defer adjustMtx.Unlock()
-	if cfg.GetBool(spNS("adjusted")) {
+	if k := spNS("adjusted"); cfg.GetBool(k) && cfg.GetSource(k) == model.SourceAgentRuntime {
 		return
 	}
 


### PR DESCRIPTION
### What does this PR do?

Ensures that `system_probe_config.adjusted` is set at runtime.

### Motivation

This config key is for runtime use only, to indicate that the configuration has been "adjusted" (setting inference, validation, etc.)

### Describe how you validated your changes

### Additional Notes
