### PR TITLE
[AGENTRUN-931] Expand parsing of check subcommand JSON output for e2e tests

### DIFF
--- a/test/e2e-framework/testing/testcommon/check/parse.go
+++ b/test/e2e-framework/testing/testcommon/check/parse.go
@@ -22,7 +22,9 @@ type Root struct {
 
 // Aggregator contains the metrics emitted by a check
 type Aggregator struct {
-	Metrics []Metric `json:"metrics"`
+	Metrics       []Metric       `json:"metrics"`
+	ServiceChecks []ServiceCheck `json:"service_checks"`
+	Events        []Event        `json:"events"`
 }
 
 // Runner contains the check execution information
@@ -41,6 +43,26 @@ type Metric struct {
 	SourceTypeName string      `json:"source_type_name"`
 	Tags           []string    `json:"tags"`
 	Type           string      `json:"type"`
+}
+
+// ServiceCheck represents a service check emitted by a check
+type ServiceCheck struct {
+	Name      string   `json:"check"`
+	Host      string   `json:"host_name"`
+	Status    int      `json:"status"`
+	Timestamp int64    `json:"timestamp"`
+	Message   string   `json:"message"`
+	Tags      []string `json:"tags"`
+}
+
+// Event represents a event emitted by a check
+type Event struct {
+	Title     string `json:"msg_title"`
+	Text      string `json:"msg_text"`
+	Host      string `json:"host"`
+	Timestamp int64  `json:"timestamp"`
+	Priority  string `json:"priority"`
+	AlertType string `json:"alert_type"`
 }
 
 // ParseJSONOutput parses the check command json output

--- a/test/e2e-framework/testing/testcommon/check/parse_test.go
+++ b/test/e2e-framework/testing/testcommon/check/parse_test.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package check
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseJSONOutput(t *testing.T) {
+	input := []byte(`[{
+		"aggregator": {
+			"events": [
+				{
+					"msg_title": "hello.event",
+					"msg_text": "hello.text",
+					"timestamp": 1234567890,
+					"priority": "normal",
+					"host": "host",
+					"alert_type": "info"
+				}
+			],
+			"metrics": [
+				{
+					"host": "host",
+					"interval": 0,
+					"metric": "hello.gauge",
+					"points": [[1234567890, 1]],
+					"source_type_name": "System",
+					"tags": [],
+					"type": "gauge"
+				}
+			],
+			"service_checks": [
+				{
+					"check": "hello.service_check",
+					"host_name": "host",
+					"timestamp": 1234567890,
+					"status": 0,
+					"message": "",
+					"tags": []
+				}
+			]
+		},
+		"runner": {
+			"TotalRuns": 1,
+			"TotalErrors": 0,
+			"TotalWarnings": 0
+		}
+	}]`)
+
+	result := ParseJSONOutput(t, input)
+	require.Len(t, result, 1)
+
+	// metric
+	require.Len(t, result[0].Aggregator.Metrics, 1)
+	metric := result[0].Aggregator.Metrics[0]
+	assert.Equal(t, "host", metric.Host)
+	assert.Equal(t, 0, metric.Interval)
+	assert.Equal(t, "hello.gauge", metric.Metric)
+	assert.Equal(t, [][]float64{{1234567890, 1}}, metric.Points)
+	assert.Equal(t, "System", metric.SourceTypeName)
+	assert.Empty(t, metric.Tags)
+	assert.Equal(t, "gauge", metric.Type)
+
+	// service check
+	require.Len(t, result[0].Aggregator.ServiceChecks, 1)
+	serviceCheck := result[0].Aggregator.ServiceChecks[0]
+	assert.Equal(t, "hello.service_check", serviceCheck.Name)
+	assert.Equal(t, "host", serviceCheck.Host)
+	assert.Equal(t, 0, serviceCheck.Status)
+	assert.Equal(t, int64(1234567890), serviceCheck.Timestamp)
+	assert.Empty(t, serviceCheck.Message)
+	assert.Empty(t, serviceCheck.Tags)
+
+	// event
+	require.Len(t, result[0].Aggregator.Events, 1)
+	event := result[0].Aggregator.Events[0]
+	assert.Equal(t, "hello.event", event.Title)
+	assert.Equal(t, "hello.text", event.Text)
+	assert.Equal(t, "host", event.Host)
+	assert.Equal(t, int64(1234567890), event.Timestamp)
+	assert.Equal(t, "normal", event.Priority)
+	assert.Equal(t, "info", event.AlertType)
+
+	// runner
+	assert.Equal(t, 1, result[0].Runner.TotalRuns)
+	assert.Equal(t, 0, result[0].Runner.TotalErrors)
+	assert.Equal(t, 0, result[0].Runner.TotalWarnings)
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds support for parsing of service checks and events in the e2e test framework.

### Motivation

With the current parsing, we can only test if a check emits metrics, not service checks or events. Currently, we can write an e2e test that tests whether a check emits something other than metrics.

### Describe how you validated your changes

Unit test for parsing JSON output containing a metric, a service check, and an event.

### Additional Notes
