### PR TITLE
[CWS] remove cgroup pointers

### DIFF
--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -578,7 +578,7 @@ func (fh *EBPFFieldHandlers) ResolveCGroupID(ev *model.Event, cont *model.CGroup
 			}
 
 			if cgroupContext, _, err := fh.resolvers.ResolveCGroupContext(cont.CGroupFile); err == nil {
-				ev.ProcessContext.CGroup = *cgroupContext
+				ev.ProcessContext.CGroup = cgroupContext
 			}
 		}
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -988,9 +988,12 @@ func (p *EBPFProbe) unmarshalProcessCacheEntry(ev *model.Event, data []byte) (in
 		return n, err
 	}
 
-	entry.Process.ContainerContext.ContainerID = ev.ProcessContext.Process.ContainerContext.ContainerID
-
-	entry.Process.CGroup.Merge(&ev.ProcessContext.Process.CGroup)
+	// at this point, only the cgroup file is available, we need to resolve the cgroup context
+	cgroupContext, _, err := p.Resolvers.ResolveCGroupContext(ev.ProcessContext.Process.CGroup.CGroupFile)
+	if err != nil {
+		return n, err
+	}
+	p.Resolvers.ProcessResolver.SetProcessCGroupContext(entry, cgroupContext)
 
 	entry.Source = model.ProcessCacheEntryFromEvent
 
@@ -1044,14 +1047,14 @@ func (p *EBPFProbe) zeroEvent() *model.Event {
 	return p.event
 }
 
-func (p *EBPFProbe) resolveCGroup(pid uint32, cgroupPathKey model.PathKey, newEntryCb func(entry *model.ProcessCacheEntry, err error)) (*model.CGroupContext, error) {
+func (p *EBPFProbe) resolveCGroup(pid uint32, cgroupPathKey model.PathKey, newEntryCb func(entry *model.ProcessCacheEntry, err error)) (model.CGroupContext, error) {
 	cgroupContext, _, err := p.Resolvers.ResolveCGroupContext(cgroupPathKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve cgroup for pid %d: %w", pid, err)
+		return cgroupContext, fmt.Errorf("failed to resolve cgroup for pid %d: %w", pid, err)
 	}
 	updated := p.Resolvers.ProcessResolver.UpdateProcessCGroupContext(pid, cgroupContext, newEntryCb)
 	if !updated {
-		return nil, fmt.Errorf("failed to update cgroup for pid %d", pid)
+		return cgroupContext, fmt.Errorf("failed to update cgroup for pid %d", pid)
 	}
 
 	return cgroupContext, nil
@@ -1649,8 +1652,8 @@ func (p *EBPFProbe) handleEarlyReturnEvents(event *model.Event, offset int, data
 		if cgroupContext, err := p.resolveCGroup(event.CgroupTracing.Pid, event.CgroupTracing.CGroupContext.CGroupFile, newEntryCb); err != nil {
 			seclog.Debugf("Failed to resolve cgroup: %s", err.Error())
 		} else {
-			event.CgroupTracing.CGroupContext = *cgroupContext
-			event.ProcessContext.Process.CGroup = *cgroupContext
+			event.CgroupTracing.CGroupContext = cgroupContext
+			event.ProcessContext.Process.CGroup = cgroupContext
 			containerID := containerutils.FindContainerID(cgroupContext.CGroupID)
 			if containerID != "" {
 				event.CgroupTracing.ContainerContext.ContainerID = containerID

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -316,16 +316,14 @@ func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
 }
 
 // GetCGroupContext returns the cgroup context with the specified path key
-func (cr *Resolver) GetCGroupContext(cgroupPath model.PathKey) (*model.CGroupContext, bool) {
+func (cr *Resolver) GetCGroupContext(cgroupPath model.PathKey) (model.CGroupContext, bool) {
 	cr.Lock()
 	defer cr.Unlock()
 
 	if cgroupContext, found := cr.cgroups.Get(cgroupPath.Inode); found {
-		// Return a copy to avoid race conditions when dereferencing the shared pointer
-		cgroupContextCopy := *cgroupContext
-		return &cgroupContextCopy, true
+		return *cgroupContext, true
 	}
-	return nil, false
+	return model.CGroupContext{}, false
 }
 
 // Iterate iterates on all cached cgroups, callback may return 'true' to break iteration

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1557,18 +1557,9 @@ func (p *EBPFResolver) Walk(callback func(entry *model.ProcessCacheEntry)) {
 	}
 }
 
-// UpdateProcessCGroupContext updates the cgroup context and container ID of the process matching the provided PID
-func (p *EBPFResolver) UpdateProcessCGroupContext(pid uint32, cgroupContext *model.CGroupContext, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
-	p.Lock()
-	defer p.Unlock()
-
-	pce := p.resolve(pid, pid, 0, false, newEntryCb)
-	if pce == nil {
-		return false
-	}
-
-	pce.Process.CGroup = *cgroupContext
-	pce.CGroup = *cgroupContext
+// SetProcessCGroupContext sets the cgroup context and container ID of the process matching the provided PID
+func (p *EBPFResolver) SetProcessCGroupContext(pce *model.ProcessCacheEntry, cgroupContext model.CGroupContext) {
+	pce.Process.CGroup = cgroupContext
 
 	if cgroupContext.CGroupID != "" {
 		pce.Process.ContainerContext.ContainerID = containerutils.FindContainerID(cgroupContext.CGroupID)
@@ -1578,6 +1569,19 @@ func (p *EBPFResolver) UpdateProcessCGroupContext(pid uint32, cgroupContext *mod
 			p.cgroupResolver.AddPID(pce)
 		}
 	}
+}
+
+// UpdateProcessCGroupContext updates the cgroup context and container ID of the process matching the provided PID
+func (p *EBPFResolver) UpdateProcessCGroupContext(pid uint32, cgroupContext model.CGroupContext, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
+	p.Lock()
+	defer p.Unlock()
+
+	pce := p.resolve(pid, pid, 0, false, newEntryCb)
+	if pce == nil {
+		return false
+	}
+
+	p.SetProcessCGroupContext(pce, cgroupContext)
 
 	return true
 }

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -885,7 +885,7 @@ func TestCGroupContext(t *testing.T) {
 			cgroupID    = containerutils.CGroupID("/kubepods/besteffort/pod8bbdd97b-f902-4e16-8235-4ac18307cef6/" + string(containerID))
 		)
 
-		resolver.UpdateProcessCGroupContext(node.ProcessCacheEntry.Pid, &model.CGroupContext{
+		resolver.UpdateProcessCGroupContext(node.ProcessCacheEntry.Pid, model.CGroupContext{
 			Releasable: &model.Releasable{},
 			CGroupID:   cgroupID,
 			CGroupFile: model.PathKey{

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -256,19 +256,20 @@ func (r *EBPFResolvers) Start(ctx context.Context) error {
 }
 
 // ResolveCGroupContext resolves the cgroup context from a cgroup path key
-func (r *EBPFResolvers) ResolveCGroupContext(pathKey model.PathKey) (*model.CGroupContext, bool, error) {
-	if cgroupContext, found := r.CGroupResolver.GetCGroupContext(pathKey); found {
+func (r *EBPFResolvers) ResolveCGroupContext(pathKey model.PathKey) (model.CGroupContext, bool, error) {
+	cgroupContext, found := r.CGroupResolver.GetCGroupContext(pathKey)
+	if found {
 		return cgroupContext, true, nil
 	}
 
-	cgroup, err := r.DentryResolver.Resolve(pathKey, false)
+	cgroupPath, err := r.DentryResolver.Resolve(pathKey, false)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to resolve cgroup file %v: %w", pathKey, err)
+		return cgroupContext, false, fmt.Errorf("failed to resolve cgroup file %v: %w", pathKey, err)
 	}
 
-	cgroupContext := &model.CGroupContext{
+	cgroupContext = model.CGroupContext{
 		Releasable: &model.Releasable{},
-		CGroupID:   containerutils.CGroupID(cgroup),
+		CGroupID:   containerutils.CGroupID(cgroupPath),
 		CGroupFile: pathKey,
 	}
 


### PR DESCRIPTION
### What does this PR do?

Eliminate certain cgroup context pointers. The aim is to reduce pointer usage, since ultimately the cgroup context within a process context is not represented as a pointer.

### Motivation

### Describe how you validated your changes

### Additional Notes
