### PR TITLE
Enable profiles in regression detector runs

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -2,6 +2,8 @@ lading:
   version: 0.30.0
 
 target:
+  ddprof_replicas: 1
+  internal_profiling_replicas: 1
 
 # Link templates for reports.
 #


### PR DESCRIPTION
### What does this PR do?

- reenables profiles in regression detector runs

### Motivation

SMP used to enable profiles by default and we removed that (https://github.com/DataDog/single-machine-performance/pull/3454). Now SMP requires that it's explicitly stated how many profile replicas are required.

_This accidentally snuck into our latest release without us realizing that it was a breaking change._

### Describe how you validated your changes

I am letting CI run and I should be able to see profiles for the regression detector.

### Additional Notes

N/A
