### PR TITLE
chore(WorkloadFilter): Use mapstructure.EnableStringUnmarshal for Configuration Option

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -245,7 +245,8 @@ new-e2e-containers:
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:22-04"
       - EXTRA_PARAMS: --run TestECSSuite
       - EXTRA_PARAMS: --run TestDockerSuite
-      - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS|Docker)Suite"
+      - EXTRA_PARAMS: --run "TestK8S(CEL|Legacy)FilteringSuite"
+      - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS|Docker|K8SCELFiltering|K8SLegacyFiltering)Suite"
 
 new-e2e-containers-eks-init:
   stage: e2e_init

--- a/comp/core/workloadfilter/catalog/filter_config.go
+++ b/comp/core/workloadfilter/catalog/filter_config.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/impl/parse"
@@ -131,19 +129,7 @@ func loadCELConfig(cfg config.Component) ([]workloadfilter.RuleBundle, error) {
 	var celConfig []workloadfilter.RuleBundle
 
 	// First try the standard UnmarshalKey method (input defined in datadog.yaml)
-	err := structure.UnmarshalKey(cfg, "cel_workload_exclude", &celConfig)
-	if err == nil {
-		return celConfig, nil
-	}
-
-	// Fallback: try to get raw value and unmarshal manually
-	rawValue := cfg.GetString("cel_workload_exclude")
-	if rawValue == "" {
-		return nil, nil
-	}
-
-	// handles both yaml and json input
-	err = yaml.Unmarshal([]byte(rawValue), &celConfig)
+	err := structure.UnmarshalKey(cfg, "cel_workload_exclude", &celConfig, structure.EnableStringUnmarshal)
 	if err == nil {
 		return celConfig, nil
 	}

--- a/comp/core/workloadfilter/catalog/filter_config_test.go
+++ b/comp/core/workloadfilter/catalog/filter_config_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestNewFilterConfig_CELFallback(t *testing.T) {
-	t.Run("successful unmarshal - no fallback needed", func(t *testing.T) {
+	// When configuration option is defined through datadog.yaml,
+	// the config component loads the value as an object.
+	t.Run("unmarshal cel workload exclude object", func(t *testing.T) {
 
 		mockConfig := configmock.New(t)
 
@@ -40,36 +42,9 @@ func TestNewFilterConfig_CELFallback(t *testing.T) {
 		assert.Contains(t, filterConfig.CELProductRules, workloadfilter.ProductMetrics)
 	})
 
-	t.Run("unmarshal fails but YAML string fallback succeeds", func(t *testing.T) {
-		mockConfig := configmock.New(t)
-
-		// Set up YAML string like what would come from configuration files
-		yamlConfig := `- products:
-  - metrics
-  rules:
-    kube_services:
-    - service.name == 'yaml-service'
-    pods:
-    - pod.namespace == 'yaml-ns'
-    containers:
-    - container.name == 'yaml-test'`
-		mockConfig.SetWithoutSource("cel_workload_exclude", yamlConfig)
-
-		filterConfig, err := NewFilterConfig(mockConfig)
-		require.NoError(t, err)
-		assert.NotNil(t, filterConfig)
-		assert.NotNil(t, filterConfig.CELProductRules)
-		assert.Contains(t, filterConfig.CELProductRules, workloadfilter.ProductMetrics)
-
-		containerRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ContainerType)
-		assert.Equal(t, "container.name == 'yaml-test'", containerRules)
-		podRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.PodType)
-		assert.Equal(t, "pod.namespace == 'yaml-ns'", podRules)
-		serviceRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ServiceType)
-		assert.Equal(t, "service.name == 'yaml-service'", serviceRules)
-	})
-
-	t.Run("unmarshal fails but JSON string fallback succeeds", func(t *testing.T) {
+	// When configuration option is defined through envvar,
+	// the config component loads the value as a string.
+	t.Run("unmarshal cel workload exclude JSON string", func(t *testing.T) {
 		mockConfig := configmock.New(t)
 		jsonConfig := `[
 			{
@@ -97,7 +72,7 @@ func TestNewFilterConfig_CELFallback(t *testing.T) {
 		assert.Equal(t, "service.name == 'test-service'", serviceRules)
 	})
 
-	t.Run("both unmarshal and fallback fail", func(t *testing.T) {
+	t.Run("unmarshal cel workload exclude invalid string", func(t *testing.T) {
 		mockConfig := configmock.New(t)
 		mockConfig.SetWithoutSource("cel_workload_exclude", "invalid string data")
 
@@ -106,7 +81,7 @@ func TestNewFilterConfig_CELFallback(t *testing.T) {
 		assert.Nil(t, filterConfig)
 	})
 
-	t.Run("no cel_workload_exclude config", func(t *testing.T) {
+	t.Run("unmarshal cel workload exclude empty config", func(t *testing.T) {
 		mockConfig := configmock.New(t)
 
 		filterConfig, err := NewFilterConfig(mockConfig)

--- a/test/new-e2e/tests/containers/fixtures/datadog-agent-cel-exclude.yml
+++ b/test/new-e2e/tests/containers/fixtures/datadog-agent-cel-exclude.yml
@@ -1,8 +1,16 @@
 datadog:
   envDict:
     DD_CEL_WORKLOAD_EXCLUDE: |-
-      - products: ["global"]
-        rules:
-          containers:
-          - container.name == "redis"
-          - container.pod.namespace == "filtered-ns"
+      [
+        {
+          "products": [
+            "global"
+          ],
+          "rules": {
+            "containers": [
+              "container.name == \"redis\"",
+              "container.pod.namespace == \"filtered-ns\""
+            ]
+          }
+        }
+      ]


### PR DESCRIPTION
### What does this PR do?

Update usage of config component to load in `cel_workload_exclude` configurations through environment variable definitions directly. No longer supports parsing of YAML environment variables. Backport #43906 

### Motivation

By default, the config component can't unmarshal envvar values. This configuration option allows the config component to properly read in environment variable values as strings to be loaded into the specified interfaces.

### Describe how you validated your changes

Unit Tests

Enforces usage of JSON input variable configuration instead of YAML.

### Additional Notes

(cherry picked from commit 8abfd8137da91fd50f012fdbb9cd871e2e9a7bf6)
