### PR TITLE
Config template and component fixes

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1224,12 +1224,6 @@ api_key:
 #
 #   integrations_logs_total_usage: 100
 
-#   # @param kublet_api_client_read_timeout - duration - optional - default: 30s
-#   # @env DD_LOGS_CONFIG_KUBELET_API_CLIENT_READ_TIMEOUT - duration - optional - default: 30s
-#   # Configure the kubelet API client's timeout used while streaming logs.
-#
-#   kublet_api_client_read_timeout: 30
-
 #   # @param k8s_container_use_kubelet_api - boolean - optional - default: false
 #   # @env DD_LOGS_CONFIG_K8S_CONTAINER_USE_KUBELET_API - boolean - optional - default: false
 #   # Enable container log collection via the kubelet API, typically used for EKS Fargate

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -484,6 +484,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.SetKnown("network_devices.autodiscovery.ping.timeout")               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.SetKnown("network_devices.autodiscovery.ping.linux.use_raw_socket")  //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.SetKnown("network_devices.autodiscovery.use_deduplication")          //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.SetKnown("network_devices.autodiscovery.collect_vpn")                //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.snmp_traps.forwarder.")
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.enabled", false)


### PR DESCRIPTION
### What does this PR do?
Fix two config issues:
- remove `kublet_api_client_read_timeout` from template since it's not used in the code (not even declared in the config)
- `network_devices.autodiscovery.collect_vpn` is documented in the template but not declared in the config (resulting in warnings)

### Motivation
Fix issues with those configs.

### Describe how you validated your changes

### Additional Notes
