### PR TITLE
Allow for heroku variant build.

### DIFF
--- a/compliance/BUILD.bazel
+++ b/compliance/BUILD.bazel
@@ -12,6 +12,19 @@ py_binary(
     deps = ["//tasks:licenses"],
 )
 
+filegroup(
+    name = "all_agent_deps",
+    srcs = [
+        "//deps:all_deps",
+    ] + select({
+        "//packages/agent:linux_heroku": [],
+        "//conditions:default": [
+            # This will become "//deps/openscap:all_deps" in the future
+            "@popt",
+        ],
+    }),
+)
+
 # Gather the licenses for dependencies that not built by omnibus any more.
 # The target is a temporary hack. In the future, it should become //distrib:agent.
 license_csv(
@@ -20,7 +33,7 @@ license_csv(
     licenses_dir = "licenses_dir",
     offers_dir = "sources_dir",
     tags = ["manual"],
-    target = "//deps:all_deps",
+    target = ":all_agent_deps",
 )
 
 # Turn the copied licenses into a target we can feed to other rules.
@@ -62,7 +75,7 @@ filter_directory(
     strip_prefix = ".",
 )
 
-# You would expect that filter_directory returns something usuable to pkg_* rules.
+# You would expect that filter_directory returns something usable to pkg_* rules.
 # It does not, so we have to wrap it.
 pkg_files(
     name = "offer_copies",

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -29,7 +29,6 @@ filegroup(
             "@libxslt",
             "@nghttp2",
             "@pcre2",
-            "@popt",
             "@zstd",
         ],
         "//:macos_arm64": [

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -25,7 +25,9 @@ build do
     # TODO too many things done here, should be split
     block do
         # Push all the pieces built with Bazel.
-        command_on_repo_root "bazelisk run -- //packages/install_dir:install --destdir=#{install_dir}",  env: {"BUILD_WORKSPACE_DIRECTORY" => "." }
+
+        # TODO: flavor can be defaulted and set from the bazel wrapper based on the environment.
+        command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/install_dir:install"
 
         # Conf files
         if windows_target?
@@ -64,6 +66,7 @@ build do
             delete "#{install_dir}/embedded/include/dbus-1.0"
         end
 
+        # TODO: Rather than move these, let's install them to the right place to start
         if linux_target?
             # Move configuration files
             mkdir "#{output_config_dir}/etc/datadog-agent"

--- a/packages/agent/BUILD.bazel
+++ b/packages/agent/BUILD.bazel
@@ -1,0 +1,45 @@
+# Agent packages
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+string_flag(
+    name = "flavor",
+    build_setting_default = "base",
+    # These values match omnibus.
+    values = [
+        "base",
+        "fips",
+        "heroku",
+    ],
+)
+
+alias(
+    name = "default_flavor",
+    actual = ":base_flavor",
+)
+
+config_setting(
+    name = "base_flavor",
+    flag_values = {"@@//packages/agent:flavor": "base"},
+)
+
+config_setting(
+    name = "fips_flavor",
+    flag_values = {"@@//packages/agent:flavor": "fips"},
+)
+
+config_setting(
+    name = "heroku_flavor",
+    flag_values = {"@@//packages/agent:flavor": "heroku"},
+)
+
+selects.config_setting_group(
+    name = "linux_heroku",
+    match_all = [
+        ":heroku_flavor",
+        "@platforms//os:linux",
+    ],
+)

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -29,11 +29,27 @@ pkg_filegroup(
     }),
 )
 
+# All the things that belong in /etc
+# This is not strictly in install_dir but it is a cousin.
+# TODO: split this cleanly.  The way the omnibus script works
+# is to install everything into install_dir (/opt/datadog-agent)
+# and then bulk move things to {output_dir}/etc/ in the finalizer.
+# We need to fix that so we just generate to the right place. For
+# now, let's just try to keep etc things separate.
+pkg_filegroup(
+    name = "etc",
+    srcs = [
+        "//deps/snmp_traps:all_files",
+    ],
+)
+
+# Gather everything that goes in /opt/datadog-agent/...
 pkg_install(
     name = "install",
     srcs = [
         ":embedded",
+        ":etc",
         ":licenses",
-        "//deps/snmp_traps:all_files",
     ],
+    destdir_flag = "//:install_dir",
 )


### PR DESCRIPTION
- Create agent "flavor" flags (none, fips, heroku)
- These can be used from the command line to install different pieces of the agent as needed.
- Use the distinction to install the correct set of OSS licenses.
- Fix license file for libpopt

### Notes
Changing for heroku will invalidate the cache, but I can live with that
- it is a smaller build than the rest, an already a distinct pipelin
- for now, we are only using it for the packaging layers.  My plan is to adopt Flagsets to be able to limit the scope of the flavor flag so that it will not reach outside of //packages/...

### Testing
- Run tests and grab the .deb files
  - datadog-agent_7.75.0~devel.git.184.f795fc1.pipeline.85441522-1_arm64.deb
  - datadog-heroku-agent_7.75.0~devel.git.184.f795fc1.pipeline.85441522-1_amd64.deb
- unpack them both
- diff em
```
$ diff -r heroku/opt/datadog-agent/LICENSES plain/opt/datadog-agent/LICENSES
Only in plain/opt/datadog-agent/LICENSES: LICENSE-agent-data-plane-3rdparty.csv
Only in plain/opt/datadog-agent/LICENSES: LICENSES
Only in plain/opt/datadog-agent/LICENSES: attr-LGPL-2.1
Only in plain/opt/datadog-agent/LICENSES: dbus-AFL-2.1.txt
Only in plain/opt/datadog-agent/LICENSES: libgcrypt-COPYING.LIB
Only in plain/opt/datadog-agent/LICENSES: libkrb5-NOTICE
Only in plain/opt/datadog-agent/LICENSES: libselinux-LICENSE
Only in plain/opt/datadog-agent/LICENSES: lua-license.html
Only in plain/opt/datadog-agent/LICENSES: openscap-COPYING
Only in plain/opt/datadog-agent/LICENSES: popt-COPYING
Only in plain/opt/datadog-agent/LICENSES: rpm-COPYING
Only in plain/opt/datadog-agent/LICENSES: secret-generic-connector-LICENSE
Only in plain/opt/datadog-agent/LICENSES: util-linux-COPYING
Only in plain/opt/datadog-agent/LICENSES: xmlsec-Copyright
Only in plain/opt/datadog-agent/LICENSES: zstd-LICENSE
```  
This is what we expect. All the openscap pieces are not in the heroku build

The important one is popt-COPYING. Since it was removed from //deps:all_deps we would not expect it, but now it is included through the flavor specific change to //compliance:all_agent_deps.

A smaller, but targeted test also shows the inclusion of popt-COPYING.
```
$ bazelisk run -- //packages/install_dir:install --destdir=/tmp/xdefault
$ bazelisk run --//packages/agent:flavor=heroku -- //packages/install_dir:install --destdir=/tmp/xhero
$ diff -r /tmp/xhero/  /tmp/xdefault/
Only in /tmp/xdefault/LICENSES: popt-COPYING
```

### Next steps
- create //deps/openscap to being the openscap build
  - collect all scap deps under there and move them out of //deps:all_deps
  - point non-heroku compliance at //deps/openscap:all_deps instead of popt
 - try this out with the Flagsets feature. 
