### PR TITLE
[CWS] make cgroup getter naming clear

### DIFF
--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -242,7 +242,7 @@ func (fh *EBPFFieldHandlers) ResolveContainerContext(ev *model.Event) (*model.Co
 	}
 
 	if ev.ProcessContext.ContainerContext.ContainerID != "" {
-		if containerContext, _ := fh.resolvers.CGroupResolver.GetWorkload(ev.ProcessContext.ContainerContext.ContainerID); containerContext != nil {
+		if containerContext, _ := fh.resolvers.CGroupResolver.GetContainerWorkload(ev.ProcessContext.ContainerContext.ContainerID); containerContext != nil {
 			ev.ProcessContext.ContainerContext = containerContext.ContainerContext
 			ev.ProcessContext.ContainerContext.Resolved = true
 		}

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -348,8 +348,8 @@ func (cr *Resolver) iterate(cb func(*cgroupModel.CacheEntry) bool) {
 	}
 }
 
-// GetWorkload returns the workload referenced by the provided ID
-func (cr *Resolver) GetWorkload(id containerutils.ContainerID) (*cgroupModel.CacheEntry, bool) {
+// GetContainerWorkload returns the workload referenced by the provided container ID
+func (cr *Resolver) GetContainerWorkload(id containerutils.ContainerID) (*cgroupModel.CacheEntry, bool) {
 	if id == "" {
 		return nil, false
 	}
@@ -360,8 +360,8 @@ func (cr *Resolver) GetWorkload(id containerutils.ContainerID) (*cgroupModel.Cac
 	return cr.containerWorkloads.Get(id)
 }
 
-// GetWorkloadByCGroupID returns the workload referenced by the provided cgroup ID
-func (cr *Resolver) GetWorkloadByCGroupID(cgroupID containerutils.CGroupID) (*cgroupModel.CacheEntry, bool) {
+// GetHostWorkload returns the workload referenced by the provided cgroup ID
+func (cr *Resolver) GetHostWorkload(cgroupID containerutils.CGroupID) (*cgroupModel.CacheEntry, bool) {
 	if cgroupID == "" {
 		return nil, false
 	}

--- a/pkg/security/resolvers/file/resolver_linux.go
+++ b/pkg/security/resolvers/file/resolver_linux.go
@@ -101,7 +101,7 @@ func (r *Resolver) ResolveFileMetadata(event *model.Event, file *model.FileEvent
 	process := event.ProcessContext.Process
 	rootPIDs := []uint32{process.Pid, 1}
 	if process.ContainerContext.ContainerID != "" && r.cgroupResolver != nil {
-		w, ok := r.cgroupResolver.GetWorkload(process.ContainerContext.ContainerID)
+		w, ok := r.cgroupResolver.GetContainerWorkload(process.ContainerContext.ContainerID)
 		if ok {
 			rootPIDs = w.GetPIDs()
 		}

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -276,7 +276,7 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, ctrID contain
 	// add pid one for hash resolution outside of a container
 	rootPIDs := []uint32{1, pid}
 	if resolver.cgroupResolver != nil {
-		w, ok := resolver.cgroupResolver.GetWorkload(ctrID)
+		w, ok := resolver.cgroupResolver.GetContainerWorkload(ctrID)
 		if ok {
 			rootPIDs = w.GetPIDs()
 		}

--- a/pkg/security/resolvers/usergroup/resolver_linux.go
+++ b/pkg/security/resolvers/usergroup/resolver_linux.go
@@ -80,7 +80,7 @@ func (r *Resolver) getFilesystem(containerID containerutils.ContainerID) (fs.FS,
 	var fsys fs.FS
 
 	if containerID != "" {
-		cgroupEntry, found := r.cgroupResolver.GetWorkload(containerID)
+		cgroupEntry, found := r.cgroupResolver.GetContainerWorkload(containerID)
 		if !found {
 			return nil, fmt.Errorf("failed to resolve container %s", containerID)
 		}

--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -367,12 +367,12 @@ func (m *Manager) cleanupTracedPids(ad *dump.ActivityDump) {
 	// Try to get workload from cgroup resolver
 	if ad.Profile.Metadata.ContainerID != "" {
 		// Container workload
-		if workload, found := m.resolvers.CGroupResolver.GetWorkload(ad.Profile.Metadata.ContainerID); found {
+		if workload, found := m.resolvers.CGroupResolver.GetContainerWorkload(ad.Profile.Metadata.ContainerID); found {
 			pids = workload.GetPIDs()
 		}
 	} else if ad.Profile.Metadata.CGroupContext.CGroupID != "" {
 		// Host workload
-		if workload, found := m.resolvers.CGroupResolver.GetWorkloadByCGroupID(ad.Profile.Metadata.CGroupContext.CGroupID); found {
+		if workload, found := m.resolvers.CGroupResolver.GetHostWorkload(ad.Profile.Metadata.CGroupContext.CGroupID); found {
 			pids = workload.GetPIDs()
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Rename cgroup getters so that it is clear what kind of workload is returned

### Motivation

### Describe how you validated your changes

### Additional Notes
