### PR TITLE
Add missing path to trigger `new-e2e-containers-eks`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -713,6 +713,7 @@ workflow:
         - pkg/aggregator/*/**
         - comp/languagedetection/**/*
         - pkg/clusteragent/admission/mutate/**/*
+        - pkg/clusteragent/languagedetection/**/*
         - pkg/collector/corechecks/cluster/**/*
         - pkg/collector/corechecks/containers/**/*
         - pkg/collector/corechecks/containerimage/**/*


### PR DESCRIPTION
### What does this PR do?
Add path that, when modified, should trigger `new-e2e-containers-eks`.

### Motivation
`new-e2e-containers-eks` was skipped in #44022 despite a change meant to improve it.

### Additional Notes
Extracted this change because we want to merge it independently from #44022 being itself merged/reverted.