### PR TITLE
[CONTP-1144] Bug-Fix(cluster-agent): release mutex before wlm.Push to prevent language detection blocking

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/util.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/util.go
@@ -139,24 +139,19 @@ func (ownersLanguages *OwnersLanguages) merge(other *OwnersLanguages) {
 
 // flush flushes to workloadmeta store containers languages that have dirty flag set to true, and then resets
 // dirty flag to false.
-// This method is not thread-safe.
+// This method acquires the mutex, collects dirty events and marks them as not dirty, releases the mutex,
+// then pushes all events in a single batch.
 func (ownersLanguages *OwnersLanguages) flush(wlm workloadmeta.Component) error {
-	pushErrors := make([]error, 0)
-
+	ownersLanguages.mutex.Lock()
+	var events []workloadmeta.Event
+	var pushErrors []error
 	for owner, containersLanguages := range ownersLanguages.containersLanguages {
-		// Skip if not dirty
 		if !containersLanguages.dirty {
 			continue
 		}
-
-		// Generate push event
 		if event := generatePushEvent(owner, containersLanguages.languages); event != nil {
-			pushError := wlm.Push(workloadmeta.SourceLanguageDetectionServer, *event)
-			if pushError != nil {
-				pushErrors = append(pushErrors, pushError)
-			} else {
-				containersLanguages.dirty = false
-			}
+			events = append(events, *event)
+			containersLanguages.dirty = false
 		} else {
 			pushErrors = append(
 				pushErrors,
@@ -168,6 +163,14 @@ func (ownersLanguages *OwnersLanguages) flush(wlm workloadmeta.Component) error 
 			)
 		}
 	}
+	ownersLanguages.mutex.Unlock()
+
+	if len(events) > 0 {
+		// Push() error is ignored because it only returns an error for invalid event types, and generatePushEvent()
+		// always creates events with valid types (EventTypeSet or EventTypeUnset).
+		// Push staying outsides the mutex prevents deadlock when Push() blocks on workloadmeta's eventCh.
+		_ = wlm.Push(workloadmeta.SourceLanguageDetectionServer, events...)
+	}
 	return errors.Join(pushErrors...)
 }
 
@@ -177,9 +180,8 @@ func (ownersLanguages *OwnersLanguages) flush(wlm workloadmeta.Component) error 
 // This method is thread-safe, and it serves as the unique entrypoint to instances of this type.
 func (ownersLanguages *OwnersLanguages) mergeAndFlush(other *OwnersLanguages, wlm workloadmeta.Component) error {
 	ownersLanguages.mutex.Lock()
-	defer ownersLanguages.mutex.Unlock()
-
 	ownersLanguages.merge(other)
+	ownersLanguages.mutex.Unlock()
 
 	return ownersLanguages.flush(wlm)
 }
@@ -188,13 +190,13 @@ func (ownersLanguages *OwnersLanguages) mergeAndFlush(other *OwnersLanguages, wl
 // This method is thread-safe.
 func (ownersLanguages *OwnersLanguages) cleanExpiredLanguages(wlm workloadmeta.Component) {
 	ownersLanguages.mutex.Lock()
-	defer ownersLanguages.mutex.Unlock()
-
 	for _, containersLanguages := range ownersLanguages.containersLanguages {
 		if containersLanguages.languages.RemoveExpiredLanguages() {
 			containersLanguages.dirty = true
 		}
 	}
+	ownersLanguages.mutex.Unlock()
+
 	_ = ownersLanguages.flush(wlm)
 }
 
@@ -203,8 +205,6 @@ func (ownersLanguages *OwnersLanguages) cleanExpiredLanguages(wlm workloadmeta.C
 // This method is thread-safe.
 func (ownersLanguages *OwnersLanguages) syncFromInjectableLanguages(wlm workloadmeta.Component, owner langUtil.NamespacedOwnerReference, injectableLanguages languagemodels.ContainersLanguages, ttl time.Duration) {
 	ownersLanguages.mutex.Lock()
-	defer ownersLanguages.mutex.Unlock()
-
 	// Update the in-memory state to match injectable languages
 	langsWithDirtyFlag := ownersLanguages.getOrInitialize(owner)
 
@@ -224,20 +224,20 @@ func (ownersLanguages *OwnersLanguages) syncFromInjectableLanguages(wlm workload
 	// This ensures DetectedLangs exactly matches InjectableLangs
 	langsWithDirtyFlag.languages = timedLangs
 	langsWithDirtyFlag.dirty = true
+	ownersLanguages.mutex.Unlock()
 
-	// Always flush to keep workloadmeta in sync
 	_ = ownersLanguages.flush(wlm)
 }
 
-// handleKubeApiServerUnsetEvents handles unset events emitted by the kubeapiserver
+// handleKubeAPIServerUnsetEvents handles unset events emitted by the kubeapiserver
 // events with type EventTypeSet are skipped
-// events with type EventTypeUnset are handled by deleted the corresponding owner from OwnersLanguages
+// events with type EventTypeUnset are handled by deleting the corresponding owner from OwnersLanguages
 // and by pushing a new event to workloadmeta that unsets detected languages data for the concerned kubernetes resource
 // This method is thread-safe.
 func (ownersLanguages *OwnersLanguages) handleKubeAPIServerUnsetEvents(events []workloadmeta.Event, wlm workloadmeta.Component) {
-	ownersLanguages.mutex.Lock()
-	defer ownersLanguages.mutex.Unlock()
+	var unsetEvents []workloadmeta.Event
 
+	ownersLanguages.mutex.Lock()
 	for _, event := range events {
 		kind := event.Entity.GetID().Kind
 
@@ -254,11 +254,16 @@ func (ownersLanguages *OwnersLanguages) handleKubeAPIServerUnsetEvents(events []
 			namespace := deploymentIDs[0]
 			deploymentName := deploymentIDs[1]
 			delete(ownersLanguages.containersLanguages, langUtil.NewNamespacedOwnerReference("apps/v1", langUtil.KindDeployment, deploymentName, namespace))
-			_ = wlm.Push(workloadmeta.SourceLanguageDetectionServer, workloadmeta.Event{
+			unsetEvents = append(unsetEvents, workloadmeta.Event{
 				Type:   workloadmeta.EventTypeUnset,
 				Entity: deployment,
 			})
 		}
+	}
+	ownersLanguages.mutex.Unlock()
+
+	if len(unsetEvents) > 0 {
+		_ = wlm.Push(workloadmeta.SourceLanguageDetectionServer, unsetEvents...)
 	}
 }
 

--- a/releasenotes-dca/notes/fix-language-detection-deadlock-1f1b237a19ad4ea5.yaml
+++ b/releasenotes-dca/notes/fix-language-detection-deadlock-1f1b237a19ad4ea5.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a deadlock in the Cluster Agent language detection handler that could cause
+    event drops with the error "collector language-detection-follower dropped event(s)
+    after 10s timeout". The fix releases the mutex before pushing events to workloadmeta
+    to prevent blocking while holding the lock.


### PR DESCRIPTION
### What does this PR do?

  Fixes a degradation in the language detection handler that causes event drops with the error:
  collector "language-detection-follower" dropped 1 event(s) after 10s timeout, wlm subscriber is not reading from channel (blocked until events are dropped)

###  Root Cause
The OwnersLanguages methods hold a mutex while calling wlm.Push(), which can block on workloadmeta's shared eventCh (buffer size = 50). This creates a circular wait: the subscriber can't read from its channel because it's blocked in down-stream function syncFromInjectableLanguages while waiting for Push() to complete, and Push() can't complete because the channel is full.

###  Fix
  Release the mutex before calling wlm.Push():
  1. Acquire mutex, collect dirty events, mark as not dirty
  2. Release mutex
  3. Batch push all events

  Applied to: 

- flush(), 
- mergeAndFlush(), handleKubeAPIServerUnsetEvents()
- cleanExpiredLanguages(), 
- syncFromInjectableLanguages(), 

###  Motivation

  Fixes CONTP-1144 - errors observed in Gizmo with cluster-agent 7.74.0-rc.1.

###  Describe how you validated your changes
  - backport required for 7.74
  - Unit tests pass
  - On staging cluster test, the following error log should disappear
```    
2025-12-09 11:23:34 UTC | CLUSTER | ERROR | (comp/core/workloadmeta/impl/store.go:929 in notifyChannel) | collector "language-detection-follower" dropped 1 event(s) after 10s timeout, subscriber is not reading from channel. This may cause data inconsistency for this subscriber.
```


