### PR TITLE
[CWS] fix process context zero

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1015,11 +1015,7 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 		panic("should always return a process cache entry")
 	}
 
-	// use ProcessCacheEntry process context as process context
 	event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
-	if event.ProcessContext == nil {
-		panic("should always return a process context")
-	}
 
 	if process.IsKThread(event.ProcessContext.PPid, event.ProcessContext.Pid) {
 		return false
@@ -1620,6 +1616,8 @@ func (p *EBPFProbe) handleBeforeProcessContext(event *model.Event, data []byte, 
 // handleEarlyReturnEvents processes events that may require early termination of the event handling pipeline.
 // It returns false if an error occurs or if the event should not be dispatched further, true otherwise
 func (p *EBPFProbe) handleEarlyReturnEvents(event *model.Event, offset int, dataLen uint64, data []byte, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
+	event.ProcessContext = &model.ProcessContext{}
+
 	var err error
 	eventType := event.GetEventType()
 	switch eventType {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -153,7 +153,7 @@ type Event struct {
 
 // NewEventZeroer returns a function that can be used to zero an Event
 func NewEventZeroer() func(*Event) {
-	var eventZero = Event{BaseEvent: BaseEvent{Os: runtime.GOOS, ProcessContext: &ProcessContext{}}}
+	var eventZero = Event{BaseEvent: BaseEvent{Os: runtime.GOOS}}
 
 	return func(e *Event) {
 		*e = eventZero


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where the zero process context was being unintentionally reused. It removes the process-context allocation from the zeroer function; the pointer should only be initialized via setProcessContext and must not be modified directly. By removing the default allocation, we can detect incorrect access patterns earlier through a panic.

### Motivation

### Describe how you validated your changes

### Additional Notes
