### PR TITLE
`codereview-complexity`: fix `yq` syntax and robustify `curl`

### DIFF
--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -16,9 +16,8 @@ runs:
   - name: Set version
     id: set-version
     run: |-
-      buildimages_version="$(yq '.variables.CI_IMAGE_LINUX' .gitlab-ci.yml)"
-      buildimages_commit="${buildimages_version#*-}"
-      version="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${buildimages_commit}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
+      buildimages_commit="$(yq -r '.variables.CI_IMAGE_LINUX | split("-") | .[-1]' .gitlab-ci.yml)"
+      version="$(curl -fsSL --retry 2 https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${buildimages_commit}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
       echo "version=${version}" >> $GITHUB_OUTPUT
     shell: bash
 


### PR DESCRIPTION
### What does this PR do?
1. add missing `-r` (raw output` to `yq` to make sure it doesn't issue surrounding quotes
2. replace `bash` post-processing by `yq` equivalent
3. make `curl` more robust: 
    - `-f`: fail on HTTP errors
    - `-S`: show errors
    - `-L`: follow redirects
    - `--retry 2`: perform up to 3 attempts

### Motivation
```
Download action repository 'DataDog/datadog-agent-dev@00e4a423088309efce1d5ba6b8c5366eef648710' (SHA:00e4a423088309efce1d5ba6b8c5366eef648710)
Run ./.github/actions/install-dda
  with:
    features: legacy-tasks
Run buildimages_version="$(yq '.variables.CI_IMAGE_LINUX' .gitlab-ci.yml)"
  buildimages_version="$(yq '.variables.CI_IMAGE_LINUX' .gitlab-ci.yml)"
  buildimages_commit="${buildimages_version#*-}"
  version="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${buildimages_commit}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
  echo "version=${version}" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
Error: Process completed with exit code 56.
```
([example](https://github.com/DataDog/datadog-agent/actions/runs/20055671493/job/57520336860))