### PR TITLE
add job env vars to KMT test run

### DIFF
--- a/pkg/ebpf/ebpftest/jobenv_test.go
+++ b/pkg/ebpf/ebpftest/jobenv_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ebpftest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobEnv(t *testing.T) {
+	if os.Getenv("GITLAB_CI") != "true" {
+		t.Skip()
+	}
+	// this is testing logic in test/new-e2e/system-probe/test-runner/main.go
+	// to ensure vars from job_env.txt are added to the KMT env vars
+	assert.NotEmpty(t, os.Getenv("CI_JOB_URL"))
+	assert.NotEmpty(t, os.Getenv("CI_JOB_ID"))
+	assert.NotEmpty(t, os.Getenv("CI_JOB_NAME"))
+	assert.NotEmpty(t, os.Getenv("CI_JOB_STAGE"))
+}

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -221,6 +221,10 @@ func collectEnvVars(testConfig *testConfig, bpfDir string) []string {
 
 	env = append(env, testConfig.AdditionalEnvVars...)
 
+	if jobEnv, err := os.ReadFile("/job_env.txt"); err == nil {
+		env = append(env, strings.Split(string(jobEnv), "\n")...)
+	}
+
 	return env
 }
 

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -222,7 +222,12 @@ func collectEnvVars(testConfig *testConfig, bpfDir string) []string {
 	env = append(env, testConfig.AdditionalEnvVars...)
 
 	if jobEnv, err := os.ReadFile("/job_env.txt"); err == nil {
-		env = append(env, strings.Split(string(jobEnv), "\n")...)
+		for line := range strings.SplitSeq(string(jobEnv), "\n") {
+			name, val, ok := strings.Cut(line, "=")
+			if ok {
+				env = append(env, fmt.Sprintf("%s=%s", name, val))
+			}
+		}
 	}
 
 	return env
@@ -296,7 +301,7 @@ func testPass(testConfig *testConfig, props map[string]string) error {
 
 		if err := cmd.Run(); err != nil {
 			// log but do not return error
-			fmt.Fprintf(os.Stderr, "cmd run %s: %s\n", testsuite, err)
+			fmt.Fprintf(os.Stderr, "cmd run %s: %s\n", strings.Join(cmd.Args, " "), err)
 		}
 
 		if err := addProperties(xmlpath, props); err != nil {

--- a/test/new-e2e/system-probe/test-runner/testcontainer.go
+++ b/test/new-e2e/system-probe/test-runner/testcontainer.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 const containerName = "kmt-test-container"
@@ -28,6 +29,7 @@ func newTestContainer(image, bpfDir string) *testContainer {
 }
 
 func (ctc *testContainer) runDockerCmd(args []string) error {
+	fmt.Printf("running: docker %s", strings.Join(args, " "))
 	cmd := exec.Command("docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
### What does this PR do?

Exposes `CI_JOB_{URL,ID,NAME,STAGE}` to KMT tests.

### Motivation

The ability to skip or make flake based on what CI job you are running in.

### Describe how you validated your changes

Added tests.

### Additional Notes
