### PR TITLE
fix: prevent wrong MarshalJSON for duration

### DIFF
--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -471,7 +471,7 @@ func (d *HumanReadableDuration) UnmarshalYAML(n *yaml.Node) error {
 
 // MarshalJSON marshals a duration to a human readable format
 func (d *HumanReadableDuration) MarshalJSON() ([]byte, error) {
-	if d == nil || d.Duration == 0 {
+	if d == nil {
 		return nil, nil
 	}
 	return json.Marshal(d.GetDuration())

--- a/pkg/security/secl/rules/model_test.go
+++ b/pkg/security/secl/rules/model_test.go
@@ -34,6 +34,24 @@ func TestDuration(t *testing.T) {
 		assert.True(t, reflect.DeepEqual(setDef, deserialized))
 	})
 
+	t.Run("json marshaling with 0 duration", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:  "set_name",
+			Value: float64(123),
+			Scope: "container",
+			TTL: &HumanReadableDuration{
+				Duration: 0,
+			},
+		}
+		bytes, err := json.Marshal(setDef)
+		assert.NoError(t, err)
+		var deserialized SetDefinition
+		err = json.Unmarshal(bytes, &deserialized)
+		assert.NoError(t, err)
+		assert.Equal(t, setDef.Value, deserialized.Value)
+		assert.True(t, reflect.DeepEqual(setDef, deserialized))
+	})
+
 	t.Run("json unmarshalling", func(t *testing.T) {
 		setDef := SetDefinition{
 			Name:  "set_name",
@@ -48,6 +66,24 @@ func TestDuration(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, reflect.DeepEqual(setDef, deserialized))
 		err = json.Unmarshal([]byte(`{"name":"set_name","value":123,"scope":"container","ttl":1000000000}`), &deserialized)
+		assert.NoError(t, err)
+		assert.True(t, reflect.DeepEqual(setDef, deserialized))
+	})
+
+	t.Run("json unmarshalling 0 duration", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:  "set_name",
+			Value: float64(123),
+			Scope: "container",
+			TTL: &HumanReadableDuration{
+				Duration: 0 * time.Second,
+			},
+		}
+		var deserialized SetDefinition
+		err := json.Unmarshal([]byte(`{"name":"set_name","value":123,"scope":"container","ttl":"0s"}`), &deserialized)
+		assert.NoError(t, err)
+		assert.True(t, reflect.DeepEqual(setDef, deserialized))
+		err = json.Unmarshal([]byte(`{"name":"set_name","value":123,"scope":"container","ttl":0}`), &deserialized)
 		assert.NoError(t, err)
 		assert.True(t, reflect.DeepEqual(setDef, deserialized))
 	})


### PR DESCRIPTION
### What does this PR do?

Change the way we serialize `HumanReadableDuration` to avoid an error

### Motivation

The datadog-agent package incorrectly returns (nil, nil) for zero durations instead of valid JSON bytes, which causes json.Marshal to fail.

### Describe how you validated your changes

- Added the unit test with a duration of 0
- Validated that the [usage of the field Every](https://github.com/DataDog/datadog-agent/blob/main/pkg/security/events/rate_limiter.go#L106) would handle a value of 0
