### PR TITLE
Remove dependency on FIPS in same group as windows + deb

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -207,8 +207,6 @@ go_e2e_test_binaries:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
-    - agent_deb-x64-a7-fips
-    - windows_msi_and_bosh_zip_x64-a7-fips
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template


### PR DESCRIPTION
### What does this PR do?

Remove unneeded FIPS build dependencies for some e2e tests jobs

### Motivation

Slightly shorten critical path for some CI by bit waiting on FIPS builds

### Describe how you validated your changes

### Additional Notes
