### PR TITLE
CONTINT-4685 - Add e2e tests for host-tags presence and values

### DIFF
--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -146,7 +146,7 @@ type Client struct {
 	ndmflowAggregator              aggregator.NDMFlowAggregator
 	netpathAggregator              aggregator.NetpathAggregator
 	ncmAggregator                  aggregator.NCMAggregator
-	hostAggregator                 aggregator.HostAggregator
+	hostAggregator                 aggregator.HostTagsAggregator
 }
 
 // NewClient creates a new fake intake client
@@ -178,7 +178,7 @@ func NewClient(fakeIntakeURL string, opts ...Option) *Client {
 		ndmflowAggregator:              aggregator.NewNDMFlowAggregator(),
 		netpathAggregator:              aggregator.NewNetpathAggregator(),
 		ncmAggregator:                  aggregator.NewNCMAggregator(),
-		hostAggregator:                 aggregator.NewHostAggregator(),
+		hostAggregator:                 aggregator.NewHostTagsAggregator(),
 	}
 	for _, opt := range opts {
 		opt(client)
@@ -345,7 +345,7 @@ func (c *Client) getNCMEvents() error {
 	return c.ncmAggregator.UnmarshallPayloads(payloads)
 }
 
-func (c *Client) getHostInfos() error {
+func (c *Client) getHostTags() error {
 	payloads, err := c.getFakePayloads(intakeEndpoint)
 	if err != nil {
 		return err
@@ -1097,24 +1097,25 @@ func (c *Client) GetNCMPayloads() ([]*aggregator.NCMPayload, error) {
 	return ncmPayloads, nil
 }
 
-// GetLatestHostInfos returns the latest host information received by the fake intake
-func (c *Client) GetLatestHostInfos() ([]*aggregator.Host, error) {
-	err := c.getHostInfos()
+// GetHostTags returns the host tags received by the fake intake
+func (c *Client) GetHostTags(hostname string) ([]*aggregator.HostTags, error) {
+	err := c.getHostTags()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.hostAggregator.GetPayloadsByName(hostname), nil
+}
+
+// GetHosts returns the list of all known hostnames that have sent some host-tags
+func (c *Client) GetHosts() ([]string, error) {
+	err := c.getHostTags()
 
 	if err != nil {
 		return nil, err
 	}
 
-	var hostInfos []*aggregator.Host
-	for _, name := range c.hostAggregator.GetNames() {
-		payloads := c.hostAggregator.GetPayloadsByName(name)
-
-		if len(payloads) > 0 {
-			hostInfos = append(hostInfos, payloads...)
-		}
-	}
-
-	return hostInfos, nil
+	return c.hostAggregator.GetNames(), nil
 }
 
 // filterPayload returns payloads matching any [MatchOpt](#MatchOpt) options

--- a/test/fakeintake/cmd/client/cmd/filter.go
+++ b/test/fakeintake/cmd/client/cmd/filter.go
@@ -24,6 +24,7 @@ func NewFilterCommand(cl **client.Client) (cmd *cobra.Command) {
 		NewFilterLogsCommand(cl),
 		NewFilterMetricsCommand(cl),
 		NewFilterSBOMCommand(cl),
+		NewFilterHostTagsCommand(cl),
 	)
 
 	return cmd

--- a/test/fakeintake/cmd/client/cmd/filterhosttags.go
+++ b/test/fakeintake/cmd/client/cmd/filterhosttags.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/client"
+)
+
+func NewFilterHostTagsCommand(cl **client.Client) (cmd *cobra.Command) {
+	var hostFlagName = "host"
+	var host string
+
+	cmd = &cobra.Command{
+		Use:     "host-tags",
+		Short:   "Filter host-tags",
+		Example: "fakeintakectl --url http://internal-crayon-gcp-fakeintake.gcp.cloud filter host-tags --host my-gcp-host",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			hostTags, err := (*cl).GetHostTags(host)
+			if err != nil {
+				return fmt.Errorf("failed to get host-tags for host %s: %w", host, err)
+			}
+
+			for _, hostTag := range hostTags {
+				hostTagStr, err := json.MarshalIndent(hostTag, "", "  ")
+				if err != nil {
+					cmd.PrintErrf("failed to format hostTag '%v' : %s", hostTag, err.Error())
+					continue
+				}
+
+				cmd.Println(string(hostTagStr))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&host, hostFlagName, "", "hostname to get host-tags from")
+
+	if err := cmd.MarkFlagRequired(hostFlagName); err != nil {
+		// only way this can fail is if the flag does not exist.
+		panic(err)
+	}
+
+	return cmd
+}

--- a/test/fakeintake/cmd/client/cmd/get.go
+++ b/test/fakeintake/cmd/client/cmd/get.go
@@ -33,7 +33,7 @@ func NewGetCommand(cl **client.Client) (cmd *cobra.Command) {
 		NewGetProcessesCommand(cl),
 		NewGetSBOMCommand(cl),
 		NewGetTracesCommand(cl),
-		NewGetHostInfosCommand(cl),
+		NewGetHosts(cl),
 	)
 
 	return cmd

--- a/test/fakeintake/cmd/client/cmd/gethosts.go
+++ b/test/fakeintake/cmd/client/cmd/gethosts.go
@@ -6,7 +6,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -14,23 +13,20 @@ import (
 	"github.com/DataDog/datadog-agent/test/fakeintake/client"
 )
 
-// NewGetHostInfosCommand adds a new command to get host infos
-func NewGetHostInfosCommand(cl **client.Client) (cmd *cobra.Command) {
+// NewGetHosts adds a new command to get host tags
+func NewGetHosts(cl **client.Client) (cmd *cobra.Command) {
 	cmd = &cobra.Command{
-		Use:   "host-infos",
-		Short: "Get Host infos",
+		Use:   "host",
+		Short: "Get Hosts",
 		RunE: func(*cobra.Command, []string) error {
-			hostInfos, err := (*cl).GetLatestHostInfos()
+			hosts, err := (*cl).GetHosts()
 			if err != nil {
 				return err
 			}
 
-			output, err := json.MarshalIndent(hostInfos, "", "  ")
-			if err != nil {
-				return err
+			for _, host := range hosts {
+				fmt.Println(host)
 			}
-
-			fmt.Println(string(output))
 
 			return nil
 		},

--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
@@ -578,4 +579,101 @@ func (suite *baseSuite[Env]) testEvent(args *testEventArgs) {
 			}
 		}, 2*time.Minute, 10*time.Second, "Failed finding `%s` with proper tags and message", prettyEventQuery)
 	})
+}
+
+type testHostTags struct {
+	ExpectedTags []string
+	OptionalTags []string
+}
+
+func sendEvent[Env any](suite *baseSuite[Env], alertType, text string, args *testHostTags) {
+	formattedArgs, err := yaml.Marshal(args)
+	suite.Require().NoError(err)
+
+	_, err = suite.DatadogClient().PostEvent(&datadog.Event{
+		Title:     pointer.Ptr("test Host-Tags " + suite.T().Name()),
+		AlertType: &alertType,
+		Tags: append([]string{
+			"app:agent-new-e2e-tests-containers",
+			"cluster_name:" + suite.clusterName,
+			"test:" + suite.T().Name(),
+		}, args.ExpectedTags...),
+		Text: pointer.Ptr(fmt.Sprintf(
+			`%%%%%%
+### Result
+
+`+"```"+`
+%s
+`+"```"+`
+
+### Expected Tags
+
+`+"```"+`
+%s
+`+"```"+`
+%%%%%%
+`, text, formattedArgs)),
+	})
+
+	if err != nil {
+		suite.T().Logf("Failed to post event: %s", err)
+	}
+}
+
+func (suite *baseSuite[Env]) testHostTags(args *testHostTags) {
+	suite.EventuallyWithT(func(ct *assert.CollectT) {
+		c := &myCollectT{
+			CollectT: ct,
+			errors:   []error{},
+		}
+
+		defer func() {
+			if len(c.errors) == 0 {
+				sendEvent(suite, "success", "All good!", args)
+			} else {
+				sendEvent(suite, "warning", errors.Join(c.errors...).Error(), args)
+			}
+		}()
+
+		hosts, err := suite.Fakeintake.GetHosts()
+		assert.NoError(c, err, "failed to get hosts from host-tags payload")
+		assert.GreaterOrEqual(c, len(hosts), 1, "empty host-tags payload, no hosts found")
+
+		regexTags := lo.Map(args.ExpectedTags, func(tag string, _ int) *regexp.Regexp {
+			return regexp.MustCompile(tag)
+		})
+
+		var optionalRegexTags []*regexp.Regexp
+		if args.OptionalTags != nil {
+			optionalRegexTags = lo.Map(args.OptionalTags, func(tag string, _ int) *regexp.Regexp {
+				return regexp.MustCompile(tag)
+			})
+		}
+
+		for _, host := range hosts {
+			suite.T().Logf("%s - validate host tags on host %s", time.Now().Format(time.TimeOnly), host)
+
+			hostInfos, err := suite.Fakeintake.GetHostTags(host)
+			require.NoError(c, err, "failed to get host-tags for host %s", host)
+			require.NotEmpty(c, hostInfos, "missing host tags in payload, should be len >= 1")
+
+			// we only want the latest known hostInfos
+			hostInfo := hostInfos[len(hostInfos)-1]
+
+			// we don't know how to handle payloads with no host-name.
+			// these are fargate host that runs side containers for the test.
+			if hostInfo.InternalHostname == "" {
+				continue
+			}
+
+			hostTags := hostInfo.HostTags
+
+			suite.T().Logf("Found host tags:\n- %s\n", strings.ReplaceAll(strings.Join(hostTags, "\n"), "\n", "\n- "))
+
+			require.NotNil(c, hostTags, "wrong payload, could not find 'host-tags' object in payload")
+			err = assertTags(hostTags, regexTags, optionalRegexTags, false)
+			assert.NoError(c, err)
+		}
+
+	}, 33*time.Minute, 1*time.Minute, "Failed to validate all host-tags")
 }

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps"
 	scenecs "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ecs"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
 
 	provecs "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/ecs"
 )
@@ -46,6 +47,9 @@ type ecsSuite struct {
 func TestECSSuite(t *testing.T) {
 	e2e.Run(t, &ecsSuite{}, e2e.WithProvisioner(provecs.Provisioner(
 		provecs.WithRunOptions(
+			scenecs.WithFakeIntakeOptions(
+				fakeintake.WithRetentionPeriod("31m"),
+			),
 			scenecs.WithECSOptions(
 				scenecs.WithFargateCapacityProvider(),
 				scenecs.WithLinuxNodeGroup(),
@@ -646,4 +650,13 @@ func (suite *ecsSuite) testTrace(taskName string) {
 		}
 		require.NoErrorf(c, err, "Failed finding trace with proper tags")
 	}, 2*time.Minute, 10*time.Second, "Failed finding trace with proper tags")
+}
+
+func (suite *ecsSuite) TestHostTags() {
+	// tag keys that are expected to be found on this docker env
+	args := &testHostTags{
+		ExpectedTags: []string{},
+	}
+
+	suite.testHostTags(args)
 }

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	sceneks "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/eks"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	proveks "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/eks"
@@ -32,6 +33,9 @@ func TestEKSSuite(t *testing.T) {
 			),
 			sceneks.WithDeployDogstatsd(),
 			sceneks.WithDeployTestWorkload(),
+			sceneks.WithFakeIntakeOptions(
+				fakeintake.WithRetentionPeriod("31m"),
+			),
 			sceneks.WithAgentOptions(kubernetesagentparams.WithDualShipping()),
 			sceneks.WithDeployArgoRollout(),
 		),
@@ -270,4 +274,31 @@ func (suite *eksSuite) TestNginxFargate() {
 			Message: `GET / HTTP/1\.1`,
 		},
 	})
+}
+
+func (suite *eksSuite) TestHostTags() {
+	// tag keys that are expected to be found on any k8s env
+	args := &testHostTags{
+		// EKS suite run multiple hosts, with various OS, various CPU architecture
+		// The only common tags are: `stackid`, `kube_distribution`, `kube_node`, `orch_cluster_id`
+		//
+		// the below 4 tags should be present on all nodes
+		ExpectedTags: []string{
+			`^kube_distribution:eks$`,
+			`^kube_node:ip-([0-9]{1,3}-){3}[0-9]{1,3}\.ec2\.internal$`,
+			`^orch_cluster_id:[0-9a-f-]{36}$`,
+			`^stackid:` + regexp.QuoteMeta(suite.clusterName) + `$`,
+		},
+		// the below list of tags is from various hosts
+		// if the tag is present
+		OptionalTags: []string{
+			`^arch:(amd|arm)64$`,
+			`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
+			`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
+			`nodegroup-image:ami-[0-9a-f]{17}`,
+			`^os:linux$`,
+		},
+	}
+
+	suite.testHostTags(args)
 }

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -6,6 +6,7 @@
 package containers
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
@@ -29,6 +30,7 @@ func TestKindSuite(t *testing.T) {
 			),
 			scenkind.WithFakeintakeOptions(
 				fakeintake.WithMemory(2048),
+				fakeintake.WithRetentionPeriod("31m"),
 			),
 			scenkind.WithDeployDogstatsd(),
 			scenkind.WithDeployTestWorkload(),
@@ -135,4 +137,38 @@ func (suite *kindSuite) TestControlPlane() {
 			},
 		},
 	})
+}
+
+func (suite *kindSuite) TestHostTags() {
+	expectedTags := []string{
+		`^os:linux$`,
+		`^arch:amd64$`,
+		`^stackid:` + regexp.QuoteMeta(suite.clusterName) + `$`,
+		`^kube_node:` + regexp.QuoteMeta(suite.clusterName) + `-control-plane`,
+		`^cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
+		`^kube_cluster_name:` + regexp.QuoteMeta(suite.clusterName) + `$`,
+		`^orch_cluster_id:[0-9a-f-]{36}$`,
+	}
+
+	// depending on the kubernetes version the expected tags for kube_node_rol varies.
+	k8sVersion, err := suite.Env().KubernetesCluster.KubernetesClient.K8sClient.Discovery().ServerVersion()
+	suite.NoError(err, "failed to request k8s server version to specify the appropriate expected host-tags")
+
+	// depending on kube version we expect different 'kube_node_role' tag value
+	// we only handle version we actually test (v1.19, v1.22, ...)
+	switch {
+	case k8sVersion.Minor == "19":
+		expectedTags = append(expectedTags, "^kube_node_role:master$")
+	case k8sVersion.Minor == "22":
+		expectedTags = append(expectedTags, "^kube_node_role:master$", "^kube_node_role:control-plane$")
+	default:
+		expectedTags = append(expectedTags, "^kube_node_role:control-plane$")
+	}
+
+	// tag keys that are expected to be found on any k8s env
+	args := &testHostTags{
+		ExpectedTags: expectedTags,
+	}
+
+	suite.testHostTags(args)
 }


### PR DESCRIPTION
### What does this PR do?

Add a new generic function that reads host-tags from `fakeintake`, then validates the received tags against the expected tags for the tests for that env.

Each env runs the test with its own expected tags and values. Some env runs with different host-type (windows and linux) and so the expected list of tags is different, we must use the optional tags for the the extra tags that are only here on some host types.

Increase the fakeintake retention period as the host-tags are gathered every 30 minutes

### Motivation

validate and test host-tags gathering

### Describe how you validated your changes

ran the new end2end test and it passed:
`dda inv new-e2e-tests.run -a ./tests/containers --run 'TestKindSuite/testHostTags'`

```
...
--- PASS: TestKindSuite (994.12s)
testing: warning: no tests to run
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/containers	996.734s [no tests to run]

DONE 1 tests in 996.726s
All tests passed
```

### Additional Notes
