### PR TITLE
[Backport 7.74x][cluster-autoscaling] fix replica nodepool creation (#44117)

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -10,6 +10,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -106,7 +107,8 @@ func (c *Controller) PreStart(ctx context.Context) {
 // this processes what's in the workqueue, comes from the store or cluster
 func (c *Controller) Process(ctx context.Context, _, _, name string) autoscaling.ProcessResult {
 	if !c.IsLeader() || !*c.storeUpdated {
-		return autoscaling.ProcessResult{}
+		// Requeue in case of a delay in leader election or the store being updated
+		return autoscaling.Requeue
 	}
 
 	// Try to get Datadog-managed NodePool from cluster
@@ -135,23 +137,39 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, nodePool *ka
 	npi, foundInStore := c.store.LockRead(name, true)
 	defer c.store.Unlock(name)
 
+	// Get Target NodePool from Lister if needed
+	targetNp := &karpenterv1.NodePool{}
+	if npi.TargetName() != "" {
+		targetNpUnstr, err := c.Lister.Get(npi.TargetName())
+		if err != nil {
+			log.Errorf("Error retrieving Target NodePool: %v", err)
+			return autoscaling.Requeue
+		}
+		err = autoscaling.FromUnstructured(targetNpUnstr, targetNp)
+		if err != nil {
+			log.Errorf("Error converting Target NodePool: %v", err)
+			return autoscaling.Requeue
+		}
+	}
+
 	if foundInStore {
+		// Only create or update if there is no TargetHash (i.e. it is fully Datadog-managed), or if the TargetHash has not changed
+		if !checkTargetHash(npi, targetNp) {
+			log.Infof("NodePool: %s TargetHash (%s) has changed since recommendation was generated; no action will be applied.", npi.Name(), npi.TargetHash())
+			return autoscaling.NoRequeue
+		}
+
 		if nodePool == nil {
 			// Present in store but not found in cluster; create it
-			if err := c.createNodePool(ctx, npi); err != nil {
+			if err := c.createNodePool(ctx, npi, targetNp); err != nil {
 				log.Errorf("Error creating NodePool: %v", err)
 				return autoscaling.Requeue
 			}
 		} else {
 			// Present in store and found in cluster; update it
-			// Only update if there is no TargetHash (i.e. it is fully Datadog-managed) or if the TargetHash has not changed
-			if npi.TargetHash() == "" || npi.TargetHash() == nodePool.GetAnnotations()[model.KarpenterNodePoolHashAnnotationKey] {
-				if err := c.patchNodePool(ctx, nodePool, npi); err != nil {
-					log.Errorf("Error updating NodePool: %v", err)
-					return autoscaling.Requeue
-				}
-			} else {
-				log.Infof("NodePool TargetHash (%s) has changed since recommendation was generated; update will not be applied.", npi.TargetHash())
+			if err := c.patchNodePool(ctx, nodePool, npi); err != nil {
+				log.Errorf("Error updating NodePool: %v", err)
+				return autoscaling.Requeue
 			}
 		}
 	} else {
@@ -167,30 +185,39 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, nodePool *ka
 		}
 	}
 
-	return autoscaling.ProcessResult{}
+	return autoscaling.NoRequeue
 }
 
-func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInternal) error {
+func checkTargetHash(npi model.NodePoolInternal, targetNp *karpenterv1.NodePool) bool {
+	return npi.TargetHash() == "" || npi.TargetHash() == targetNp.GetAnnotations()[model.KarpenterNodePoolHashAnnotationKey]
+}
+
+func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInternal, knp *karpenterv1.NodePool) error {
 	log.Infof("Creating NodePool: %s", npi.Name())
 
-	// Get NodeClass. If there's none or more than one, then we should not create the NodePool
-	ncList, err := c.Client.Resource(nodeClassGVR).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to list NodeClasses: %w", err)
+	// Create replica of original NodePool if TargetName exists; otherwise use NodePoolInternal to create a NodePool
+	if knp != nil {
+		model.BuildReplicaNodePool(knp, npi)
+	} else {
+		// Get NodeClass. If there's none or more than one, then we should not create the NodePool
+		ncList, err := c.Client.Resource(nodeClassGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to list NodeClasses: %w", err)
+		}
+
+		if len(ncList.Items) == 0 {
+			return errors.New("no NodeClasses found, NodePool cannot be created")
+		}
+
+		if len(ncList.Items) > 1 {
+			return fmt.Errorf("too many NodeClasses found (%v), NodePool cannot be created", len(ncList.Items))
+		}
+
+		u := ncList.Items[0]
+		knp = model.ConvertToKarpenterNodePool(npi, u.GetName())
 	}
 
-	if len(ncList.Items) == 0 {
-		return fmt.Errorf("no NodeClasses found, NodePool cannot be created")
-	}
-
-	if len(ncList.Items) > 1 {
-		return fmt.Errorf("too many NodeClasses found (%v), NodePool cannot be created", len(ncList.Items))
-	}
-
-	u := ncList.Items[0]
-	npObj := model.ConvertToKarpenterNodePool(npi, u.GetName())
-
-	npUnstr, err := autoscaling.ToUnstructured(npObj)
+	npUnstr, err := autoscaling.ToUnstructured(knp)
 	if err != nil {
 		return err
 	}

--- a/releasenotes/notes/cluster-autoscaling-replica-nodepool-fixes-1f0d17427171dd08.yaml
+++ b/releasenotes/notes/cluster-autoscaling-replica-nodepool-fixes-1f0d17427171dd08.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Creates replica NodePool by copying the target NodePool Spec, rather than creating from scratch
+  - |
+    Update reconcile to requeue when delays in LeaderElection may occur


### PR DESCRIPTION
Backports #44117 

----
- Fixes an issue where replica NodePool creation was not replicating the target NodePool spec
- Fixes an issue where a delay in LeaderElection resulted in the task not being requeued

More details:
Previously, a replica NodePool was being created based on the Target NodePool as designed, but it was being created only with the information coming from the backend - i.e. the labels, taints, and recommendations. Now the replica is copying the Spec of the Target NodePool, and then updating the `Spec.Requirements` with the recommendations.

For the second issue, a delay in LeaderElection would result in new NodePoolInternal objects in the store to never get reconciled. The NPI object would get added to the store correctly, but because `IsLeader()` is still `false` [here](https://github.com/DataDog/datadog-agent/blob/0bc5cd3d8ea3c210a61aa5c78d92a8834477cde0/pkg/clusteragent/autoscaling/cluster/controller.go#L110), the Process function exits and the item would not be requeued again (until a new payload is received from RC).

Realized the issue when doing an inventory check on all the features/expected behaviors.

Tested on a test EKS cluster linked to Staging


(cherry picked from commit bc17e1a78b1f0bd1f488c8860fc24dfb991cfa4a)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
