### PR TITLE
[CWS] add better protection against corrupted profiles when loading from disk

### DIFF
--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -139,6 +139,15 @@ func NewDirectory(directoryPath string, maxProfiles int) (*Directory, error) {
 			seclog.Warnf("failed to load profile from file [%s]: %s", file.path, err)
 			continue
 		}
+		if pProto.Metadata == nil {
+			seclog.Warnf("profile loaded from file [%s] has no metadata", file.path)
+			continue
+		}
+		if pProto.Selector == nil {
+			seclog.Warnf("profile loaded from file [%s] has no selector", file.path)
+			continue
+		}
+
 		profiles.Add(pProto.Metadata.Name, &profileEntry{
 			selector:  cgroupModel.ProtoToWorkloadSelector(pProto.Selector),
 			filePaths: []string{file.path},


### PR DESCRIPTION
### What does this PR do?

`proto.Metadata` and `proto.Selector` are pointer fields, and can be nil. Let's handle that correctly when loading profiles from disk.

### Motivation

[Fix this panic on staging](https://ddstaging.datadoghq.com/logs?query=kube_container_name%3Asystem-probe%20status%3Aerror%20panic&agg_m=count&agg_m_source=base&agg_q=cluster_name&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZsG5HCelmTuAgAAABhBWnNHNUhmZ0FBQ25IdkpiNzlCazJRQUMAAAAkZjE5YjA2ZTUtYmE1Yy00NDEwLTkzZmEtMjcyNzk1MTU4NjI5AA5SlQ&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1765346973000&to_ts=1765347273000&live=false) 

### Describe how you validated your changes

### Additional Notes
