### PR TITLE
[SBOM] Do not modify cluster agent config between tests

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -1502,19 +1502,12 @@ type scanResult struct {
 func (suite *k8sSuite) TestSBOM() {
 	scanMethods := []scanMethod{
 		{
-			mode: "default",
-			helmValues: `
-clusterAgent:
-  envDict:
-    DD_CSI_ENABLED: "true"
-`,
+			mode:       "default",
+			helmValues: ``,
 		},
 		{
 			mode: "mount",
 			helmValues: `
-clusterAgent:
-  envDict:
-    DD_CSI_ENABLED: "true"
 datadog:
   sbom:
     containerImage:
@@ -1524,9 +1517,6 @@ datadog:
 		{
 			mode: "overlayfs",
 			helmValues: `
-clusterAgent:
-  envDict:
-    DD_CSI_ENABLED: "true"
 datadog:
   sbom:
     containerImage:


### PR DESCRIPTION
### What does this PR do?

This PR do not alter the cluster agent configuration between SBOM tests.

### Motivation

The cluster agent configuration was modified and caused the cluster agent to be
reployed without any good reason.

### Describe how you validated your changes

The TestVersion test should not be flaky any more.

### Additional Notes
