### PR TITLE
reduce min interval in host metadata to 60s

### DIFF
--- a/comp/metadata/host/hostimpl/host.go
+++ b/comp/metadata/host/hostimpl/host.go
@@ -41,7 +41,7 @@ const defaultCollectInterval = 1800 * time.Second
 const defaultEarlyInterval = 300 * time.Second
 
 // the host metadata collector interval can be set through configuration within acceptable bounds
-const minAcceptedInterval = 300   // 5min
+const minAcceptedInterval = 60    // 1min
 const maxAcceptedInterval = 14400 // 4h
 
 const providerName = "host"

--- a/comp/metadata/host/hostimpl/host_test.go
+++ b/comp/metadata/host/hostimpl/host_test.go
@@ -61,15 +61,15 @@ func TestNewHostProviderIntervalValidation(t *testing.T) {
 		},
 		{
 			name:                 "both intervals invalid - too low",
-			mainInterval:         100,
-			earlyInterval:        50,
+			mainInterval:         30,
+			earlyInterval:        30,
 			expectedMaxInterval:  defaultCollectInterval,
 			expectedInitInterval: defaultEarlyInterval, // main invalid means whole provider ignored
 		},
 		{
 			name:                 "main valid, early invalid - too low",
 			mainInterval:         1800,
-			earlyInterval:        100,
+			earlyInterval:        30,
 			expectedMaxInterval:  1800 * time.Second,
 			expectedInitInterval: defaultEarlyInterval,
 		},
@@ -89,7 +89,7 @@ func TestNewHostProviderIntervalValidation(t *testing.T) {
 		},
 		{
 			name:                 "main invalid, early valid",
-			mainInterval:         100,
+			mainInterval:         30,
 			earlyInterval:        600,
 			expectedMaxInterval:  defaultCollectInterval,
 			expectedInitInterval: defaultEarlyInterval, // main invalid means whole provider ignored


### PR DESCRIPTION
### What does this PR do?
Give the ability to set the minimum accepted interval for host metadata from 5 minutes to 60 seconds to allow faster frontloading of host payload attempts.

### Motivation
https://datadoghq.atlassian.net/browse/CONS-7920?focusedCommentId=2824754

### Describe how you validated your changes
```
metadata_providers:
  - early_interval: 60
    interval: 1800
    name: host
```
<img width="1371" height="75" alt="image" src="https://github.com/user-attachments/assets/7295503f-6f59-42bb-89e0-30c54ddbce23" />

### Additional Notes
