### PR TITLE
`kmt_run_sysprobe_tests_x64` flakiness: increase first timeout in `TestDetectsContainer`

### DIFF
--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -110,7 +110,7 @@ func (s *probeTestSuite) waitForExpectedCudasampleEvents(probe *Probe, pid int) 
 		hasGlobalStreams := probe.streamHandlers.globalStreamsCount() == 1 && handlers.global != nil && len(handlers.global.pendingMemorySpans) > 0
 		hasNonGlobalStreams := probe.streamHandlers.streamsCount() == 1 && handlers.stream != nil && len(handlers.stream.pendingKernelSpans) > 0
 		return hasGlobalStreams && hasNonGlobalStreams
-	}, 3*time.Second, 100*time.Millisecond, "stream and global handlers not found: existing is %v", probe.consumer.deps.streamHandlers)
+	}, 10*time.Second, 100*time.Millisecond, "stream and global handlers not found: existing is %v", probe.consumer.deps.streamHandlers)
 
 	// Check that we're receiving the events we expect
 	telemetryMock, ok := probe.deps.Telemetry.(telemetry.Mock)


### PR DESCRIPTION
### What does this PR do?
This is a tentative fix for the `TestDetectsContainer` test that has been frequently failing in CI (`main` branch):
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1283115751
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1283115734
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1283115730
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1283115712
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1283115705
- ...

### Motivation
Based on the CI logs, it might be that the first timeout in the test is too short for the test workflow:
- when failing once, the test seems to fail consistently across all runs (2 retries),
- test duration when failing: ~13-15 seconds,
- the `cudasample` test binary has a **5-second** startup delay (`StartWaitTimeSec` parameter in `defaultCudaSampleArgs`),
- the test is first waiting **3 seconds** for stream handlers to populate.

Naive conclusion: the timeout in probe_test.go (line 113) doesn't seem to account for the full workflow.

Proposed change: increase first timeout to **10 seconds** to provide more margin for the complete workflow.

### Additional Notes
Note: the other timeouts in the same function (lines 145 and 274) remain at 3 seconds as they execute after the initial events are generated.