### PR TITLE
[OTELS-844][OTEL-1791] Clean up OTLP span error mapping

### DIFF
--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -1432,54 +1432,17 @@ func TestOTLPHelpers(t *testing.T) {
 	})
 
 	t.Run("status2Error", func(t *testing.T) {
-		for _, tt := range []*struct {
+		for i, tt := range []*struct {
 			status ptrace.StatusCode
 			msg    string
 			events ptrace.SpanEventSlice
+			meta   map[string]string
 			out    pb.Span
 		}{
 			{
-				status: ptrace.StatusCodeError,
-				events: makeEventsSlice("exception", map[string]any{
-					"exception.message":    "Out of memory",
-					"exception.type":       "mem",
-					"exception.stacktrace": "1/2/3",
-				}, 0, 0),
-				out: pb.Span{
-					Error: 1,
-					Meta: map[string]string{
-						"error.msg":   "Out of memory",
-						"error.type":  "mem",
-						"error.stack": "1/2/3",
-					},
-				},
-			},
-			{
-				status: ptrace.StatusCodeError,
-				events: makeEventsSlice("exception", map[string]any{
-					"exception.message": "Out of memory",
-				}, 0, 0),
-				out: pb.Span{
-					Error: 1,
-					Meta:  map[string]string{"error.msg": "Out of memory"},
-				},
-			},
-			{
-				status: ptrace.StatusCodeError,
-				events: makeEventsSlice("EXCEPTION", map[string]any{
-					"exception.message": "Out of memory",
-				}, 0, 0),
-				out: pb.Span{
-					Error: 1,
-					Meta:  map[string]string{"error.msg": "Out of memory"},
-				},
-			},
-			{
-				status: ptrace.StatusCodeError,
-				events: makeEventsSlice("OTher", map[string]any{
-					"exception.message": "Out of memory",
-				}, 0, 0),
-				out: pb.Span{Error: 1},
+				status: ptrace.StatusCodeOk,
+				events: ptrace.NewSpanEventSlice(),
+				out:    pb.Span{Error: 0},
 			},
 			{
 				status: ptrace.StatusCodeError,
@@ -1490,38 +1453,81 @@ func TestOTLPHelpers(t *testing.T) {
 				status: ptrace.StatusCodeError,
 				msg:    "Error number #24",
 				events: ptrace.NewSpanEventSlice(),
-				out:    pb.Span{Error: 1, Meta: map[string]string{"error.msg": "Error number #24"}},
+				out: pb.Span{
+					Error: 1,
+					Meta:  map[string]string{"error.msg": "Error number #24"},
+				},
 			},
 			{
-				status: ptrace.StatusCodeOk,
+				status: ptrace.StatusCodeError,
+				msg:    "Error number #25",
 				events: ptrace.NewSpanEventSlice(),
-				out:    pb.Span{Error: 0},
+				meta: map[string]string{
+					"http.response.status_code": "500",
+				},
+				out: pb.Span{
+					Error: 1,
+					Meta:  map[string]string{"error.msg": "Error number #25"},
+				},
 			},
 			{
-				status: ptrace.StatusCodeOk,
+				status: ptrace.StatusCodeError,
+				events: ptrace.NewSpanEventSlice(),
+				meta: map[string]string{
+					"http.response.status_code": "500",
+				},
+				out: pb.Span{
+					Error: 1,
+					Meta:  map[string]string{"error.msg": "500 Internal Server Error"},
+				},
+			},
+			{
+				// We no longer map `http.status_text` to the error message
+				status: ptrace.StatusCodeError,
+				events: ptrace.NewSpanEventSlice(),
+				meta: map[string]string{
+					"http.response.status_code": "500",
+					"http.status_text":          "deprecated",
+				},
+				out: pb.Span{
+					Error: 1,
+					Meta:  map[string]string{"error.msg": "500 Internal Server Error"},
+				},
+			},
+			{
+				// We no longer map exception event attributes onto the span
+				status: ptrace.StatusCodeError,
 				events: makeEventsSlice("exception", map[string]any{
 					"exception.message":    "Out of memory",
 					"exception.type":       "mem",
 					"exception.stacktrace": "1/2/3",
 				}, 0, 0),
-				out: pb.Span{Error: 0},
+				out: pb.Span{
+					Error: 1,
+					Meta:  map[string]string{},
+				},
 			},
 		} {
-			assert := assert.New(t)
-			span := pb.Span{Meta: make(map[string]string)}
-			status := ptrace.NewStatus()
-			status.SetCode(tt.status)
-			status.SetMessage(tt.msg)
-			got := transform.Status2Error(status, tt.events, span.Meta)
-			assert.Equal(tt.out.Error, got)
-			for _, prop := range []string{"error.msg", "error.type", "error.stack"} {
-				if v, ok := tt.out.Meta[prop]; ok {
-					assert.Equal(v, span.Meta[prop])
-				} else {
-					_, ok := span.Meta[prop]
-					assert.False(ok, prop)
+			t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+				assert := assert.New(t)
+				span := pb.Span{Meta: tt.meta}
+				if span.Meta == nil {
+					span.Meta = make(map[string]string)
 				}
-			}
+				status := ptrace.NewStatus()
+				status.SetCode(tt.status)
+				status.SetMessage(tt.msg)
+				got := transform.Status2Error(status, tt.events, span.Meta)
+				assert.Equal(tt.out.Error, got)
+				for _, prop := range []string{"error.msg", "error.type", "error.stack"} {
+					if v, ok := tt.out.Meta[prop]; ok {
+						assert.Equal(v, span.Meta[prop])
+					} else {
+						_, ok := span.Meta[prop]
+						assert.False(ok, prop)
+					}
+				}
+			})
 		}
 	})
 
@@ -1676,9 +1682,7 @@ func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"version":                       "v1.2.3",
 					"events":                        `[{"time_unix_nano":123,"name":"boom","attributes":{"key":"Out of memory","accuracy":2.4},"dropped_attributes_count":2},{"time_unix_nano":456,"name":"exception","attributes":{"exception.message":"Out of memory","exception.type":"mem","exception.stacktrace":"1/2/3"},"dropped_attributes_count":2}]`,
 					"_dd.span_links":                `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","tracestate":"dd=asdf256,ee=jkl;128", "attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
-					"error.msg":                     "Out of memory",
-					"error.type":                    "mem",
-					"error.stack":                   "1/2/3",
+					"error.msg":                     "Error",
 					"span.kind":                     "server",
 					"_dd.span_events.has_exception": "true",
 				},
@@ -1802,9 +1806,7 @@ func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"version":                       "v1.2.3",
 					"events":                        "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":2.4},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
 					"_dd.span_links":                `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","tracestate":"dd=asdf256,ee=jkl;128","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
-					"error.msg":                     "Out of memory",
-					"error.type":                    "mem",
-					"error.stack":                   "1/2/3",
+					"error.msg":                     "Error",
 					"http.method":                   "GET",
 					"http.route":                    "/path",
 					"peer.service":                  "userbase",
@@ -1942,9 +1944,7 @@ func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"otel.trace_id":                 "72df520af2bde7a5240031ead750e5f3",
 					"events":                        "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":2.4},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
 					"_dd.span_links":                `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","tracestate":"dd=asdf256,ee=jkl;128","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
-					"error.msg":                     "Out of memory",
-					"error.type":                    "mem",
-					"error.stack":                   "1/2/3",
+					"error.msg":                     "Error",
 					"http.method":                   "GET",
 					"http.route":                    "/path",
 					"span.kind":                     "server",
@@ -2077,7 +2077,7 @@ func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"otel.library.name":    "ddtracer",
 					"otel.library.version": "v2",
 					"otel.status_code":     "Error",
-					"error.msg":            "201",
+					"error.msg":            "201 Created",
 					"http.method":          "POST",
 					"url.path":             "/uploads/4",
 					"url.scheme":           "https",
@@ -2135,7 +2135,7 @@ func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"otel.library.name":    "ddtracer",
 					"otel.library.version": "v2",
 					"otel.status_code":     "Error",
-					"error.msg":            "201",
+					"error.msg":            "201 Created",
 					"http.method":          "POST",
 					"url.path":             "/uploads/4",
 					"url.scheme":           "https",
@@ -2698,9 +2698,7 @@ func testOTLPConvertSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"version":                       "v1.2.3",
 					"events":                        `[{"time_unix_nano":123,"name":"boom","attributes":{"key":"Out of memory","accuracy":2.4},"dropped_attributes_count":2},{"time_unix_nano":456,"name":"exception","attributes":{"exception.message":"Out of memory","exception.type":"mem","exception.stacktrace":"1/2/3"},"dropped_attributes_count":2}]`,
 					"_dd.span_links":                `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","tracestate":"dd=asdf256,ee=jkl;128", "attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
-					"error.msg":                     "Out of memory",
-					"error.type":                    "mem",
-					"error.stack":                   "1/2/3",
+					"error.msg":                     "Error",
 					"span.kind":                     "server",
 					"_dd.span_events.has_exception": "true",
 				},
@@ -2827,9 +2825,7 @@ func testOTLPConvertSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"version":                       "v1.2.3",
 					"events":                        "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":2.4},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
 					"_dd.span_links":                `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","tracestate":"dd=asdf256,ee=jkl;128","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
-					"error.msg":                     "Out of memory",
-					"error.type":                    "mem",
-					"error.stack":                   "1/2/3",
+					"error.msg":                     "Error",
 					"http.method":                   "GET",
 					"http.route":                    "/path",
 					"peer.service":                  "userbase",
@@ -2957,9 +2953,7 @@ func testOTLPConvertSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"otel.trace_id":                 "72df520af2bde7a5240031ead750e5f3",
 					"events":                        "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":2.4},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
 					"_dd.span_links":                `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","tracestate":"dd=asdf256,ee=jkl;128","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
-					"error.msg":                     "Out of memory",
-					"error.type":                    "mem",
-					"error.stack":                   "1/2/3",
+					"error.msg":                     "Error",
 					"http.method":                   "GET",
 					"http.route":                    "/path",
 					"span.kind":                     "server",
@@ -3082,7 +3076,7 @@ func testOTLPConvertSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"otel.library.name":         "ddtracer",
 					"otel.library.version":      "v2",
 					"otel.status_code":          "Error",
-					"error.msg":                 "201",
+					"error.msg":                 "201 Created",
 					"http.request.method":       "POST",
 					"http.method":               "POST",
 					"url.path":                  "/uploads/4",
@@ -3142,7 +3136,7 @@ func testOTLPConvertSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 					"otel.library.name":    "ddtracer",
 					"otel.library.version": "v2",
 					"otel.status_code":     "Error",
-					"error.msg":            "201",
+					"error.msg":            "201 Created",
 					"http.method":          "POST",
 					"url.path":             "/uploads/4",
 					"url.scheme":           "https",

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -672,37 +673,19 @@ func Status2Error(status ptrace.Status, events ptrace.SpanEventSlice, metaMap ma
 	if status.Code() != ptrace.StatusCodeError {
 		return 0
 	}
-	for i := 0; i < events.Len(); i++ {
-		e := events.At(i)
-		if strings.ToLower(e.Name()) != "exception" {
-			continue
-		}
-		attrs := e.Attributes()
-		if v, ok := attrs.Get(string(semconv.ExceptionMessageKey)); ok {
-			metaMap["error.msg"] = v.AsString()
-		}
-		if v, ok := attrs.Get(string(semconv.ExceptionTypeKey)); ok {
-			metaMap["error.type"] = v.AsString()
-		}
-		if v, ok := attrs.Get(string(semconv.ExceptionStacktraceKey)); ok {
-			metaMap["error.stack"] = v.AsString()
-		}
-	}
 	if _, ok := metaMap["error.msg"]; !ok {
 		// no error message was extracted, find alternatives
 		if status.Message() != "" {
 			// use the status message
 			metaMap["error.msg"] = status.Message()
-		} else if _, httpcode := GetFirstFromMap(metaMap, "http.response.status_code", "http.status_code"); httpcode != "" {
+		} else if _, httpCode := GetFirstFromMap(metaMap, "http.response.status_code", "http.status_code"); httpCode != "" {
 			// `http.status_code` was renamed to `http.response.status_code` in the HTTP stabilization from v1.23.
 			// See https://opentelemetry.io/docs/specs/semconv/http/migration-guide/#summary-of-changes
-
-			// http.status_text was removed in spec v0.7.0 (https://github.com/open-telemetry/opentelemetry-specification/pull/972)
-			// TODO (OTEL-1791) Remove this and use a map from status code to status text.
-			if httptext, ok := metaMap["http.status_text"]; ok {
-				metaMap["error.msg"] = fmt.Sprintf("%s %s", httpcode, httptext)
+			httpCodeInt, _ := strconv.Atoi(httpCode) // Value returned in case of error will not pass the next test
+			if httptext := http.StatusText(httpCodeInt); httptext != "" {
+				metaMap["error.msg"] = fmt.Sprintf("%s %s", httpCode, httptext)
 			} else {
-				metaMap["error.msg"] = httpcode
+				metaMap["error.msg"] = httpCode
 			}
 		}
 	}

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -669,7 +669,7 @@ func SetMetricOTLPIfEmpty(s *pb.Span, k string, v float64) {
 
 // Status2Error checks the given status and events and applies any potential error and messages
 // to the given span attributes.
-func Status2Error(status ptrace.Status, events ptrace.SpanEventSlice, metaMap map[string]string) int32 {
+func Status2Error(status ptrace.Status, _ ptrace.SpanEventSlice, metaMap map[string]string) int32 {
 	if status.Code() != ptrace.StatusCodeError {
 		return 0
 	}

--- a/releasenotes/notes/otlp-http-error-msg-debfd954c0aed2fc.yaml
+++ b/releasenotes/notes/otlp-http-error-msg-debfd954c0aed2fc.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    OTLP spans describing an HTTP error now derive the `error.msg` attribute from the status code,
+    instead of sourcing it from the deprecated `http.status_text` attribute.
+    In other words, a span that previously had `error.msg: "500"` will now have `error.msg: "500 Internal Server Error"`.
+    Users who relied on this attribute to extract the status code should use `http.response.status_code` instead,
+    or can set `error.msg` manually to override this behavior.

--- a/releasenotes/notes/otlp-http-error-msg-debfd954c0aed2fc.yaml
+++ b/releasenotes/notes/otlp-http-error-msg-debfd954c0aed2fc.yaml
@@ -8,8 +8,9 @@
 ---
 enhancements:
   - |
-    OTLP spans describing an HTTP error now derive the `error.msg` attribute from the status code,
-    instead of sourcing it from the deprecated `http.status_text` attribute.
-    In other words, a span that previously had `error.msg: "500"` will now have `error.msg: "500 Internal Server Error"`.
-    Users who relied on this attribute to extract the status code should use `http.response.status_code` instead,
-    or can set `error.msg` manually to override this behavior.
+    OTLP spans describing an HTTP error without an explicit error message will now fallback
+    to one with a description, eg. "500 Internal Server Error" instead of just "500".
+    Users who relied on the error message to extract the status code should use `http.response.status_code` instead.
+    
+    Additionally, the error message is no longer sourced from the deprecated `http.status_text` attribute.
+    This behavior can be overridden by explicitly setting the span's status message.

--- a/releasenotes/notes/otlp-remove-exception-event-mapping-cec09ae3782fcc91.yaml
+++ b/releasenotes/notes/otlp-remove-exception-event-mapping-cec09ae3782fcc91.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    OTLP span events recording exceptions no longer have their stack trace duplicated on the parent span.
+    This previously led to duplicate errors on the Error Tracking page.


### PR DESCRIPTION
### What does this PR do?

Removes old code which previously duplicated attributes of `exception` span events onto their parent spans, to avoid duplicate errors in Error Tracking.

Also removes old code sourcing error messages from the deprecated attribute `http.status_text`, and instead automatically derives the message from the HTTP status code.

### Motivation

See support ticket linked in title. The second change was a TODO in the same part of the code.

### Describe how you validated your changes

The changes should be validated by the updated tests in `otlp_test.go`

### Additional Notes
