### PR TITLE
[CWS] do not allocate in pce.Hash() method

### DIFF
--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -957,10 +957,18 @@ func NewIPArrayVariable(value []net.IPNet, opts VariableOpts) *IPArrayVariable {
 	return v
 }
 
+// ScopeHashKey is the key used to identify a variable scope
+// it currently contains an integer and a string to cover most common use cases
+// the goal of this is to prevent the need to allocate a string for each `Hash()` call
+type ScopeHashKey struct {
+	Integer uint32
+	String  string
+}
+
 // VariableScope is the interface to be implemented by scoped variable in order to be released
 type VariableScope interface {
 	AppendReleaseCallback(callback func())
-	Hash() string
+	Hash() ScopeHashKey
 	ParentScope() (VariableScope, bool)
 }
 
@@ -1060,7 +1068,7 @@ func (v *Variables) CleanupExpiredVariables() {
 }
 
 // GetScopedVariables returns nothing for global variables
-func (v *Variables) GetScopedVariables(_ string) map[string]Variable {
+func (v *Variables) GetScopedVariables(_ string) map[ScopeHashKey]Variable {
 	return nil
 }
 
@@ -1076,9 +1084,9 @@ type ScopedVariables struct {
 	scoperName     string
 	scoper         Scoper
 	varsLock       sync.RWMutex
-	vars           map[string]map[string]MutableSECLVariable
+	vars           map[ScopeHashKey]map[string]MutableSECLVariable
 	expirablesLock sync.RWMutex
-	expirables     map[string][]expirableVariable
+	expirables     map[ScopeHashKey][]expirableVariable
 }
 
 // Len returns the length of the variable map
@@ -1229,7 +1237,7 @@ func (v *ScopedVariables) CleanupExpiredVariables() {
 }
 
 // ReleaseVariable releases a scoped variable
-func (v *ScopedVariables) ReleaseVariable(key string) {
+func (v *ScopedVariables) ReleaseVariable(key ScopeHashKey) {
 	v.varsLock.Lock()
 	delete(v.vars, key)
 	v.varsLock.Unlock()
@@ -1239,8 +1247,8 @@ func (v *ScopedVariables) ReleaseVariable(key string) {
 }
 
 // GetScopedVariables returns all scoped variables that match the given name
-func (v *ScopedVariables) GetScopedVariables(name string) map[string]Variable {
-	variables := make(map[string]Variable)
+func (v *ScopedVariables) GetScopedVariables(name string) map[ScopeHashKey]Variable {
+	variables := make(map[ScopeHashKey]Variable)
 	v.varsLock.RLock()
 	defer v.varsLock.RUnlock()
 	for key, vars := range v.vars {
@@ -1258,7 +1266,7 @@ func NewScopedVariables(scoperName string, scoper Scoper) *ScopedVariables {
 	return &ScopedVariables{
 		scoperName: scoperName,
 		scoper:     scoper,
-		vars:       make(map[string]map[string]MutableSECLVariable),
-		expirables: make(map[string][]expirableVariable),
+		vars:       make(map[ScopeHashKey]map[string]MutableSECLVariable),
+		expirables: make(map[ScopeHashKey][]expirableVariable),
 	}
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -101,8 +101,10 @@ type ContainerContext struct {
 }
 
 // Hash returns a unique key for the entity
-func (c *ContainerContext) Hash() string {
-	return string(c.ContainerID)
+func (c *ContainerContext) Hash() eval.ScopeHashKey {
+	return eval.ScopeHashKey{
+		String: string(c.ContainerID),
+	}
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -12,7 +12,6 @@
 package model
 
 import (
-	"fmt"
 	"net"
 	"net/netip"
 	"runtime"
@@ -191,8 +190,10 @@ func (cg *CGroupContext) Merge(cg2 *CGroupContext) {
 }
 
 // Hash returns a unique key for the entity
-func (cg *CGroupContext) Hash() string {
-	return string(cg.CGroupID)
+func (cg *CGroupContext) Hash() eval.ScopeHashKey {
+	return eval.ScopeHashKey{
+		String: string(cg.CGroupID),
+	}
 }
 
 // ParentScope returns the parent entity scope
@@ -396,8 +397,11 @@ func SetAncestorFields(pce *ProcessCacheEntry, subField string, _ interface{}) (
 }
 
 // Hash returns a unique key for the entity
-func (pc *ProcessCacheEntry) Hash() string {
-	return fmt.Sprintf("%d/%s", pc.Pid, pc.Comm)
+func (pc *ProcessCacheEntry) Hash() eval.ScopeHashKey {
+	return eval.ScopeHashKey{
+		Integer: pc.Pid,
+		String:  pc.Comm,
+	}
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -11,7 +11,6 @@ package model
 
 import (
 	"runtime"
-	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -244,8 +243,10 @@ func SetAncestorFields(_ *ProcessCacheEntry, _ string, _ interface{}) (bool, err
 }
 
 // Hash returns a unique key for the entity
-func (pc *ProcessCacheEntry) Hash() string {
-	return strconv.Itoa(int(pc.Pid))
+func (pc *ProcessCacheEntry) Hash() eval.ScopeHashKey {
+	return eval.ScopeHashKey{
+		Integer: pc.Pid,
+	}
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -17,7 +17,7 @@ import (
 type VariableProvider interface {
 	NewSECLVariable(name string, value interface{}, scope string, opts eval.VariableOpts) (eval.SECLVariable, error)
 	CleanupExpiredVariables()
-	GetScopedVariables(name string) map[string]eval.Variable
+	GetScopedVariables(name string) map[eval.ScopeHashKey]eval.Variable
 }
 
 // VariableProviderFactory describes a function called to instantiate a variable provider

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1280,7 +1280,7 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalO
 }
 
 // GetScopedVariables returns all scoped variables that match the given name and scope
-func (rs *RuleSet) GetScopedVariables(scope Scope, name string) map[string]eval.Variable {
+func (rs *RuleSet) GetScopedVariables(scope Scope, name string) map[eval.ScopeHashKey]eval.Variable {
 	variableProvider, found := rs.scopedVariables[scope]
 	if !found {
 		return nil

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -101,8 +101,10 @@ type ContainerContext struct {
 }
 
 // Hash returns a unique key for the entity
-func (c *ContainerContext) Hash() string {
-	return string(c.ContainerID)
+func (c *ContainerContext) Hash() eval.ScopeHashKey {
+	return eval.ScopeHashKey{
+		String: string(c.ContainerID),
+	}
 }
 
 // ParentScope returns the parent entity scope

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -11,7 +11,6 @@ package model
 
 import (
 	"runtime"
-	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -244,8 +243,10 @@ func SetAncestorFields(_ *ProcessCacheEntry, _ string, _ interface{}) (bool, err
 }
 
 // Hash returns a unique key for the entity
-func (pc *ProcessCacheEntry) Hash() string {
-	return strconv.Itoa(int(pc.Pid))
+func (pc *ProcessCacheEntry) Hash() eval.ScopeHashKey {
+	return eval.ScopeHashKey{
+		Integer: pc.Pid,
+	}
 }
 
 // ParentScope returns the parent entity scope


### PR DESCRIPTION
### What does this PR do?

Instead of allocating a new string on each `Hash()` call, let's just return a composite struct that can be hashed and compared without allocation. This will allow to remove a lot of the allocations generated by the variable system (listing all variables especially).

### Motivation

[This kind of profiles](https://app.datadoghq.com/profiling/explorer?query=env%3Asingle-machine-performance%20service%3Asystem-probe%20experiment%3Aquality_gate_idle_all_features&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZsN8wRjyA5ERgAAABhBWnNOOHdWNEFBQWptRHptWXFXWFJRQUEAAAAkZjE5YjBkZjctNjZiOS00ZTA4LWJkNDMtN2Y2MWZkODVkYzgzABQDdg&fromUser=true&my_code=disabled&profile_type=alloc-size&profileId=AZsN8wV4AAAjmDzmYqWXRQAA&refresh_mode=paused&stream_sort=%40metrics.core_cpu_cores%2Cdesc&viz=stream&from_ts=1765451496328&to_ts=1765480296328&live=false)

### Describe how you validated your changes

### Additional Notes
