### PR TITLE
Interim improvement to libpopt build

### DIFF
--- a/deps/popt.BUILD.bazel
+++ b/deps/popt.BUILD.bazel
@@ -1,15 +1,17 @@
+load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
-load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+
+package(default_package_metadata = [":license"])
 
 license(
     name = "license",
     license_kinds = ["@rules_license//licenses/spdx:MIT"],
-    license_text = "LICENSE",
+    license_text = "COPYING",
     visibility = ["//visibility:public"],
 )
 

--- a/omnibus/config/software/popt.rb
+++ b/omnibus/config/software/popt.rb
@@ -21,15 +21,6 @@ license "MIT"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-dependency "config_guess"
-
-version "1.19" do
-  source url: "http://ftp.rpm.org/popt/releases/popt-1.x/popt-#{version}.tar.gz",
-         sha256: "c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9"
-end
-
-relative_path "popt-#{version}"
-
 build do
   command_on_repo_root "bazelisk run -- @popt//:install --destdir='#{install_dir}/embedded'"
   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \


### PR DESCRIPTION
- Fix license attribution for popt built with Bazel
- Do not do the (unused) omnibus download download of the sources

Eventually there will be no omnibus script for this, but it is cleaner to fix he license thing now, than to add it as a side effect to some other PR.