### PR TITLE
[backport] [AGENTRUN-902] [inc-45784] Update password detection scrubber rule

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -137,12 +137,12 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 		// * key: case-insensitive, optionally quoted (pass | password | pswd | pwd), not anchored to match on args like --mysql_password= etc.
 		// * separator: (= or :) with optional opening quote we don't want to match as part of the password
 		// * password string: alphanum + special chars except quotes and semicolon
-		Regex: regexp.MustCompile(`(?i)(\"?(?:pass(?:word)?|pswd|pwd)\"?)((?:=| = |: )\"?)([0-9A-Za-z#!$%&()*+,\-./:<=>?@[\\\]^_{|}~]+)`),
+		Regex: regexp.MustCompile(`(?i)([\"\']?(?:pass(?:word)?|pswd|pwd)[\"\']?)((?:=| = |: )[\"\']?)([0-9A-Za-z#!$%&()*+,\-./:<=>?@[\\\]^_{|}~]+)`),
 		// replace the 3rd capture group (password string) with ********
 		Repl: []byte(`$1$2********`),
 
-		// https://github.com/DataDog/datadog-agent/pull/28144
-		LastUpdated: parseVersion("7.57.0"),
+		// https://github.com/DataDog/datadog-agent/pull/43188
+		LastUpdated: parseVersion("7.73.1"),
 	}
 	tokenReplacer := matchYAMLKeyEnding(
 		`token`,

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -235,6 +235,26 @@ func TestTextStripLogPassword(t *testing.T) {
 			want: `2024-07-02 10:40:18 EDT | CORE | ERROR | (pkg/collector/worker/check_logger.go:71 in Error) | check:sqlserver | Error running check: [{"message": "Unable to connect: {"username": "userme",  "password": "********"}"`,
 		},
 		{
+			name: "logged as json with single quotes (eg. 'password':)",
+			log:  `2024-07-02 10:40:18 EDT | CORE | ERROR | (pkg/collector/worker/check_logger.go:71 in Error) | check:sqlserver | Error running check: [{"message": "Unable to connect: {'username': 'userme',  'password': '$AeVtn8*gbyaf!hnUHx^L.'}`,
+			want: `2024-07-02 10:40:18 EDT | CORE | ERROR | (pkg/collector/worker/check_logger.go:71 in Error) | check:sqlserver | Error running check: [{"message": "Unable to connect: {'username': 'userme',  'password': '********'}`,
+		},
+		{
+			name: "single-quoted key with equals (eg. 'password'=)",
+			log:  `2024-07-02 10:40:18 EDT | CORE | ERROR | Error: 'password'=MyS3cr3t!Pass user='admin'`,
+			want: `2024-07-02 10:40:18 EDT | CORE | ERROR | Error: 'password'=******** user='admin'`,
+		},
+		{
+			name: "single-quoted pwd key (eg. 'pwd':)",
+			log:  `Connection config: {'host': 'localhost', 'pwd': 'Secr3t@123', 'port': 5432}`,
+			want: `Connection config: {'host': 'localhost', 'pwd': '********', 'port': 5432}`,
+		},
+		{
+			name: "single-quoted pswd key (eg. 'pswd'=)",
+			log:  `Auth failed: 'pswd'=P@ssw0rd123`,
+			want: `Auth failed: 'pswd'=********`,
+		},
+		{
 			name: "logged PSWD (eg. PSWD=)",
 			log:  `2024-07-02 10:40:18 EDT | CORE | ERROR | (pkg/collector/worker/check_logger.go:71 in Error) | check:sqlserver | Error running check: [{"message": "Unable to connect: USER=userme PSWD=$AeVtn8*gbyaf!hnUHx^L."`,
 			want: `2024-07-02 10:40:18 EDT | CORE | ERROR | (pkg/collector/worker/check_logger.go:71 in Error) | check:sqlserver | Error running check: [{"message": "Unable to connect: USER=userme PSWD=********"`,


### PR DESCRIPTION
The scrubber rule only supports double quotes, but we have found incidences of single-quoted password records. Update the scrubber rule to support both single and double quotes.

Added unit testing to validate the change.

**Note**: This change backports #43188 