### PR TITLE
`docker_image_build_otel` flakiness: enable `curl` retries

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -48,7 +48,7 @@ RUN GO_VERSION=$(cat .go-version) && \
     else \
     echo "Unsupported architecture: $ARCH" && exit 1; \
     fi && \
-    curl -OL https://golang.org/dl/go${GO_VERSION}.$GO_ARCH.tar.gz && \
+    curl -fsSLO --retry 4 https://golang.org/dl/go${GO_VERSION}.$GO_ARCH.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.$GO_ARCH.tar.gz && \
     rm go${GO_VERSION}.$GO_ARCH.tar.gz
 
@@ -67,7 +67,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     DDA_VERSION=${DDA_VERSION} && \
     if [ "$ARCH" = "amd64" ]; then DDA_ARCH="x86_64"; \
     elif [ "$ARCH" = "arm64" ]; then DDA_ARCH="aarch64"; fi && \
-    curl -fsSL "https://github.com/DataDog/datadog-agent-dev/releases/download/${DDA_VERSION}/dda-${DDA_ARCH}-unknown-linux-gnu.tar.gz" \
+    curl -fsSL --retry 4 "https://github.com/DataDog/datadog-agent-dev/releases/download/${DDA_VERSION}/dda-${DDA_ARCH}-unknown-linux-gnu.tar.gz" \
     | tar -xzf - -C /usr/local/bin && \
     chmod +x /usr/local/bin/dda && \
     dda self dep sync -f legacy-tasks
@@ -87,7 +87,7 @@ ARG PACKAGE_TYPE
 RUN if [ -n "$PACKAGE_TYPE" ]; then \
     ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "amd64" ]; then ARCH="x86_64"; fi && \
-    curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v2.43.0/nfpm_2.43.0_linux_${ARCH}.tar.gz" | tar -xzf - -C /usr/local/bin/ && \
+    curl -fsSL --retry 4 "https://github.com/goreleaser/nfpm/releases/download/v2.43.0/nfpm_2.43.0_linux_${ARCH}.tar.gz" | tar -xzf - -C /usr/local/bin/ && \
     chmod +x /usr/local/bin/nfpm; \
     fi
 


### PR DESCRIPTION
### What does this PR do?
Enable `curl` retry strategy for known errors, esp. HTTP 503.

Doesn't mean this will fix long-standing server errors, but at least we'll be first retrying single commands before retrying the whole job.

### Motivation
Numerous failures happened recently, for instance: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1287074156