### PR TITLE
`new-e2e-containers-eks` flakiness: requeue unacked language detection events

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -8,6 +8,7 @@
 package languagedetection
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -108,16 +109,12 @@ func (handler *languageDetectionHandler) preHandler(w http.ResponseWriter, r *ht
 		return false
 	}
 
-	return true
-}
-
-// leaderHandler is called only by the leader and used to patch the annotations
-func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r *http.Request) {
+	// Process and push to workloadmeta on ALL pods (followers and leader) to survive leadership changes
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request body", http.StatusBadRequest)
 		ProcessedRequests.Inc(statusError)
-		return
+		return false
 	}
 
 	// Create a new instance of the protobuf message type
@@ -128,7 +125,7 @@ func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r 
 	if err != nil {
 		http.Error(w, "Failed to unmarshal request body", http.StatusBadRequest)
 		ProcessedRequests.Inc(statusError)
-		return
+		return false
 	}
 
 	ownersLanguagesFromRequest := getOwnersLanguages(requestData, time.Now().Add(handler.cfg.languageTTL))
@@ -144,9 +141,16 @@ func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r 
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to store some (or all) languages in workloadmeta store: %s", err), http.StatusInternalServerError)
 		ProcessedRequests.Inc(statusError)
-		return
+		return false
 	}
 
+	// Restore the body for downstream handlers (leaderHandler or forward)
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+	return true
+}
+
+// leaderHandler is called only by the leader
+func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, _ *http.Request) {
 	ProcessedRequests.Inc(statusSuccess)
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/clusteragent/languagedetection/patcher.go
+++ b/pkg/clusteragent/languagedetection/patcher.go
@@ -251,7 +251,7 @@ func (lp *languagePatcher) processOwner(ctx context.Context, owner langUtil.Name
 	if !lp.isLeader() {
 		lp.logger.Tracef("Skipping patch for %s: %s/%s - not leader", owner.Kind, owner.Namespace, owner.Name)
 		Patches.Inc(owner.Kind, owner.Name, owner.Namespace, statusSkip)
-		return nil
+		return apiserver.ErrNotLeader
 	}
 
 	var err error

--- a/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
+++ b/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
@@ -200,6 +200,19 @@ func WithDualShipping() func(*Params) error {
 	}
 }
 
+// WithClusterAgentLanguageDetectionPatcherShortBackoff configures shortened backoff for the cluster agent's
+// language detection patcher to avoid test timeouts in E2E tests.
+func WithClusterAgentLanguageDetectionPatcherShortBackoff() func(*Params) error {
+	return WithHelmValues(`
+clusterAgent:
+  env:
+    - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_BASE_BACKOFF
+      value: "10s"
+    - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_MAX_BACKOFF
+      value: "1m"
+`)
+}
+
 func WithOTelAgent() func(*Params) error {
 	return func(p *Params) error {
 		p.OTelAgent = true

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -33,7 +33,10 @@ func TestEKSSuite(t *testing.T) {
 			),
 			sceneks.WithDeployDogstatsd(),
 			sceneks.WithDeployTestWorkload(),
-			sceneks.WithAgentOptions(kubernetesagentparams.WithDualShipping()),
+			sceneks.WithAgentOptions(
+				kubernetesagentparams.WithDualShipping(),
+				kubernetesagentparams.WithClusterAgentLanguageDetectionPatcherShortBackoff(),
+			),
 			sceneks.WithDeployArgoRollout(),
 		),
 	)))

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -34,6 +34,7 @@ func TestKindSuite(t *testing.T) {
 			scenkind.WithDeployTestWorkload(),
 			scenkind.WithAgentOptions(
 				kubernetesagentparams.WithDualShipping(),
+				kubernetesagentparams.WithClusterAgentLanguageDetectionPatcherShortBackoff(),
 			),
 			scenkind.WithDeployArgoRollout(),
 		),


### PR DESCRIPTION
### What does this PR do?
This is a tentative fix for a race condition in language detection where events appear to be silently dropped when the Cluster Agent is not the leader (rolling updates, multiple replicas...), which may be causing `TestAdmissionControllerWithAutoDetectedLanguage` to flake.

The change proposes to make the non-leader case to return `ErrNotLeader` instead of `nil`.
This should allow the workqueue to requeue the event with exponential backoff until a leader is elected and can process it.

### Motivation
See logs (`main` pipeline):
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1279349200#L1238
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1288699301#L286
```
=== FAIL: test/new-e2e/tests/containers TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage (364.58s)
    base_test.go:37: START  eksSuite/TestAdmissionControllerWithAutoDetectedLanguage 2025-12-09 15:05:42.472157044 +0000 UTC m=+329.810291814
    suite.go:384: No change in provisioners, skipping environment update
    k8s_test.go:1268: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:1287
        	            				/usr/local/go/src/runtime/asm_amd64.s:1700
        	Error:      	Should be true
    k8s_test.go:1268: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:1268
        	            				/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:1228
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:196
        	            				/go/pkg/mod/github.com/!data!dog/dd-trace-go/v2@v2.2.2/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go:242
        	Error:      	Condition never satisfied
        	Test:       	TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
        	Messages:   	The deployment with name mutated-with-auto-detected-language in namespace workload-mutated-lib-injection does not exist or does not have the auto detected languages annotation
```

The test `TestAdmissionControllerWithAutoDetectedLanguage` has been flaky since ~Dec 2024.
The test waits up to 5 minutes for the Cluster Agent to add the `internal.dd.datadoghq.com/.*\.detected_langs` annotation on deployments, but this annotation sometimes never appears.

Prior art:
- #24732
- #32422
- #32469
- #40526

From `pkg/clusteragent/languagedetection/patcher.go`:
```go
if !lp.isLeader() {
    lp.logger.Tracef("Skipping patch for %s: %s/%s - not leader", ...)
    return nil
    //     ^^^ event is dropped, not requeued
}
```

Since all Cluster Agent pods receive events independently from `workloadmeta`, and the workqueue handles retries when errors are returned, returning `nil` causes the event to be forgotten rather than retried.

### Describe how you validated your changes
Added `TestPatcherRequeuesWhenNotLeader` to verify events are requeued when not leader.

### Additional Notes
:warning: This is all new to me, and it's very possible that I may have missed something.

Another culprit might be involved (e.g., the language detection itself may be timing out or failing).