### PR TITLE
Add `pkg/security` to system-probe KMT trigger paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -609,6 +609,7 @@ workflow:
   - pkg/ebpf/**/*
   - pkg/network/**/*
   - pkg/process/monitor/*
+  - pkg/security/**/*
   - pkg/util/kernel/**/*
   - pkg/dyninst/**/*
   - pkg/gpu/**/*


### PR DESCRIPTION
### Motivation
Changes in `pkg/security/**/*` should trigger system-probe KMT tests since `system-probe` depends on security components.
This path was missing from `.system_probe_change_paths`, causing the KMT tests to not run in CI for PRs modifying these files.
The breaking changes were only discovered after merging to `main`, requiring reverts:
- #44065
- #44046