### PR TITLE
Add dda lab command with support for local kind provider, allowing streamlined local build + deploy

### DIFF
--- a/.dda/extend/commands/lab/__init__.py
+++ b/.dda/extend/commands/lab/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dda.cli.base import dynamic_group
+
+
+@dynamic_group(
+    short_help="Lab environments to experiment with the Agent",
+)
+def cmd() -> None:
+    pass

--- a/.dda/extend/commands/lab/__init__.py
+++ b/.dda/extend/commands/lab/__init__.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from dda.cli.base import dynamic_group
 
+# Import providers to register them
+from lab.providers.local import kind  # noqa: F401
+
 
 @dynamic_group(
     short_help="Lab environments to experiment with the Agent",

--- a/.dda/extend/commands/lab/delete/__init__.py
+++ b/.dda/extend/commands/lab/delete/__init__.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+from dda.cli.base import dynamic_command, pass_app
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+@dynamic_command(short_help="Delete a lab environment")
+@click.option("--name", "-n", default=None, help="Name of the environment to delete (interactive if not provided)")
+@click.option("--force", "-f", is_flag=True, help="Skip confirmation prompt")
+@pass_app
+def cmd(app: Application, *, name: str | None, force: bool) -> None:
+    """
+    Delete a lab environment.
+
+    Works with any environment type (kind, gke, eks, etc.).
+    The provider-specific cleanup is handled automatically.
+
+    If --name is not provided, shows an interactive selection menu.
+    """
+    from lab import LabEnvironment
+    from lab.providers import get_provider
+
+    # If no name provided, show interactive selection
+    if name is None:
+        environments = LabEnvironment.load_all(app)
+        if not environments:
+            app.display_info("No lab environments found.")
+            return
+
+        choices = [f"{e.name} ({e.env_type})" for e in environments]
+
+        app.display_info("Select an environment to delete:\n")
+        for i, choice in enumerate(choices, 1):
+            app.display_info(f"  {i}. {choice}")
+        app.display_info("")
+
+        selection = app.prompt(
+            "Enter number",
+            type=click.IntRange(1, len(choices)),
+        )
+        name = environments[selection - 1].name
+
+    env = LabEnvironment.load(app, name)
+
+    if env is None:
+        app.display_error(f"Environment '{name}' not found.")
+
+        environments = LabEnvironment.load_all(app)
+        if environments:
+            app.display_info("\nAvailable environments:")
+            for e in environments:
+                app.display_info(f"  - {e.name} ({e.env_type})")
+        return
+
+    if not force:
+        if not click.confirm(f"Delete {env.env_type} environment '{name}'?"):
+            app.display_info("Aborting.")
+            return
+
+    app.display_info(f"Deleting {env.env_type} environment '{name}'...")
+
+    try:
+        provider = get_provider(env.env_type)
+        provider.destroy(app, name)
+    except ValueError:
+        app.display_warning(f"Provider '{env.env_type}' not found, removing from storage only.")
+
+    env.delete()
+    app.display_success(f"Environment '{name}' deleted.")

--- a/.dda/extend/commands/lab/delete/__init__.py
+++ b/.dda/extend/commands/lab/delete/__init__.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
     default=None,
     help="Environment id to delete (interactive if not provided)",
 )
-@click.option("--force", "-f", is_flag=True, help="Skip confirmation prompt")
+@click.option("--yes", "-y", is_flag=True, help="Auto-accept confirmation prompt")
 @pass_app
-def cmd(app: Application, *, id: str | None, force: bool) -> None:
+def cmd(app: Application, *, id: str | None, yes: bool) -> None:
     """
     Delete a lab environment.
 
@@ -65,7 +65,7 @@ def cmd(app: Application, *, id: str | None, force: bool) -> None:
                 app.display_info(f"  - {e.name} ({e.env_type})")
         return
 
-    if not force:
+    if not yes:
         if not click.confirm(f"Delete {env.env_type} environment '{id}'?"):
             app.display_info("Aborting.")
             return

--- a/.dda/extend/commands/lab/delete/__init__.py
+++ b/.dda/extend/commands/lab/delete/__init__.py
@@ -56,7 +56,7 @@ def cmd(app: Application, *, id: str | None, yes: bool) -> None:
     try:
         env = LabEnvironment.load(app, id)
     except Exception as exception:
-        app.display_error(f"Error loading environment '{id}': {exception}")
+        app.abort(f"Error loading environment '{id}': {exception}")
         return
 
     if env is None:

--- a/.dda/extend/commands/lab/delete/__init__.py
+++ b/.dda/extend/commands/lab/delete/__init__.py
@@ -53,7 +53,11 @@ def cmd(app: Application, *, id: str | None, yes: bool) -> None:
         )
         id = environments[selection - 1].name
 
-    env = LabEnvironment.load(app, id)
+    try:
+        env = LabEnvironment.load(app, id)
+    except Exception as exception:
+        app.display_error(f"Error loading environment '{id}': {exception}")
+        return
 
     if env is None:
         app.display_error(f"Environment '{id}' not found.")
@@ -78,5 +82,10 @@ def cmd(app: Application, *, id: str | None, yes: bool) -> None:
     except ValueError:
         app.display_warning(f"Provider '{env.env_type}' not found, removing from storage only.")
 
-    env.delete()
+    try:
+        env.delete()
+    except FileNotFoundError:
+        app.display_error(f"Environment '{id}' not found.")
+        return
+
     app.display_success(f"Environment '{id}' deleted.")

--- a/.dda/extend/commands/lab/list/__init__.py
+++ b/.dda/extend/commands/lab/list/__init__.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+from dda.cli.base import dynamic_command, pass_app
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+    from lab import LabEnvironment
+
+
+def _format_age(created_at: str) -> str:
+    """Format creation time as human-readable age."""
+    from datetime import datetime
+
+    if not created_at or created_at == "unknown":
+        return "unknown"
+
+    try:
+        created = datetime.fromisoformat(created_at)
+        now = datetime.now()
+        delta = now - created
+
+        if delta.days > 30:
+            months = delta.days // 30
+            return f"{months}mo ago"
+        if delta.days > 0:
+            return f"{delta.days}d ago"
+        hours = delta.seconds // 3600
+        if hours > 0:
+            return f"{hours}h ago"
+        minutes = delta.seconds // 60
+        return f"{minutes}m ago"
+    except (ValueError, TypeError):
+        return created_at[:10] if len(created_at) >= 10 else created_at
+
+
+def _get_category(env_type: str) -> str:
+    """Get the category for an environment type."""
+    local_types = {"kind", "minikube", "k3d", "docker"}
+    if env_type in local_types:
+        return "local"
+    return "cloud"
+
+
+def _format_env_row(env: LabEnvironment) -> dict[str, str]:
+    """Extract display values for an environment."""
+    return {
+        "name": env.name,
+        "type": env.env_type,
+        "age": _format_age(env.created_at),
+    }
+
+
+@dynamic_command(short_help="List all lab environments")
+@click.option("--type", "-t", "env_type", default=None, help="Filter by environment type (e.g., kind, gke, eks)")
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed information including all metadata")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+@pass_app
+def cmd(app: Application, *, env_type: str | None, verbose: bool, as_json: bool) -> None:
+    """
+    List all lab environments.
+
+    Examples:
+
+        # List all environments
+        dda lab list
+
+        # List only kind environments
+        dda lab list --type kind
+
+        # Show detailed info
+        dda lab list --verbose
+
+        # Output as JSON for scripting
+        dda lab list --json
+    """
+    import json
+
+    from lab import LabEnvironment
+
+    environments = LabEnvironment.load_all(app, env_type=env_type)
+
+    if not environments:
+        if as_json:
+            app.output("[]")
+            return
+        if env_type:
+            app.display_info(f"No {env_type} environments found.")
+        else:
+            app.display_info("No lab environments found.")
+        return
+
+    # JSON output mode
+    if as_json:
+        output = [
+            {
+                "name": env.name,
+                "type": env.env_type,
+                "category": env.metadata.get("category", _get_category(env.env_type)),
+                "created_at": env.created_at,
+                "info": env.info,
+                "metadata": env.metadata,
+            }
+            for env in environments
+        ]
+        app.j(json.dumps(output, indent=2))
+        return
+
+    rows = [_format_env_row(env) for env in sorted(environments, key=lambda e: e.name)]
+
+    columns = ["name", "type", "age"]
+    headers = {"name": "NAME", "type": "TYPE", "age": "AGE"}
+    widths = {col: max(len(headers[col]), max(len(row[col]) for row in rows)) for col in columns}
+
+    header_line = "  ".join(headers[col].ljust(widths[col]) for col in columns)
+    separator = "  ".join("─" * widths[col] for col in columns)
+
+    app.display_info("")
+    app.display_info(header_line)
+    app.display_info(separator)
+
+    for row in rows:
+        line = "  ".join(row[col].ljust(widths[col]) for col in columns)
+        app.display_info(line)
+
+    app.display_info("")
+
+    if verbose:
+        for env in sorted(environments, key=lambda e: e.name):
+            app.display_info(f"{env.name}:")
+            # Show all non-internal metadata
+            for key, value in env.metadata.items():
+                if not key.startswith("_") and value:
+                    app.display_info(f"  {key}: {value}")
+            app.display_info("")

--- a/.dda/extend/commands/lab/list/__init__.py
+++ b/.dda/extend/commands/lab/list/__init__.py
@@ -10,56 +10,11 @@ if TYPE_CHECKING:
 
     from lab import LabEnvironment
 
-
-def _format_age(created_at: str) -> str:
-    """Format creation time as human-readable age."""
-    from datetime import datetime
-
-    if not created_at or created_at == "unknown":
-        return "unknown"
-
-    try:
-        created = datetime.fromisoformat(created_at)
-        now = datetime.now()
-        delta = now - created
-
-        if delta.days > 30:
-            months = delta.days // 30
-            return f"{months}mo ago"
-        if delta.days > 0:
-            return f"{delta.days}d ago"
-        hours = delta.seconds // 3600
-        if hours > 0:
-            return f"{hours}h ago"
-        minutes = delta.seconds // 60
-        return f"{minutes}m ago"
-    except (ValueError, TypeError):
-        return created_at[:10] if len(created_at) >= 10 else created_at
-
-
-def _get_category(env_type: str) -> str:
-    """Get the category for an environment type."""
-    local_types = {"kind", "minikube", "k3d", "docker"}
-    if env_type in local_types:
-        return "local"
-    return "cloud"
-
-
-def _format_env_row(env: LabEnvironment) -> dict[str, str]:
-    """Extract display values for an environment."""
-    return {
-        "name": env.name,
-        "type": env.env_type,
-        "age": _format_age(env.created_at),
-    }
-
-
-@dynamic_command(short_help="List all lab environments")
+@dynamic_command(short_help="List all lab active environments")
 @click.option("--type", "-t", "env_type", default=None, help="Filter by environment type (e.g., kind, gke, eks)")
-@click.option("--verbose", "-v", is_flag=True, help="Show detailed information including all metadata")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 @pass_app
-def cmd(app: Application, *, env_type: str | None, verbose: bool, as_json: bool) -> None:
+def cmd(app: Application, *, env_type: str | None, as_json: bool) -> None:
     """
     List all lab environments.
 
@@ -70,9 +25,6 @@ def cmd(app: Application, *, env_type: str | None, verbose: bool, as_json: bool)
 
         # List only kind environments
         dda lab list --type kind
-
-        # Show detailed info
-        dda lab list --verbose
 
         # Output as JSON for scripting
         dda lab list --json
@@ -97,42 +49,22 @@ def cmd(app: Application, *, env_type: str | None, verbose: bool, as_json: bool)
     if as_json:
         output = [
             {
-                "name": env.name,
+                "id": env.name,
                 "type": env.env_type,
-                "category": env.metadata.get("category", _get_category(env.env_type)),
+                "category": env.category,
                 "created_at": env.created_at,
-                "info": env.info,
                 "metadata": env.metadata,
             }
             for env in environments
         ]
-        app.j(json.dumps(output, indent=2))
+        app.display(json.dumps(output, indent=2))
         return
 
-    rows = [_format_env_row(env) for env in sorted(environments, key=lambda e: e.name)]
-
-    columns = ["name", "type", "age"]
-    headers = {"name": "NAME", "type": "TYPE", "age": "AGE"}
-    widths = {col: max(len(headers[col]), max(len(row[col]) for row in rows)) for col in columns}
-
-    header_line = "  ".join(headers[col].ljust(widths[col]) for col in columns)
-    separator = "  ".join("─" * widths[col] for col in columns)
-
-    app.display_info("")
-    app.display_info(header_line)
-    app.display_info(separator)
-
-    for row in rows:
-        line = "  ".join(row[col].ljust(widths[col]) for col in columns)
-        app.display_info(line)
-
-    app.display_info("")
-
-    if verbose:
-        for env in sorted(environments, key=lambda e: e.name):
-            app.display_info(f"{env.name}:")
-            # Show all non-internal metadata
-            for key, value in env.metadata.items():
-                if not key.startswith("_") and value:
-                    app.display_info(f"  {key}: {value}")
-            app.display_info("")
+    table = {}
+    for env in environments:
+        if env.category not in table:
+            table[env.category] = {}
+        if env.env_type not in table[env.category]:
+            table[env.category][env.env_type] = {}
+        table[env.category][env.env_type][env.name] = env.to_dict()
+    app.display_table(table)

--- a/.dda/extend/commands/lab/list/__init__.py
+++ b/.dda/extend/commands/lab/list/__init__.py
@@ -8,7 +8,6 @@ from dda.cli.base import dynamic_command, pass_app
 if TYPE_CHECKING:
     from dda.cli.application import Application
 
-    from lab import LabEnvironment
 
 @dynamic_command(short_help="List all lab active environments")
 @click.option("--type", "-t", "env_type", default=None, help="Filter by environment type (e.g., kind, gke, eks)")

--- a/.dda/extend/commands/lab/local/__init__.py
+++ b/.dda/extend/commands/lab/local/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+"""
+Local environment providers.
+
+This group auto-discovers providers with category="local" and generates
+subcommands for each:
+    dda lab local kind create
+    dda lab local kind destroy
+    dda lab local kind status
+"""
+
+from __future__ import annotations
+
+from lab.providers.commands import create_provider_group
+
+# Import providers to register them
+from lab.providers.local import kind  # noqa: F401
+
+# Auto-generate commands for all "local" category providers
+cmd = create_provider_group(
+    category="local",
+    short_help="Local environment providers",
+)

--- a/.dda/extend/commands/lab/local/__init__.py
+++ b/.dda/extend/commands/lab/local/__init__.py
@@ -15,9 +15,6 @@ from __future__ import annotations
 
 from lab.providers.commands import create_provider_group
 
-# Import providers to register them
-from lab.providers.local import kind  # noqa: F401
-
 # Auto-generate commands for all "local" category providers
 cmd = create_provider_group(
     category="local",

--- a/.dda/extend/pythonpath/lab/__init__.py
+++ b/.dda/extend/pythonpath/lab/__init__.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -46,6 +46,7 @@ class LabEnvironment:
     Attributes:
         app: Application instance for storage access
         name: Unique identifier for the environment
+        category: Category of the environment (e.g., "local", "aws", "gcp")
         env_type: Type of environment (e.g., "kind", "gke", "eks", "minikube")
         created_at: ISO timestamp when the environment was created
         metadata: Type-specific metadata (flexible dict for provider-specific data)
@@ -54,6 +55,7 @@ class LabEnvironment:
     app: Application = field(repr=False, compare=False)
     name: str
     env_type: str
+    category: str
     created_at: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -67,6 +69,7 @@ class LabEnvironment:
         return cls(
             app=app,
             name=data["name"],
+            category=data["category"],
             env_type=data["env_type"],
             created_at=data.get("created_at", "unknown"),
             metadata=data.get("metadata", {}),
@@ -76,6 +79,7 @@ class LabEnvironment:
         """Convert to dictionary (excludes app)."""
         return {
             "name": self.name,
+            "category": self.category,
             "env_type": self.env_type,
             "created_at": self.created_at,
             "metadata": self.metadata,
@@ -129,25 +133,3 @@ class LabEnvironment:
     def exists(cls, app: Application, name: str) -> bool:
         """Check if an environment with this name exists."""
         return _get_environment_path(app, name).exists()
-
-
-# =============================================================================
-# Convenience Functions (delegate to LabEnvironment)
-# =============================================================================
-
-
-def add_environment(
-    app: Application,
-    name: str,
-    env_type: str,
-    metadata: dict[str, Any] | None = None,
-) -> LabEnvironment:
-    """Add a lab environment to storage."""
-    env = LabEnvironment(
-        app=app,
-        name=name,
-        env_type=env_type,
-        metadata=metadata or {},
-    )
-    env.save()
-    return env

--- a/.dda/extend/pythonpath/lab/__init__.py
+++ b/.dda/extend/pythonpath/lab/__init__.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+ENVIRONMENTS_DIR = "environments"
+
+
+# =============================================================================
+# Environment Storage - One file per environment
+# =============================================================================
+
+
+def _get_environments_dir(app: Application) -> Path:
+    """Get the environments storage directory.
+
+    Each environment is stored as a separate JSON file.
+    Structure: ~/.local/share/dda/lab/environments/{name}.json
+    """
+    storage_dir = Path(app.config.storage.join("lab").data) / ENVIRONMENTS_DIR
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    return storage_dir
+
+
+def _get_environment_path(app: Application, name: str) -> Path:
+    """Get the path to a specific environment's JSON file."""
+    return _get_environments_dir(app) / f"{name}.json"
+
+
+@dataclass
+class LabEnvironment:
+    """
+    Generic lab environment that can represent any type of environment.
+
+    Attributes:
+        app: Application instance for storage access
+        name: Unique identifier for the environment
+        env_type: Type of environment (e.g., "kind", "gke", "eks", "minikube")
+        created_at: ISO timestamp when the environment was created
+        metadata: Type-specific metadata (flexible dict for provider-specific data)
+    """
+
+    app: Application = field(repr=False, compare=False)
+    name: str
+    env_type: str
+    created_at: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.created_at:
+            self.created_at = datetime.now().isoformat()
+
+    @classmethod
+    def from_dict(cls, app: Application, data: dict[str, Any]) -> LabEnvironment:
+        """Create a LabEnvironment from a dictionary."""
+        return cls(
+            app=app,
+            name=data["name"],
+            env_type=data["env_type"],
+            created_at=data.get("created_at", "unknown"),
+            metadata=data.get("metadata", {}),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary (excludes app)."""
+        return {
+            "name": self.name,
+            "env_type": self.env_type,
+            "created_at": self.created_at,
+            "metadata": self.metadata,
+        }
+
+    def save(self) -> None:
+        """Save this environment to its own file."""
+        path = _get_environment_path(self.app, self.name)
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    def delete(self) -> bool:
+        """Delete this environment's file. Returns True if found and removed."""
+        path = _get_environment_path(self.app, self.name)
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+    @classmethod
+    def load(cls, app: Application, name: str) -> LabEnvironment | None:
+        """Load a specific environment by name."""
+        path = _get_environment_path(app, name)
+        if not path.exists():
+            return None
+        try:
+            with open(path) as f:
+                data = json.load(f)
+                return cls.from_dict(app, data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Error parsing environment file {path}: {e}") from e
+
+    @classmethod
+    def load_all(cls, app: Application, env_type: str | None = None) -> list[LabEnvironment]:
+        """Load all stored environments, optionally filtered by type."""
+        envs_dir = _get_environments_dir(app)
+        envs: list[LabEnvironment] = []
+        for path in envs_dir.glob("*.json"):
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+                    env = cls.from_dict(app, data)
+                    if env_type is None or env.env_type == env_type:
+                        envs.append(env)
+            except (json.JSONDecodeError, KeyError):
+                # Skip invalid files
+                continue
+        return envs
+
+    @classmethod
+    def exists(cls, app: Application, name: str) -> bool:
+        """Check if an environment with this name exists."""
+        return _get_environment_path(app, name).exists()
+
+
+# =============================================================================
+# Convenience Functions (delegate to LabEnvironment)
+# =============================================================================
+
+
+def add_environment(
+    app: Application,
+    name: str,
+    env_type: str,
+    metadata: dict[str, Any] | None = None,
+) -> LabEnvironment:
+    """Add a lab environment to storage."""
+    env = LabEnvironment(
+        app=app,
+        name=name,
+        env_type=env_type,
+        metadata=metadata or {},
+    )
+    env.save()
+    return env

--- a/.dda/extend/pythonpath/lab/__init__.py
+++ b/.dda/extend/pythonpath/lab/__init__.py
@@ -91,13 +91,13 @@ class LabEnvironment:
         with open(path, "w") as f:
             json.dump(self.to_dict(), f, indent=2)
 
-    def delete(self) -> bool:
+    def delete(self):
         """Delete this environment's file. Returns True if found and removed."""
         path = _get_environment_path(self.app, self.name)
         if path.exists():
             path.unlink()
             return True
-        return False
+        raise FileNotFoundError(f"Environment '{self.name}' not found")
 
     @classmethod
     def load(cls, app: Application, name: str) -> LabEnvironment | None:
@@ -105,12 +105,9 @@ class LabEnvironment:
         path = _get_environment_path(app, name)
         if not path.exists():
             return None
-        try:
-            with open(path) as f:
-                data = json.load(f)
-                return cls.from_dict(app, data)
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Error parsing environment file {path}: {e}") from e
+        with open(path) as f:
+            data = json.load(f)
+            return cls.from_dict(app, data)
 
     @classmethod
     def load_all(cls, app: Application, env_type: str | None = None) -> list[LabEnvironment]:

--- a/.dda/extend/pythonpath/lab/agent.py
+++ b/.dda/extend/pythonpath/lab/agent.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+DEFAULT_LOCAL_IMAGE_TAG = "datadog/agent-dev:local"
+
+
+def build_local_image(
+    app: Application,
+    tag: str = DEFAULT_LOCAL_IMAGE_TAG,
+    *,
+    process_agent: bool = False,
+    trace_agent: bool = False,
+    system_probe: bool = False,
+    security_agent: bool = False,
+    devenv: str = "",
+) -> str:
+    """
+    Build a local agent image using hacky-dev-image-build.
+
+    Runs the build inside a devcontainer to ensure proper build environment.
+
+    Args:
+        tag: Docker image tag for the built image.
+        process_agent: Include process-agent in the build.
+        trace_agent: Include trace-agent in the build.
+        system_probe: Include system-probe in the build.
+        security_agent: Include security-agent in the build.
+        devenv: Developer environment ID to use (default: "default").
+
+    Returns:
+        The image tag.
+    """
+    app.display_info(f"Building local agent image with tag '{tag}'...")
+
+    cmd = ["dda", "inv", "agent.hacky-dev-image-build", "--target-image", tag]
+
+    if process_agent:
+        cmd.append("--process-agent")
+    if trace_agent:
+        cmd.append("--trace-agent")
+    if system_probe:
+        cmd.append("--system-probe")
+    if security_agent:
+        cmd.append("--security-agent")
+
+    # Run in devcontainer for proper build environment
+    devenv_cmd = ["dda", "env", "dev", "run"]
+    if devenv:
+        devenv_cmd.extend(["--id", devenv])
+    devenv_cmd.append("--")
+
+    full_cmd = devenv_cmd + cmd
+    app.subprocess.run(full_cmd, check=True)
+
+    return tag
+
+
+def install_with_helm(
+    app: Application,
+    *,
+    cluster_name: str,
+    api_key: str,
+    app_key: str = "",
+    agent_image: str = "",
+    cluster_agent_image: str = "",
+    helm_values: str | None = None,
+    image_pull_policy: str = "IfNotPresent",
+) -> None:
+    """Install Datadog Agent using Helm."""
+    app.display_info("Installing Datadog Agent via Helm...")
+
+    # Add Datadog Helm repo
+    app.subprocess.run(["helm", "repo", "add", "datadog", "https://helm.datadoghq.com"], check=False)
+    app.subprocess.run(["helm", "repo", "update"], check=True)
+
+    # Build helm install command
+    helm_cmd = [
+        "helm",
+        "upgrade",
+        "--install",
+        "datadog",
+        "datadog/datadog",
+        "--namespace",
+        "datadog",
+        "--create-namespace",
+        "--set",
+        f"datadog.apiKey={api_key}",
+        "--set",
+        f"datadog.clusterName={cluster_name}",
+        "--set",
+        "datadog.kubelet.tlsVerify=false",
+        "--set",
+        "agents.useHostNetwork=true",
+        "--set",
+        "clusterAgent.enabled=true",
+        "--set",
+        "clusterAgent.metricsProvider.enabled=true",
+    ]
+
+    if app_key:
+        helm_cmd.extend(["--set", f"datadog.appKey={app_key}"])
+
+    if agent_image:
+        repo, image_tag = _parse_image(agent_image)
+        helm_cmd.extend(
+            [
+                "--set",
+                f"agents.image.repository={repo}",
+                "--set",
+                f"agents.image.tag={image_tag}",
+                "--set",
+                "agents.image.doNotCheckTag=true",
+                "--set",
+                f"agents.image.pullPolicy={image_pull_policy}",
+            ]
+        )
+
+    if cluster_agent_image:
+        repo, image_tag = _parse_image(cluster_agent_image)
+        helm_cmd.extend(
+            [
+                "--set",
+                f"clusterAgent.image.repository={repo}",
+                "--set",
+                f"clusterAgent.image.tag={image_tag}",
+                "--set",
+                f"clusterAgent.image.pullPolicy={image_pull_policy}",
+            ]
+        )
+
+    if helm_values:
+        helm_cmd.extend(["-f", helm_values])
+
+    app.subprocess.run(helm_cmd, check=True)
+
+    app.display_success("Datadog Agent installed successfully!")
+    app.display_info("""
+To check agent status:
+    kubectl get pods -n datadog
+    kubectl exec -it $(kubectl get pods -n datadog -l app=datadog -o jsonpath='{.items[0].metadata.name}') -n datadog -- agent status
+""")
+
+
+def _parse_image(image: str) -> tuple[str, str]:
+    """Parse image string into (repository, tag)."""
+    if ":" in image:
+        return image.rsplit(":", 1)
+    return image, "latest"

--- a/.dda/extend/pythonpath/lab/agent.py
+++ b/.dda/extend/pythonpath/lab/agent.py
@@ -40,11 +40,11 @@ def build_local_image(
         "inv",
         "agent.hacky-dev-image-build",
         "--target-image",
+        tag,
         "--process-agent",
         "--trace-agent",
         "--system-probe",
         "--security-agent",
-        tag,
     ]
 
     # Run in devcontainer for proper build environment

--- a/.dda/extend/pythonpath/lab/agent.py
+++ b/.dda/extend/pythonpath/lab/agent.py
@@ -16,6 +16,7 @@ def build_local_image(
     app: Application,
     tag: str = DEFAULT_LOCAL_IMAGE_TAG,
     devenv: str = "",
+    build_command: str = "",
 ) -> str:
     """
     Build a local agent image using hacky-dev-image-build.
@@ -41,11 +42,10 @@ def build_local_image(
         "agent.hacky-dev-image-build",
         "--target-image",
         tag,
-        "--process-agent",
-        "--trace-agent",
-        "--system-probe",
-        "--security-agent",
     ]
+
+    if build_command:
+        cmd = build_command.split(" ")
 
     # Run in devcontainer for proper build environment
     devenv_cmd = ["dda", "env", "dev", "run"]

--- a/.dda/extend/pythonpath/lab/agent.py
+++ b/.dda/extend/pythonpath/lab/agent.py
@@ -15,11 +15,6 @@ DEFAULT_LOCAL_IMAGE_TAG = "datadog/agent-dev:local"
 def build_local_image(
     app: Application,
     tag: str = DEFAULT_LOCAL_IMAGE_TAG,
-    *,
-    process_agent: bool = False,
-    trace_agent: bool = False,
-    system_probe: bool = False,
-    security_agent: bool = False,
     devenv: str = "",
 ) -> str:
     """
@@ -40,16 +35,17 @@ def build_local_image(
     """
     app.display_info(f"Building local agent image with tag '{tag}'...")
 
-    cmd = ["dda", "inv", "agent.hacky-dev-image-build", "--target-image", tag]
-
-    if process_agent:
-        cmd.append("--process-agent")
-    if trace_agent:
-        cmd.append("--trace-agent")
-    if system_probe:
-        cmd.append("--system-probe")
-    if security_agent:
-        cmd.append("--security-agent")
+    cmd = [
+        "dda",
+        "inv",
+        "agent.hacky-dev-image-build",
+        "--target-image",
+        "--process-agent",
+        "--trace-agent",
+        "--system-probe",
+        "--security-agent",
+        tag,
+    ]
 
     # Run in devcontainer for proper build environment
     devenv_cmd = ["dda", "env", "dev", "run"]

--- a/.dda/extend/pythonpath/lab/config.py
+++ b/.dda/extend/pythonpath/lab/config.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROFILE_FILENAME = ".test_infra_config.yaml"
+
+
+@dataclass
+class AwsConfig:
+    """AWS-specific configuration."""
+
+    key_pair_name: str | None = None
+    public_key_path: str | None = None
+    private_key_path: str | None = None
+    private_key_password: str | None = None
+    account: str | None = None
+    team_tag: str | None = None
+
+    def get_account(self) -> str:
+        if self.account is None:
+            return "agent-sandbox"
+        return self.account
+
+
+@dataclass
+class AzureConfig:
+    """Azure-specific configuration."""
+
+    public_key_path: str | None = None
+    account: str = "agent-sandbox"
+
+
+@dataclass
+class GCPConfig:
+    """GCP-specific configuration."""
+
+    public_key_path: str | None = None
+    pull_secret_path: str | None = None
+    account: str = "agent-sandbox"
+
+
+@dataclass
+class LocalConfig:
+    """Local environment configuration."""
+
+    public_key_path: str | None = None
+
+
+@dataclass
+class AgentConfig:
+    """Datadog Agent configuration."""
+
+    api_key: str | None = None
+    app_key: str | None = None
+    verify_code_signature: bool = True
+
+
+@dataclass
+class PulumiConfig:
+    """Pulumi-specific configuration."""
+
+    log_level: int | None = None
+    log_to_stderr: bool | None = None
+    verbose_progress_streams: bool | None = None
+
+
+@dataclass
+class LabConfig:
+    """Main configuration for lab environments."""
+
+    aws: AwsConfig = field(default_factory=AwsConfig)
+    azure: AzureConfig = field(default_factory=AzureConfig)
+    gcp: GCPConfig = field(default_factory=GCPConfig)
+    local: LocalConfig = field(default_factory=LocalConfig)
+    agent: AgentConfig = field(default_factory=AgentConfig)
+    pulumi: PulumiConfig = field(default_factory=PulumiConfig)
+    stack_params: dict[str, dict[str, str]] = field(default_factory=dict)
+    dev_mode: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> LabConfig:
+        """Create a LabConfig from a dictionary (parsed YAML)."""
+        if data is None:
+            return cls()
+
+        config_params = data.get("configParams", {}) or {}
+        stack_params = data.get("stackParams", {}) or {}
+
+        # Parse AWS config
+        aws_data = config_params.get("aws", {}) or {}
+        aws = AwsConfig(
+            key_pair_name=aws_data.get("keyPairName"),
+            public_key_path=aws_data.get("publicKeyPath"),
+            private_key_path=aws_data.get("privateKeyPath"),
+            private_key_password=aws_data.get("privateKeyPassword"),
+            account=aws_data.get("account"),
+            team_tag=aws_data.get("teamTag"),
+        )
+
+        # Parse Azure config
+        azure_data = config_params.get("azure", {}) or {}
+        azure = AzureConfig(
+            public_key_path=azure_data.get("publicKeyPath"),
+            account=azure_data.get("account", "agent-sandbox"),
+        )
+
+        # Parse GCP config
+        gcp_data = config_params.get("gcp", {}) or {}
+        gcp = GCPConfig(
+            public_key_path=gcp_data.get("publicKeyPath"),
+            pull_secret_path=gcp_data.get("pullSecretPath"),
+            account=gcp_data.get("account", "agent-sandbox"),
+        )
+
+        # Parse Local config
+        local_data = config_params.get("local", {}) or {}
+        local = LocalConfig(
+            public_key_path=local_data.get("publicKeyPath"),
+        )
+
+        # Parse Agent config
+        agent_data = config_params.get("agent", {}) or {}
+        agent = AgentConfig(
+            api_key=agent_data.get("apiKey"),
+            app_key=agent_data.get("appKey"),
+            verify_code_signature=agent_data.get("verifyCodeSignature", True),
+        )
+
+        # Parse Pulumi config
+        pulumi_data = config_params.get("pulumi", {}) or {}
+        pulumi = PulumiConfig(
+            log_level=pulumi_data.get("logLevel"),
+            log_to_stderr=pulumi_data.get("logToStdErr"),
+            verbose_progress_streams=pulumi_data.get("verboseProgressStreams"),
+        )
+
+        return cls(
+            aws=aws,
+            azure=azure,
+            gcp=gcp,
+            local=local,
+            agent=agent,
+            pulumi=pulumi,
+            stack_params=stack_params,
+            dev_mode=config_params.get("devMode", False),
+        )
+
+    def get_api_key(self) -> str | None:
+        """Get API key from config or environment variable."""
+        # First try environment variable
+        api_key = os.environ.get("E2E_API_KEY")
+        if api_key:
+            return api_key
+        # Fall back to config
+        return self.agent.api_key
+
+    def get_app_key(self) -> str | None:
+        """Get APP key from config or environment variable."""
+        # First try environment variable
+        app_key = os.environ.get("E2E_APP_KEY")
+        if app_key:
+            return app_key
+        # Fall back to config
+        return self.agent.app_key
+
+
+def get_config_path(config_path: str | None = None) -> Path:
+    """Get the full path to the config file."""
+    if config_path:
+        return Path(config_path).expanduser().absolute()
+    return Path.home() / PROFILE_FILENAME
+
+
+def load_config(config_path: str | None = None) -> LabConfig:
+    """Load configuration from file."""
+    path = get_config_path(config_path)
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+            return LabConfig.from_dict(data)
+    except FileNotFoundError:
+        return LabConfig()
+    except yaml.YAMLError as e:
+        raise ValueError(f"Error parsing config file {path}: {e}") from e

--- a/.dda/extend/pythonpath/lab/kind.py
+++ b/.dda/extend/pythonpath/lab/kind.py
@@ -5,24 +5,21 @@
 
 from __future__ import annotations
 
-import subprocess
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from dda.cli.application import Application
 
 
-def cluster_exists(name: str) -> bool:
+def cluster_exists(app: Application, name: str) -> bool:
     """Check if a kind cluster with the given name exists."""
-    return name in get_clusters()
+    return name in get_clusters(app)
 
 
-def get_clusters() -> list[str]:
+def get_clusters(app: Application) -> list[str]:
     """Get list of existing kind clusters."""
-    result = subprocess.run(["kind", "get", "clusters"], capture_output=True, check=False)
-    if result.returncode != 0:
-        return []
-    clusters = result.stdout.decode().strip().split("\n")
+    result = app.subprocess.capture(["kind", "get", "clusters"], check=False)
+    clusters = result.strip().split("\n")
     return [c for c in clusters if c]
 
 

--- a/.dda/extend/pythonpath/lab/kind.py
+++ b/.dda/extend/pythonpath/lab/kind.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+"""Kind cluster management utilities."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+def cluster_exists(name: str) -> bool:
+    """Check if a kind cluster with the given name exists."""
+    return name in get_clusters()
+
+
+def get_clusters() -> list[str]:
+    """Get list of existing kind clusters."""
+    result = subprocess.run(["kind", "get", "clusters"], capture_output=True, check=False)
+    if result.returncode != 0:
+        return []
+    clusters = result.stdout.decode().strip().split("\n")
+    return [c for c in clusters if c]
+
+
+def create_cluster(app: Application, name: str, config_path: str, node_image: str) -> None:
+    """Create a kind cluster."""
+    app.subprocess.run(
+        ["kind", "create", "cluster", "--name", name, "--config", config_path, "--image", node_image, "--wait", "60s"],
+        check=True,
+    )
+
+
+def delete_cluster(app: Application, name: str) -> None:
+    """Delete a kind cluster."""
+    app.subprocess.run(["kind", "delete", "cluster", "--name", name], check=True)
+
+
+def show_cluster_info(app: Application, name: str) -> None:
+    """Show cluster info."""
+    app.subprocess.run(["kubectl", "cluster-info", "--context", f"kind-{name}"], check=False)
+
+
+def load_image(app: Application, cluster_name: str, image: str) -> None:
+    """Load a docker image into a kind cluster."""
+    app.display_info(f"Loading image '{image}' into kind cluster '{cluster_name}'...")
+    app.subprocess.run(["kind", "load", "docker-image", image, "--name", cluster_name], check=True)

--- a/.dda/extend/pythonpath/lab/providers/__init__.py
+++ b/.dda/extend/pythonpath/lab/providers/__init__.py
@@ -163,7 +163,7 @@ class BaseProvider(ABC):
         ...
 
     @abstractmethod
-    def destroy(self, app: Application, name: str, *, force: bool = False) -> None:
+    def destroy(self, app: Application, name: str) -> None:
         """Destroy the environment. Storage cleanup is handled by dda lab delete."""
         ...
 

--- a/.dda/extend/pythonpath/lab/providers/__init__.py
+++ b/.dda/extend/pythonpath/lab/providers/__init__.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+"""
+Lab environment provider system with automatic command generation.
+
+Providers register themselves and automatically get CLI commands.
+Environment storage is handled automatically by the framework.
+
+Example provider definition:
+
+    @register_provider
+    class KindProvider(BaseProvider):
+        name = "kind"
+        category = "local"  # -> dda lab local kind
+        description = "Local Kind cluster"
+
+        create_options = [
+            Option("--k8s-version", default="v1.31.0", help="Kubernetes version"),
+        ]
+
+        def create(self, app, config) -> dict[str, Any] | None:
+            # Create the resource
+            # return metadata about what was created
+            ...
+
+        def destroy(self, app, name, *, force=False):
+            # Destroy the resource
+            ...
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+    from lab.config import LabConfig
+
+
+@dataclass
+class Option:
+    """Definition for a CLI option."""
+
+    name: str
+    default: Any = None
+    type: type | None = None
+    help: str = ""
+    is_flag: bool = False
+    required: bool = False
+    envvar: str | None = None
+    show_default: bool = True
+
+
+@dataclass
+class MissingPrerequisite:
+    """A missing prerequisite with remediation instructions."""
+
+    name: str
+    """What is missing (e.g., 'kind', 'helm', 'developer environment')."""
+
+    remediation: str
+    """How to fix it (e.g., 'brew install kind', 'dda env dev start')."""
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.remediation})"
+
+
+@dataclass
+class ProviderConfig:
+    """Raw configuration passed to provider for options parsing."""
+
+    name: str
+    options: dict[str, Any] = field(default_factory=dict)
+    lab_config: LabConfig = None  # LabConfig instance, injected by command framework
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.options.get(key, default)
+
+    def get_api_key(self) -> str | None:
+        """Get API key from options, lab config, or environment."""
+        # First check if explicitly passed as option
+        if api_key := self.get("api_key"):
+            return api_key
+        # Then try lab config
+        if self.lab_config:
+            return self.lab_config.get_api_key()
+        return None
+
+    def get_app_key(self) -> str | None:
+        """Get APP key from options, lab config, or environment."""
+        # First check if explicitly passed as option
+        if app_key := self.get("app_key"):
+            return app_key
+        # Then try lab config
+        if self.lab_config:
+            return self.lab_config.get_app_key()
+        return None
+
+
+@dataclass
+class ProviderOptions:
+    """Base class for typed provider options."""
+
+    name: str
+
+    @classmethod
+    def from_config(cls, config: ProviderConfig) -> ProviderOptions:
+        """Create options from ProviderConfig. Override in subclasses."""
+        return cls(name=config.name)
+
+
+class BaseProvider(ABC):
+    """
+    Base class for lab environment providers.
+
+    Subclasses define:
+    - name: unique identifier (e.g., "kind", "gke")
+    - category: command grouping (e.g., "local", "gcp", "aws")
+    - description: human-readable description
+    - create_options: list of Option for create command
+    - options_class: typed options dataclass for this provider
+
+    Environment storage is handled automatically by the framework:
+    - After successful create(): environment is saved with returned metadata
+    - After successful destroy(): environment is removed (via dda lab delete)
+    """
+
+    # Required class attributes (set in subclasses)
+    name: str
+    category: str
+    description: str
+
+    # CLI options for create command (override in subclasses)
+    create_options: list[Option] = []
+
+    # Typed options class for this provider (override in subclasses)
+    options_class: type[ProviderOptions] = ProviderOptions
+
+    @abstractmethod
+    def create(self, app: Application, options: ProviderOptions) -> dict[str, Any] | None:
+        """
+        Create the environment.
+
+        Args:
+            app: Application instance
+            options: Typed options for this provider (subclass of ProviderOptions)
+
+        Returns:
+            Optional dict of metadata about what was created (IPs, endpoints, etc.)
+            This metadata is stored and shown in `dda lab list`.
+
+        Example:
+            return {
+                "ip": "192.168.1.100",
+                "endpoint": "https://my-cluster.example.com",
+                "node_count": 3,
+            }
+        """
+        ...
+
+    @abstractmethod
+    def destroy(self, app: Application, name: str, *, force: bool = False) -> None:
+        """Destroy the environment. Storage cleanup is handled by dda lab delete."""
+        ...
+
+    def check_prerequisites(self, app: Application, options: ProviderOptions) -> list[MissingPrerequisite]:
+        """Return list of missing prerequisites. Override in subclasses."""
+        return []
+
+
+# Provider registry
+_PROVIDERS: dict[str, type[BaseProvider]] = {}
+
+
+def register_provider(cls: type[BaseProvider]) -> type[BaseProvider]:
+    """Decorator to register a provider class."""
+    _PROVIDERS[cls.name] = cls
+    return cls
+
+
+def get_provider(name: str) -> BaseProvider:
+    """Get a provider instance by name."""
+    if name not in _PROVIDERS:
+        available = ", ".join(sorted(_PROVIDERS.keys()))
+        raise ValueError(f"Unknown provider '{name}'. Available: {available}")
+    return _PROVIDERS[name]()
+
+
+def list_providers() -> list[type[BaseProvider]]:
+    """List all registered provider classes."""
+    return list(_PROVIDERS.values())
+
+
+def get_providers_by_category() -> dict[str, list[type[BaseProvider]]]:
+    """Group providers by category."""
+    by_category: dict[str, list[type[BaseProvider]]] = {}
+    for provider_cls in _PROVIDERS.values():
+        category = provider_cls.category
+        by_category.setdefault(category, []).append(provider_cls)
+    return by_category
+
+
+def _discover_providers() -> None:
+    """Auto-discover and import all provider modules to trigger registration."""
+    import importlib
+    from pathlib import Path
+
+    providers_dir = Path(__file__).parent
+
+    # Find all category subdirectories (local/, cloud/, etc.)
+    for category_dir in providers_dir.iterdir():
+        if not category_dir.is_dir() or category_dir.name.startswith("_"):
+            continue
+
+        # Import each provider module in the category
+        for provider_file in category_dir.glob("*.py"):
+            if provider_file.name.startswith("_"):
+                continue
+            module_name = f"lab.providers.{category_dir.name}.{provider_file.stem}"
+            try:
+                importlib.import_module(module_name)
+            except ImportError:
+                pass  # Skip modules that fail to import
+
+
+# Auto-discover providers on module load
+_discover_providers()

--- a/.dda/extend/pythonpath/lab/providers/__init__.py
+++ b/.dda/extend/pythonpath/lab/providers/__init__.py
@@ -189,30 +189,3 @@ def get_providers_by_category() -> dict[str, list[type[BaseProvider]]]:
         category = provider_cls.category
         by_category.setdefault(category, []).append(provider_cls)
     return by_category
-
-
-def _discover_providers() -> None:
-    """Auto-discover and import all provider modules to trigger registration."""
-    import importlib
-    from pathlib import Path
-
-    providers_dir = Path(__file__).parent
-
-    # Find all category subdirectories (local/, cloud/, etc.)
-    for category_dir in providers_dir.iterdir():
-        if not category_dir.is_dir() or category_dir.name.startswith("_"):
-            continue
-
-        # Import each provider module in the category
-        for provider_file in category_dir.glob("*.py"):
-            if provider_file.name.startswith("_"):
-                continue
-            module_name = f"lab.providers.{category_dir.name}.{provider_file.stem}"
-            try:
-                importlib.import_module(module_name)
-            except ImportError:
-                pass  # Skip modules that fail to import
-
-
-# Auto-discover providers on module load
-_discover_providers()

--- a/.dda/extend/pythonpath/lab/providers/__init__.py
+++ b/.dda/extend/pythonpath/lab/providers/__init__.py
@@ -36,23 +36,10 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from click import Option
     from dda.cli.application import Application
 
     from lab.config import LabConfig
-
-
-@dataclass
-class Option:
-    """Definition for a CLI option."""
-
-    name: str
-    default: Any = None
-    type: type | None = None
-    help: str = ""
-    is_flag: bool = False
-    required: bool = False
-    envvar: str | None = None
-    show_default: bool = True
 
 
 @dataclass

--- a/.dda/extend/pythonpath/lab/providers/commands.py
+++ b/.dda/extend/pythonpath/lab/providers/commands.py
@@ -114,23 +114,7 @@ def generate_create_command(provider_cls: type[BaseProvider]) -> DynamicCommand:
     create_cmd = click.option("--id", "-i", default=None, help="Environment id")(create_cmd)
 
     for opt in reversed(provider_cls.create_options):
-        kwargs: dict[str, Any] = {"help": opt.help}
-
-        if opt.is_flag:
-            kwargs["is_flag"] = True
-        else:
-            kwargs["default"] = opt.default
-            kwargs["show_default"] = opt.show_default
-            if opt.type:
-                kwargs["type"] = opt.type
-
-        if opt.required:
-            kwargs["required"] = True
-        if opt.envvar:
-            kwargs["envvar"] = opt.envvar
-
-        decorator = click.option(opt.name, **kwargs)
-        create_cmd = decorator(create_cmd)
+        opt(create_cmd)
 
     # Wrap with dynamic_command
     create_cmd = dynamic_command(short_help=f"Create a {provider_cls.description}")(create_cmd)

--- a/.dda/extend/pythonpath/lab/providers/commands.py
+++ b/.dda/extend/pythonpath/lab/providers/commands.py
@@ -75,6 +75,8 @@ def generate_create_command(provider_cls: type[BaseProvider]) -> DynamicCommand:
         from lab.config import load_config
 
         provider = provider_cls()
+        if not name:
+            name = f"{provider.category}-{provider.name}"
 
         # Load lab config once and inject into provider config
         lab_config = load_config()
@@ -108,7 +110,7 @@ def generate_create_command(provider_cls: type[BaseProvider]) -> DynamicCommand:
         ).save()
 
     # Apply options dynamically
-    create_cmd = click.option("--name", "-n", required=True, help="Environment name")(create_cmd)
+    create_cmd = click.option("--name", "-n", default=None, help="Environment name")(create_cmd)
 
     for opt in reversed(provider_cls.create_options):
         kwargs: dict[str, Any] = {"help": opt.help}

--- a/.dda/extend/pythonpath/lab/providers/commands.py
+++ b/.dda/extend/pythonpath/lab/providers/commands.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+"""
+Dynamic command generation for lab providers.
+
+Providers get auto-generated create commands:
+    dda lab local kind create --name foo
+
+Deletion is generic (works for any provider):
+    dda lab delete --name foo
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import click
+from dda.cli.base import DynamicCommand, DynamicGroup
+
+if TYPE_CHECKING:
+    from lab.providers import BaseProvider
+
+
+def create_provider_group(category: str, short_help: str) -> DynamicGroup:
+    """
+    Create a dynamic group that auto-discovers providers for a category.
+
+    Each provider gets a subcommand that directly runs create (no subgroup).
+    """
+
+    class ProviderGroup(DynamicGroup):
+        """Dynamic group that generates create commands from providers."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self._provider_category = category
+
+        def list_commands(self, ctx: click.Context) -> list[str]:
+            from lab.providers import get_providers_by_category
+
+            providers = get_providers_by_category().get(self._provider_category, [])
+            return sorted(p.name for p in providers)
+
+        def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+            from lab.providers import get_providers_by_category
+
+            providers = get_providers_by_category().get(self._provider_category, [])
+
+            for provider_cls in providers:
+                if provider_cls.name == cmd_name:
+                    return generate_create_command(provider_cls)
+
+            return None
+
+    @click.group(cls=ProviderGroup, short_help=short_help)
+    def group() -> None:
+        pass
+
+    group.__doc__ = f"Commands for {short_help.lower()}."
+    return group
+
+
+def generate_create_command(provider_cls: type[BaseProvider]) -> DynamicCommand:
+    """Generate a create command for a provider."""
+    from dda.cli.application import Application
+    from dda.cli.base import dynamic_command, pass_app
+
+    from lab import LabEnvironment
+    from lab.providers import ProviderConfig
+
+    # Build the command function
+    @pass_app
+    def create_cmd(app: Application, *, name: str, **kwargs: Any) -> None:
+        from lab.config import load_config
+
+        provider = provider_cls()
+
+        # Load lab config once and inject into provider config
+        lab_config = load_config()
+        config = ProviderConfig(name=name, options=kwargs, lab_config=lab_config)
+
+        # Create typed options for this provider
+        options = provider.options_class.from_config(config)
+
+        # Check prerequisites
+        missing = provider.check_prerequisites(app, options)
+        if missing:
+            lines = ["Missing prerequisites:"]
+            for prereq in missing:
+                lines.append(f"  • {prereq.name}")
+                lines.append(f"    → {prereq.remediation}")
+            app.abort("\n".join(lines))
+
+        result = provider.create(app, options)
+
+        # Merge provider-returned metadata with options
+        metadata = {"category": provider_cls.category, **kwargs}
+        if result:
+            metadata["output"] = result  # Store under _info to separate from options
+
+        # Automatically save environment after successful create
+        LabEnvironment(
+            app,
+            name=name,
+            env_type=provider_cls.name,
+            metadata=metadata or {},
+        ).save()
+
+    # Apply options dynamically
+    create_cmd = click.option("--name", "-n", required=True, help="Environment name")(create_cmd)
+
+    for opt in reversed(provider_cls.create_options):
+        kwargs: dict[str, Any] = {"help": opt.help}
+
+        if opt.is_flag:
+            kwargs["is_flag"] = True
+        else:
+            kwargs["default"] = opt.default
+            kwargs["show_default"] = opt.show_default
+            if opt.type:
+                kwargs["type"] = opt.type
+
+        if opt.required:
+            kwargs["required"] = True
+        if opt.envvar:
+            kwargs["envvar"] = opt.envvar
+
+        decorator = click.option(opt.name, **kwargs)
+        create_cmd = decorator(create_cmd)
+
+    # Wrap with dynamic_command
+    create_cmd = dynamic_command(short_help=f"Create a {provider_cls.description}")(create_cmd)
+    create_cmd.__doc__ = f"Create a {provider_cls.description}."
+    create_cmd.name = provider_cls.name
+
+    return create_cmd

--- a/.dda/extend/pythonpath/lab/providers/commands.py
+++ b/.dda/extend/pythonpath/lab/providers/commands.py
@@ -105,6 +105,7 @@ def generate_create_command(provider_cls: type[BaseProvider]) -> DynamicCommand:
         LabEnvironment(
             app,
             name=id,
+            category=provider_cls.category,
             env_type=provider_cls.name,
             metadata=metadata or {},
         ).save()

--- a/.dda/extend/pythonpath/lab/providers/commands.py
+++ b/.dda/extend/pythonpath/lab/providers/commands.py
@@ -85,8 +85,8 @@ def generate_create_command(provider_cls: type[BaseProvider]) -> DynamicCommand:
         # Create typed options for this provider
         options = provider.options_class.from_config(config)
 
-        # Check prerequisites
-        missing = provider.check_prerequisites(app, options)
+        # Check prerequisites (action-specific filtering)
+        missing = [p for p in provider.check_prerequisites(app, options) if "create" in p.actions]
         if missing:
             lines = ["Missing prerequisites:"]
             for prereq in missing:

--- a/.dda/extend/pythonpath/lab/providers/local/__init__.py
+++ b/.dda/extend/pythonpath/lab/providers/local/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/.dda/extend/pythonpath/lab/providers/local/kind.py
+++ b/.dda/extend/pythonpath/lab/providers/local/kind.py
@@ -133,7 +133,7 @@ class KindProvider(BaseProvider):
             )
             options._local_image = True
 
-        existing = cluster_exists(name)
+        existing = cluster_exists(app, name)
         if existing:
             if options.force:
                 app.display_info(f"Deleting existing cluster '{name}'...")
@@ -200,7 +200,7 @@ nodes:
     def destroy(self, app: Application, name: str) -> None:
         from lab.kind import cluster_exists, delete_cluster
 
-        if not cluster_exists(name):
+        if not cluster_exists(app, name):
             app.display_warning(f"Cluster '{name}' does not exist in kind")
             return
 

--- a/.dda/extend/pythonpath/lab/providers/local/kind.py
+++ b/.dda/extend/pythonpath/lab/providers/local/kind.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+"""Kind (Kubernetes in Docker) provider."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from lab.providers import BaseProvider, MissingPrerequisite, Option, ProviderConfig, ProviderOptions, register_provider
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+@dataclass
+class KindOptions(ProviderOptions):
+    """Typed options for Kind provider."""
+
+    # Kind-specific options
+    k8s_version: str = "v1.32.0"
+    install_agent: bool = False
+    agent_image: str = ""
+    load_image: str = ""
+    build_agent: bool = False
+    with_process_agent: bool = False
+    with_trace_agent: bool = False
+    with_system_probe: bool = False
+    with_security_agent: bool = False
+    helm_values: str = ""
+    devenv: str = ""
+    force: bool = False
+    # Credentials (resolved from config/env)
+    api_key: str = ""
+    app_key: str = ""
+    # Internal state (set during create)
+    _local_image: bool = False
+
+    @classmethod
+    def from_config(cls, config: ProviderConfig) -> KindOptions:
+        """Create KindOptions from ProviderConfig."""
+        return cls(
+            name=config.name,
+            k8s_version=config.options.get("k8s_version", "v1.32.0"),
+            install_agent=config.options.get("install_agent", False),
+            agent_image=config.options.get("agent_image", ""),
+            load_image=config.options.get("load_image", ""),
+            build_agent=config.options.get("build_agent", False),
+            with_process_agent=config.options.get("with_process_agent", False),
+            with_trace_agent=config.options.get("with_trace_agent", False),
+            with_system_probe=config.options.get("with_system_probe", False),
+            with_security_agent=config.options.get("with_security_agent", False),
+            helm_values=config.options.get("helm_values", ""),
+            devenv=config.options.get("devenv", ""),
+            force=config.options.get("force", False),
+            api_key=config.get_api_key() or "",
+            app_key=config.get_app_key() or "",
+        )
+
+    @property
+    def wants_agent(self) -> bool:
+        """Check if agent installation is requested."""
+        return self.install_agent or self.build_agent or bool(self.load_image)
+
+
+@register_provider
+class KindProvider(BaseProvider):
+    """Provider for local Kind clusters."""
+
+    name = "kind"
+    category = "local"
+    description = "Kind cluster (Kubernetes in Docker)"
+    options_class = KindOptions
+
+    create_options = [
+        Option("--k8s-version", default="v1.32.0", help="Kubernetes version"),
+        Option("--install-agent", is_flag=True, help="Install Datadog Agent"),
+        Option("--agent-image", default="", help="Custom agent image"),
+        Option("--load-image", default="", help="Load existing local docker image into cluster"),
+        Option("--build-agent", is_flag=True, help="Build local agent image before deploying"),
+        Option("--with-process-agent", is_flag=True, help="Include process-agent in local build"),
+        Option("--with-trace-agent", is_flag=True, help="Include trace-agent in local build"),
+        Option("--with-system-probe", is_flag=True, help="Include system-probe in local build"),
+        Option("--with-security-agent", is_flag=True, help="Include security-agent in local build"),
+        Option("--helm-values", default="", help="Path to custom Helm values.yaml file"),
+        Option("--devenv", default="", help="Developer environment ID for building (see dda env dev)"),
+        Option("--force", "-f", is_flag=True, help="Recreate if exists"),
+    ]
+
+    def check_prerequisites(self, app: Application, options: KindOptions) -> list[MissingPrerequisite]:
+        missing: list[MissingPrerequisite] = []
+
+        if not shutil.which("kind"):
+            missing.append(
+                MissingPrerequisite(
+                    name="kind",
+                    remediation="https://kind.sigs.k8s.io/docs/user/quick-start/#installation",
+                )
+            )
+        if not shutil.which("helm"):
+            missing.append(
+                MissingPrerequisite(
+                    name="helm",
+                    remediation="https://helm.sh/docs/intro/install/",
+                )
+            )
+
+        # Check dev environment is running if building locally
+        if options.build_agent:
+            if not self._is_devenv_running(options.devenv):
+                env_id = options.devenv or "default"
+                missing.append(
+                    MissingPrerequisite(
+                        name=f"Developer environment '{env_id}' not running",
+                        remediation="dda env dev start" + (f" --id {options.devenv}" if options.devenv else ""),
+                    )
+                )
+
+        return missing
+
+    def create(self, app: Application, options: KindOptions) -> dict[str, Any] | None:
+        from lab.agent import build_local_image
+        from lab.kind import cluster_exists, create_cluster, delete_cluster, load_image, show_cluster_info
+
+        name = options.name
+
+        # Build local agent image if requested (do this before cluster operations)
+        if options.build_agent:
+            options.agent_image = build_local_image(
+                app,
+                tag=options.agent_image or "datadog/agent-dev:local",
+                process_agent=options.with_process_agent,
+                trace_agent=options.with_trace_agent,
+                system_probe=options.with_system_probe,
+                security_agent=options.with_security_agent,
+                devenv=options.devenv,
+            )
+
+        existing = cluster_exists(name)
+        if existing:
+            if options.force:
+                app.display_info(f"Deleting existing cluster '{name}'...")
+                delete_cluster(app, name)
+                existing = False
+            elif options.wants_agent:
+                # Cluster exists but user wants to install/update agent - that's fine
+                app.display_info(f"Cluster '{name}' exists. Installing/updating agent...")
+            else:
+                app.abort(f"Cluster '{name}' exists. Use --force to recreate.")
+
+        # Create cluster if needed
+        if not existing:
+            app.display_info(f"Creating kind cluster '{name}' with Kubernetes {options.k8s_version}...")
+
+            kind_config = """
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+"""
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+                f.write(kind_config)
+                config_path = f.name
+
+            try:
+                create_cluster(app, name, config_path, f"kindest/node:{options.k8s_version}")
+            finally:
+                os.unlink(config_path)
+
+            app.display_success(f"Cluster '{name}' created")
+            show_cluster_info(app, name)
+
+        # Load built image into cluster
+        if options.build_agent and options.agent_image:
+            load_image(app, name, options.agent_image)
+            options._local_image = True
+
+        # Load existing image if specified
+        if options.load_image:
+            load_image(app, name, options.load_image)
+            if not options.agent_image:
+                options.agent_image = options.load_image
+            options._local_image = True
+
+        # Install agent if requested
+        if options.wants_agent:
+            self._install_agent(app, name, options)
+
+        app.display_success(f"Cluster '{name}' is ready")
+        app.display_info(f"Use: kubectl config use-context kind-{name}")
+
+        # Return metadata about what was created
+        return {
+            "context": f"kind-{name}",
+            "k8s_version": options.k8s_version,
+            "agent_installed": options.wants_agent,
+            "agent_image": options.agent_image or None,
+        }
+
+    def destroy(self, app: Application, name: str) -> None:
+        from lab.kind import cluster_exists, delete_cluster
+
+        if not cluster_exists(name):
+            app.display_warning(f"Cluster '{name}' does not exist in kind")
+            return
+
+        app.display_info(f"Destroying cluster '{name}'...")
+        delete_cluster(app, name)
+        app.display_success(f"Cluster '{name}' destroyed")
+
+    def _is_devenv_running(self, devenv: str) -> bool:
+        """Check if the developer environment is running."""
+        import subprocess
+
+        env_id = devenv or "default"
+        cmd = ["dda", "env", "dev", "status", "--id", env_id]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        return result.returncode == 0 and "started" in result.stdout.lower()
+
+    def _install_agent(self, app: Application, name: str, options: KindOptions) -> None:
+        from lab.agent import install_with_helm
+
+        if not options.api_key:
+            app.abort("API key required. Set E2E_API_KEY environment variable or configure in lab config.")
+
+        # Use Never pull policy for local images (built or loaded)
+        image_pull_policy = "Never" if options._local_image else "IfNotPresent"
+
+        install_with_helm(
+            app,
+            cluster_name=name,
+            api_key=options.api_key,
+            app_key=options.app_key,
+            agent_image=options.agent_image,
+            helm_values=options.helm_values or None,
+            image_pull_policy=image_pull_policy,
+        )

--- a/docs/public/tutorials/dev/lab/index.md
+++ b/docs/public/tutorials/dev/lab/index.md
@@ -1,0 +1,53 @@
+# Lab environments
+
+-----
+
+Lab environments are Kubernetes clusters for testing the Datadog Agent. The `dda lab` command group manages these environments.
+
+## Supported providers
+
+| Provider | Category | Description |
+|----------|----------|-------------|
+| [Kind](kind.md) | Local | Kubernetes in Docker - lightweight local clusters |
+
+## Common commands
+
+### List environments
+
+```bash
+dda lab list
+
+# Filter by type
+dda lab list --type kind
+
+# JSON output for scripting
+dda lab list --json
+```
+
+### Delete environment
+
+```bash
+dda lab delete --name <name>
+
+# Skip confirmation
+dda lab delete --name <name> --force
+```
+
+## Configuration
+
+API keys can be configured via environment variables:
+
+```bash
+export E2E_API_KEY=your_api_key
+export E2E_APP_KEY=your_app_key  # optional
+```
+
+Or in `~/.test_infra_config.yaml`:
+
+```yaml
+configParams:
+  agent:
+    apiKey: your_api_key
+    appKey: your_app_key
+```
+

--- a/docs/public/tutorials/dev/lab/index.md
+++ b/docs/public/tutorials/dev/lab/index.md
@@ -27,15 +27,15 @@ dda lab list --json
 ### Delete environment
 
 ```bash
-dda lab delete --name <name>
+dda lab delete
 
-# Skip confirmation
-dda lab delete --name <name> --force
+# Non-interactive deletion
+dda lab delete --id <id> --yes
 ```
 
 ## Configuration
 
-API keys can be configured via environment variables:
+If the environment provider installs the Agent (for example `dda lab local kind`), you must provide an API key. API keys can be configured via environment variables:
 
 ```bash
 export E2E_API_KEY=your_api_key

--- a/docs/public/tutorials/dev/lab/kind.md
+++ b/docs/public/tutorials/dev/lab/kind.md
@@ -91,9 +91,7 @@ kubectl config use-context kind-dev
 kubectl get pods -n datadog
 
 # View agent status
-kubectl exec -it -n datadog \
-    $(kubectl get pods -n datadog -l app=datadog -o jsonpath='{.items[0].metadata.name}') \
-    -- agent status
+kubectl exec -n datadog daemonset/datadog-agent -- agent status
 
 # View agent logs
 kubectl logs -n datadog -l app=datadog -f
@@ -116,4 +114,3 @@ kubectl logs -n datadog -l app=datadog -f
 | `--with-security-agent` | Include security-agent in build |
 | `--devenv` | Developer environment ID for building |
 | `--force`, `-f` | Recreate cluster if exists |
-

--- a/docs/public/tutorials/dev/lab/kind.md
+++ b/docs/public/tutorials/dev/lab/kind.md
@@ -1,0 +1,119 @@
+# Kind
+
+-----
+
+[Kind](https://kind.sigs.k8s.io/) (Kubernetes in Docker) creates lightweight local Kubernetes clusters for development and testing.
+
+## Prerequisites
+
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [helm](https://helm.sh/docs/intro/install/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+
+## Quick start
+
+```bash
+# Create cluster with agent
+dda lab local kind --name dev --install-agent
+```
+
+## Create cluster
+
+```bash
+# Basic cluster (no agent)
+dda lab local kind --name dev
+
+# With agent installation
+dda lab local kind --name dev --install-agent
+
+# With specific Kubernetes version
+dda lab local kind --name dev --k8s-version v1.30.0
+
+# Recreate existing cluster
+dda lab local kind --name dev --force
+```
+
+## Deploy agent
+
+### From registry
+
+```bash
+# Default agent image
+dda lab local kind --name dev --install-agent
+
+# Custom image
+dda lab local kind --name dev --install-agent --agent-image gcr.io/datadoghq/agent:7.50.0
+
+# With custom Helm values
+dda lab local kind --name dev --install-agent --helm-values ./values.yaml
+```
+
+### Build locally
+
+Builds run inside a [developer environment](../env.md) to ensure proper build tooling.
+
+/// note
+The developer environment must be running before building. Start it with:
+```bash
+dda env dev start
+```
+///
+
+```bash
+# Build and deploy agent
+dda lab local kind --name dev --build-agent
+
+# Include additional components
+dda lab local kind --name dev --build-agent \
+    --with-process-agent \
+    --with-trace-agent \
+    --with-system-probe \
+    --with-security-agent
+
+# Use a specific developer environment
+dda lab local kind --name dev --build-agent --devenv myenv
+```
+
+### Load existing image
+
+```bash
+# Load pre-built local image
+dda lab local kind --name dev --load-image myagent:dev
+```
+
+## Working with the cluster
+
+```bash
+# Switch kubectl context
+kubectl config use-context kind-dev
+
+# Check agent pods
+kubectl get pods -n datadog
+
+# View agent status
+kubectl exec -it -n datadog \
+    $(kubectl get pods -n datadog -l app=datadog -o jsonpath='{.items[0].metadata.name}') \
+    -- agent status
+
+# View agent logs
+kubectl logs -n datadog -l app=datadog -f
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--name`, `-n` | Cluster name (required) |
+| `--k8s-version` | Kubernetes version (default: v1.32.0) |
+| `--install-agent` | Install Datadog Agent |
+| `--agent-image` | Custom agent image |
+| `--helm-values` | Path to Helm values.yaml |
+| `--build-agent` | Build local agent image |
+| `--load-image` | Load local Docker image |
+| `--with-process-agent` | Include process-agent in build |
+| `--with-trace-agent` | Include trace-agent in build |
+| `--with-system-probe` | Include system-probe in build |
+| `--with-security-agent` | Include security-agent in build |
+| `--devenv` | Developer environment ID for building |
+| `--force`, `-f` | Recreate cluster if exists |
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,9 @@ nav:
 - Tutorials:
   - Develop:
     - Environment usage: tutorials/dev/env.md
+    - Lab environments:
+      - tutorials/dev/lab/index.md
+      - Kind: tutorials/dev/lab/kind.md
 - Guidelines:
   - Contributing: guidelines/contributing.md
   - Documentation: guidelines/docs.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ quote-style = "preserve"
 
 [tool.mypy]
 python_version = "3.12"
+# Make mypy aware of dda extension modules (e.g. `lab`).
+mypy_path = [".dda/extend/pythonpath"]
 # Follows imports and type-check imported modules.
 follow_imports = "normal"
 # Ignore errors about imported packages that don't provide type hints.


### PR DESCRIPTION
### What does this PR do?

Add a new `dda lab` subcommand group that is made to contains utilities to run experimentation environment for the agent quickly. That aims to be a replacement to `dda inv create-*` invoke tasks.
For now I implemented a local kind lab, that does not reuse Pulumi because it was having bad performance (refreshing + planning state is slow) compared to what we have by simply running directly `kind create` command.

The doc has been update and is in `docs/public/tutorials/dev/lab`

### Motivation

### Describe how you validated your changes

### Additional Notes
