### PR TITLE
[CWS] remove skip field from pendingMsg

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -73,7 +73,6 @@ type pendingMsg struct {
 	extTagsCb       func() ([]string, bool)
 	sendAfter       time.Time
 	retry           int
-	skip            bool
 
 	sshSessionPatcher sshSessionPatcher
 }
@@ -247,10 +246,6 @@ func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg) bool) {
 			return true
 		}
 
-		if msg.skip {
-			return true
-		}
-
 		if msg.retry >= maxRetry {
 			seclog.Errorf("failed to sent event, max retry reached: %d", msg.retry)
 			return true
@@ -341,8 +336,8 @@ func (a *APIServer) start(ctx context.Context) {
 				if a.containerFilter != nil {
 					containerName, imageName, podNamespace := utils.GetContainerFilterTags(msg.tags)
 					if a.containerFilter.IsExcluded(nil, containerName, imageName, podNamespace) {
-						msg.skip = true
-						return false
+						// similar return value as if we had sent the message
+						return true
 					}
 				}
 


### PR DESCRIPTION
### What does this PR do?

There is no need to keep the `skip` field in `pendingMsg` we can simply drop the message once we decided to exclude it.

### Motivation

### Describe how you validated your changes

### Additional Notes
