### PR TITLE
[PROF-13299][host-profiler] Use remotehostname for hostname resolution in Agent mode

### DIFF
--- a/cmd/host-profiler/subcommands/run/command.go
+++ b/cmd/host-profiler/subcommands/run/command.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/host-profiler/globalparams"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
@@ -74,7 +74,7 @@ func runHostProfilerCommand(ctx context.Context, cliParams *cliParams) error {
 	if cliParams.GlobalParams.CoreConfPath != "" {
 		opts = append(opts,
 			core.Bundle(),
-			hostnameimpl.Module(),
+			remotehostnameimpl.Module(),
 			fx.Supply(core.BundleParams{
 				ConfigParams: config.NewAgentParams(cliParams.GlobalParams.CoreConfPath),
 				LogParams:    log.ForDaemon(command.LoggerName, "log_file", setup.DefaultHostProfilerLogFile),


### PR DESCRIPTION
### What does this PR do?

- Change the Agent mode's hostname resolution module to use the one relying on the Agent instead of internal resolution.
### Motivation

- Internal hostname resolution fails when `infraattributesprocessor` tries to resolve hostname when one was given in agent's configuration file.
- The logs of `host-profiler` show we are able to resolve the hostname using the agent's connection but `infraattributesprocessor` doesn't rely on it. 

### Describe how you validated your changes
Check `datadog.host.name` resource attribute and see the same hostname as Agent's hostname resolution.

### Additional Notes
