### PR TITLE
[CWS] make sure failures in TestMoveMount are associated with the sub test

### DIFF
--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -255,7 +255,7 @@ func TestMoveMountRecursiveNoPropagation(t *testing.T) {
 	}
 	defer test.Close()
 
-	t.Run("moved-attached-recursive-no-propagation", func(_ *testing.T) {
+	t.Run("moved-attached-recursive-no-propagation", func(t *testing.T) {
 		err = test.GetProbeEvent(func() error {
 			err = unix.MoveMount(te.fsmountfd, "", unix.AT_FDCWD, te.submountDirDst, unix.MOVE_MOUNT_F_EMPTY_PATH)
 			if err == nil {
@@ -307,7 +307,7 @@ func TestMoveMountRecursivePropagation(t *testing.T) {
 	}
 	defer test.Close()
 
-	t.Run("moved-recursive-with-propagation", func(_ *testing.T) {
+	t.Run("moved-recursive-with-propagation", func(t *testing.T) {
 		allMounts := map[uint32]uint32{}
 
 		te, err := newTestEnvironment(false, t.TempDir())


### PR DESCRIPTION

### What does this PR do?

Otherwise failures are associated with the top level test instead of the `t.Run` one.

### Motivation

### Describe how you validated your changes

### Additional Notes
