### PR TITLE
Add troubleshooting doc link for permission errors

### DIFF
--- a/pkg/logs/status/utils/status.go
+++ b/pkg/logs/status/utils/status.go
@@ -7,6 +7,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -46,7 +47,11 @@ func (s *LogStatus) Error(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.status = isError
-	s.err = "Error: " + err.Error()
+	if strings.Contains(err.Error(), "permission denied") {
+		s.err = fmt.Sprintf("Error: %s. See https://docs.datadoghq.com/logs/guide/log-collection-troubleshooting-guide/?tab=linux#permission-issues-tailing-log-files for details on how to troubleshoot this issue", err.Error())
+	} else {
+		s.err = fmt.Sprintf("Error: %s", err.Error())
+	}
 }
 
 // IsPending returns whether the current status is not yet determined.


### PR DESCRIPTION
### What does this PR do?
Adding a doc link for file permission errors when configuring tailing log files

https://docs.datadoghq.com/agent/logs/?tab=tailfiles#custom-log-collection
Key troubleshooting step set
https://docs.datadoghq.com/logs/guide/log-collection-troubleshooting-guide/?tab=linux#permission-issues-tailing-log-files


### Motivation
Better Agent Error messages. project
Increased doc visibility for customers to troubleshoot
### Describe how you validated your changes
Tested locally with a DDA build of the Agent, by changing permissions to tailing log file

### Additional Notes
<img width="868" height="187" alt="image" src="https://github.com/user-attachments/assets/1669d3b0-b5ee-4181-afc2-0fd95c15e799" />
