### PR TITLE
Remove no (longer) existing integrations from recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,11 +12,9 @@
 		// Python
 		"ms-python.python",
 		"charliermarsh.ruff",
-		"alexsweet.vulture-vscode",
 		// Others
 		"redhat.vscode-yaml",
 		"timonwong.shellcheck",
-		"jasonnutter.vscode-codeowners",
 		"usernamehw.errorlens"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.


### PR DESCRIPTION
### What does this PR do?

Remove two extensions that make `dda inv vscode.setup` fail because they no longer exist

### Motivation

### Describe how you validated your changes

### Additional Notes
