### PR TITLE
chore(dda): fixup the option in new-e2e-tests.run to keep the stack

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -228,6 +228,7 @@ def build_binaries(
         "use_prebuilt_binaries": "Use pre-built test binaries instead of building on the fly",
         "max_retries": "Maximum number of retries for failed tests, default 3",
         "impacted": "Only run tests that are impacted by the changes (only available in CI for now)",
+        "keep_stack": "Keep the stack after running the test, you are responsible for destroying the stack later.",
     },
 )
 def run(
@@ -244,7 +245,7 @@ def run(
     cws_supported_osdescriptors="",
     src_agent_version="",
     dest_agent_version="",
-    keep_stacks=False,
+    keep_stack=False,
     extra_flags="",
     cache=False,
     junit_tar="",
@@ -378,7 +379,7 @@ def run(
             f"--raw-command {os.path.join(os.path.dirname(__file__), 'tools', 'gotest-scrubbed.sh')} {{packages}}"
         )
 
-    cmd += f'{{junit_file_flag}} {{json_flag}} --packages="{{packages}}" {raw_command} -- -ldflags="-X {{REPO_PATH}}/test/new-e2e/tests/containers.GitCommit={{commit}}" {{verbose}} -mod={{go_mod}} -vet=off -timeout {{timeout}} -tags "{{go_build_tags}}" {{nocache}} {{run}} {{skip}} {{test_run_arg}} -args {{osdescriptors}} {{flavor}} {{cws_supported_osdescriptors}} {{src_agent_version}} {{dest_agent_version}} {{keep_stacks}} {{extra_flags}}'
+    cmd += f'{{junit_file_flag}} {{json_flag}} --packages="{{packages}}" {raw_command} -- -ldflags="-X {{REPO_PATH}}/test/new-e2e/tests/containers.GitCommit={{commit}}" {{verbose}} -mod={{go_mod}} -vet=off -timeout {{timeout}} -tags "{{go_build_tags}}" {{nocache}} {{run}} {{skip}} {{test_run_arg}} -args {{osdescriptors}} {{flavor}} {{cws_supported_osdescriptors}} {{src_agent_version}} {{dest_agent_version}} {{extra_flags}}'
     # Strinbuilt_binaries:gs can come with extra double-quotes which can break the command, remove them
     clean_run = []
     clean_skip = []
@@ -404,7 +405,6 @@ def run(
         else "",
         "src_agent_version": f"-src-agent-version {src_agent_version}" if src_agent_version else "",
         "dest_agent_version": f"-dest-agent-version {dest_agent_version}" if dest_agent_version else "",
-        "keep_stacks": '-keep-stacks' if keep_stacks else "",
         "extra_flags": extra_flags,
     }
 
@@ -418,6 +418,9 @@ def run(
             env_vars["E2E_SKIP_DELETE_ON_FAILURE"] = "true"
         else:
             env_vars.pop("E2E_SKIP_DELETE_ON_FAILURE", None)
+
+        if keep_stack is True:
+            env_vars["E2E_DEV_MODE"] = "true"
 
         partial_result_json = f"{result_json}.{attempt}.part"
         result_jsons.append(partial_result_json)


### PR DESCRIPTION
### What does this PR do?

When running the dda command `new-e2e-tests.run` it shows an option to keep the stack in end in order to re-run the tests `--keep_stack`.

This option does not work.

Keep the option, make it public by adding the option to the `--help` so users can see it.

Make it so it sets the env variable `E2E_DEV_MODE` which is the current option to keep the stack after running a test, this is the way.

### Motivation

when running a new tests, it will most probably fail, so I would need to keep the stack to re-run the test.

### Describe how you validated your changes

previous use of the option:

```
dda inv new-e2e-tests.run -a ./tests/containers --run 'TestEKSSuite/testHostTags'  --keep-stacks
flag provided but not defined: -keep-stacks
....
  -test.trace file
    	write an execution trace to file
  -test.v
    	verbose: print additional output
  -testify.m string
    	regular expression to select tests of the testify suite to run
  -v value
    	log level for V logs
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
FAIL	github.com/DataDog/datadog-agent/test/new-e2e/tests/containers	2.481s

=== Failed
=== FAIL: test/new-e2e/tests/containers  (0.00s)
```

Now after removing the handover to go test and only setting the env var:

```
dda inv new-e2e-tests.run -a ./tests/containers --run 'TestEKSSuite/testHostTags'  -k
=== RUN   TestEKSSuite
.....
```

### Additional Notes

One ca still use the env var `E2E_DEV_MODE` for backward compatibility, but now the command line option is more convenient. 
