### PR TITLE
`new-e2e-containers-eks`: avoid exec'ing on evicted pods

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -214,6 +214,22 @@ func (suite *k8sSuite) TestAdmissionControllerWebhooksExist() {
 	})
 }
 
+// selectPodForExec selects a suitable pod for exec from a list of pods for a given container.
+// It filters out pods being deleted and containers not ready.
+func selectPodForExec(pods []corev1.Pod, containerName string) *corev1.Pod {
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == containerName && cs.Ready {
+				return &pod
+			}
+		}
+	}
+	return nil
+}
+
 func (suite *k8sSuite) TestVersion() {
 	ctx := context.Background()
 	versionExtractor := regexp.MustCompile(`Commit: ([[:xdigit:]]+)`)
@@ -247,10 +263,12 @@ func (suite *k8sSuite) TestVersion() {
 		suite.Run(tt.podType+" pods are running the good version", func() {
 			linuxPods, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
 				LabelSelector: fields.OneTermEqualSelector("app", tt.appSelector).String(),
-				Limit:         1,
 			})
 			if suite.NoError(err) && len(linuxPods.Items) >= 1 {
-				stdout, stderr, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", linuxPods.Items[0].Name, tt.container, []string{"agent", "version"})
+				suite.T().Logf("Found %d running pods matching selector", len(linuxPods.Items))
+				execPod := selectPodForExec(linuxPods.Items, tt.container)
+				suite.Require().NotNil(execPod, "No running pods found with container %s ready", tt.container)
+				stdout, stderr, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", execPod.Name, tt.container, []string{"agent", "version"})
 				if suite.NoError(err) {
 					suite.Emptyf(stderr, "Standard error of `agent version` should be empty,")
 					match := versionExtractor.FindStringSubmatch(stdout)


### PR DESCRIPTION
### What does this PR do?
This fixes a race condition in `TestEKSSuite/TestVersion/cluster_agent_pods_are_running_the_good_version` where the test would randomly fail with:
> unable to upgrade connection: container not found

### Motivation
The test was using `Limit: 1` to select a single pod, which would return an arbitrary pod from the list.
During an eviction, this could select a pod scheduled for deletion, causing the connection to fail.

From the [failing job logs](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1275146058) in `main`:
```
Error:          	Received unexpected error:
                	command terminated with exit code 126
                	unable to upgrade connection: container not found ("cluster-agent")
```

Post-failure diagnostics showed 2 `cluster-agent` pods were running after the test, suggesting that it would have been possible to `exec` on one of them.

### Additional Notes
Proposed solution:
- remove `Limit: 1` to get all candidate pods,
- filter out pods being evicted (`DeletionTimestamp != nil`),
- filter out containers that are not `Ready` yet.