### PR TITLE
`tests_windows-x64` flakiness: add error tracing

### DIFF
--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -1,3 +1,8 @@
+trap {
+    Write-Host "trap: $($_.InvocationInfo.Line.Trim()) - $_" -ForegroundColor Yellow
+    continue
+}
+
 <#
 .SYNOPSIS
 Copies files from C:\mnt into C:\buildroot\datadog-agent and sets the current directory to the buildroot.


### PR DESCRIPTION
### Motivation
The `tests_windows-x64` job still fails at times with too minimal diagnostic information, making it difficult to identify root causes. For example, in https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1286075782 (`main` pipeline), the job fails with only:
```
Switching to buildroot c:\buildroot\datadog-agent
Leaving buildroot
ERROR: Job failed: exit status 1
```

The script runs for only ~12 seconds and exits between `Enter-BuildRoot` and `Exit-BuildRoot` without any error messages, suggesting a silent failure in one of:
- `Check-go-version`
- `Enable-DevEnv` (`ridk enable`?)
- `Expand-ModCache`
- `Install-Deps`
- `Install-TestingDeps`

### What does this PR do?
This change adds a global `trap` statement to `common.ps1` that traces all errors _without changing script behavior_ by using `continue` (terminating errors still terminate, non-terminating errors still continue) while logging the failed command and error message in yellow (rather conventional for warnings) for visibility.