### PR TITLE
git-worktree compatibility for omnibus docker-build

### DIFF
--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -62,7 +62,11 @@ def download_go_dependencies(
                 return
             if attempt < max_retry - 1:
                 wait = 10 ** (attempt + 1)
-                print(f"  [{attempt + 1}/{max_retry}] Failed `{cmd}` in {path}, retrying in {wait}s")
+                error_preview = (result.stderr or result.stdout or "no output")[:500]
+                print(
+                    f"  [{attempt + 1}/{max_retry}] Failed `{cmd}` in {path} (exit code {result.returncode}), retrying in {wait}s\n"
+                    f"    Error: {error_preview}"
+                )
                 sleep(wait)
         error_output = result.stderr or result.stdout if result else "unknown error"
         raise Exit(f"go mod failed for {path}: {error_output}", code=1)

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -639,30 +640,32 @@ def docker_build(
     for d in [omnibus_dir, omnibus_state_dir, git_cache_subdir, opt_subdir, gems_dir, go_mod_dir, go_build_dir]:
         os.makedirs(d, exist_ok=True)
 
-    # Get current working directory (repo root)
-    repo_root = os.getcwd()
-
-    # GIT ISOLATION: Pre-generate version cache and shadow .git to isolate the build.
-    # This solves two problems:
-    # 1. Git worktrees use a .git file with absolute path that doesn't exist in Docker
-    # 2. We want read-only mounts so the build can't affect the local filesystem
+    # REPO ISOLATION: Copy repo to temp directory so the build can't modify the working tree.
+    # This also solves git worktree issues (worktrees use absolute paths that don't exist in Docker).
     #
-    # Solution: Shadow .git with an empty file/dir so git operations see "not a repo"
-    # instead of failing on invalid worktree paths. The repo mount is read-only.
+    # We use `git ls-files` to respect .gitignore, keeping the copy small (~34MB vs full repo).
+    # The version cache is pre-generated since git won't be available in the copy.
     from tasks.libs.releasing.version import create_version_json
 
+    print("Pre-generating version cache (git won't be available in container)...")
     create_version_json(ctx)
 
-    # Create shadow for .git - must match type (file for worktree, dir for regular repo)
-    git_path = os.path.join(repo_root, '.git')
-    git_shadow_path = None
-    if os.path.isfile(git_path):
-        # Worktree: .git is a file, shadow with empty file
-        git_shadow_fd, git_shadow_path = tempfile.mkstemp(prefix='git-shadow-')
-        os.close(git_shadow_fd)
-    elif os.path.isdir(git_path):
-        # Regular repo: .git is a directory, shadow with empty directory
-        git_shadow_path = tempfile.mkdtemp(prefix='git-shadow-')
+    print("Creating isolated repo copy (respecting .gitignore)...")
+    temp_repo = tempfile.mkdtemp(prefix='agent-build-repo-')
+
+    # Use git ls-files to get all tracked + untracked non-ignored files, then tar/untar
+    # -c = cached (tracked), -o = others (untracked), --exclude-standard = respect .gitignore
+    # -z = null-terminated for safe handling of special characters
+    #
+    # We pipe through tar for speed (~2s for 18k files vs ~30s+ for Python file-by-file).
+    # The tar command uses POSIX options that work on both GNU and BSD tar.
+    ctx.run(
+        f"git ls-files -coz --exclude-standard | tar -c --null -T - | tar -xC {temp_repo}",
+        hide=True,
+    )
+
+    file_count = ctx.run("git ls-files -co --exclude-standard | wc -l", hide=True).stdout.strip()
+    print(f"Copied {file_count} files to {temp_repo}")
 
     # Build environment variables
     env_args = [
@@ -679,7 +682,7 @@ def docker_build(
     ]
 
     # Build volume mounts (note: /opt/datadog-agent is a symlink created in build_cmd)
-    # The repo is mounted read-only with .git shadowed by an empty file/dir
+    # The temp repo copy is mounted (writable, since Go needs to update go.work.sum etc)
     container_repo_path = "/go/src/github.com/DataDog/datadog-agent"
     volume_args = [
         f"-v {omnibus_dir}:/omnibus",
@@ -687,11 +690,8 @@ def docker_build(
         f"-v {gems_dir}:/gems",
         f"-v {go_mod_dir}:/go/pkg/mod",
         f"-v {go_build_dir}:/root/.cache/go-build",
-        f"-v {repo_root}:{container_repo_path}:ro",
+        f"-v {temp_repo}:{container_repo_path}",
     ]
-    # Shadow .git with empty file/dir (must come after repo mount to override)
-    if git_shadow_path:
-        volume_args.append(f"-v {git_shadow_path}:{container_repo_path}/.git:ro")
 
     # Build the docker command
     env_str = " ".join(env_args)
@@ -708,11 +708,7 @@ def docker_build(
         '"'
     )
     docker_cmd = (
-        f"docker run --rm "
-        f"{env_str} {vol_str} "
-        f"-w {container_repo_path} "
-        f"{build_image} "
-        f"{build_cmd}"
+        f"docker run --rm " f"{env_str} {vol_str} " f"-w {container_repo_path} " f"{build_image} " f"{build_cmd}"
     )
 
     print(f"Building Datadog Agent for {arch}")
@@ -721,16 +717,13 @@ def docker_build(
     print(f"Workers: {workers}")
     print()
 
-    # Run the omnibus build, ensuring shadow cleanup happens even on failure
+    # Run the omnibus build, ensuring temp repo cleanup happens even on failure
     try:
         ctx.run(docker_cmd)
     finally:
-        # Clean up the temporary shadow file/dir
-        if git_shadow_path:
-            if os.path.isfile(git_shadow_path):
-                os.unlink(git_shadow_path)
-            elif os.path.isdir(git_shadow_path):
-                os.rmdir(git_shadow_path)
+        # Clean up the temporary repo copy
+        print(f"Cleaning up temp repo: {temp_repo}")
+        shutil.rmtree(temp_repo, ignore_errors=True)
 
     # Build Docker image from the tarball
     print("\n" + "=" * 60)


### PR DESCRIPTION
### What does this PR do?

Git worktrees use a .git file containing an absolute path to the parent
repo. Inside Docker, this path doesn't exist, breaking git operations.

Fixes:
1. Pre-generate version cache on host (for `git describe`)
2. Temporarily rename .git file during build (for omnibus `git ls-remote`)

### Motivation

`inv omnibus.docker-build` was unusable in a git worktree checkout, this works
around the discovered issues

### Describe how you validated your changes

Locally successfully build in both worktree and main checkout

### Additional Notes


