### PR TITLE
Remove syslog tls config from template

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2875,24 +2875,6 @@ api_key:
 #
 # syslog_rfc: false
 
-## @param syslog_pem - string - optional
-## @env DD_SYSLOG_PEM - string - optional
-## If TLS enabled, you must specify a path to a PEM certificate here.
-#
-# syslog_pem: <PEM_CERTIFICATE_PATH>
-
-## @param syslog_key - string - optional
-## @env DD_SYSLOG_KEY - string - optional
-## If TLS enabled, you must specify a path to a private key here.
-#
-# syslog_key: <PEM_KEY_PATH>
-
-## @param syslog_tls_verify - boolean - optional - default: true
-## @env DD_SYSLOG_TLS_VERIFY - boolean - optional - default: true
-## If TLS enabled, you may enforce TLS verification here.
-#
-# syslog_tls_verify: true
-
 ## @param log_format_rfc3339 - boolean - optional - default false
 ## @env DD_LOG_FORMAT_RFC3339 - boolean - optional - default false
 ## If enabled the Agent will log using the RFC3339 format for the log time.


### PR DESCRIPTION
### What does this PR do?
Remove the syslog tls configs from template.

### Motivation
The feature was removed by https://github.com/DataDog/datadog-agent/pull/39781.

### Describe how you validated your changes

### Additional Notes
