### PR TITLE
upgrade(fleet): Make installer refresh rate configurable

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1184,6 +1184,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("installer.registry.auth", "")
 	config.BindEnvAndSetDefault("installer.registry.username", "")
 	config.BindEnvAndSetDefault("installer.registry.password", "")
+	config.BindEnvAndSetDefault("installer.refresh_interval", time.Duration(30*time.Second))
+	config.BindEnvAndSetDefault("installer.gc_interval", time.Duration(time.Hour))
+
 	// Legacy installer configuration
 	config.SetKnown("remote_policies") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -39,10 +39,6 @@ import (
 )
 
 const (
-	// gcInterval is the interval at which the GC will run
-	gcInterval = 1 * time.Hour
-	// refreshStateInterval is the interval at which the state will be refreshed
-	refreshStateInterval = 30 * time.Second
 	// disableClientIDCheck is the magic string to disable the client ID check.
 	disableClientIDCheck = "disable-client-id-check"
 )
@@ -98,6 +94,8 @@ type daemonImpl struct {
 	requestsWG      sync.WaitGroup
 	taskDB          *taskDB
 	clientID        string
+	refreshInterval time.Duration
+	gcInterval      time.Duration
 }
 
 func newInstaller(installerBin string) func(env *env.Env) installer.Installer {
@@ -151,10 +149,12 @@ func NewDaemon(hostname string, rcFetcher client.ConfigFetcher, config agentconf
 		ConfigID:             configID,
 	}
 	installer := newInstaller(installerBin)
-	return newDaemon(rc, installer, env, taskDB), nil
+	refreshInterval := config.GetDuration("installer.refresh_interval")
+	gcInterval := config.GetDuration("installer.gc_interval")
+	return newDaemon(rc, installer, env, taskDB, refreshInterval, gcInterval), nil
 }
 
-func newDaemon(rc *remoteConfig, installer func(env *env.Env) installer.Installer, env *env.Env, taskDB *taskDB) *daemonImpl {
+func newDaemon(rc *remoteConfig, installer func(env *env.Env) installer.Installer, env *env.Env, taskDB *taskDB, refreshInterval time.Duration, gcInterval time.Duration) *daemonImpl {
 	i := &daemonImpl{
 		env:             env,
 		clientID:        rc.client.GetClientID(),
@@ -167,6 +167,8 @@ func newDaemon(rc *remoteConfig, installer func(env *env.Env) installer.Installe
 		configsOverride: make(map[string]installerConfig),
 		stopChan:        make(chan struct{}),
 		taskDB:          taskDB,
+		refreshInterval: refreshInterval,
+		gcInterval:      gcInterval,
 	}
 	i.refreshState(context.Background())
 	return i
@@ -309,9 +311,9 @@ func (d *daemonImpl) Start(_ context.Context) error {
 	}
 
 	go func() {
-		gcTicker := time.NewTicker(gcInterval)
+		gcTicker := time.NewTicker(d.gcInterval)
 		defer gcTicker.Stop()
-		refreshStateTicker := time.NewTicker(refreshStateInterval)
+		refreshStateTicker := time.NewTicker(d.refreshInterval)
 		defer refreshStateTicker.Stop()
 		for {
 			select {

--- a/pkg/fleet/daemon/daemon_test.go
+++ b/pkg/fleet/daemon/daemon_test.go
@@ -250,6 +250,8 @@ func newTestInstaller(t *testing.T) *testInstaller {
 		func(_ *env.Env) installer.Installer { return pm },
 		&env.Env{RemoteUpdates: true},
 		taskDB,
+		30*time.Second,
+		1*time.Hour,
 	)
 	i := &testInstaller{
 		daemonImpl: daemon,
@@ -493,6 +495,8 @@ func TestRefreshStateRunningVersions(t *testing.T) {
 		func(_ *env.Env) installer.Installer { return pm },
 		testEnv,
 		taskDB,
+		30*time.Second,
+		1*time.Hour,
 	)
 	i := &testInstaller{
 		daemonImpl: daemon,


### PR DESCRIPTION
### What does this PR do?
Allows configuration of the Datadog installer refresh rates

### Motivation
Customer feedback about too many `datadog-installer` binary calls, which only happen during refreshes

### Describe how you validated your changes
Manual QA

### Additional Notes
