### PR TITLE
[EBPF] attacher: improve testing cases when using PEDS to detect running processes

### DIFF
--- a/pkg/ebpf/uprobes/testutil/standalone_attacher/standalone_attacher.go
+++ b/pkg/ebpf/uprobes/testutil/standalone_attacher/standalone_attacher.go
@@ -24,6 +24,7 @@ import (
 )
 
 var configName = flag.String("config", "", "config name")
+var useEventStream = flag.Bool("use-event-stream", false, "use event stream")
 
 func main() {
 	// use testing.Main so that we have a testing.T to pass to the runners.
@@ -38,7 +39,7 @@ func main() {
 }
 
 func run(t *testing.T) {
-	runner := uprobes.NewSameProcessAttacherRunner()
+	runner := uprobes.NewSameProcessAttacherRunner(*useEventStream)
 
 	if *configName == "" {
 		t.Fatal("config name is required")

--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -498,3 +498,22 @@ func (sh *StreamHandler) isInactive(now int64, maxInactivity time.Duration) bool
 	// delete a stream that has just been created
 	return sh.lastEventKtimeNs > 0 && now-int64(sh.lastEventKtimeNs) > maxInactivity.Nanoseconds()
 }
+
+// String returns a human-readable representation of the StreamHandler. Used for better debugging in tests
+func (sh *StreamHandler) String() string {
+	sh.kernelLaunchesMutex.RLock()
+	kernelLaunchCount := len(sh.kernelLaunches)
+	sh.kernelLaunchesMutex.RUnlock()
+
+	return fmt.Sprintf("StreamHandler{pid=%d, streamID=%d, gpu=%s, container=%s, ended=%t, kernelLaunches=%d, pendingKernelSpans=%d, pendingMemorySpans=%d, memAllocEvents=%d}",
+		sh.metadata.pid,
+		sh.metadata.streamID,
+		sh.metadata.gpuUUID,
+		sh.metadata.containerID,
+		sh.ended,
+		kernelLaunchCount,
+		len(sh.pendingKernelSpans),
+		len(sh.pendingMemorySpans),
+		sh.memAllocEvents.Len(),
+	)
+}

--- a/pkg/gpu/stream_collection.go
+++ b/pkg/gpu/stream_collection.go
@@ -9,6 +9,7 @@ package gpu
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"golang.org/x/sys/unix"
@@ -369,4 +370,30 @@ func (sc *streamCollection) clean(nowKtime int64) {
 	sc.cleanHandlerMap(&sc.globalStreams, nowKtime)
 
 	sc.telemetry.activeHandlers.Set(float64(sc.allStreamsCount()))
+}
+
+// String returns a human-readable representation of the streamCollection. Used for better debugging in tests
+func (sc *streamCollection) String() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("streamCollection{streams=%d, globalStreams=%d}\n", sc.streamsCount(), sc.globalStreamsCount()))
+
+	sc.streams.Range(func(key, value interface{}) bool {
+		if k, ok := key.(streamKey); ok {
+			if handler, ok := value.(*StreamHandler); ok {
+				sb.WriteString(fmt.Sprintf("  [pid=%d, stream=%d]: %s\n", k.pid, k.stream, handler.String()))
+			}
+		}
+		return true
+	})
+
+	sc.globalStreams.Range(func(key, value interface{}) bool {
+		if k, ok := key.(globalStreamKey); ok {
+			if handler, ok := value.(*StreamHandler); ok {
+				sb.WriteString(fmt.Sprintf("  [pid=%d, gpu=%s (global)]: %s\n", k.pid, k.gpuUUID, handler.String()))
+			}
+		}
+		return true
+	})
+
+	return sb.String()
 }


### PR DESCRIPTION
### What does this PR do?

Improves the testing in the attacher to also use the Process Event Data Stream to listen for processes. It also adds `String()` methods to the StreamCollection and StreamHandler structs for better debugging, as the issues with container attachment were harder to debug because of the output of that test.

### Motivation

Improve debugging related to #incident-46749

### Describe how you validated your changes

CI passing

### Additional Notes
