### PR TITLE
dyninst/procsubscribe: remove useless Clear call

### DIFF
--- a/pkg/dyninst/procsubscribe/procscan/scanner.go
+++ b/pkg/dyninst/procsubscribe/procscan/scanner.go
@@ -229,7 +229,6 @@ func (p *Scanner) Scan() (
 		p.mu.live.Delete(pid)
 		return true
 	})
-	noLongerLive.Clear(true)
 
 	p.mu.Lock()
 	for _, newProc := range ret {


### PR DESCRIPTION
We were clearing a BTree, which strongly suggested that we're going to reuse it. It is not reused though, so get rid of the confusing call.
