### PR TITLE
Update stable-nightly-build conductor

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -91,11 +91,11 @@ extensions:
           branch: "conductor-sandbox"
           parent_environments: ["staging"]
         - name: "stable-nightly-build"
-          ci_pipeline: "//fake_placeholder:fake_placeholder"
           branch: "7.73.x"
           schedule: "30 2 * * *"
-          parent_environments: ["staging"]
           build_only: true
+          options:
+            disable_bia: true
   datadoghq.com/change-detection:
     source_patterns:
       - service.datadog.yaml


### PR DESCRIPTION
### What does this PR do?

We observed issue where `stable-nightly-build` conductor stopped running one month ago. By looking at the config I think the reason was related to the conductor incorrectly analyzing the diff between runs and because of that skipped the consequent runs. Only recent bump in the branch caused it to run again.

Based on that I propose following updates:
1) Remove `ci_placeholder` and `parent_environments` - according to the documentation the first one is not required and the second one seems misleading, as we don't use it anywhere in other targets,
2) Set `disable_bia: true` - this should make the pipeline run every day, regardless if there were new changes merged. This should be the default behavior, as we want to catch the issues that may be caused by external factor and resolved on time.

### Motivation

Stabilize nightly branch builds.
