### PR TITLE
Set GIT_DEPTH to 0 for SQG

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,7 +105,7 @@
 /.gitlab/binary_build/include.yml                    @DataDog/agent-devx
 /.gitlab/binary_build/linux.yml                      @DataDog/agent-devx @DataDog/agent-build
 /.gitlab/functional_test/include.yml                 @DataDog/agent-devx
-/.gitlab/functional_test/static_quality_gate.yml     @DataDog/agent-build @cmourot @dd-ddamien
+/.gitlab/functional_test/static_quality_gate.yml     @DataDog/agent-build
 /.gitlab/install_script_testing/install_script_testing.yml          @DataDog/agent-build @DataDog/agent-onboarding
 /.gitlab/integration_test/dogstatsd.yml              @DataDog/agent-devx @DataDog/agent-metric-pipelines
 /.gitlab/integration_test/include.yml                @DataDog/agent-devx
@@ -783,6 +783,7 @@
 /test/new-e2e/tests/gpu                       @DataDog/ebpf-platform
 /test/otel/                                   @DataDog/opentelemetry-agent
 /test/static/                                 @DataDog/agent-build
+/test/static/static_quality_gates.yml        @DataDog/agent-build @cmourot @dd-ddamien
 /test/system/                                 @DataDog/agent-runtimes
 /test/system/dogstatsd/                       @DataDog/agent-metric-pipelines
 /test/benchmarks/apm_scripts/                 @DataDog/agent-apm

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -65,6 +65,8 @@ static_quality_gates:
       - extract_rpm_package_report
       - static_gate_report.json
     expire_in: 1 week
+  variables:
+    GIT_DEPTH: 0
 
 manual_gate_threshold_update:
   stage: functional_test


### PR DESCRIPTION
### What does this PR do?
It sets GIT_DEPTH to 0 to ensure that we pull the entire commit history. It also fixes ownership of the configuration yaml file. Originally the ownership was set for Gitlab job definition and not threshold config.

### Motivation
We do see sometimes SQG are using wrong ancestor commit for size comparison ([example](https://github.com/DataDog/datadog-agent/pull/43843)).
