### PR TITLE
dyninst/module: ensure diagnostics emitted after toggle

### DIFF
--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -326,6 +326,17 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 		Attached:     1,
 	})
 
+	// Ensure that the diagnostics states are as expected.
+	require.Equal(t,
+		[]map[string][]string{
+			{
+				"look_at_the_request": {"received", "installed", "emitted"},
+				"http_handler":        {"received", "installed", "emitted"},
+			},
+		},
+		slices.Collect(maps.Values(ts.module.DiagnosticsStates())),
+	)
+
 	// Clear the remote config.
 	ts.rc.UpdateRemoteConfig(nil)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -346,17 +357,9 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 		})
 	}, 10*time.Second, 100*time.Millisecond, "probes should be removed")
 
-	// Ensure that the diagnostics states are as expected, and get cleared
-	// when the process exits.
-	require.Equal(t,
-		[]map[string][]string{
-			{
-				"look_at_the_request": {"received", "installed", "emitted"},
-				"http_handler":        {"received", "installed", "emitted"},
-			},
-		},
-		slices.Collect(maps.Values(ts.module.DiagnosticsStates())),
-	)
+	// Ensure that the diagnostics states have been cleared.
+	require.Empty(t, ts.module.DiagnosticsStates())
+
 	require.NoError(t, ts.serviceCmd.Process.Signal(os.Interrupt))
 	require.NoError(t, ts.serviceCmd.Wait())
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/dyninst/module/diagnostics_test.go
+++ b/pkg/dyninst/module/diagnostics_test.go
@@ -132,6 +132,159 @@ func (f *fakeDiagsUploader) last() *uploader.DiagnosticMessage {
 	return f.msgs[len(f.msgs)-1]
 }
 
+func TestDiagnosticTracker_Retain(t *testing.T) {
+	t.Run("basic retention", func(t *testing.T) {
+		tr := newDiagnosticTracker("test")
+
+		// Mark several probes across multiple runtime IDs.
+		tr.mark("rid1", "p1", 1)
+		tr.mark("rid1", "p2", 1)
+		tr.mark("rid1", "p3", 2)
+		tr.mark("rid2", "p1", 1)
+		tr.mark("rid2", "p4", 1)
+
+		// Retain only p1 and p3 for rid1.
+		probes := []ir.ProbeDefinition{
+			testProbeDefinition{testProbe{id: "p1", v: 1}},
+			testProbeDefinition{testProbe{id: "p3", v: 2}},
+		}
+		tr.retain("rid1", probes)
+
+		// p1 and p3 should still be marked (return false).
+		require.False(
+			t, tr.mark("rid1", "p1", 1),
+			"expected p1 to still be marked",
+		)
+		require.False(
+			t, tr.mark("rid1", "p3", 2),
+			"expected p3 to still be marked",
+		)
+
+		// p2 should have been removed (return true).
+		require.True(
+			t, tr.mark("rid1", "p2", 1),
+			"expected p2 to have been removed",
+		)
+
+		// rid2 probes should be unaffected.
+		require.False(
+			t, tr.mark("rid2", "p1", 1),
+			"expected rid2 p1 to still be marked",
+		)
+		require.False(
+			t, tr.mark("rid2", "p4", 1),
+			"expected rid2 p4 to still be marked",
+		)
+	})
+
+	t.Run("empty probe list", func(t *testing.T) {
+		tr := newDiagnosticTracker("test")
+
+		// Mark several probes.
+		tr.mark("rid1", "p1", 1)
+		tr.mark("rid1", "p2", 2)
+		tr.mark("rid1", "p3", 1)
+
+		// Retain with empty probe list should remove all probes for rid1.
+		tr.retain("rid1", []ir.ProbeDefinition{})
+
+		// All probes should have been removed.
+		require.True(
+			t, tr.mark("rid1", "p1", 1),
+			"expected p1 to be removed",
+		)
+		require.True(
+			t, tr.mark("rid1", "p2", 2),
+			"expected p2 to be removed",
+		)
+		require.True(
+			t, tr.mark("rid1", "p3", 1),
+			"expected p3 to be removed",
+		)
+	})
+
+	t.Run("different versions", func(t *testing.T) {
+		tr := newDiagnosticTracker("test")
+
+		// Mark probes with different versions.
+		tr.mark("rid1", "p1", 1)
+		tr.mark("rid1", "p1", 2)
+		tr.mark("rid1", "p2", 1)
+
+		// Retain p1 with version 2 (higher version).
+		probes := []ir.ProbeDefinition{
+			testProbeDefinition{testProbe{id: "p1", v: 2}},
+		}
+		tr.retain("rid1", probes)
+
+		// Version 2 should still be marked.
+		require.False(
+			t, tr.mark("rid1", "p1", 2),
+			"expected p1 v2 to still be marked",
+		)
+
+		// p2 should have been removed.
+		require.True(
+			t, tr.mark("rid1", "p2", 1),
+			"expected p2 to have been removed",
+		)
+	})
+
+	t.Run("non-existent runtime", func(t *testing.T) {
+		tr := newDiagnosticTracker("test")
+
+		// Mark some probes.
+		tr.mark("rid1", "p1", 1)
+		tr.mark("rid1", "p2", 1)
+
+		// Retain on a different runtime ID should not affect rid1.
+		probes := []ir.ProbeDefinition{
+			testProbeDefinition{testProbe{id: "p1", v: 1}},
+		}
+		tr.retain("rid2", probes)
+
+		// rid1 probes should be unaffected.
+		require.False(
+			t, tr.mark("rid1", "p1", 1),
+			"expected rid1 p1 to still be marked",
+		)
+		require.False(
+			t, tr.mark("rid1", "p2", 1),
+			"expected rid1 p2 to still be marked",
+		)
+	})
+}
+
+type testProbeDefinition struct {
+	testProbe
+}
+
+func (p testProbeDefinition) GetTags() []string {
+	return nil
+}
+
+func (p testProbeDefinition) GetKind() ir.ProbeKind {
+	return ir.ProbeKind(0)
+}
+
+func (p testProbeDefinition) GetWhere() ir.Where {
+	return nil
+}
+
+func (p testProbeDefinition) GetCaptureConfig() ir.CaptureConfig {
+	return nil
+}
+
+func (p testProbeDefinition) GetThrottleConfig() ir.ThrottleConfig {
+	return nil
+}
+
+func (p testProbeDefinition) GetTemplate() ir.TemplateDefinition {
+	return nil
+}
+
+var _ ir.ProbeDefinition = testProbeDefinition{}
+
 func contains(ss []string, s string) bool {
 	for _, x := range ss {
 		if x == s {

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -326,6 +326,7 @@ func (m *Module) handleProcessesUpdate(update process.ProcessesUpdate) {
 				Info:   update.Info,
 				Probes: update.Probes,
 			})
+			m.diagnostics.retain(runtimeID, update.Probes)
 			for _, probe := range update.Probes {
 				m.diagnostics.reportReceived(runtimeID, probe)
 			}

--- a/pkg/dyninst/module/module_test.go
+++ b/pkg/dyninst/module/module_test.go
@@ -989,3 +989,375 @@ func createTestProgram() *ir.Program {
 		},
 	}
 }
+
+// TestDiagnosticRetentionAcrossProgramLoads verifies that diagnostic state is
+// properly retained and cleared when probes are added/removed across program
+// loads. This ensures that when a probe is removed and later re-added, fresh
+// diagnostics are sent.
+func TestDiagnosticRetentionAcrossProgramLoads(t *testing.T) {
+	deps := newFakeTestingDependencies(t)
+	decoder := &fakeDecoder{output: `{"test":"data"}`}
+	deps.decoderFactory.decoder = decoder
+	processUpdate := createTestProcessConfig()
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
+
+	collectVersions := func(
+		status uploader.Status,
+	) map[string]int {
+		return collectDiagnosticVersions(deps.diagUploader, status)
+	}
+
+	// Phase 1: Start with p1 and p2, verify diagnostics are sent.
+	program1 := &ir.Program{
+		ID: ir.ProgramID(100),
+		Probes: []*ir.Probe{
+			{ProbeDefinition: processUpdate.Probes[0]},
+			{ProbeDefinition: processUpdate.Probes[1]},
+		},
+	}
+	deps.irGenerator.program = program1
+	deps.sendUpdates(processUpdate)
+
+	require.Equal(
+		t, map[string]int{"probe-1": 1, "probe-2": 1},
+		collectVersions(uploader.StatusReceived),
+		"expected received diagnostics for both probes",
+	)
+
+	loaded1, err := deps.actuator.runtime.Load(
+		program1.ID,
+		processUpdate.Executable,
+		processUpdate.ProcessID,
+		processUpdate.Probes,
+	)
+	require.NoError(t, err)
+
+	_, err = loaded1.Attach(processUpdate.ProcessID, processUpdate.Executable)
+	require.NoError(t, err)
+	require.Equal(
+		t, map[string]int{"probe-1": 1, "probe-2": 1},
+		collectVersions(uploader.StatusInstalled),
+		"expected installed diagnostics for both probes",
+	)
+
+	// Trigger events to generate emitting diagnostics.
+	sink1 := deps.dispatcher.sinks[program1.ID]
+	require.NotNil(t, sink1)
+
+	decoder.probe = processUpdate.Probes[0]
+	require.NoError(
+		t, sink1.HandleEvent(makeFakeEvent(output.EventHeader{}, []byte("event"))),
+	)
+	require.Equal(
+		t, map[string]int{"probe-1": 1},
+		collectVersions(uploader.StatusEmitting),
+		"expected emitting diagnostic for probe-1",
+	)
+
+	decoder.probe = processUpdate.Probes[1]
+	require.NoError(
+		t, sink1.HandleEvent(makeFakeEvent(output.EventHeader{}, []byte("event"))),
+	)
+	require.Equal(
+		t, map[string]int{"probe-1": 1, "probe-2": 1},
+		collectVersions(uploader.StatusEmitting),
+		"expected emitting diagnostics for both probes",
+	)
+
+	// Phase 2: Change to just p1, verify no new diagnostics are sent.
+	require.NoError(t, loaded1.Close())
+
+	processUpdateP1Only := process.Config{
+		Info:      processUpdate.Info,
+		Probes:    []ir.ProbeDefinition{processUpdate.Probes[0]},
+		RuntimeID: processUpdate.RuntimeID,
+	}
+	program2 := &ir.Program{
+		ID: ir.ProgramID(101),
+		Probes: []*ir.Probe{
+			{ProbeDefinition: processUpdate.Probes[0]},
+		},
+	}
+	deps.irGenerator.program = program2
+
+	diagCountBeforeP1Only := len(deps.diagUploader.messages)
+	deps.sendUpdates(processUpdateP1Only)
+
+	// After retainReceived, p2's received state should be cleared but p1
+	// should remain, so no new received diagnostic for p1.
+	diagCountAfterP1Only := len(deps.diagUploader.messages)
+	require.Equal(
+		t, diagCountBeforeP1Only,
+		diagCountAfterP1Only,
+		"expected no new received diagnostic for p1 (already tracked)",
+	)
+
+	loaded2, err := deps.actuator.runtime.Load(
+		program2.ID,
+		processUpdate.Executable,
+		processUpdate.ProcessID,
+		processUpdateP1Only.Probes,
+	)
+	require.NoError(t, err)
+
+	diagCountBeforeAttach2 := len(deps.diagUploader.messages)
+	_, err = loaded2.Attach(
+		processUpdate.ProcessID, processUpdate.Executable,
+	)
+	require.NoError(t, err)
+
+	// No new installed diagnostic for p1 since it was already tracked.
+	diagCountAfterAttach2 := len(deps.diagUploader.messages)
+	require.Equal(
+		t, diagCountBeforeAttach2,
+		diagCountAfterAttach2,
+		"expected no new installed diagnostic for p1 on second attach",
+	)
+
+	// Phase 3: Add back p1 and p2, verify fresh diagnostics for p2.
+	require.NoError(t, loaded2.Close())
+
+	program3 := &ir.Program{
+		ID: ir.ProgramID(102),
+		Probes: []*ir.Probe{
+			{ProbeDefinition: processUpdate.Probes[0]},
+			{ProbeDefinition: processUpdate.Probes[1]},
+		},
+	}
+	deps.irGenerator.program = program3
+
+	diagCountBeforeP2Return := len(deps.diagUploader.messages)
+	deps.sendUpdates(processUpdate)
+
+	// p2's received state was cleared, so it should get a fresh received
+	// diagnostic.
+	diagCountAfterP2Return := len(deps.diagUploader.messages)
+	require.Equal(
+		t, diagCountBeforeP2Return+1,
+		diagCountAfterP2Return,
+		"expected exactly one new received diagnostic for p2",
+	)
+	require.Equal(
+		t, map[string]int{"probe-1": 1, "probe-2": 1},
+		collectVersions(uploader.StatusReceived),
+		"expected p2 to get fresh received diagnostic",
+	)
+
+	loaded3, err := deps.actuator.runtime.Load(
+		program3.ID,
+		processUpdate.Executable,
+		processUpdate.ProcessID,
+		processUpdate.Probes,
+	)
+	require.NoError(t, err)
+
+	_, err = loaded3.Attach(processUpdate.ProcessID, processUpdate.Executable)
+	require.NoError(t, err)
+
+	// p2 should get a fresh installed diagnostic.
+	installedAfterP2Return := collectVersions(uploader.StatusInstalled)
+	require.Equal(
+		t, map[string]int{"probe-1": 1, "probe-2": 1},
+		installedAfterP2Return,
+		"expected p2 to get fresh installed diagnostic",
+	)
+
+	// Verify p2 gets a fresh emitting diagnostic.
+	sink3 := deps.dispatcher.sinks[program3.ID]
+	require.NotNil(t, sink3)
+
+	decoder.probe = processUpdate.Probes[1]
+	require.NoError(
+		t, sink3.HandleEvent(makeFakeEvent(output.EventHeader{}, []byte("event"))),
+	)
+	emittingAfterP2Return := collectVersions(uploader.StatusEmitting)
+	require.Equal(
+		t, map[string]int{"probe-1": 1, "probe-2": 1},
+		emittingAfterP2Return,
+		"expected p2 to get fresh emitting diagnostic",
+	)
+
+	require.NoError(t, loaded3.Close())
+}
+
+// TestDiagnosticRetentionSingleProbeRemoval verifies that when a single probe
+// is removed and then re-added, it receives fresh diagnostics for all lifecycle
+// stages (received, installed, emitting).
+func TestDiagnosticRetentionSingleProbeRemoval(t *testing.T) {
+	deps := newFakeTestingDependencies(t)
+	decoder := &fakeDecoder{output: `{"test":"data"}`}
+	deps.decoderFactory.decoder = decoder
+
+	// Start with just probe-1.
+	processUpdateP1 := process.Config{
+		Info: process.Info{
+			ProcessID:  process.ID{PID: 12345},
+			Executable: process.Executable{Path: "/usr/bin/test"},
+			Service:    "test-service",
+		},
+		Probes:    []ir.ProbeDefinition{createTestProbe("probe-1")},
+		RuntimeID: "runtime-123",
+	}
+
+	tombstoneFilePath := "" // don't use tombstone files
+	_ = module.NewUnstartedModule(deps.toDeps(), tombstoneFilePath)
+
+	collectVersions := func(
+		status uploader.Status,
+	) map[string]int {
+		return collectDiagnosticVersions(deps.diagUploader, status)
+	}
+
+	// Phase 1: Start with p1, verify all diagnostics are sent.
+	program1 := &ir.Program{
+		ID: ir.ProgramID(200),
+		Probes: []*ir.Probe{
+			{ProbeDefinition: processUpdateP1.Probes[0]},
+		},
+	}
+	deps.irGenerator.program = program1
+	deps.sendUpdates(processUpdateP1)
+
+	require.Equal(
+		t, map[string]int{"probe-1": 1},
+		collectVersions(uploader.StatusReceived),
+		"expected received diagnostic for probe-1",
+	)
+
+	loaded1, err := deps.actuator.runtime.Load(
+		program1.ID,
+		processUpdateP1.Executable,
+		processUpdateP1.ProcessID,
+		processUpdateP1.Probes,
+	)
+	require.NoError(t, err)
+
+	_, err = loaded1.Attach(
+		processUpdateP1.ProcessID, processUpdateP1.Executable,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, map[string]int{"probe-1": 1},
+		collectVersions(uploader.StatusInstalled),
+		"expected installed diagnostic for probe-1",
+	)
+
+	// Trigger event to generate emitting diagnostic.
+	sink1 := deps.dispatcher.sinks[program1.ID]
+	require.NotNil(t, sink1)
+
+	decoder.probe = processUpdateP1.Probes[0]
+	require.NoError(
+		t,
+		sink1.HandleEvent(makeFakeEvent(output.EventHeader{}, []byte("event"))),
+	)
+	require.Equal(
+		t, map[string]int{"probe-1": 1},
+		collectVersions(uploader.StatusEmitting),
+		"expected emitting diagnostic for probe-1",
+	)
+
+	receivedCountAfterPhase1 := len(deps.diagUploader.messages)
+
+	// Phase 2: Remove p1 (send empty probe list).
+	require.NoError(t, loaded1.Close())
+
+	processUpdateEmpty := process.Config{
+		Info:      processUpdateP1.Info,
+		Probes:    []ir.ProbeDefinition{},
+		RuntimeID: processUpdateP1.RuntimeID,
+	}
+	deps.sendUpdates(processUpdateEmpty)
+
+	// No new diagnostics should be sent for empty update.
+	require.Equal(
+		t, receivedCountAfterPhase1,
+		len(deps.diagUploader.messages),
+		"expected no new diagnostics for empty probe list",
+	)
+
+	// Phase 3: Add p1 back and verify the bug.
+	program2 := &ir.Program{
+		ID: ir.ProgramID(201),
+		Probes: []*ir.Probe{
+			{ProbeDefinition: processUpdateP1.Probes[0]},
+		},
+	}
+	deps.irGenerator.program = program2
+
+	diagCountBeforeP1Return := len(deps.diagUploader.messages)
+	deps.sendUpdates(processUpdateP1)
+
+	// p1's diagnostic state was cleared, so it gets a fresh received
+	// diagnostic.
+	diagCountAfterP1Return := len(deps.diagUploader.messages)
+	require.Equal(
+		t, diagCountBeforeP1Return+1,
+		diagCountAfterP1Return,
+		"expected fresh received diagnostic for probe-1",
+	)
+	require.Equal(
+		t, map[string]int{"probe-1": 1},
+		collectVersions(uploader.StatusReceived),
+		"expected fresh received diagnostic for probe-1",
+	)
+
+	loaded2, err := deps.actuator.runtime.Load(
+		program2.ID,
+		processUpdateP1.Executable,
+		processUpdateP1.ProcessID,
+		processUpdateP1.Probes,
+	)
+	require.NoError(t, err)
+
+	diagCountBeforeAttach2 := len(deps.diagUploader.messages)
+	_, err = loaded2.Attach(
+		processUpdateP1.ProcessID, processUpdateP1.Executable,
+	)
+	require.NoError(t, err)
+
+	// p1's installed state was cleared when it was removed, so a fresh
+	// installed diagnostic is sent.
+	diagCountAfterAttach2 := len(deps.diagUploader.messages)
+	require.Equal(
+		t, diagCountBeforeAttach2+1,
+		diagCountAfterAttach2,
+		"expected fresh installed diagnostic for probe-1",
+	)
+
+	installedAfterP1Return := collectVersions(uploader.StatusInstalled)
+	require.Equal(
+		t, map[string]int{"probe-1": 1},
+		installedAfterP1Return,
+		"expected fresh installed diagnostic for probe-1",
+	)
+
+	// p1's emitting state was cleared when it was removed, so a fresh
+	// emitting diagnostic is sent.
+	sink2 := deps.dispatcher.sinks[program2.ID]
+	require.NotNil(t, sink2)
+
+	diagCountBeforeEvent := len(deps.diagUploader.messages)
+	decoder.probe = processUpdateP1.Probes[0]
+	require.NoError(
+		t,
+		sink2.HandleEvent(makeFakeEvent(output.EventHeader{}, []byte("event"))),
+	)
+
+	diagCountAfterEvent := len(deps.diagUploader.messages)
+	require.Equal(
+		t, diagCountBeforeEvent+1,
+		diagCountAfterEvent,
+		"expected fresh emitting diagnostic for probe-1",
+	)
+
+	emittingAfterP1Return := collectVersions(uploader.StatusEmitting)
+	require.Equal(
+		t, map[string]int{"probe-1": 1},
+		emittingAfterP1Return,
+		"expected fresh emitting diagnostic for probe-1",
+	)
+
+	require.NoError(t, loaded2.Close())
+}

--- a/pkg/dyninst/module/test_utils.go
+++ b/pkg/dyninst/module/test_utils.go
@@ -7,10 +7,6 @@
 
 package module
 
-import (
-	"sync"
-)
-
 // DiagnosticsStates returns the diagnostics states for the controller.
 func (m *Module) DiagnosticsStates() map[string]map[string][]string {
 	var states = make(map[string]map[string][]string)
@@ -20,19 +16,15 @@ func (m *Module) DiagnosticsStates() map[string]map[string][]string {
 		m.diagnostics.emitted,
 		m.diagnostics.errors,
 	} {
-		t.byRuntimeID.Range(func(runtimeIDAny, probesAny interface{}) bool {
-			runtimeID := runtimeIDAny.(string)
-			m, ok := states[runtimeID]
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		t.mu.btree.Ascend(func(item diagnosticItem) bool {
+			m, ok := states[item.key.runtimeID]
 			if !ok {
 				m = make(map[string][]string)
-				states[runtimeID] = m
+				states[item.key.runtimeID] = m
 			}
-			probes := probesAny.(*sync.Map)
-			probes.Range(func(probeIDAny, _ interface{}) bool {
-				probeID := probeIDAny.(string)
-				m[probeID] = append(m[probeID], t.name)
-				return true
-			})
+			m[item.key.probeID] = append(m[item.key.probeID], t.name)
 			return true
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Added diagnosticsManager.retain() to clear all diagnostic states (received,
installed, emitted, errors) on every process update. This ensures fresh
diagnostics are sent when probes are removed and re-added.

### Motivation

When probes are removed and re-added at the same version, we wouldn't re-emit diagnostics. The probe tracker did not like that.

### Describe how you validated your changes

A fair bit of testing.

### Additional Notes

Fixes [DEBUG-4755](https://datadoghq.atlassian.net/browse/DEBUG-4755)

[DEBUG-4755]: https://datadoghq.atlassian.net/browse/DEBUG-4755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ