### PR TITLE
[Backport 7.74.x] [EBPF-956] gpu: fix detection of devices assigned to Docker containers (PR #43779)

### DIFF
--- a/pkg/gpu/containers/containers.go
+++ b/pkg/gpu/containers/containers.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
@@ -30,6 +31,7 @@ var numberedResourceRegex = regexp.MustCompile(`^nvidia([0-9]+)$`)
 
 const (
 	nvidiaVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"
+	dockerInspectTimeout       = 100 * time.Millisecond
 )
 
 // HasGPUs returns true if the container has GPUs assigned to it.
@@ -66,13 +68,24 @@ func MatchContainerDevices(container *workloadmeta.Container, devices []ddnvml.D
 }
 
 func getDockerVisibleDevicesEnv(container *workloadmeta.Container) (string, error) {
-	// We can't use container.EnvVars as it doesn't contain the environment variables
-	// added by the container runtime. We need to get them from the main PID environment.
+	// We can't use container.EnvVars as it doesn't contain the environment
+	// variables added by the container runtime, we only get those defined by
+	// the container image, and those can be overridden by the container
+	// runtime. We need to get them from the main PID environment.
 	envVar, err := kernel.GetProcessEnvVariable(container.PID, kernel.ProcFSRoot(), nvidiaVisibleDevicesEnvVar)
-	if err != nil {
-		return "", fmt.Errorf("error getting %s for container %s: %w", nvidiaVisibleDevicesEnvVar, container.ID, err)
+	if err == nil {
+		return strings.TrimSpace(envVar), nil
 	}
-	return strings.TrimSpace(envVar), nil
+
+	// If we have an error (e.g, the agent does not have permissions to inspect
+	// the process environment variables) fall back to the container runtime
+	// data
+	envVar, dockerErr := inspectDockerDevices(container)
+	if dockerErr == nil {
+		return strings.TrimSpace(envVar), nil
+	}
+
+	return "", errors.Join(err, dockerErr)
 }
 
 func matchDockerDevices(container *workloadmeta.Container, devices []ddnvml.Device) ([]ddnvml.Device, error) {

--- a/pkg/gpu/containers/containers_docker.go
+++ b/pkg/gpu/containers/containers_docker.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && nvml && docker
+
+// Package containers has utilities to work with GPU assignment to containers
+package containers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+// inspectDockerDevices returns the value of the NVIDIA_VISIBLE_DEVICES environment variable by
+// inspecting the container data from the Docker API.
+func inspectDockerDevices(container *workloadmeta.Container) (string, error) {
+	dockerUtil, err := docker.GetDockerUtil()
+	if err != nil {
+		return "", fmt.Errorf("error getting docker util: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dockerInspectTimeout)
+	defer cancel()
+
+	containerInspect, err := dockerUtil.Inspect(ctx, container.ID, false)
+	if err != nil {
+		return "", fmt.Errorf("error inspecting container %s: %w", container.ID, err)
+	}
+
+	if containerInspect.HostConfig == nil {
+		return "", fmt.Errorf("container %s has no host config", container.ID)
+	}
+
+	for _, device := range containerInspect.HostConfig.Resources.DeviceRequests {
+		for _, capabilityGroup := range device.Capabilities {
+			if slices.Contains(capabilityGroup, "gpu") {
+				numGpus := device.Count
+				if numGpus == -1 {
+					return "all", nil
+				}
+
+				// return 0,1,...numGpus-1 as the assumed visible devices variable,
+				// that's how Docker assigns devices to containers, there's no exclusive
+				// allocation.
+				visibleDevices := make([]string, numGpus)
+				for i := 0; i < numGpus; i++ {
+					visibleDevices[i] = strconv.Itoa(i)
+				}
+				return strings.Join(visibleDevices, ","), nil
+			}
+		}
+	}
+
+	return "", nil
+}

--- a/pkg/gpu/containers/containers_nodocker.go
+++ b/pkg/gpu/containers/containers_nodocker.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && nvml && !docker
+
+// Package containers has utilities to work with GPU assignment to containers
+package containers
+
+import workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+
+func inspectDockerDevices(_container *workloadmeta.Container) (string, error) {
+	return "", nil
+}

--- a/test/new-e2e/tests/gpu/capabilities.go
+++ b/test/new-e2e/tests/gpu/capabilities.go
@@ -63,6 +63,7 @@ type suiteCapabilities interface {
 	RunContainerWorkloadWithGPUs(image string, arguments ...string) (string, error)
 	GetRestartCount(component agentComponent) int
 	CheckWorkloadErrors(containerID string) error
+	ExpectedWorkloadTags() []string
 }
 
 // hostCapabilities is an implementation of suiteCapabilities for the Host environment
@@ -187,6 +188,11 @@ func (c *hostCapabilities) CheckWorkloadErrors(containerID string) error {
 	}
 
 	return nil
+}
+
+// ExpectedWorkloadTags returns tags that are expected to be present on workloads
+func (c *hostCapabilities) ExpectedWorkloadTags() []string {
+	return []string{"container_id", "container_name", "short_image"}
 }
 
 // kubernetesCapabilities is an implementation of suiteCapabilities for the Kubernetes environment
@@ -342,4 +348,10 @@ func (c *kubernetesCapabilities) GetRestartCount(component agentComponent) int {
 	}
 
 	return restartCount
+}
+
+// ExpectedWorkloadTags returns tags that are expected to be present on workloads
+func (c *kubernetesCapabilities) ExpectedWorkloadTags() []string {
+	// Kubernetes tag support not added yet
+	return nil
 }

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -93,15 +92,6 @@ var gpuSystems = map[systemName]systemData{
 
 func dockerImageName() string {
 	return fmt.Sprintf("%s:%s", vectorAddDockerImg, *imageTag)
-}
-
-func mandatoryMetricTagRegexes() []*regexp.Regexp {
-	regexes := make([]*regexp.Regexp, 0, len(mandatoryMetricTags))
-	for _, tag := range mandatoryMetricTags {
-		regexes = append(regexes, regexp.MustCompile(fmt.Sprintf("%s:.*", tag)))
-	}
-
-	return regexes
 }
 
 type gpuHostSuite struct {
@@ -285,10 +275,10 @@ func (s *gpuK8sSuite) AfterTest(suiteName, testName string) {
 
 // runCudaDockerWorkload runs a CUDA workload in a Docker container and returns the container ID
 func (v *gpuBaseSuite[Env]) runCudaDockerWorkload() string {
-	// Configure some defaults
-	vectorSize := 50000
-	numLoops := 100      // Loop extra times to ensure the kernel runs for a bit
-	waitTimeSeconds := 5 // Give enough time to our monitor to hook the probes
+	// Configure some defaults. Big vector size and number of loops to ensure the kernel runs for a bit
+	vectorSize := 2000000
+	numLoops := 10000000
+	waitTimeSeconds := 30 // Give enough time to our monitor to hook the probes and for workloadmeta to detect containers
 	binary := "/usr/local/bin/cuda-basic"
 	args := []string{binary, strconv.Itoa(vectorSize), strconv.Itoa(numLoops), strconv.Itoa(waitTimeSeconds)}
 
@@ -349,9 +339,9 @@ func (v *gpuBaseSuite[Env]) TestLimitMetricsAreReported() {
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		metricNames := []string{"gpu.core.limit", "gpu.memory.limit"}
 		for _, metricName := range metricNames {
-			metrics, err := v.caps.FakeIntake().Client().FilterMetrics(metricName, client.WithMetricValueHigherThan(0), client.WithMatchingTags[*aggregator.MetricSeries](mandatoryMetricTagRegexes()))
+			metrics, err := v.caps.FakeIntake().Client().FilterMetrics(metricName, client.WithMetricValueHigherThan(0))
 			assert.NoError(c, err)
-			assert.Greater(c, len(metrics), 0, "no '%s' with value higher than 0 yet", metricName)
+			assertMetricsHaveExpectedTagKeys(c, metrics, mandatoryMetricTags, metricName)
 		}
 	}, 5*time.Minute, 10*time.Second)
 }
@@ -371,6 +361,8 @@ func (v *gpuBaseSuite[Env]) TestVectorAddProgramDetected() {
 	flake.MarkOnLog(v.T(), "error code CUDA-capable device(s) is/are busy or unavailable")
 	containerID := v.runCudaDockerWorkload()
 
+	expectedTags := v.caps.ExpectedWorkloadTags()
+	expectedTags = append(expectedTags, mandatoryMetricTags...)
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		// Check for workload errors first
 		err := v.caps.CheckWorkloadErrors(containerID)
@@ -378,27 +370,21 @@ func (v *gpuBaseSuite[Env]) TestVectorAddProgramDetected() {
 
 		// We are not including "gpu.memory", as that represents the "current
 		// memory usage" and that might be zero at the time it's checked
-		metricNames := []string{"gpu.process.core.usage"}
+		metricToExpectedTags := map[string][]string{
+			"gpu.process.core.usage": append(expectedTags, "pid"),
+			"gpu.sm_active":          expectedTags,
+		}
 
 		var usageMetricTags []string
-		for _, metricName := range metricNames {
-			metrics, err := v.caps.FakeIntake().Client().FilterMetrics(metricName, client.WithMetricValueHigherThan(0), client.WithMatchingTags[*aggregator.MetricSeries](mandatoryMetricTagRegexes()))
+		for metricName, metricExpectedTags := range metricToExpectedTags {
+			metrics, err := v.caps.FakeIntake().Client().FilterMetrics(metricName, client.WithMetricValueHigherThan(0))
 			assert.NoError(c, err)
-			assert.Greater(c, len(metrics), 0, "no '%s' with value higher than 0 yet", metricName)
+			assertMetricsHaveExpectedTagKeys(c, metrics, metricExpectedTags, metricName)
 
 			if metricName == "gpu.process.core.usage" && len(metrics) > 0 {
 				usageMetricTags = metrics[0].Tags
 			}
 		}
-
-		hasPidTag := false
-		for _, tag := range usageMetricTags {
-			if strings.HasPrefix(tag, "pid:") {
-				hasPidTag = true
-				break
-			}
-		}
-		assert.True(c, hasPidTag, "no tag starting with 'pid:' found in usage metric tags")
 
 		if len(usageMetricTags) > 0 {
 			// Ensure we get the limit metric with the same tags as the usage one
@@ -429,16 +415,12 @@ func (v *gpuBaseSuite[Env]) TestNvmlMetricsPresent() {
 		for _, metric := range metrics {
 			// We don't care about values, as long as the metrics are there. Values come from NVML
 			// so we cannot control that.
-			var options []client.MatchOpt[*aggregator.MetricSeries]
-			if metric.deviceSpecific {
-				// device-specific metrics should be tagged with device tags
-				options = append(options, client.WithMatchingTags[*aggregator.MetricSeries](mandatoryMetricTagRegexes()))
-			}
-
-			metrics, err := v.caps.FakeIntake().Client().FilterMetrics(metric.name, options...)
+			metrics, err := v.caps.FakeIntake().Client().FilterMetrics(metric.name)
 			assert.NoError(c, err)
 
-			assert.Greater(c, len(metrics), 0, "no metric '%s' found", metric.name)
+			if metric.deviceSpecific {
+				assertMetricsHaveExpectedTagKeys(c, metrics, mandatoryMetricTags, metric.name)
+			}
 		}
 	}, 5*time.Minute, 10*time.Second)
 }
@@ -472,4 +454,46 @@ func (v *gpuBaseSuite[Env]) TestZZAgentDidNotRestart() {
 		finalCount := v.caps.GetRestartCount(service)
 		v.Assert().Equal(initialCount, finalCount, "Service %s restarted during test suite", service)
 	}
+}
+
+func assertMetricsHaveExpectedTagKeys(c *assert.CollectT, metrics []*aggregator.MetricSeries, expectedTagKeys []string, metricName string) bool {
+	smallestMissingTagSet := expectedTagKeys
+
+	if !assert.Greater(c, len(metrics), 0, "no metric values found for metric %s", metricName) {
+		// Don't follow with the rest of the assertions in the function, but
+		// also don't use require so that the caller of the function can
+		// continue with other assertions.
+		return false
+	}
+
+	missingTags := make(map[string]bool)
+	for _, metric := range metrics {
+		for _, expectedTagKey := range expectedTagKeys {
+			missingTags[expectedTagKey] = true
+		}
+
+		for _, tag := range metric.GetTags() {
+			tagParts := strings.SplitN(tag, ":", 2)
+			if len(tagParts) == 2 {
+				tagKey := tagParts[0]
+
+				if _, ok := missingTags[tagKey]; ok {
+					missingTags[tagKey] = false
+				}
+			}
+		}
+
+		missingTagSet := []string{}
+		for tagKey, isMissing := range missingTags {
+			if isMissing {
+				missingTagSet = append(missingTagSet, tagKey)
+			}
+		}
+
+		if len(missingTagSet) < len(smallestMissingTagSet) {
+			smallestMissingTagSet = missingTagSet
+		}
+	}
+
+	return assert.Empty(c, smallestMissingTagSet, "no metric %s found with expected tag keys %v. The closest tagset we got had the following missing tag keys: %v", metricName, expectedTagKeys, smallestMissingTagSet)
 }


### PR DESCRIPTION
(cherry picked from commit 12125c3acb5da121c6871d9b51ed143ba22f6055)


### What does this PR do?
Fixes the detection of the devices assigned to Docker containers. Depending on how the agent is running, it might not have permissions to access the `/proc/\<pid>/environ` file and therefore it cannot know the value of the `NVIDIA_VISIBLE_DEVICES` variable. This PR adds a fallback where the check will query the Docker runtime by inspecting the container.

### Motivation
Fix for https://datadoghq.atlassian.net/browse/EBPF-956

### Describe how you validated your changes
Added e2e test code for this specific scenario, including a fix to ensure that the Docker socket is accessible in e2e tests. Part of these tests fulfill https://datadoghq.atlassian.net/browse/EBPF-952 and https://datadoghq.atlassian.net/browse/EBPF-771

## Additional notes

This PR patches the GPU code only, so that the fix can be backported to 7.74.x with reduced risk. A future PR will ensure that this data is ingested in workloadmeta and used in a generic manner.

