### PR TITLE
[CWS] Do not trigger chown event for unchanged uid or gid

### DIFF
--- a/pkg/security/secl/rules/fim_test.go
+++ b/pkg/security/secl/rules/fim_test.go
@@ -34,7 +34,7 @@ func TestExpandFIM(t *testing.T) {
 				},
 				{
 					id:   "__fim_expanded_chown__test",
-					expr: "chown.file.path == \"/tmp/test\"",
+					expr: "(chown.file.path == \"/tmp/test\") && ((chown.file.destination.uid != -1 && chown.file.destination.uid != chown.file.uid) || (chown.file.destination.gid != -1 && chown.file.destination.gid != chown.file.gid))",
 				},
 				{
 					id:   "__fim_expanded_link__test",
@@ -72,7 +72,7 @@ func TestExpandFIM(t *testing.T) {
 				},
 				{
 					id:   "__fim_expanded_chown__complex",
-					expr: "(chown.file.path == \"/tmp/test\" || chown.file.name == \"abc\") && process.file.name == \"def\" && container.id != \"\"",
+					expr: "((chown.file.path == \"/tmp/test\" || chown.file.name == \"abc\") && process.file.name == \"def\" && container.id != \"\") && ((chown.file.destination.uid != -1 && chown.file.destination.uid != chown.file.uid) || (chown.file.destination.gid != -1 && chown.file.destination.gid != chown.file.gid))",
 				},
 				{
 					id:   "__fim_expanded_link__complex",

--- a/pkg/security/secl/rules/fim_unix.go
+++ b/pkg/security/secl/rules/fim_unix.go
@@ -31,8 +31,11 @@ func expandFim(baseID, groupID, baseExpr string) []expandedRule {
 	var expandedRules []expandedRule
 	for _, eventType := range []string{"open", "chmod", "chown", "link", "rename", "unlink", "utimes"} {
 		expr := strings.ReplaceAll(baseExpr, "fim.write.file.", eventType+".file.")
-		if eventType == "open" {
+		switch eventType {
+		case "open":
 			expr = fmt.Sprintf("(%s) && open.flags & (O_CREAT|O_TRUNC|O_APPEND|O_RDWR|O_WRONLY) > 0", expr)
+		case "chown":
+			expr = fmt.Sprintf("(%s) && ((chown.file.destination.uid != -1 && chown.file.destination.uid != chown.file.uid) || (chown.file.destination.gid != -1 && chown.file.destination.gid != chown.file.gid))", expr)
 		}
 
 		id := fmt.Sprintf("__fim_expanded_%s_%s_%s", eventType, groupID, baseID)


### PR DESCRIPTION
### What does this PR do?

Do not trigger chown event for unchanged uid or gid

### Motivation

chown :mygroup caused a `fim` rule to trigger even if the file is already owned by mygroup.

### Describe how you validated your changes

### Additional Notes
