### PR TITLE
Create placeholder targets for the agent package - plain and heroku flavors

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -192,6 +192,9 @@ include("//deps/cpython:cpython.MODULE.bazel")
 include("//deps/gstatus:gstatus.MODULE.bazel")
 
 # buildifier: leave-alone
+include("//deps/openscap:openscap.MODULE.bazel")
+
+# buildifier: leave-alone
 include("//deps/openssl3:openssl3.MODULE.bazel")
 
 # buildifier: leave-alone

--- a/compliance/package_licenses.bzl
+++ b/compliance/package_licenses.bzl
@@ -43,13 +43,6 @@ def package_licenses(name = None, src = None):
         strip_prefix = ".",
     )
 
-    # You would expect that filter_directory returns something usuable to pkg_* rules.
-    # It does not, so we have to wrap it.
-    pkg_files(
-        name = "%s_license_copies_" % name,
-        srcs = [":%s_license_dir_stripped_" % name],
-    )
-
     # Turn the copied offers into a target we can feed to other rules.
     native.filegroup(
         name = "%s_copied_offer_dir_" % name,

--- a/compliance/package_licenses.bzl
+++ b/compliance/package_licenses.bzl
@@ -1,0 +1,83 @@
+"""Collect licenses for a product package in a way we can ship them."""
+
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "filter_directory", "pkg_files")
+load("//compliance:license_csv.bzl", "license_csv")
+
+visibility("public")
+
+def package_licenses(name = None, src = None):
+    """Collects all the licenses for a source target and makes them available for packaging.
+
+    This result of this rule is a pkg_filegorup suitable for use in pkg_* rules.
+    The pkg_install target '{name}_install' is provided as a convenience.
+
+    Args:
+        name: name
+        src: target to search. This is typically a filegroup of the top level
+             elements that will be bundled into a distribution artifact.
+    """
+
+    # Collect everything
+    license_csv(
+        name = "%s_licenses_" % name,
+        target = src,
+        csv_out = "%s_licenses.csv" % name,
+        licenses_dir = "%s_licenses_dir_" % name,
+        offers_dir = "%s_sources_dir_" % name,
+        tags = ["manual"],
+    )
+
+    # Turn the copied licenses into a target we can feed to other rules.
+    native.filegroup(
+        name = "%s_copied_license_dir_" % name,
+        srcs = [":%s_licenses_" % name],
+        output_group = "licenses",
+    )
+
+    # This silliness strips the directory name of the license TreeArtifact.
+    filter_directory(
+        name = "%s_license_dir_stripped_" % name,
+        src = ":%s_copied_license_dir_" % name,
+        outdir_name = "LICENSES",
+        strip_prefix = ".",
+    )
+
+    # You would expect that filter_directory returns something usuable to pkg_* rules.
+    # It does not, so we have to wrap it.
+    pkg_files(
+        name = "%s_license_copies_" % name,
+        srcs = [":%s_license_dir_stripped_" % name],
+    )
+
+    # Turn the copied offers into a target we can feed to other rules.
+    native.filegroup(
+        name = "%s_copied_offer_dir_" % name,
+        srcs = [":%s_licenses_" % name],
+        output_group = "offers",
+    )
+
+    # This silliness strips the directory name of the offer TreeArtifact.
+    filter_directory(
+        name = "%s_offer_dir_stripped_" % name,
+        src = ":%s_copied_offer_dir_" % name,
+        outdir_name = "sources",
+        strip_prefix = ".",
+    )
+
+    # You would expect that filter_directory returns something usuable to pkg_* rules.
+    # It does not, so we have to wrap it.
+    pkg_files(
+        name = name,
+        srcs = [
+            ":%s_license_dir_stripped_" % name,
+            ":%s_offer_dir_stripped_" % name,
+        ],
+        visibility = ["//visibility:public"],
+    )
+
+    pkg_install(
+        name = "%s_install" % name,
+        srcs = [name],
+        tags = ["manual"],  # Do not catch in ... expansion.
+    )

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -35,29 +35,3 @@ filegroup(
         "//packages:__subpackages__",
     ],
 )
-
-# This is temporary to separate heroku from non-heroku deps
-#
-filegroup(
-    name = "openscap_deps",
-    srcs = select({
-        "@platforms//os:linux": [
-            "@acl",
-            "@attr",
-            "@gcrypt",
-            "@gpg-error",
-            "@libpcap//:pcap",
-            "@libselinux//:selinux",
-            "@libsepol//:sepol",
-            "@libxml2",
-            "@libxslt",
-            "@pcre2",
-            "@zstd",
-        ],
-        "//conditions:default": [],
-    }),
-    visibility = [
-        "//compliance:__pkg__",
-        "//packages:__subpackages__",
-    ],
-)

--- a/deps/openscap/BUILD.bazel
+++ b/deps/openscap/BUILD.bazel
@@ -1,0 +1,13 @@
+# openscap
+
+alias(
+    name = "all_deps",
+    actual = "@openscap//:all_deps",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    visibility = [
+        "//compliance:__pkg__",
+        "//packages:__subpackages__",
+    ],
+)

--- a/deps/openscap/openscap.MODULE.bazel
+++ b/deps/openscap/openscap.MODULE.bazel
@@ -1,0 +1,15 @@
+# openscap
+
+http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
+
+VERSION = "1.4.2"
+
+http_archive(
+    name = "openscap",
+    files = {
+        "BUILD.bazel": "//deps/openscap:overlay/overlay.BUILD.bazel",
+    },
+    sha256 = "1d5309fadd9569190289d7296016dc534594f7f7d4fd870fe9e847e24940073d",
+    strip_prefix = "openscap-{version}".format(version = VERSION),
+    url = "https://github.com/OpenSCAP/openscap/releases/download/{version}/openscap-{version}.tar.gz".format(version = VERSION),
+)

--- a/deps/openscap/overlay/overlay.BUILD.bazel
+++ b/deps/openscap/overlay/overlay.BUILD.bazel
@@ -1,0 +1,57 @@
+"""BUILD for openscap."""
+
+load("@@//compliance/rules:purl.bzl", "purl_for_generic")
+load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_package_metadata = [":package_metadata"],
+    default_visibility = [
+        "@@//compliance:__subpackages__",
+        "@@//deps/openscap:__pkg__",
+        "@@//packages:__subpackages__",
+    ],
+)
+
+VERSION = "1.4.2"
+
+package_metadata(
+    name = "package_metadata",
+    attributes = [
+        ":license",
+    ],
+    purl = purl_for_generic(
+        package = "openscap",
+        version = VERSION,
+        download_url = "https://github.com/OpenSCAP/openscap/releases/download/{version}/openscap-{version}.tar.gz",
+    ),
+)
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:LGPL-3.0-or-later"],
+    license_text = "COPYING",
+    visibility = ["//visibility:public"],
+)
+
+# This is temporary. Eventually there will be a cc_library for openscap.
+filegroup(
+    name = "all_deps",
+    srcs = [
+        "@libyaml",
+        "@lua//:liblua",
+        "@acl",
+        "@attr",
+        "@bzip2//:bz2",
+        "@gcrypt",
+        "@gpg-error",
+        "@libpcap//:pcap",
+        "@libsepol//:sepol",
+        "@libxml2",
+        "@libxslt",
+        "@nghttp2",
+        "@pcre2",
+        "@popt",
+        "@zstd",
+    ],
+)

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -29,6 +29,14 @@ build do
         # TODO: flavor can be defaulted and set from the bazel wrapper based on the environment.
         command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/install_dir:install"
 
+	if linux_target?
+	    if heroku_target?
+               command_on_repo_root "bazelisk run -- //packages/agent/heroku:license_files_install --destdir=#{install_dir}"
+            else
+               command_on_repo_root "bazelisk run -- //packages/agent/linux:license_files_install --destdir=#{install_dir}"
+            end
+        end
+
         # Conf files
         if windows_target?
             conf_dir = "#{install_dir}/etc/datadog-agent"

--- a/packages/agent/heroku/BUILD.bazel
+++ b/packages/agent/heroku/BUILD.bazel
@@ -1,0 +1,15 @@
+# agent heroku distribution packages
+
+load("//compliance:package_licenses.bzl", "package_licenses")
+
+filegroup(
+    name = "all_deps",
+    srcs = [
+        "//deps:all_deps",
+    ],
+)
+
+package_licenses(
+    name = "license_files",
+    src = ":all_deps",
+)

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -1,0 +1,22 @@
+# agent linux distribution packages
+
+load("//compliance:package_licenses.bzl", "package_licenses")
+
+# This is a placeholder for an eventual group containg (the future) top level binaries
+# such as //cmd/agent:agent
+filegroup(
+    name = "all_deps",
+    srcs = [
+        "//deps:all_deps",
+    ] + select({
+        "@platforms//os:linux": [
+            "//deps/openscap:all_deps",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+package_licenses(
+    name = "license_files",
+    src = ":all_deps",
+)


### PR DESCRIPTION
Create placeholder targets for the agent package - plain and heroku flavors

- Macro-ize the chain of targets needed to push license files.
- Create //packages/agent/linux and //packages/agernt/heroku
  - They only contain an `all_deps` target and a rule to collect licenses.
  - In the future, `all_deps` will be replaced with set of targets such as the top level binaries, agent, system-probe, ...
- Call the right choice of plain linux / heroku in agent-finalize
   - As the migration continues there will be fewer of these conditionals. They will move towards a single build of the the distribution artifact targets.

### Describe how you validated your changes
```
$ bazel run -- //packages/agent/linux:license_files_install --destdir=/tmp/xilinux
$ bazel run -- //packages/agent/heroku:license_files_install --destdir=/tmp/xihero
$ diff -r /tmp/xihero/ /tmp/xilinux/
Only in /tmp/xilinux/LICENSES: acl-COPYING.LGPL
Only in /tmp/xilinux/LICENSES: attr-COPYING.LGPL
Only in /tmp/xilinux/LICENSES: gcrypt-COPYING.LIB
Only in /tmp/xilinux/LICENSES: libpcap-LICENSE
Only in /tmp/xilinux/LICENSES: nghttp2-COPYING
Only in /tmp/xilinux/LICENSES: openscap-COPYING
Only in /tmp/xilinux/LICENSES: popt-COPYING
Only in /tmp/xilinux/sources: acl
Only in /tmp/xilinux/sources: attr
```

### Comparison against https://github.com/DataDog/datadog-agent/pull/43984

- #43984 uses a build flag to set the flavor.  We can used that in `select()` clauses to pull in the right deps for each flavor.
- This PR puts all the selection at the top level packaging rule. This means means anything requiring a variation based on flavor will need to run a parallel tree of dependencies to the depth where the select matters.

The this becomes clearest in the different way we include licenses. With a flavor, we can push the selection into the compliance package. With distinct targets, we need to turn the license gathering into a rule (a big macro, actually) and instantiate it separately for each flavor.

Opinion: Let's use this approach for now.
- The rewrite of the license tools is good anyway
- The top level package targets are going to be needed anyway
- The potential for parallel trees of targets to be a future nuisance is real, but perhaps it is only the license gathering.
- The build flag could be a cache problem. Flagsets may eliminate that, but it is still experimental.

Overall, there is little to throw away if we decide to go to a build flag in the future.