### PR TITLE
Make `bazel:mod-deps` blocking again with retry strategy

### DIFF
--- a/.gitlab/bazel/lint.yaml
+++ b/.gitlab/bazel/lint.yaml
@@ -1,15 +1,18 @@
 bazel:mod-deps:
-  allow_failure: true  #incident-46079
   extends: .bazel:runner:linux-amd64
   stage: lint
   script:
-    - bazel mod deps --lockfile_mode=error
+    - |
+      if ! bazel mod deps --lockfile_mode=error; then
+        echo >&2 "🟡️ triggering in-memory cache refresh to try again"
+        bazel mod deps --lockfile_mode=refresh
+        git diff --exit-code || git restore MODULE.bazel.lock
+        bazel mod deps --lockfile_mode=error
+      fi
   after_script:
     - |-
       if [ $CI_JOB_STATUS = failed ]; then
         echo >&2 "💡 bazel mod deps"
-        bazel mod deps
-        git diff
       fi
 
 bazel:run-buildifier-test:


### PR DESCRIPTION
### What does this PR do?
The `bazel:mod-deps` job was temporarily set to `allow_failure` due to incident-46079.
This change makes it blocking again, but implements a retry strategy in case of stale in-memory cache (more likely on persistent CI runners) without requiring `bazel clean` nor even `shutdown`.

### Motivation
Quick recap:
- last occurrence: Dec 2, 2025 (https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1265753104),
- happened after `bazel` 8.4.2 bump and cache generalization, allowing both to be eliminated from culprits,
- likely cause: `bazel` server/daemon on persistent runners does not refresh its module state automatically, similar to `repository_rules` without `local=True` whose purpose it to:
  > Indicate that this rule fetches everything from the local system and should be reevaluated at every fetch.

### Additional Notes
Proposed retry strategy:
1. first attempt, by the book: `bazel mod deps --lockfile_mode=error`,
2. on failure:
   - instruct `bazel` to refresh its internal module cache with `--lockfile_mode=refresh`,
   - restore `MODULE.bazel.lock`, if applicable,
   - retry verification with `--lockfile_mode=error`.

Further reading:
- https://bazel.build/external/lockfile
- https://github.com/bazelbuild/bazel/issues/23841
- https://mindfulchase.com/explore/troubleshooting-tips/build-bundling/advanced-bazel-troubleshooting-for-persistent-rebuilds-and-cache-invalidation.html