### PR TITLE
[CWS] do not wait for 1 minutes waiting for tags

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -58,9 +58,10 @@ const (
 	//   . a kill can be queued up to the end of the first disarmer period (1min by default)
 	//   . so, we set the server retry period to 1min and 2sec (+2sec to have the
 	//     time to trigger the kill and wait to catch the process exit)
-	maxRetryForMsgWithActions = 62
-	maxRetryForRegularMsgs    = 5
-	retryDelay                = time.Second
+	maxRetryForMsgWithActions    = 62
+	maxRetryForMsgWithSSHContext = 62
+	maxRetryForRegularMsgs       = 5
+	retryDelay                   = time.Second
 )
 
 type pendingMsg struct {
@@ -81,6 +82,10 @@ type pendingMsg struct {
 func (p *pendingMsg) getMaxRetry() int {
 	if len(p.actionReports) != 0 {
 		return maxRetryForMsgWithActions
+	}
+
+	if p.sshSessionPatcher != nil {
+		return maxRetryForMsgWithSSHContext
 	}
 
 	return maxRetryForRegularMsgs

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -80,15 +80,17 @@ type pendingMsg struct {
 }
 
 func (p *pendingMsg) getMaxRetry() int {
+	retry := maxRetryForRegularMsgs
+
 	if len(p.actionReports) != 0 {
-		return maxRetryForMsgWithActions
+		retry = max(retry, maxRetryForMsgWithActions)
 	}
 
 	if p.sshSessionPatcher != nil {
-		return maxRetryForMsgWithSSHContext
+		retry = max(retry, maxRetryForMsgWithSSHContext)
 	}
 
-	return maxRetryForRegularMsgs
+	return retry
 }
 
 func (p *pendingMsg) isResolved() bool {


### PR DESCRIPTION
### What does this PR do?

We currently retry sending events for up to a minute if they are missing associated tags, or if an action report is still pending. While it makes sense to wait a minute for a hash action report, it doesn't make sense to wait a full minute for tags. This PR makes sure we only wait around 5 seconds for tags.

### Motivation

### Describe how you validated your changes

### Additional Notes
