### PR TITLE
Patch openssl with right OPENSSLDIR

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -282,9 +282,7 @@ pkg_files(
     srcs = [":openssl_bin"],
     prefix = "bin",
     attributes = pkg_attributes(
-        group = "root",
         mode = "0755",
-        owner = "root",
     ),
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -93,7 +93,7 @@ configure_make(
         "//conditions:default": DEFAULT_CONFIG,
     }),
     install_prefix = select({
-        "@platforms//os:windows": "C:/Program Files/Datadog/Datadog Agent/embedded3",
+        "@platforms//os:windows": "",
         "//conditions:default": "/opt/datadog-agent/embedded",
     }),
     env = select({

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -37,23 +37,32 @@ LINUX_LIBCRYPTO = "libcrypto.so"
 MACOS_LIBSSL = "libssl.dylib"
 MACOS_LIBCRYPTO = "libcrypto.dylib"
 
-# Common script to fix OPENSSLDIR, ENGINESDIR, MODULESDIR paths in binaries
+# Common script to fix OPENSSLDIR, ENGINESDIR, MODULESDIR and other paths in binaries
 # Expects $LIBS to be set by caller to the list of libraries to patch
 # In case of OPENSSLDIR there is no additional slash between BUILD_TMPDIR and INSTALL_PREFIX,
 # but there is for ENGINESDIR and MODULESDIR.
 FIX_OPENSSL_PATHS = """
-    # Fix OPENSSLDIR, ENGINESDIR, MODULESDIR paths in binaries
+    # Fix OpenSSL hardcoded paths in binaries
     SANDBOX="$$BUILD_TMPDIR$$INSTALL_PREFIX"
     TARGET="$$INSTALL_PREFIX"
 
-    # OPENSSLDIR
+    # OPENSSLDIR: /ssl"
     OLD_PATH="$${SANDBOX}/ssl\\"" NEW_PATH="$${TARGET}/ssl\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
+    # SSL private dir: /ssl/private
+    OLD_PATH="$${SANDBOX}/ssl/private" NEW_PATH="$${TARGET}/ssl/private" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+
+    # SSL certs dir: /ssl/certs
+    OLD_PATH="$${SANDBOX}/ssl/certs" NEW_PATH="$${TARGET}/ssl/certs" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+
+    # SSL cert.pem: /ssl/cert.pem
+    OLD_PATH="$${SANDBOX}/ssl/cert.pem" NEW_PATH="$${TARGET}/ssl/cert.pem" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+
     SANDBOX="$$BUILD_TMPDIR/$$INSTALL_PREFIX"
-    # ENGINESDIR
+    # ENGINESDIR: /lib/engines-3"
     OLD_PATH="$${SANDBOX}/lib/engines-3\\"" NEW_PATH="$${TARGET}/lib/engines-3\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
-    # MODULESDIR
+    # MODULESDIR: /lib/ossl-modules"
     OLD_PATH="$${SANDBOX}/lib/ossl-modules\\"" NEW_PATH="$${TARGET}/lib/ossl-modules\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 """
 

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -2,7 +2,7 @@ load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -36,6 +36,26 @@ LINUX_LIBCRYPTO = "libcrypto.so"
 
 MACOS_LIBSSL = "libssl.dylib"
 MACOS_LIBCRYPTO = "libcrypto.dylib"
+
+# Common script to fix OPENSSLDIR, ENGINESDIR, MODULESDIR paths in binaries
+# Expects $LIBS to be set by caller to the list of libraries to patch
+# In case of OPENSSLDIR there is no additional slash between BUILD_TMPDIR and INSTALL_PREFIX,
+# but there is for ENGINESDIR and MODULESDIR.
+FIX_OPENSSL_PATHS = """
+    # Fix OPENSSLDIR, ENGINESDIR, MODULESDIR paths in binaries
+    SANDBOX="$$BUILD_TMPDIR$$INSTALL_PREFIX"
+    TARGET="$$INSTALL_PREFIX"
+
+    # OPENSSLDIR
+    OLD_PATH="$${SANDBOX}/ssl\\"" NEW_PATH="$${TARGET}/ssl\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+
+    SANDBOX="$$BUILD_TMPDIR/$$INSTALL_PREFIX"
+    # ENGINESDIR
+    OLD_PATH="$${SANDBOX}/lib/engines-3\\"" NEW_PATH="$${TARGET}/lib/engines-3\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+
+    # MODULESDIR
+    OLD_PATH="$${SANDBOX}/lib/ossl-modules\\"" NEW_PATH="$${TARGET}/lib/ossl-modules\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+"""
 
 configure_make(
     name = "openssl",
@@ -71,6 +91,10 @@ configure_make(
             "no-uplink",
         ] + DEFAULT_CONFIG[:-1],
         "//conditions:default": DEFAULT_CONFIG,
+    }),
+    install_prefix = select({
+        "@platforms//os:windows": "C:/Program Files/Datadog/Datadog Agent/embedded3",
+        "//conditions:default": "/opt/datadog-agent/embedded",
     }),
     env = select({
         "@platforms//os:macos": {
@@ -111,7 +135,7 @@ configure_make(
             WIN_LIBCRYPTO,
             "openssl.exe",
         ],
-        "//conditions:default": [],
+        "//conditions:default": ["openssl"],
     }),
     deps = select({
         "//conditions:default": [
@@ -123,6 +147,22 @@ configure_make(
     }),
     copts = ["-O2"],
     targets = ["depend", "", "install_sw", "install_ssldirs"],
+    # Fix install names, as openssl's build system might not get them right
+    postfix_script = select({
+        "@platforms//os:macos": """
+            # Fix install names
+            for lib in libcrypto.dylib libssl.dylib; do
+                install_name_tool -id @rpath/$$lib $$INSTALLDIR/lib/$$lib
+                for dep in $$(otool -L $$INSTALLDIR/lib/$$lib | grep 'sandbox.*execroot' | awk '{print $$1}'); do
+                    install_name_tool -change $$dep "@loader_path/$$(basename $$dep)" $$INSTALLDIR/lib/$$lib
+                done
+            done
+            LIBS="$$INSTALLDIR/lib/libcrypto.dylib $$INSTALLDIR/lib/libssl.dylib"
+        """ + FIX_OPENSSL_PATHS,
+        "//conditions:default": """
+            LIBS="$$INSTALLDIR/lib/libcrypto.so $$INSTALLDIR/lib/libssl.so"
+        """ + FIX_OPENSSL_PATHS,
+    }),
 )
 
 filegroup(
@@ -222,6 +262,27 @@ pkg_files(
     prefix = "lib",
 )
 
+filegroup(
+    name = "openssl_bin",
+    srcs = [":openssl"],
+    output_group = "openssl",
+)
+
+pkg_files(
+    name = "openssl_bin_file",
+    srcs = [":openssl_bin"],
+    prefix = "bin",
+    attributes = pkg_attributes(
+        group = "root",
+        mode = "0755",
+        owner = "root",
+    ),
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
+
 pkg_install(
     name = "install",
     srcs = [
@@ -234,6 +295,7 @@ pkg_install(
             ":openssl_exe_file",
         ],
         "//conditions:default": [
+            ":openssl_bin_file",
             ":openssl_pkgconfig",
         ],
     }),

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -47,7 +47,8 @@ build do
       command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix #{install_dir}/embedded" \
         " #{install_dir}/embedded/lib/libssl#{lib_extension}" \
         " #{install_dir}/embedded/lib/libcrypto#{lib_extension}" \
-        " #{install_dir}/embedded/lib/pkgconfig/*.pc"
+        " #{install_dir}/embedded/lib/pkgconfig/*.pc" \
+        " #{install_dir}/embedded/bin/openssl"
     end
   else
 


### PR DESCRIPTION
### What does this PR do?
openssl's build process sets `OPENSSLDIR` at build time to use it at runtime. Unfortunately, there is no way to overwrite that value in runtime via environment variables, thus, we are patching binaries directly to set the right path.

