### PR TITLE
[dyninst/ebpf] Track length of captured slices/strings

### DIFF
--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -298,7 +298,12 @@ func (ce *captureEvent) init(
 			continue
 		}
 		key := typeAndAddr{irType: item.Type(), addr: item.Header().Address}
-		ce.dataItems[key] = item
+		// We may capture dynamically sized objects multiple times with different lengths.
+		// Here we just pick the most data we have, decoder will look at relevant prefix.
+		prev, exists := ce.dataItems[key]
+		if !exists || prev.Header().Length < item.Header().Length {
+			ce.dataItems[key] = item
+		}
 	}
 	if rootType == nil {
 		return errors.New("no root type found")

--- a/pkg/dyninst/ebpf/chased_pointers_trie.h
+++ b/pkg/dyninst/ebpf/chased_pointers_trie.h
@@ -1,5 +1,5 @@
-#ifndef __TRIE_H__
-#define __TRIE_H__
+#ifndef __CHASED_POINTERS_TRIE_H__
+#define __CHASED_POINTERS_TRIE_H__
 
 // The critbit trie stores sets of typed pointers: 64-bit address + 32-bit
 // type_id. Based on the patricia trie or djb's critbit trie but binpacked
@@ -173,8 +173,8 @@ __attribute__((always_inline)) static inline uint8_t clz64(uint64_t x) {
 }
 
 typedef enum chased_pointers_trie_insert_result {
-  CHASED_POINTERS_TRIE_EXISTS = 0,
-  CHASED_POINTERS_TRIE_SUCCESS = 1,
+  CHASED_POINTERS_TRIE_ALREADY_EXISTS = 0,
+  CHASED_POINTERS_TRIE_INSERTED = 1,
   CHASED_POINTERS_TRIE_FULL = 2,
   CHASED_POINTERS_TRIE_NULL = 3,
   CHASED_POINTERS_TRIE_ERROR = 4,
@@ -193,7 +193,7 @@ chased_pointers_trie_insert(
     trie->leaves[0].type_id = type_id;
     trie->len = 1;
     trie->root = 0 | CPT_LEAF_BIT; // Set root to point to first leaf
-    return CHASED_POINTERS_TRIE_SUCCESS;
+    return CHASED_POINTERS_TRIE_INSERTED;
   }
 
   // Traverse until we reach a leaf.
@@ -244,7 +244,7 @@ chased_pointers_trie_insert(
   } else if (diff_type_id) {
     crit_bit = 64 + 31 - clz32(diff_type_id);
   } else {
-    return CHASED_POINTERS_TRIE_EXISTS; // keys are identical
+    return CHASED_POINTERS_TRIE_ALREADY_EXISTS; // keys are identical
   }
 
   // Determine direction for new key at critical bit.
@@ -287,7 +287,7 @@ chased_pointers_trie_insert(
   } else {
     trie->nodes[parent & CPT_NODE_MASK].left = new_internal;
   }
-  return CHASED_POINTERS_TRIE_SUCCESS;
+  return CHASED_POINTERS_TRIE_INSERTED;
 }
 
 void chased_pointers_trie_clear(chased_pointers_trie_t* trie) {
@@ -335,4 +335,4 @@ static uint16_t chased_pointers_trie_len(chased_pointers_trie_t* trie) {
 }
 #endif
 
-#endif // __TRIE_H__
+#endif // __CHASED_POINTERS_TRIE_H__

--- a/pkg/dyninst/ebpf/chased_slices.h
+++ b/pkg/dyninst/ebpf/chased_slices.h
@@ -1,0 +1,49 @@
+#ifndef __CHASED_SLICES_H__
+#define __CHASED_SLICES_H__
+
+// Naive implementation of the visited set for strings and slices, using a
+// sequential array.
+
+#include "bpf_tracing.h"
+
+typedef struct chased_slice {
+  uint64_t addr;
+  uint32_t type_id;
+  uint32_t len;
+} chased_slice_t;
+
+#define MAX_CHASED_SLICES 128
+typedef struct chased_slices {
+  uint16_t len;
+  chased_slice_t slices[MAX_CHASED_SLICES];
+} chased_slices_t;
+
+void chased_slices_init(chased_slices_t* slices) {
+  slices->len = 0;
+}
+
+static bool chased_slices_push(chased_slices_t* slices, uint64_t addr, uint32_t type_id, uint32_t len) {
+  if (!slices) {
+    LOG(1, "chased_slices_push: null %lld %d %d\n", addr, type_id, len);
+    return false;
+  }
+  uint32_t slices_len = slices->len;
+  if (slices_len >= MAX_CHASED_SLICES) {
+    LOG(3, "chased_slices_push: full %lld %d %d\n", addr, type_id, len);
+    return false;
+  }
+  for (int32_t i = slices_len - 1; i >= 0; i--) {
+    if (slices->slices[i].addr == addr && slices->slices[i].type_id == type_id && slices->slices[i].len >= len) {
+      return false;
+    }
+  }
+  slices->slices[slices_len] = (chased_slice_t){
+      .addr = addr,
+      .type_id = type_id,
+      .len = len,
+  };
+  slices->len++;
+  return true;
+}
+
+#endif // __CHASED_SLICES_H__

--- a/pkg/dyninst/ebpf/context.h
+++ b/pkg/dyninst/ebpf/context.h
@@ -6,6 +6,7 @@
 #include "queue.h"
 #include "scratch.h"
 #include "chased_pointers_trie.h"
+#include "chased_slices.h"
 
 typedef uint32_t type_t;
 
@@ -50,6 +51,7 @@ typedef struct stack_machine {
 
   pointers_queue_t pointers_queue;
   chased_pointers_trie_t chased;
+  chased_slices_t chased_slices;
   // Remaining pointer chasing limit, given currently processed data item.
   // Maybe 0, in which case data might still be processed (i.e. interface type rewrite),
   // but no further pointers will be chased.
@@ -97,6 +99,7 @@ static stack_machine_t* stack_machine_ctx_load(const probe_params_t* probe_param
   stack_machine->pc_stack_pointer = 0;
   stack_machine->data_stack_pointer = 0;
   chased_pointers_trie_init(&stack_machine->chased);
+  chased_slices_init(&stack_machine->chased_slices);
   stack_machine->pointer_chasing_ttl = probe_params->pointer_chasing_limit;
   stack_machine->collection_size_limit = probe_params->collection_size_limit;
   stack_machine->string_size_limit = probe_params->string_size_limit;

--- a/pkg/dyninst/testdata/decoded/sample/testSubslices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubslices.json
@@ -85,9 +85,12 @@
                   {
                     "type": "uint",
                     "value": "2"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "3"
                   }
-                ],
-                "notCapturedReason": "collectionSize"
+                ]
               }
             }
           }
@@ -95,6 +98,6 @@
       }
     },
     "timestamp": "[ts]",
-    "message": "[1, 2], [1], [1, 2, ...]"
+    "message": "[1, 2], [1], [1, 2, 3]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
@@ -60,9 +60,7 @@
               },
               "c": {
                 "type": "string",
-                "size": "6",
-                "truncated": true,
-                "value": "abcd"
+                "value": "abcdef"
               }
             }
           }
@@ -70,6 +68,6 @@
       }
     },
     "timestamp": "[ts]",
-    "message": "abcd, ab, abcd..."
+    "message": "abcd, ab, abcdef"
   }
 ]


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/DEBUG-4821

When slice/string buffer is aliased with different lengths, we want to capture the longest one.

We track up to 128 slices/strings, same limit as we had before for all chased pointers.

We also track internal hmap/swissmap buffers this way, they are not expected to be aliased, but this is simpler.
