### PR TITLE
dyninst/procscan: cache proc start times

### DIFF
--- a/pkg/dyninst/procsubscribe/procscan/start_time_cache.go
+++ b/pkg/dyninst/procsubscribe/procscan/start_time_cache.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procscan
+
+// startTimeCache caches process start times keyed by PID.
+//
+// It stores ticks since boot, and uses the high bit as a "seen in this scan"
+// marker.
+//
+// getStartTime marks any accessed PID as seen. sweep keeps seen entries
+// (clearing the marker) and deletes unseen ones (PIDs not observed in procfs).
+//
+// The cache is bounded by maxSize. When full, new entries are discarded.
+//
+// The embedded high bit is safe because it would require hundreds of millions
+// of years of ticks since boot to be set by a real start time.
+type startTimeCache struct {
+	entries map[uint32]ticks
+	maxSize int
+}
+
+// Each entry is 16 bytes, so we'll spend at most roughly 16KiB on the cache
+// when full (though the actual memory usage will be higher due to map load
+// factors and internal overhead).
+const defaultStartTimeCacheSize = 1024
+
+const startTimeCacheSeenBit ticks = ticks(uint64(1) << 63)
+
+func makeStartTimeCache(maxSize int) startTimeCache {
+	return startTimeCache{
+		entries: make(map[uint32]ticks),
+		maxSize: maxSize,
+	}
+}
+
+func (c *startTimeCache) getStartTime(pid uint32) (ticks, bool) {
+	startTime, ok := c.entries[pid]
+	if !ok {
+		return 0, false
+	}
+	c.entries[pid] = startTime | startTimeCacheSeenBit
+	return startTime &^ startTimeCacheSeenBit, true
+}
+
+func (c *startTimeCache) insert(pid uint32, startTime ticks) {
+	if c.maxSize > 0 && len(c.entries) >= c.maxSize {
+		// Already full.
+		return
+	}
+	c.entries[pid] = startTime | startTimeCacheSeenBit
+}
+
+func (c *startTimeCache) sweep() {
+	for pid, startTime := range c.entries {
+		if startTime&startTimeCacheSeenBit != 0 {
+			c.entries[pid] = startTime &^ startTimeCacheSeenBit
+			continue
+		}
+		delete(c.entries, pid)
+	}
+}

--- a/pkg/dyninst/procsubscribe/procscan/start_time_cache_test.go
+++ b/pkg/dyninst/procsubscribe/procscan/start_time_cache_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procscan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartTimeCacheEvictsWhenFull(t *testing.T) {
+	cache := makeStartTimeCache(2)
+
+	cache.insert(1, ticks(10))
+	cache.insert(2, ticks(20))
+
+	// Cache is full, so inserting PID 3 is discarded.
+	cache.insert(3, ticks(30))
+	require.Len(t, cache.entries, 2)
+	_, ok := cache.entries[3]
+	require.False(t, ok)
+
+	v1, ok := cache.getStartTime(1)
+	require.True(t, ok)
+	require.Equal(t, ticks(10), v1)
+
+	v2, ok := cache.getStartTime(2)
+	require.True(t, ok)
+	require.Equal(t, ticks(20), v2)
+
+	// When full, insert is a no-op even for existing PIDs.
+	cache.insert(1, ticks(99))
+	v1, ok = cache.getStartTime(1)
+	require.True(t, ok)
+	require.Equal(t, ticks(10), v1)
+
+	v3, ok := cache.getStartTime(3)
+	require.False(t, ok)
+	require.Zero(t, v3)
+}
+
+func TestStartTimeCacheSweep(t *testing.T) {
+	cache := makeStartTimeCache(10)
+
+	// Insert PID 1 and clear its seen bit via sweep.
+	_, ok := cache.getStartTime(1)
+	require.False(t, ok)
+	cache.insert(1, ticks(1))
+	_, ok = cache.getStartTime(1)
+	require.True(t, ok)
+	cache.sweep()
+	_, ok = cache.entries[1]
+	require.True(t, ok)
+
+	// PID 2 is inserted without being seen in a scan, so sweep deletes it.
+	cache.entries[2] = ticks(2)
+	cache.sweep()
+	_, ok = cache.entries[2]
+	require.False(t, ok)
+}


### PR DESCRIPTION
### What does this PR do?

Cache the start time for processes (up to 1024) to making scanning procfs cheaper.

### Motivation

We see that reading these start times is the primary overhead of
the dyninst subsystem. We can trade a small amount of RAM to make
this scanning much cheaper (over 90% I suspect).

### Describe how you validated your changes

There's testing.

### Additional Notes

Fixes [DEBUG-4857](https://datadoghq.atlassian.net/browse/DEBUG-4857)

[DEBUG-4857]: https://datadoghq.atlassian.net/browse/DEBUG-4857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ