### PR TITLE
[CWS] skip container filter tags fetching if there is no container filter

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -338,10 +338,12 @@ func (a *APIServer) start(ctx context.Context) {
 					return false
 				}
 
-				containerName, imageName, podNamespace := utils.GetContainerFilterTags(msg.tags)
-				if a.containerFilter != nil && a.containerFilter.IsExcluded(nil, containerName, imageName, podNamespace) {
-					msg.skip = true
-					return false
+				if a.containerFilter != nil {
+					containerName, imageName, podNamespace := utils.GetContainerFilterTags(msg.tags)
+					if a.containerFilter.IsExcluded(nil, containerName, imageName, podNamespace) {
+						msg.skip = true
+						return false
+					}
 				}
 
 				data, err := msg.toJSON()


### PR DESCRIPTION

### What does this PR do?

If there is not container filter, no need to extract the container tags from the tags list. No functional change otherwise

### Motivation

### Describe how you validated your changes

### Additional Notes
