### PR TITLE
Fix forwarder nil panic during secret refresh when 403 is hit

### DIFF
--- a/comp/forwarder/connectionsforwarder/impl/connectionsforwarder.go
+++ b/comp/forwarder/connectionsforwarder/impl/connectionsforwarder.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
@@ -24,8 +25,9 @@ import (
 type Requires struct {
 	Lifecycle compdef.Lifecycle
 
-	Config config.Component
-	Logger log.Component
+	Config  config.Component
+	Logger  log.Component
+	Secrets secrets.Component
 }
 
 // Provides defines the output of the connectionsforwarder component
@@ -50,6 +52,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 	if err != nil {
 		return Provides{}, err
 	}
+	processForwarderOpts.Secrets = reqs.Secrets
 
 	forwarder := defaultforwarder.NewDefaultForwarder(reqs.Config, reqs.Logger, processForwarderOpts)
 	reqs.Lifecycle.Append(compdef.Hook{

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -434,7 +434,9 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 		log.Errorf("API Key invalid (403 response), dropping transaction for %s", logURL)
 
 		// Trigger throttled secret refresh based on secret_refresh_on_api_key_failure_interval on API key error
-		_, _ = secrets.Refresh(false)
+		if secrets != nil {
+			_, _ = secrets.Refresh(false)
+		}
 
 		TransactionsDroppedByEndpoint.Add(transactionEndpointName, 1)
 		TransactionsDropped.Add(1)


### PR DESCRIPTION
### What does this PR do?

- `b27c986e9e` - defensive check to ensure we don't panic
- `d0cc658d86` - wire secrets into the connection forwarder component

### Motivation

In certain combinations of deployed features + network conditions, you can end up getting a nil panic in the connections forwarder.


### Describe how you validated your changes

I have a local KIND cluster that reproduces this by setting an invalid api key, with this code change, I no longer see this panic.

### Additional Notes
