### PR TITLE
[APM] Mark test as flaky on macOS

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -3499,6 +3499,10 @@ func TestMergeDuplicates(t *testing.T) {
 }
 
 func TestProcessStatsTimeout(t *testing.T) {
+	if os.Getenv("CI") == "true" && runtime.GOOS == "darwin" {
+		t.Skip("TestProcessStatsTimeout is known to fail on the macOS Gitlab runners.")
+	}
+
 	cfg := config.New()
 	cfg.Endpoints[0].APIKey = "test"
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
### What does this PR do?

This test is flaky on macos Gitlub runners ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1285899883))

### Motivation

### Describe how you validated your changes

### Additional Notes
