### PR TITLE
Revert "dyninst: set debugger.type on symdb and diagnostics (#43434)"

### DIFF
--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -177,10 +177,7 @@ func (s *SymDBUploader) uploadInner(ctx context.Context, symdbData []byte) error
 	meta := []byte(`{
 "ddsource": "dd_debugger",
 "service": "` + s.service + `",
-"runtimeId": "` + s.runtimeID + `",
-"debugger": {
-	"type": "symdb"
-}
+"runtimeId": "` + s.runtimeID + `"
 }`)
 	if _, err := eventPart.Write(meta); err != nil {
 		return fmt.Errorf("failed to write event data: %w", err)

--- a/pkg/dyninst/uploader/diagnostics.go
+++ b/pkg/dyninst/uploader/diagnostics.go
@@ -25,24 +25,9 @@ type DiagnosticMessage struct {
 	DDSource  debuggerSource `json:"ddsource"`
 	Timestamp int64          `json:"timestamp"`
 
-	Debugger debugger `json:"debugger"`
-}
-
-// debugger wraps the diagnostics message and provides JSON marshaling in the
-// format expected by the backend.
-type debugger struct {
-	Diagnostic `json:"diagnostics"`
-}
-
-func (d debugger) MarshalJSON() ([]byte, error) {
-	type alias struct {
+	Debugger struct {
 		Diagnostic `json:"diagnostics"`
-		Type       string `json:"type"`
-	}
-	return json.Marshal(alias{
-		Diagnostic: d.Diagnostic,
-		Type:       "diagnostic",
-	})
+	} `json:"debugger"`
 }
 
 type debuggerSource struct{}
@@ -65,7 +50,9 @@ func (d debuggerSource) UnmarshalJSON(b []byte) error {
 func NewDiagnosticMessage(service string, d Diagnostic) *DiagnosticMessage {
 	return &DiagnosticMessage{
 		Service: service,
-		Debugger: debugger{
+		Debugger: struct {
+			Diagnostic `json:"diagnostics"`
+		}{
 			Diagnostic: d,
 		},
 	}


### PR DESCRIPTION
### What does this PR do?
This reverts commit 9d97650feec9e475cabc5c5e3e0dfaf26c267291.

### Motivation
[#incident-46780](https://dd.enterprise.slack.com/archives/C0A3MPT610Q): `static_quality_gates` failing on `main`.