### PR TITLE
Prefer version cache over live git operations during build

### DIFF
--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -12,6 +12,7 @@ from invoke import Context
 from invoke.exceptions import Exit
 
 from tasks.libs.common.color import Color, color_message
+from tasks.libs.common.constants import AGENT_VERSION_CACHE_NAME
 from tasks.libs.common.user_interactions import yes_no_question
 
 if TYPE_CHECKING:
@@ -221,6 +222,26 @@ def check_local_branch(ctx, branch):
 
 
 def get_commit_sha(ctx, commit="HEAD", short=False) -> str:
+    """
+    Get the commit SHA for the given commit reference.
+
+    For HEAD commits, tries to read from agent-version.cache first (useful for
+    environments without .git, like omnibus docker builds), then falls back to git.
+    """
+    # Only use cache for HEAD - other refs need actual git resolution
+    if commit == "HEAD" and os.path.exists(AGENT_VERSION_CACHE_NAME):
+        import json
+
+        try:
+            with open(AGENT_VERSION_CACHE_NAME) as f:
+                cache_data = json.load(f)
+            # Cache format: {"7": [version, pre, commits_since_version, git_sha, pipeline_id], ...}
+            cached_sha = cache_data.get("7", [None, None, None, None])[3]
+            if cached_sha:
+                return cached_sha[:7] if short else cached_sha
+        except (OSError, json.JSONDecodeError, IndexError, KeyError):
+            pass
+
     return ctx.run(f"git rev-parse {'--short ' if short else ''}{commit}", hide=True).stdout.strip()
 
 

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -126,7 +126,11 @@ def get_modified_files(ctx, base_branch=None) -> list[str]:
 
 
 def get_current_branch(ctx) -> str:
-    return ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
+    result = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True, warn=True)
+    if result.ok:
+        return result.stdout.strip()
+    # Not in a git repo (e.g., gitless omnibus build) - return placeholder
+    return "unknown"
 
 
 def is_a_release_branch(ctx, branch=None) -> bool:

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -8,6 +8,7 @@ import os
 import platform
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -425,9 +426,17 @@ def get_go_version():
 
 def get_root():
     """
-    Get the root of the Go project
+    Get the root of the Go project.
+
+    Falls back to using __file__ path if not in a git repository
+    (e.g., during gitless builds like omnibus.docker-build).
     """
-    return check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
+    try:
+        return check_output(['git', 'rev-parse', '--show-toplevel'], stderr=subprocess.DEVNULL).decode('utf-8').strip()
+    except subprocess.CalledProcessError:
+        # Not in a git repo - fall back to deriving root from this file's location
+        # This file is at tasks/libs/common/utils.py, so repo root is 4 levels up
+        return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
 
 
 @contextmanager

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -8,7 +8,6 @@ import os
 import platform
 import re
 import shutil
-import subprocess
 import sys
 import tempfile
 import time

--- a/tasks/unit_tests/libs/common/git_tests.py
+++ b/tasks/unit_tests/libs/common/git_tests.py
@@ -77,7 +77,7 @@ class TestGit(unittest.TestCase):
         branch = get_current_branch(self.ctx_mock)
 
         self.assertEqual(branch, "main")
-        self.ctx_mock.run.assert_called_once_with("git rev-parse --abbrev-ref HEAD", hide=True)
+        self.ctx_mock.run.assert_called_once_with("git rev-parse --abbrev-ref HEAD", hide=True, warn=True)
 
     def test_check_uncommitted_changes(self):
         tests = [
@@ -125,7 +125,11 @@ class TestGit(unittest.TestCase):
                 )
                 self.ctx_mock.run.reset_mock()
 
-    def test_get_commit_sha(self):
+    # Mock os.path.exists to prevent get_commit_sha from reading agent-version.cache
+    # (if present in local checkout). This ensures the test uses the mocked git command
+    # instead of bypassing it via the cache fallback for gitless builds.
+    @unittest.mock.patch("os.path.exists", return_value=False)
+    def test_get_commit_sha(self, _):
         tests = [
             {
                 "short": False,


### PR DESCRIPTION
### What does this PR do?

This prefers reading git version sha from the version-cache file locally vs
running `git` commands

### Motivation

Requiring `.git` for an Agent build sucks, if for no other reason than working
in a git worktree.

### Describe how you validated your changes

`dda inv omnibus.docker-build` works when mounted without git dir.

### Additional Notes

