### PR TITLE
[CWS] Put ssh session logs with trace status

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -88,7 +88,7 @@ func (p *pendingMsg) isResolved() bool {
 
 	if p.sshSessionPatcher != nil {
 		if err := p.sshSessionPatcher.IsResolved(); err != nil {
-			seclog.Debugf("ssh session not resolved: %v", err)
+			seclog.Tracef("ssh session not resolved: %v", err)
 			return false
 		}
 	}

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -58,7 +58,7 @@ func (p *EBPFProbe) HandleSSHUserSession(event *model.Event) {
 				event.ProcessContext.UserSession.SSHClientPort = port
 			}
 		} else {
-			seclog.Warnf("SSH_CLIENT is not in the expected format: %q", sshClientVar)
+			seclog.Tracef("SSH_CLIENT is not in the expected format: %q", sshClientVar)
 		}
 	}
 }

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -452,7 +452,7 @@ func (r *Resolver) StartSSHUserSessionResolver() error {
 	if path == "" {
 		// // Don't want to continue in case there is no log file
 		// TODO : use journalctl instead
-		seclog.Warnf("no ssh log file found")
+		seclog.Trace("no ssh log file found")
 		return nil
 	}
 	// Initialize the SSH log reader


### PR DESCRIPTION
### What does this PR do?

### Motivation
Some SSH session logs were being spammed. In addition, this could cause issues in the end-to-end tests. 
We can now enable or disable this behavior by using the trace status.