### PR TITLE
[CWS] Fix corrupted replay events

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -838,8 +838,7 @@ func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 
 	for _, event := range events {
 		p.DispatchEvent(event, notifyConsumers)
-		p.resetEvent(event)
-		p.eventPool.Put(event)
+		p.putBackPoolEvent(event)
 	}
 }
 
@@ -1044,12 +1043,18 @@ func (p *EBPFProbe) zeroEvent() *model.Event {
 	return p.event
 }
 
-func (p *EBPFProbe) resetEvent(event *model.Event) {
+func (p *EBPFProbe) getPoolEvent() *model.Event {
+	event := p.eventPool.Get()
+	event.FieldHandlers = p.fieldHandlers
+	return event
+}
+
+func (p *EBPFProbe) putBackPoolEvent(event *model.Event) {
 	if event.ProcessCacheEntry != nil {
 		event.ProcessCacheEntry.Release()
 	}
 	probeEventZeroer(event)
-	event.FieldHandlers = p.fieldHandlers
+	p.eventPool.put(event)
 }
 
 func (p *EBPFProbe) resolveCGroup(pid uint32, cgroupPathKey model.PathKey, newEntryCb func(entry *model.ProcessCacheEntry, err error)) (*model.CGroupContext, error) {
@@ -1167,8 +1172,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 	// send related events
 	for _, relatedEvent := range relatedEvents {
 		p.DispatchEvent(relatedEvent, true)
-		p.resetEvent(event)
-		p.eventPool.Put(relatedEvent)
+		p.putBackPoolEvent(relatedEvent)
 	}
 	relatedEvents = relatedEvents[0:0]
 
@@ -3473,7 +3477,7 @@ func (p *EBPFProbe) newEBPFPooledEventFromPCE(entry *model.ProcessCacheEntry) *m
 		eventType = model.ForkEventType
 	}
 
-	event := p.eventPool.Get()
+	event := p.getPoolEvent()
 
 	event.Type = uint32(eventType)
 	event.TimestampRaw = uint64(time.Now().UnixNano())
@@ -3486,11 +3490,12 @@ func (p *EBPFProbe) newEBPFPooledEventFromPCE(entry *model.ProcessCacheEntry) *m
 
 // newBindEventFromReplay returns a new bind event with a process context
 func (p *EBPFProbe) newBindEventFromReplay(entry *model.ProcessCacheEntry, snapshottedBind model.SnapshottedBoundSocket) *model.Event {
-	event := p.eventPool.Get()
+	event := p.getPoolEvent()
 	event.TimestampRaw = uint64(time.Now().UnixNano())
 	event.Type = uint32(model.BindEventType)
 	event.ProcessCacheEntry = entry
 	event.ProcessContext = &entry.ProcessContext
+	event.AddToFlags(model.EventFlagsFromReplay)
 
 	event.Bind.SyscallEvent.Retval = 0
 	event.Bind.AddrFamily = snapshottedBind.Family

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1054,7 +1054,7 @@ func (p *EBPFProbe) putBackPoolEvent(event *model.Event) {
 		event.ProcessCacheEntry.Release()
 	}
 	probeEventZeroer(event)
-	p.eventPool.put(event)
+	p.eventPool.Put(event)
 }
 
 func (p *EBPFProbe) resolveCGroup(pid uint32, cgroupPathKey model.PathKey, newEntryCb func(entry *model.ProcessCacheEntry, err error)) (*model.CGroupContext, error) {

--- a/pkg/security/probe/probe_ebpf_test.go
+++ b/pkg/security/probe/probe_ebpf_test.go
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && test
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
+)
+
+func newTestEBPFProbe() *EBPFProbe {
+	fieldHandlers := &EBPFFieldHandlers{}
+	p := &EBPFProbe{
+		fieldHandlers: fieldHandlers,
+	}
+	p.eventPool = ddsync.NewTypedPool(func() *model.Event {
+		return &model.Event{}
+	})
+	return p
+}
+
+func TestGetPoolEvent(t *testing.T) {
+	p := newTestEBPFProbe()
+
+	t.Run("get event from pool assigns field handlers", func(t *testing.T) {
+		event := p.getPoolEvent()
+
+		assert.NotNil(t, event)
+		assert.Equal(t, p.fieldHandlers, event.FieldHandlers)
+	})
+
+	t.Run("get multiple events from pool", func(t *testing.T) {
+		event1 := p.getPoolEvent()
+		event2 := p.getPoolEvent()
+
+		assert.NotNil(t, event1)
+		assert.NotNil(t, event2)
+		assert.Equal(t, p.fieldHandlers, event1.FieldHandlers)
+		assert.Equal(t, p.fieldHandlers, event2.FieldHandlers)
+	})
+}
+
+func TestPutBackPoolEvent(t *testing.T) {
+	p := newTestEBPFProbe()
+
+	t.Run("put back event with nil ProcessCacheEntry", func(t *testing.T) {
+		event := p.getPoolEvent()
+		event.ProcessCacheEntry = nil
+		// Set some fields to verify they get reset
+		event.Type = uint32(model.ExecEventType)
+		event.TimestampRaw = 12345
+
+		p.putBackPoolEvent(event)
+
+		// Get a new event from the pool (should be the one we just put back)
+		newEvent := p.getPoolEvent()
+
+		// Verify that the event was reset (Type should be 0)
+		assert.Equal(t, uint32(0), newEvent.Type)
+		assert.Equal(t, uint64(0), newEvent.TimestampRaw)
+	})
+
+	t.Run("put back event with ProcessCacheEntry with refCount 1", func(t *testing.T) {
+		event := p.getPoolEvent()
+
+		// Create a ProcessCacheEntry with a release callback to track if Release was called
+		releaseCalled := false
+		pce := model.NewProcessCacheEntry(func(_ *model.ProcessCacheEntry) {
+			releaseCalled = true
+		})
+		pce.Retain() // refCount becomes 1
+		event.ProcessCacheEntry = pce
+
+		// Set some fields to verify they get reset
+		event.Type = uint32(model.ExecEventType)
+		event.TimestampRaw = 12345
+
+		p.putBackPoolEvent(event)
+
+		// Verify that Release was called (since refCount was 1, coreRelease callback should be called)
+		assert.True(t, releaseCalled, "Release callback should have been called")
+
+		// Get a new event from the pool (should be the one we just put back)
+		newEvent := p.getPoolEvent()
+
+		// Verify that the event was reset (Type should be 0)
+		assert.Equal(t, uint32(0), newEvent.Type)
+		assert.Equal(t, uint64(0), newEvent.TimestampRaw)
+	})
+
+	t.Run("put back event with ProcessCacheEntry with refCount greater than 1", func(t *testing.T) {
+		event := p.getPoolEvent()
+
+		// Create a ProcessCacheEntry with a release callback to track if Release was called
+		releaseCalled := false
+		pce := model.NewProcessCacheEntry(func(_ *model.ProcessCacheEntry) {
+			releaseCalled = true
+		})
+		pce.Retain() // refCount becomes 1
+		pce.Retain() // refCount becomes 2
+		event.ProcessCacheEntry = pce
+
+		// Set some fields to verify they get reset
+		event.Type = uint32(model.ExecEventType)
+		event.TimestampRaw = 12345
+
+		p.putBackPoolEvent(event)
+
+		// Verify that Release was called but coreRelease callback was NOT called
+		// (since refCount > 1, it should just decrement the counter)
+		assert.False(t, releaseCalled, "Release callback should NOT have been called when refCount > 1")
+
+		// Get a new event from the pool (should be the one we just put back)
+		newEvent := p.getPoolEvent()
+
+		// Verify that the event was reset (Type should be 0)
+		assert.Equal(t, uint32(0), newEvent.Type)
+		assert.Equal(t, uint64(0), newEvent.TimestampRaw)
+	})
+
+	t.Run("put back event preserves Os field after reset", func(t *testing.T) {
+		event := p.getPoolEvent()
+		event.ProcessCacheEntry = nil
+		event.Type = uint32(model.ExecEventType)
+		event.Os = "linux"
+
+		p.putBackPoolEvent(event)
+
+		// Get a new event from the pool (should be the one we just put back)
+		newEvent := p.getPoolEvent()
+
+		// Verify that the Os field is preserved after reset (should be "linux")
+		assert.Equal(t, "linux", newEvent.Os)
+	})
+}
+
+func TestGetAndPutBackPoolEventRoundTrip(t *testing.T) {
+	p := newTestEBPFProbe()
+
+	t.Run("round trip get and put back event", func(t *testing.T) {
+		// Get an event
+		event := p.getPoolEvent()
+		assert.NotNil(t, event)
+		assert.Equal(t, p.fieldHandlers, event.FieldHandlers)
+
+		// Modify the event
+		event.Type = uint32(model.ExecEventType)
+		event.TimestampRaw = 99999
+
+		// Put it back
+		p.putBackPoolEvent(event)
+
+		// Get another event (should be the same one, reset)
+		event2 := p.getPoolEvent()
+		assert.Equal(t, uint32(0), event2.Type)
+		assert.Equal(t, uint64(0), event2.TimestampRaw)
+		assert.Equal(t, p.fieldHandlers, event2.FieldHandlers)
+	})
+}


### PR DESCRIPTION
### What does this PR do?

This PR resets replay events before pushing them back to pool, avoiding to take "dirty" events from the pool leading to corrupted events.

### Motivation

### Describe how you validated your changes

Unit tests has been added

### Additional Notes
