### PR TITLE
[CWS] allow caching valid lineage result in whole pce tree

### DIFF
--- a/pkg/security/secl/model/errors.go
+++ b/pkg/security/secl/model/errors.go
@@ -80,6 +80,9 @@ var ErrNoProcessContext = errors.New("process context not resolved")
 // ErrFailedDNSPacketDecoding defines a dns packet that failed to be decoded
 var ErrFailedDNSPacketDecoding = errors.New("dns packet couldn't be decoded")
 
+// ErrCycleInProcessLineage is returned when a cycle is detected in the process lineage
+var ErrCycleInProcessLineage = errors.New("cycle detected in process lineage")
+
 // ErrProcessBrokenLineage returned when a process lineage is broken
 type ErrProcessBrokenLineage struct {
 	Err error

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -382,10 +382,14 @@ type Process struct {
 	Source uint64 `field:"-"`
 
 	// lineage
-	hasValidLineage *bool `field:"-"`
-	lineageError    error `field:"-"`
+	validLineageResult *validLineageResult `field:"-"`
 
 	IsThroughSymLink bool `field:"-"` // Indicates whether the process is through a symlink
+}
+
+type validLineageResult struct {
+	valid bool
+	err   error
 }
 
 // SetAncestorFields force the process cache entry to be valid

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -64,7 +64,12 @@ func hasValidLineage(pc *ProcessCacheEntry, result *validLineageResult) (bool, e
 
 // HasValidLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1 or if a new is having a missing parent
 func (pc *ProcessCacheEntry) HasValidLineage() (bool, error) {
-	vlres := new(validLineageResult)
+	vlres := &validLineageResult{
+		valid: false,
+		// if this error is returned, it means that we saw this cache entry in
+		// an ancestor of the current pce, hence a cycle
+		err: ErrCycleInProcessLineage,
+	}
 
 	res, err := hasValidLineage(pc, vlres)
 

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -26,22 +26,23 @@ func (pc *ProcessCacheEntry) SetAncestor(parent *ProcessCacheEntry) {
 		pc.Ancestor.Release()
 	}
 
-	pc.hasValidLineage = nil
+	pc.validLineageResult = nil
 	pc.Ancestor = parent
 	pc.Parent = &parent.Process
 	parent.Retain()
 }
 
-func hasValidLineage(pc *ProcessCacheEntry) (bool, error) {
+func hasValidLineage(pc *ProcessCacheEntry, result *validLineageResult) (bool, error) {
 	var (
 		pid, ppid uint32
 		ctrID     containerutils.ContainerID
 	)
 
 	for pc != nil {
-		if pc.hasValidLineage != nil {
-			return *pc.hasValidLineage, pc.lineageError
+		if pc.validLineageResult != nil {
+			return pc.validLineageResult.valid, pc.validLineageResult.err
 		}
+		pc.validLineageResult = result
 
 		pid, ppid, ctrID = pc.Pid, pc.PPid, pc.ContainerContext.ContainerID
 
@@ -63,8 +64,13 @@ func hasValidLineage(pc *ProcessCacheEntry) (bool, error) {
 
 // HasValidLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1 or if a new is having a missing parent
 func (pc *ProcessCacheEntry) HasValidLineage() (bool, error) {
-	res, err := hasValidLineage(pc)
-	pc.hasValidLineage, pc.lineageError = &res, err
+	vlres := new(validLineageResult)
+
+	res, err := hasValidLineage(pc, vlres)
+
+	vlres.valid = res
+	vlres.err = err
+
 	return res, err
 }
 

--- a/pkg/security/secl/model/process_cache_entry_unix_test.go
+++ b/pkg/security/secl/model/process_cache_entry_unix_test.go
@@ -82,6 +82,21 @@ func TestHasValidLineage(t *testing.T) {
 		var mn *ErrProcessMissingParentNode
 		assert.ErrorAs(t, err, &mn)
 	})
+
+	t.Run("cycle-detection", func(t *testing.T) {
+		pid1 := newPCE(2, nil, false)
+		child1 := newPCE(3, pid1, false)
+		child2 := newPCE(4, child1, false)
+
+		// create cycle
+		pid1.SetAncestor(child2)
+
+		isValid, err := child2.HasValidLineage()
+		assert.False(t, isValid)
+		assert.NotNil(t, err)
+
+		assert.ErrorIs(t, err, ErrCycleInProcessLineage)
+	})
 }
 
 func TestEntryEquals(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

When we check the validity of a process lineage, we currently cache the result of the top level pce we checked. This PR improves this system by making sure we cache the result for the whole tree of pces we looked at (that all have the same lineage validity by definition).

### Motivation

### Describe how you validated your changes

### Additional Notes
