### PR TITLE
Replace all `filepath.Walk` by `filepath.WalkDir`

### DIFF
--- a/comp/core/autodiscovery/providers/process_log.go
+++ b/comp/core/autodiscovery/providers/process_log.go
@@ -107,14 +107,14 @@ func discoverIntegrationSources() map[string]bool {
 			continue
 		}
 
-		err := filepath.Walk(searchPath, func(path string, info os.FileInfo, err error) error {
+		err := filepath.WalkDir(searchPath, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return nil // Continue walking, don't fail on individual errors
 			}
-			if info.IsDir() {
+			if d.IsDir() {
 				return nil
 			}
-			if info.Name() != "conf.yaml.example" && info.Name() != "conf.yaml" {
+			if d.Name() != "conf.yaml.example" && d.Name() != "conf.yaml" {
 				return nil
 			}
 

--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -387,11 +387,11 @@ func (fb *builder) copyDirTo(shouldScrub bool, srcDir string, destDir string, sh
 
 	fb.RegisterFilePerm(srcDir)
 
-	err = filepath.Walk(srcDir, func(src string, f os.FileInfo, _ error) error {
-		if f == nil {
+	err = filepath.WalkDir(srcDir, func(src string, d os.DirEntry, _ error) error {
+		if d == nil {
 			return nil
 		}
-		if f.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
@@ -458,8 +458,8 @@ func (fb *builder) RegisterDirPerm(path string) {
 		return
 	}
 
-	_ = filepath.Walk(path, func(src string, f os.FileInfo, _ error) error {
-		if f != nil {
+	_ = filepath.WalkDir(path, func(src string, d os.DirEntry, _ error) error {
+		if d != nil {
 			fb.permsInfos.add(src)
 		}
 		return nil

--- a/comp/forwarder/defaultforwarder/internal/retry/file_removal_policy_test.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/file_removal_policy_test.go
@@ -88,12 +88,12 @@ func createFile(a *assert.Assertions, root string, filename string) string {
 
 func getRemainingFiles(a *assert.Assertions, folder string) []string {
 	var files []string
-	a.NoError(filepath.Walk(folder,
-		func(p string, info os.FileInfo, err error) error {
+	a.NoError(filepath.WalkDir(folder,
+		func(p string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if info.Mode().IsRegular() {
+			if d.Type().IsRegular() {
 				files = append(files, p)
 			}
 			return nil

--- a/pkg/compliance/aptconfig/aptconfig.go
+++ b/pkg/compliance/aptconfig/aptconfig.go
@@ -59,8 +59,8 @@ func LoadConfiguration(_ context.Context, hostroot string) (types.ResourceType, 
 	systemdConfDir := filepath.Join(hostroot, systemdConfDir)
 	systemdTimersConfs := make(map[string]interface{})
 	var systemdConfFiles []string
-	_ = filepath.Walk(systemdConfDir, func(path string, info fs.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
+	_ = filepath.WalkDir(systemdConfDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
 			return err
 		}
 		base := filepath.Base(path)

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -354,11 +354,11 @@ func buildOperationsFromLegacyInstaller(rootPath string) []FileOperation {
 		FilePath:          "/managed",
 	})
 
-	err = filepath.Walk(stableDirPath, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(stableDirPath, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -474,13 +474,13 @@ func TestNoOutsideImport(t *testing.T) {
 	}
 
 	// Walk the directory tree
-	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Only check .go files
-		if !info.IsDir() && strings.HasSuffix(info.Name(), ".go") {
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".go") {
 			// Create a file set and parse the file
 			fs := token.NewFileSet()
 			node, err := parser.ParseFile(fs, path, nil, parser.ImportsOnly)

--- a/pkg/fleet/installer/packages/file/file.go
+++ b/pkg/fleet/installer/packages/file/file.go
@@ -254,7 +254,7 @@ func chown(ctx context.Context, path string, username string, group string) (err
 
 func filesInDir(dir string) ([]string, error) {
 	var files []string
-	err := filepath.Walk(dir, func(path string, _ os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir, func(path string, _ os.DirEntry, err error) error {
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("error walking path: %w", err)
 		}

--- a/pkg/fleet/installer/packages/integrations/integrations.go
+++ b/pkg/fleet/installer/packages/integrations/integrations.go
@@ -92,7 +92,7 @@ func RestoreCustomIntegrations(ctx context.Context, installPath string) (err err
 // It walks through the installPath and collects paths that match the './embedded/lib/python*/site-packages/datadog_*' pattern.
 func getAllIntegrations(installPath string) ([]string, error) {
 	allIntegrations := make([]string, 0)
-	err := filepath.Walk(installPath, func(path string, _ os.FileInfo, err error) error {
+	err := filepath.WalkDir(installPath, func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -180,18 +180,18 @@ func RemoveCompiledFiles(installPath string) error {
 		}
 	}
 	// Remove files in {installPath}/bin/agent/dist
-	err = filepath.Walk(filepath.Join(installPath, "bin", "agent", "dist"), func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(filepath.Join(installPath, "bin", "agent", "dist"), func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			if !os.IsNotExist(err) {
 				return nil
 			}
 			return err
 		}
-		if info.IsDir() && info.Name() == "__pycache__" {
+		if d.IsDir() && d.Name() == "__pycache__" {
 			if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
 				return err
 			}
-		} else if strings.HasSuffix(info.Name(), ".pyc") || strings.HasSuffix(info.Name(), ".pyo") {
+		} else if strings.HasSuffix(d.Name(), ".pyc") || strings.HasSuffix(d.Name(), ".pyo") {
 			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 				return err
 			}
@@ -202,18 +202,18 @@ func RemoveCompiledFiles(installPath string) error {
 		return fmt.Errorf("failed to remove compiled files: %w", err)
 	}
 	// Remove files in {installPath}/python-scripts
-	err = filepath.Walk(filepath.Join(installPath, "python-scripts"), func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(filepath.Join(installPath, "python-scripts"), func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			if !os.IsNotExist(err) {
 				return nil
 			}
 			return err
 		}
-		if info.IsDir() && info.Name() == "__pycache__" {
+		if d.IsDir() && d.Name() == "__pycache__" {
 			if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
 				return err
 			}
-		} else if strings.HasSuffix(info.Name(), ".pyc") || strings.HasSuffix(info.Name(), ".pyo") {
+		} else if strings.HasSuffix(d.Name(), ".pyc") || strings.HasSuffix(d.Name(), ".pyo") {
 			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 				return err
 			}

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -558,11 +558,11 @@ func (l *link) Delete() error {
 
 func buildFileMap(rootPath string) (map[string]struct{}, error) {
 	files := make(map[string]struct{})
-	err := filepath.Walk(rootPath, func(path string, info fs.FileInfo, err error) error {
+	err := filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
+		if !d.IsDir() {
 			relPath, err := filepath.Rel(rootPath, path)
 			if err != nil {
 				return fmt.Errorf("failed to get relative path: %w", err)
@@ -603,7 +603,7 @@ func repairDirectory(sourcePath, targetPath string) error {
 	}
 
 	// Walk through source directory and compare/copy files
-	return filepath.Walk(sourcePath, func(path string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(sourcePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -617,8 +617,12 @@ func repairDirectory(sourcePath, targetPath string) error {
 		// Construct target path
 		targetFilePath := filepath.Join(targetPath, relPath)
 
-		if info.IsDir() {
+		if d.IsDir() {
 			// Create directory if it doesn't exist
+			info, err := d.Info()
+			if err != nil {
+				return fmt.Errorf("failed to get directory info: %w", err)
+			}
 			return os.MkdirAll(targetFilePath, info.Mode())
 		}
 

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -401,9 +401,9 @@ func ShouldIgnore(validatePodContainerID bool, file *tailer.File) bool {
 	}
 
 	infos := make(map[string]string)
-	err := filepath.Walk(ContainersLogsDir, func(containerLogFilename string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(ContainersLogsDir, func(containerLogFilename string, d os.DirEntry, err error) error {
 		// we only wants to follow symlinks
-		if info == nil || info.Mode()&os.ModeSymlink != os.ModeSymlink || info.IsDir() {
+		if d == nil || d.Type()&os.ModeSymlink != os.ModeSymlink || d.IsDir() {
 			// not a symlink, we are not interested in this file
 			return nil
 		}

--- a/pkg/security/probe/sysctl/snapshot.go
+++ b/pkg/security/probe/sysctl/snapshot.go
@@ -114,17 +114,21 @@ func (s *Snapshot) Snapshot(ignoredBaseNames []string, kernelCompilationFlags ma
 
 // snapshotProcSys recursively reads files in /proc/sys and builds a nested JSON structure.
 func (s *Snapshot) snapshotProcSys(ignoredBaseNames []string) error {
-	return filepath.Walk(kernel.HostProc("/sys"), func(file string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(kernel.HostProc("/sys"), func(file string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Skip directories
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
 		// Skip if mode doesn't allow reading
+		info, err := d.Info()
+		if err != nil {
+			return nil // Skip files that can't be read
+		}
 		mode := info.Mode()
 		if mode&0444 == 0 {
 			return nil
@@ -159,17 +163,21 @@ func (s *Snapshot) snapshotSys(ignoredBaseNames []string) error {
 	}
 
 	// fetch secure boot status, ignore when missing
-	_ = filepath.Walk(kernel.HostSys("/firmware/efi/efivars/"), func(file string, info fs.FileInfo, err error) error {
+	_ = filepath.WalkDir(kernel.HostSys("/firmware/efi/efivars/"), func(file string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Skip directories
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
 		// Skip if mode doesn't allow reading
+		info, err := d.Info()
+		if err != nil {
+			return nil // Skip files we can't read info for
+		}
 		mode := info.Mode()
 		if mode&0444 == 0 {
 			return nil
@@ -197,17 +205,21 @@ func (s *Snapshot) snapshotSys(ignoredBaseNames []string) error {
 	})
 
 	// add CPU vulnerabilities, ignore when missing
-	_ = filepath.Walk(kernel.HostSys("/devices/system/cpu/vulnerabilities"), func(file string, info fs.FileInfo, err error) error {
+	_ = filepath.WalkDir(kernel.HostSys("/devices/system/cpu/vulnerabilities"), func(file string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Skip directories
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
 		// Skip if mode doesn't allow reading
+		info, err := d.Info()
+		if err != nil {
+			return nil // Skip files we can't read info for
+		}
 		mode := info.Mode()
 		if mode&0444 == 0 {
 			return nil

--- a/pkg/security/probe/sysctl/snapshot.go
+++ b/pkg/security/probe/sysctl/snapshot.go
@@ -127,7 +127,7 @@ func (s *Snapshot) snapshotProcSys(ignoredBaseNames []string) error {
 		// Skip if mode doesn't allow reading
 		info, err := d.Info()
 		if err != nil {
-			return nil // Skip files that can't be read
+			return err
 		}
 		mode := info.Mode()
 		if mode&0444 == 0 {
@@ -176,7 +176,7 @@ func (s *Snapshot) snapshotSys(ignoredBaseNames []string) error {
 		// Skip if mode doesn't allow reading
 		info, err := d.Info()
 		if err != nil {
-			return nil // Skip files we can't read info for
+			return err
 		}
 		mode := info.Mode()
 		if mode&0444 == 0 {
@@ -218,7 +218,7 @@ func (s *Snapshot) snapshotSys(ignoredBaseNames []string) error {
 		// Skip if mode doesn't allow reading
 		info, err := d.Info()
 		if err != nil {
-			return nil // Skip files we can't read info for
+			return err
 		}
 		mode := info.Mode()
 		if mode&0444 == 0 {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -2869,12 +2869,12 @@ func BenchmarkThroughput(b *testing.B) {
 	log.SetLogger(log.NoopLogger) // disable logging
 
 	folder := filepath.Join(env, "benchmarks")
-	filepath.Walk(folder, func(path string, info os.FileInfo, _ error) error {
+	filepath.WalkDir(folder, func(path string, d os.DirEntry, _ error) error {
 		ext := filepath.Ext(path)
 		if ext != ".msgp" {
 			return nil
 		}
-		b.Run(info.Name(), benchThroughput(path))
+		b.Run(d.Name(), benchThroughput(path))
 		return nil
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Replace all `filepath.Walk` by `filepath.WalkDir`.

### Motivation

On a staging cluster I used to profile the datadog agent, I noticed that the `filepath.Walk` called by the files logs launcher was consuming almost 4% of CPU.
<img width="3171" height="1136" alt="image" src="https://github.com/user-attachments/assets/2a406bf7-74c9-4504-a083-7f304fff03d0" />

The [Go documentation](https://pkg.go.dev/path/filepath#Walk) says that:
> Walk is less efficient than [WalkDir](https://pkg.go.dev/path/filepath#WalkDir), introduced in Go 1.16, which avoids calling `os.Lstat` on every visited file or directory.

And, when zooming in on the CPU profile, we can see that the said `Lstat` that can be saved by migrating from `filepath.Walk` to `filepath.WalkDir` represents almost 1.5% of CPU:
<img width="1808" height="1135" alt="image" src="https://github.com/user-attachments/assets/70ad0261-6ded-49bc-9aca-e2832a9d7086" />


### Describe how you validated your changes

No functional change is expected. Let the CI run the e2e tests.

### Additional Notes

I decided to migrate all the `filepath.Walk` even if they don’t appear on a hot path on profiles because there shouldn’t be any drawback of using the more modern API.
In some cases, we still need the `os.FileInfo` to check file permissions. In those cases, we call `d.Info()`, but only for the subset of files we’re interested in.