### PR TITLE
Add Docker Image nightly and manual builds for ddot-ebpf

### DIFF
--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -5,6 +5,7 @@
   SRC_DCA: registry.ddbuild.io/ci/datadog-agent/cluster-agent
   SRC_CWS_INSTRUMENTATION: registry.ddbuild.io/ci/datadog-agent/cws-instrumentation
   SRC_OTEL_AGENT: registry.ddbuild.io/ci/datadog-agent/otel-agent
+  SRC_DDOT_EBPF: registry.ddbuild.io/ci/datadog-agent/ddot-ebpf
 
 .docker_publish_job_definition:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
@@ -20,8 +21,8 @@
       else
         export ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
       fi
-    - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_OTEL_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
-    - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_OTEL_AGENT}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
+    - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_OTEL_AGENT}|${SRC_DDOT_EBPF}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
+    - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_OTEL_AGENT}|${SRC_DDOT_EBPF}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
     - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/public-images --git-ref main --timeout 1800
       --variable IMG_VARIABLES
       --variable IMG_REGISTRIES

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -218,6 +218,19 @@ dev_branch-ot-standalone:
     IMG_SOURCES: ${SRC_OTEL_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_OTEL_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
     IMG_DESTINATIONS: otel-agent-dev:${CI_COMMIT_REF_SLUG}-7
 
+dev_nightly-host-profiler-standalone:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.on_deploy_nightly_repo_branch]
+  needs:
+    - docker_build_host_profiler_standalone_amd64
+    - docker_build_host_profiler_standalone_arm64
+  variables:
+    IMG_REGISTRIES: dev
+    IMG_SOURCES: ${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
+    IMG_DESTINATIONS: ddot-ebpf-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA},ddot-ebpf-dev:nightly-${CI_COMMIT_REF_SLUG}
+
 dev_branch-host-profiler-standalone:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
@@ -229,4 +242,4 @@ dev_branch-host-profiler-standalone:
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-    IMG_DESTINATIONS: ddot-ebpf-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA},ddot-ebpf-dev:nightly-${CI_COMMIT_REF_SLUG}
+    IMG_DESTINATIONS: ddot-ebpf-dev:${CI_COMMIT_REF_SLUG}

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -217,3 +217,16 @@ dev_branch-ot-standalone:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_OTEL_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_OTEL_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
     IMG_DESTINATIONS: otel-agent-dev:${CI_COMMIT_REF_SLUG}-7
+
+dev_branch-host-profiler-standalone:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.manual]
+  needs:
+    - docker_build_host_profiler_standalone_amd64
+    - docker_build_host_profiler_standalone_arm64
+  variables:
+    IMG_REGISTRIES: dev
+    IMG_SOURCES: ${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
+    IMG_DESTINATIONS: ddot-ebpf-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA},ddot-ebpf-dev:nightly-${CI_COMMIT_REF_SLUG}


### PR DESCRIPTION
### What does this PR do?

This PR adds nightly/manual builds for the ddot-ebpf image in repo [ddot-ebpf-dev](https://hub.docker.com/r/datadog/ddot-ebpf-dev).

### Motivation

### Describe how you validated your changes

### Additional Notes
