### PR TITLE
Fix initialization of secrets refresh goroutine

### DIFF
--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -100,7 +100,6 @@ type secretResolver struct {
 	refreshInterval        time.Duration
 	refreshIntervalScatter bool
 	scatterDuration        time.Duration
-	ticker                 *clock.Ticker
 	// filename to write audit records to
 	auditFilename    string
 	auditFileMaxSize int
@@ -295,9 +294,6 @@ func (r *secretResolver) Configure(params secrets.ConfigParams) {
 
 	r.refreshInterval = time.Duration(params.RefreshInterval) * time.Second
 	r.refreshIntervalScatter = params.RefreshIntervalScatter
-	if r.refreshInterval != 0 {
-		r.startRefreshRoutine(nil)
-	}
 
 	r.commandAllowGroupExec = params.GroupExecPerm
 	r.removeTrailingLinebreak = params.RemoveLinebreak
@@ -315,11 +311,23 @@ func (r *secretResolver) Configure(params secrets.ConfigParams) {
 	r.imageToHandle = params.ImageToHandle
 
 	r.apiKeyFailureRefreshInterval = time.Duration(params.APIKeyFailureRefreshInterval) * time.Minute
+
+	// If either timed interval refresh, or invalid key refresh, are set then we need a goroutine
+	if r.refreshInterval != 0 || r.apiKeyFailureRefreshInterval != 0 {
+		log.Debug("Secrets refresh routine starting...")
+		r.startRefreshRoutine(nil)
+	} else {
+		log.Debug("Secrets does not need refresh routine")
+	}
 }
 
-func (r *secretResolver) setupRefreshInterval(rd *rand.Rand) <-chan time.Time {
+func (r *secretResolver) setupRefreshInterval(rd *rand.Rand) *clock.Ticker {
 	if r.refreshInterval <= 0 {
-		return nil
+		log.Debug("Secrets refresh using no-op clock")
+		noopClock := clock.NewMock()
+		neverTicker := noopClock.Ticker(time.Hour * 24 * 365)
+		neverTicker.Stop()
+		return neverTicker
 	}
 
 	if r.refreshIntervalScatter {
@@ -331,49 +339,45 @@ func (r *secretResolver) setupRefreshInterval(rd *rand.Rand) <-chan time.Time {
 		}
 		// Scatter when the refresh happens within the interval, with a minimum of 1 second
 		r.scatterDuration = time.Duration(int63) + time.Second
-		log.Infof("first secret refresh will happen in %s", r.scatterDuration)
+		log.Debugf("Secrets refresh using scatter, first refresh will be in %d seconds", r.scatterDuration)
 	} else {
 		r.scatterDuration = r.refreshInterval
+		log.Debugf("Secrets refresh not using scatter, refresh in %d seconds", r.scatterDuration)
 	}
-	r.ticker = r.clk.Ticker(r.scatterDuration)
-	return r.ticker.C
+
+	return r.clk.Ticker(r.scatterDuration)
 }
 
 func (r *secretResolver) startRefreshRoutine(rd *rand.Rand) {
-	if r.ticker != nil {
-		return
-	}
-
-	timer := r.setupRefreshInterval(rd)
+	refreshTicker := r.setupRefreshInterval(rd)
 
 	go func() {
-		if timer != nil {
-			// initial refresh
-			<-timer
-			if _, err := r.performRefresh(); err != nil {
-				log.Infof("Error with refreshing secrets: %s", err)
-			}
-			// we want to reset the refresh interval to the refreshInterval after the first refresh in case a scattered first refresh interval was configured
-			r.ticker.Reset(r.refreshInterval)
-		}
-
 		for {
 			select {
-			case <-timer:
+			case <-refreshTicker.C:
+				log.Debug("Secrets refresh got tick, performing now")
+
 				// scheduled refresh
 				if _, err := r.performRefresh(); err != nil {
 					log.Infof("Error with refreshing secrets: %s", err)
 				}
+				// we want to reset the refresh interval to the refreshInterval after the refreshing in case a scattered first refresh interval was configured
+				// this is safe to do repeatedly, as the interval will always stay the same after being Reset
+				refreshTicker.Reset(r.refreshInterval)
 			// triggered refresh
 			case <-r.refreshTrigger:
+				log.Debug("Secrets refresh got async request")
 				// disabled
 				if r.apiKeyFailureRefreshInterval == 0 {
+					log.Debug("Secrets refresh async request: disabled")
 					continue
 				}
 				// throttle if last refresh was less than apiKeyFailureRefreshInterval ago
 				if time.Since(r.lastThrottledRefresh) < r.apiKeyFailureRefreshInterval {
+					log.Debug("Secrets refresh async request: throttled")
 					continue
 				}
+				log.Debug("Secrets refresh async request, performing now")
 				r.lastThrottledRefresh = time.Now()
 				// throttled refresh
 				if result, err := r.performRefresh(); err != nil {

--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -324,6 +324,10 @@ func (r *secretResolver) Configure(params secrets.ConfigParams) {
 func (r *secretResolver) setupRefreshInterval(rd *rand.Rand) *clock.Ticker {
 	if r.refreshInterval <= 0 {
 		log.Debug("Secrets refresh using no-op clock")
+		// We need to return an actual Ticker object with a channel, so that the select block
+		// below has something to query. However, we don't want to produce any actual ticks.
+		// This pattern basically builds a no-op clock by setting a huge time delay of 1 year
+		// and then calling Stop to prevent ticks from being produced.
 		noopClock := clock.NewMock()
 		neverTicker := noopClock.Ticker(time.Hour * 24 * 365)
 		neverTicker.Stop()

--- a/comp/core/secrets/impl/secrets_test.go
+++ b/comp/core/secrets/impl/secrets_test.go
@@ -797,11 +797,6 @@ func TestRefreshModes(t *testing.T) {
 		resolver.apiKeyFailureRefreshInterval = 100 * time.Millisecond
 		resolver.lastThrottledRefresh = time.Time{}
 		resolver.startRefreshRoutine(nil)
-		defer func() {
-			if resolver.ticker != nil {
-				resolver.ticker.Stop()
-			}
-		}()
 
 		calls.Store(0)
 
@@ -823,9 +818,6 @@ func TestRefreshModes(t *testing.T) {
 
 	t.Run("feature disabled drops all refreshes", func(t *testing.T) {
 		resolver.apiKeyFailureRefreshInterval = 0
-		if resolver.ticker == nil {
-			resolver.startRefreshRoutine(nil)
-		}
 
 		calls.Store(0)
 		resolver.Refresh(false)
@@ -908,7 +900,6 @@ func TestStartRefreshRoutineWithScatter(t *testing.T) {
 			resolver.SubscribeToChanges(func(_, _ string, _ []string, _, _ any) {
 				changeDetected <- struct{}{}
 			})
-			require.NotNil(t, resolver.ticker)
 
 			if tc.scatter {
 				// The set random seed has a the scatterDuration is 6.477027098s
@@ -982,8 +973,10 @@ func TestScatterWithSmallRandomValue(t *testing.T) {
 	// NOTE: clock and ticker are not mocked, as the mock ticker doesn't fail on a
 	// zero parameter the way a real ticker does
 	r := rand.New(&alwaysZeroSource{})
-	resolver.startRefreshRoutine(r)
-	require.NotNil(t, resolver.ticker)
+	ticker := resolver.setupRefreshInterval(r)
+	require.NotNil(t, ticker)
+	require.True(t, resolver.scatterDuration > 0)
+
 }
 
 // helper to read number of rows in the audit file


### PR DESCRIPTION
### What does this PR do?

Allow usage of `secret_refresh_on_api_key_failure_interval` without also having `secret_refresh_interval` configured. In short, if either setting is enabled, we need a running goroutine to handle timed and async secret refreshes.

### Motivation

Support secret refresh secrets.

### Describe how you validated your changes

Ran the agent with `DD_LOG_LEVEL=debug` and `secret_refresh_on_api_key_failure_interval` and observed the debug log messages. Then did the same with `secret_refresh_interval`.

### Additional Notes
