### PR TITLE
dyninst/procscan: support late tracer starts via windows

### DIFF
--- a/pkg/dyninst/procsubscribe/procscan/scanner.go
+++ b/pkg/dyninst/procsubscribe/procscan/scanner.go
@@ -28,19 +28,42 @@ import (
 // ProcessID is a unique identifier for a process.
 type ProcessID uint32
 
+// timeWindow represents a time range for process discovery based on how long
+// a process has been alive. The window advances with each scan, capturing
+// processes that have "aged into" the eligibility threshold.
+type timeWindow struct {
+	// startDelay is how long a process must be alive before being eligible.
+	startDelay ticks
+}
+
+// contains checks if a process start time falls within this window for the
+// given current time.
+func (w *timeWindow) contains(startTime, now, lastScan ticks) bool {
+	lastWatermark := computeWatermark(lastScan, w.startDelay)
+	nextWatermark := computeWatermark(now, w.startDelay)
+	return startTime > lastWatermark && startTime <= nextWatermark
+}
+
+// computeNextWatermark calculates the upper bound of the current time window.
+func computeWatermark(now ticks, delay ticks) ticks {
+	if now < delay {
+		return 0
+	}
+	return now - delay
+}
+
 // Scanner discovers Go processes for instrumentation using a watermark-based
 // algorithm. Processes are analyzed exactly once when they've been alive for
-// at least startDelay. Processes that exit before startDelay are never
-// analyzed.
+// at least the duration specified by one of the time windows. Processes that
+// exit before becoming eligible are never analyzed.
 //
 // Thread-safety: Scan is not thread-safe, use from a single goroutine only.
 type Scanner struct {
-
-	// startDelay is how long a process must be alive before analysis.
-	startDelay ticks
-
-	// lastWatermark is the upper bound of the previous scan's time window.
-	lastWatermark ticks
+	// lastScan is the last scan time in ticks since boot.
+	lastScan ticks
+	// windows defines the time windows for process eligibility. A process is
+	// analyzed if its start time falls within any of these windows.
+	windows []timeWindow
 
 	// nowTicks returns the current time in ticks since boot.
 	nowTicks func() (ticks, error)
@@ -65,17 +88,29 @@ type Scanner struct {
 }
 
 // NewScanner creates a new Scanner that discovers processes in the given
-// procfs root that have been alive for at least startDelay.
+// procfs root.
+//
+// Each processDelay defines a time window for discovering processes. A process
+// becomes eligible for discovery when it has been alive for at least the
+// specified delay. Multiple delays provide redundancy: if metadata isn't
+// available when the first window covers a process, a longer delay window may
+// still catch it later. Windows with smaller delays catch processes sooner but
+// have less time for metadata to become available.
 func NewScanner(
 	procfsRoot string,
-	startDelay time.Duration,
+	processDelays ...time.Duration,
 ) *Scanner {
-	startDelayTicks := ticks(
-		(startDelay.Nanoseconds() * int64(clkTck)) / time.Second.Nanoseconds(),
-	)
+	windows := make([]timeWindow, 0, len(processDelays))
+	for _, delay := range processDelays {
+		windows = append(windows, timeWindow{
+			startDelay: ticks(
+				(delay.Nanoseconds() * int64(clkTck)) / time.Second.Nanoseconds(),
+			),
+		})
+	}
 	reader := newStartTimeReader(procfsRoot)
 	return newScanner(
-		startDelayTicks,
+		windows,
 		nowTicks,
 		func() iter.Seq2[uint32, error] {
 			return listPids(procfsRoot, 512)
@@ -99,7 +134,7 @@ func NewScanner(
 // newScanner creates a Scanner with injected dependencies. Used by NewScanner
 // for production code and by tests for dependency injection.
 func newScanner(
-	startDelay ticks,
+	windows []timeWindow,
 	nowTicks func() (ticks, error),
 	listPids func() iter.Seq2[uint32, error],
 	readStartTime func(pid int32) (ticks, error),
@@ -107,7 +142,7 @@ func newScanner(
 	resolveExecutable func(pid int32) (process.Executable, error),
 ) *Scanner {
 	s := &Scanner{
-		startDelay:           startDelay,
+		windows:              windows,
 		nowTicks:             nowTicks,
 		listPids:             listPids,
 		readStartTime:        readStartTime,
@@ -148,13 +183,6 @@ func (p *Scanner) Scan() (
 		return nil, nil, fmt.Errorf("get timestamp: %w", err)
 	}
 
-	nextWatermark := now - p.startDelay
-
-	// Handle edge cases: machine just booted or clock went backward.
-	if now < p.startDelay || nextWatermark < p.lastWatermark {
-		nextWatermark = now
-	}
-
 	// Rate-limit logging about errors that are interesting.
 	maybeLogErr := func(prefix string, err error) {
 		if err == nil ||
@@ -190,13 +218,13 @@ func (p *Scanner) Scan() (
 			continue
 		}
 
-		// Only analyze processes in the watermark window.
+		// Only analyze processes whose start time falls within a time window.
 		startTime, err := p.readStartTime(int32(pid))
 		if err != nil {
 			maybeLogErr("read start time", err)
 			continue
 		}
-		if startTime < p.lastWatermark || startTime > nextWatermark {
+		if !p.matchesAnyWindow(startTime, now, p.lastScan) {
 			continue
 		}
 
@@ -237,8 +265,19 @@ func (p *Scanner) Scan() (
 	}
 	p.mu.Unlock()
 
-	p.lastWatermark = nextWatermark
+	p.lastScan = now
 	return ret, removed, nil
+}
+
+// matchesAnyWindow returns true if the given start time falls within any of
+// the scanner's time windows.
+func (p *Scanner) matchesAnyWindow(startTime, now, lastScan ticks) bool {
+	for i := range p.windows {
+		if p.windows[i].contains(startTime, now, lastScan) {
+			return true
+		}
+	}
+	return false
 }
 
 // LiveProcesses returns the list of processes that were alive as of the last

--- a/pkg/dyninst/procsubscribe/procscan/scanner_test.go
+++ b/pkg/dyninst/procsubscribe/procscan/scanner_test.go
@@ -139,37 +139,38 @@ func runScannerSnapshotTest(t *testing.T, file string, rewrite bool) {
 
 // scannerTestState manages the test state for scanner tests.
 type scannerTestState struct {
-	t               *testing.T
-	scanner         *Scanner
-	currentTime     ticks
-	processes       map[int32]*testProcess
-	executables     map[int32]process.Executable
-	startDelayTicks ticks
-	lastCommand     command
-	lastScanResult  *scanResult
-	initialized     bool
-	firstOutput     bool
+	t                  *testing.T
+	scanner            *Scanner
+	currentTime        ticks
+	processes          map[int32]*testProcess
+	executables        map[int32]process.Executable
+	processDelaysTicks []ticks
+	lastCommand        command
+	lastScanResult     *scanResult
+	initialized        bool
+	firstOutput        bool
 }
 
 type testProcess struct {
-	pid            int32
-	startTime      ticks
-	tracerMetadata tracermetadata.TracerMetadata
+	pid                 int32
+	startTime           ticks
+	metadataAvailableAt ticks
+	tracerMetadata      tracermetadata.TracerMetadata
 }
 
 func newScannerTestState(t *testing.T) *scannerTestState {
-	const defaultStartDelay = 100 // 100 ticks
+	const defaultProcessDelay = 100 // 100 ticks
 	ts := &scannerTestState{
-		t:               t,
-		currentTime:     0,
-		processes:       make(map[int32]*testProcess),
-		executables:     make(map[int32]process.Executable),
-		startDelayTicks: defaultStartDelay,
-		firstOutput:     true,
+		t:                  t,
+		currentTime:        0,
+		processes:          make(map[int32]*testProcess),
+		executables:        make(map[int32]process.Executable),
+		processDelaysTicks: []ticks{defaultProcessDelay},
+		firstOutput:        true,
 	}
 
 	ts.scanner = newScanner(
-		defaultStartDelay,
+		[]timeWindow{{startDelay: defaultProcessDelay}},
 		func() (ticks, error) { return ts.currentTime, nil },
 		ts.listPids,
 		ts.readStartTime,
@@ -215,9 +216,10 @@ func (t *tracerMetadataInput) toTracerMetadata() tracermetadata.TracerMetadata {
 }
 
 type createProcessCommand struct {
-	PID            int32               `yaml:"pid"`
-	StartTime      uint64              `yaml:"start_time"`
-	TracerMetadata tracerMetadataInput `yaml:"tracer_metadata"`
+	PID                 int32               `yaml:"pid"`
+	StartTime           uint64              `yaml:"start_time"`
+	MetadataAvailableAt *uint64             `yaml:"metadata_available_at,omitempty"`
+	TracerMetadata      tracerMetadataInput `yaml:"tracer_metadata"`
 }
 
 func (c *createProcessCommand) execute(
@@ -227,10 +229,15 @@ func (c *createProcessCommand) execute(
 	if _, exists := ts.processes[c.PID]; exists {
 		return fmt.Errorf("process %d already exists", c.PID)
 	}
+	metadataAvailableAt := ticks(c.StartTime)
+	if c.MetadataAvailableAt != nil {
+		metadataAvailableAt = ticks(*c.MetadataAvailableAt)
+	}
 	ts.processes[c.PID] = &testProcess{
-		pid:            c.PID,
-		startTime:      ticks(c.StartTime),
-		tracerMetadata: c.TracerMetadata.toTracerMetadata(),
+		pid:                 c.PID,
+		startTime:           ticks(c.StartTime),
+		metadataAvailableAt: metadataAvailableAt,
+		tracerMetadata:      c.TracerMetadata.toTracerMetadata(),
 	}
 	ts.executables[c.PID] = process.Executable{
 		Path: fmt.Sprintf("/proc/%d/exe", c.PID),
@@ -272,8 +279,8 @@ func (c *advanceTimeCommand) execute(
 }
 
 type initializeCommand struct {
-	CurrentTime uint64 `yaml:"current_time"`
-	StartDelay  uint64 `yaml:"start_delay"`
+	CurrentTime   uint64   `yaml:"current_time"`
+	ProcessDelays []uint64 `yaml:"process_delays"`
 }
 
 func (c *initializeCommand) execute(
@@ -281,8 +288,16 @@ func (c *initializeCommand) execute(
 	ts *scannerTestState,
 ) error {
 	ts.currentTime = ticks(c.CurrentTime)
-	ts.startDelayTicks = ticks(c.StartDelay)
-	ts.scanner.startDelay = ticks(c.StartDelay)
+
+	// Build time windows from process delays.
+	ts.processDelaysTicks = make([]ticks, len(c.ProcessDelays))
+	windows := make([]timeWindow, len(c.ProcessDelays))
+	for i, delay := range c.ProcessDelays {
+		ts.processDelaysTicks[i] = ticks(delay)
+		windows[i] = timeWindow{startDelay: ticks(delay)}
+	}
+	ts.scanner.windows = windows
+
 	ts.initialized = true
 	return nil
 }
@@ -338,6 +353,12 @@ func (ts *scannerTestState) readTracerMetadata(
 			"process %d does not exist", pid,
 		)
 	}
+	// Metadata is only available after metadataAvailableAt.
+	if ts.currentTime < proc.metadataAvailableAt {
+		return tracermetadata.TracerMetadata{}, fmt.Errorf(
+			"metadata not yet available for process %d", pid,
+		)
+	}
 	return proc.tracerMetadata, nil
 }
 
@@ -352,11 +373,11 @@ func (ts *scannerTestState) resolveExecutable(
 }
 
 type scannerStateSnapshot struct {
-	CurrentTime       uint64  `yaml:"current_time"`
-	LastWatermark     uint64  `yaml:"last_watermark"`
-	StartDelay        uint64  `yaml:"start_delay,omitempty"`
-	Live              []int32 `yaml:"live,omitempty,flow"`
-	ProcessesInProcfs []int32 `yaml:"processes_in_procfs,omitempty,flow"`
+	CurrentTime       uint64   `yaml:"current_time"`
+	LastScan          uint64   `yaml:"last_scan"`
+	ProcessDelays     []uint64 `yaml:"process_delays,omitempty,flow"`
+	Live              []int32  `yaml:"live,omitempty,flow"`
+	ProcessesInProcfs []int32  `yaml:"processes_in_procfs,omitempty,flow"`
 }
 
 // Output structures for test commands.
@@ -372,7 +393,7 @@ type scanOutput struct {
 }
 
 func (ts *scannerTestState) cloneState(
-	includeStartDelay bool,
+	includeProcessDelays bool,
 ) *scannerStateSnapshot {
 	ts.scanner.mu.Lock()
 	defer ts.scanner.mu.Unlock()
@@ -391,13 +412,16 @@ func (ts *scannerTestState) cloneState(
 
 	snapshot := &scannerStateSnapshot{
 		CurrentTime:       uint64(ts.currentTime),
-		LastWatermark:     uint64(ts.scanner.lastWatermark),
+		LastScan:          uint64(ts.scanner.lastScan),
 		Live:              live,
 		ProcessesInProcfs: pids,
 	}
 
-	if includeStartDelay {
-		snapshot.StartDelay = uint64(ts.startDelayTicks)
+	if includeProcessDelays {
+		snapshot.ProcessDelays = make([]uint64, len(ts.processDelaysTicks))
+		for i, d := range ts.processDelaysTicks {
+			snapshot.ProcessDelays[i] = uint64(d)
+		}
 	}
 
 	return snapshot

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/basic_discovery.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/basic_discovery.yaml
@@ -2,7 +2,9 @@
 # A process starts at tick 50, time advances to 200, and scan discovers it.
 - !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [10]
+- !advance-time {to: 30}
+- !scan {}
 - !create-process
   pid: 1001
   start_time: 50
@@ -11,12 +13,22 @@
     service: "my-service"
     version: "1.0.0"
     env: "production"
+- !advance-time {to: 51}
+- !scan {}
 - !advance-time {to: 200}
 - !scan {}
 ---
 command: !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [10]
+---
+command: !advance-time {to: 30}
+---
+command: !scan {}
+state:
+  current_time: 30
+  last_scan: 30
+  process_delays: [10]
 ---
 command: !create-process
   pid: 1001
@@ -27,13 +39,20 @@ command: !create-process
     version: "1.0.0"
     env: "production"
 ---
+command: !advance-time {to: 51}
+---
+command: !scan {}
+state:
+  current_time: 51
+  last_scan: 51
+  processes_in_procfs: [1001]
+---
 command: !advance-time {to: 200}
 ---
 command: !scan {}
 new: [1001]
 state:
   current_time: 200
-  last_watermark: 100
-  start_delay: 100
+  last_scan: 200
   live: [1001]
   processes_in_procfs: [1001]

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/early_boot.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/early_boot.yaml
@@ -1,9 +1,10 @@
-# Test edge case: now < startDelay (machine just booted).
-# Scanner should handle this by setting nextWatermark = now instead of (now - startDelay).
-# This prevents negative watermarks and ensures we scan all processes from boot.
+# Test early-boot edge case: current_time < startDelay.
+# The watermark computation should clamp to 0 so we scan from boot, and we
+# should still discover processes that started early once they age past the
+# startDelay window.
 - !initialize
   current_time: 50
-  start_delay: 100
+  process_delays: [100]
 - !create-process
   pid: 1001
   start_time: 10
@@ -25,6 +26,10 @@
   start_time: 101
   tracer_metadata: {language: "go", service: "a-bit-after-that"}
 - !scan {}
+- !advance-time {to: 150}
+- !scan {}
+- !advance-time {to: 151}
+- !scan {}
 - !advance-time {to: 202}
 - !create-process
   pid: 1005
@@ -34,7 +39,7 @@
 ---
 command: !initialize
   current_time: 50
-  start_delay: 100
+  process_delays: [100]
 ---
 command: !create-process
   pid: 1001
@@ -47,12 +52,10 @@ command: !create-process
   tracer_metadata: {language: "go", service: "early-service"}
 ---
 command: !scan {}
-new: [1001, 1002]
 state:
   current_time: 50
-  last_watermark: 50
-  start_delay: 100
-  live: [1001, 1002]
+  last_scan: 50
+  process_delays: [100]
   processes_in_procfs: [1001, 1002]
 ---
 command: !advance-time {to: 51}
@@ -63,11 +66,9 @@ command: !create-process
   tracer_metadata: {language: "go", service: "a-bit-later"}
 ---
 command: !scan {}
-new: [1003]
 state:
   current_time: 51
-  last_watermark: 51
-  live: [1001, 1002, 1003]
+  last_scan: 51
   processes_in_procfs: [1001, 1002, 1003]
 ---
 command: !advance-time {to: 102}
@@ -78,11 +79,29 @@ command: !create-process
   tracer_metadata: {language: "go", service: "a-bit-after-that"}
 ---
 command: !scan {}
-new: [1004]
 state:
   current_time: 102
-  last_watermark: 102
-  live: [1001, 1002, 1003, 1004]
+  last_scan: 102
+  processes_in_procfs: [1001, 1002, 1003, 1004]
+---
+command: !advance-time {to: 150}
+---
+command: !scan {}
+new: [1001, 1002]
+state:
+  current_time: 150
+  last_scan: 150
+  live: [1001, 1002]
+  processes_in_procfs: [1001, 1002, 1003, 1004]
+---
+command: !advance-time {to: 151}
+---
+command: !scan {}
+new: [1003]
+state:
+  current_time: 151
+  last_scan: 151
+  live: [1001, 1002, 1003]
   processes_in_procfs: [1001, 1002, 1003, 1004]
 ---
 command: !advance-time {to: 202}
@@ -93,8 +112,9 @@ command: !create-process
   tracer_metadata: {language: "go", service: "even-later"}
 ---
 command: !scan {}
+new: [1004]
 state:
   current_time: 202
-  last_watermark: 102
+  last_scan: 202
   live: [1001, 1002, 1003, 1004]
   processes_in_procfs: [1001, 1002, 1003, 1004, 1005]

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/multiple_processes.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/multiple_processes.yaml
@@ -2,7 +2,7 @@
 # Create three processes at different times, scan should discover all eligible ones.
 - !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 - !create-process
   pid: 1001
   start_time: 50
@@ -20,7 +20,7 @@
 ---
 command: !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 ---
 command: !create-process
   pid: 1001
@@ -43,7 +43,7 @@ command: !scan {}
 new: [1001, 1002, 1003]
 state:
   current_time: 200
-  last_watermark: 100
-  start_delay: 100
+  last_scan: 200
+  process_delays: [100]
   live: [1001, 1002, 1003]
   processes_in_procfs: [1001, 1002, 1003]

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/multiple_windows_delayed_metadata.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/multiple_windows_delayed_metadata.yaml
@@ -1,0 +1,78 @@
+# Test discovery with multiple process delay windows and delayed metadata.
+# This demonstrates how a longer delay window can catch a process that was
+# missed by the shorter window.
+#
+# Setup:
+# - Two process delay windows: 100 ticks (short) and 300 ticks (long)
+# - Process 1001: starts at tick 1000, metadata available at tick 1250
+#
+# The key insight: window 2 (300 delay) has a SMALLER nextWatermark than
+# window 1 (100 delay), meaning it covers processes that started further in
+# the past. This gives processes more time for metadata to become available.
+#
+# Timeline:
+# - At tick 1100: Window 1 range [0, 1000] includes process, Window 2 range
+#   [0, 800] excludes it. Metadata at 1250 > 1100, not available.
+# - At tick 1200: Window 1 range [1000, 1100] includes process, Window 2 range
+#   [800, 900] excludes it. Metadata at 1250 > 1200, not available.
+# - At tick 1300: Window 1 range [1100, 1200] excludes process (1000 < 1100)!
+#   Window 2 range [900, 1000] includes it! Metadata at 1250 <= 1300, available!
+#   Process discovered via the longer delay window.
+- !initialize
+  current_time: 0
+  process_delays: [100, 300]
+- !create-process
+  pid: 1001
+  start_time: 1000
+  metadata_available_at: 1250
+  tracer_metadata:
+    language: "go"
+    service: "slow-metadata-service"
+# First scan: window 1 catches, metadata not ready
+- !advance-time {to: 1100}
+- !scan {}
+# Second scan: window 1 still catches, metadata still not ready
+- !advance-time {to: 1200}
+- !scan {}
+# Third scan: window 1 has moved past, but window 2 catches, metadata ready!
+- !advance-time {to: 1300}
+- !scan {}
+---
+command: !initialize
+  current_time: 0
+  process_delays: [100, 300]
+---
+command: !create-process
+  pid: 1001
+  start_time: 1000
+  metadata_available_at: 1250
+  tracer_metadata:
+    language: "go"
+    service: "slow-metadata-service"
+---
+command: !advance-time {to: 1100}
+---
+command: !scan {}
+state:
+  current_time: 1100
+  last_scan: 1100
+  process_delays: [100, 300]
+  processes_in_procfs: [1001]
+---
+command: !advance-time {to: 1200}
+---
+command: !scan {}
+state:
+  current_time: 1200
+  last_scan: 1200
+  processes_in_procfs: [1001]
+---
+command: !advance-time {to: 1300}
+---
+command: !scan {}
+new: [1001]
+state:
+  current_time: 1300
+  last_scan: 1300
+  live: [1001]
+  processes_in_procfs: [1001]

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/no_rediscovery.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/no_rediscovery.yaml
@@ -2,7 +2,7 @@
 # Scan twice - second scan should not rediscover the same process.
 - !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 - !create-process
   pid: 1001
   start_time: 50
@@ -16,7 +16,7 @@
 ---
 command: !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 ---
 command: !create-process
   pid: 1001
@@ -31,8 +31,8 @@ command: !scan {}
 new: [1001]
 state:
   current_time: 200
-  last_watermark: 100
-  start_delay: 100
+  last_scan: 200
+  process_delays: [100]
   live: [1001]
   processes_in_procfs: [1001]
 ---
@@ -41,6 +41,6 @@ command: !advance-time {to: 300}
 command: !scan {}
 state:
   current_time: 300
-  last_watermark: 200
+  last_scan: 300
   live: [1001]
   processes_in_procfs: [1001]

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/non_go_process.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/non_go_process.yaml
@@ -2,7 +2,7 @@
 # Create a Python process - it should never be discovered.
 - !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 - !create-process
   pid: 1001
   start_time: 50
@@ -14,7 +14,7 @@
 ---
 command: !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 ---
 command: !create-process
   pid: 1001
@@ -28,6 +28,6 @@ command: !advance-time {to: 200}
 command: !scan {}
 state:
   current_time: 200
-  last_watermark: 100
-  start_delay: 100
+  last_scan: 200
+  process_delays: [100]
   processes_in_procfs: [1001]

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/process_exit.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/process_exit.yaml
@@ -2,7 +2,7 @@
 # Discover a process, then remove it, next scan should report it as removed.
 - !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 - !create-process
   pid: 1001
   start_time: 50
@@ -17,7 +17,7 @@
 ---
 command: !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 ---
 command: !create-process
   pid: 1001
@@ -32,8 +32,8 @@ command: !scan {}
 new: [1001]
 state:
   current_time: 200
-  last_watermark: 100
-  start_delay: 100
+  last_scan: 200
+  process_delays: [100]
   live: [1001]
   processes_in_procfs: [1001]
 ---
@@ -45,4 +45,4 @@ command: !scan {}
 removed: [1001]
 state:
   current_time: 300
-  last_watermark: 200
+  last_scan: 300

--- a/pkg/dyninst/procsubscribe/procscan/testdata/scanner/process_too_new.yaml
+++ b/pkg/dyninst/procsubscribe/procscan/testdata/scanner/process_too_new.yaml
@@ -3,7 +3,7 @@
 # Process is too new (started at 150 > watermark 100) so it's not discovered.
 - !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 - !create-process
   pid: 1001
   start_time: 150
@@ -17,7 +17,7 @@
 ---
 command: !initialize
   current_time: 0
-  start_delay: 100
+  process_delays: [100]
 ---
 command: !create-process
   pid: 1001
@@ -31,8 +31,8 @@ command: !advance-time {to: 200}
 command: !scan {}
 state:
   current_time: 200
-  last_watermark: 100
-  start_delay: 100
+  last_scan: 200
+  process_delays: [100]
   processes_in_procfs: [1001]
 ---
 command: !advance-time {to: 300}
@@ -41,6 +41,6 @@ command: !scan {}
 new: [1001]
 state:
   current_time: 300
-  last_watermark: 200
+  last_scan: 300
   live: [1001]
   processes_in_procfs: [1001]


### PR DESCRIPTION
### What does this PR do?

Refactor Scanner to accept multiple process delays instead of a single startDelay. Each delay defines a time window for discovering processes. Longer delay windows provide a safety net for processes whose metadata takes longer to become available.

### Motivation

We've seen services that don't start their tracer for over a minute after they were started.

### Describe how you validated your changes

Has testing.

### Additional Notes

Fixes [DEBUG-4856](https://datadoghq.atlassian.net/browse/DEBUG-4856)

[DEBUG-4856]: https://datadoghq.atlassian.net/browse/DEBUG-4856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ