### PR TITLE
[e2e] Fix CNM flake of 1host test

### DIFF
--- a/test/new-e2e/tests/npm/common_1host.go
+++ b/test/new-e2e/tests/npm/common_1host.go
@@ -139,13 +139,18 @@ func test1HostFakeIntakeNPM600cnxBucket[Env any](v *e2e.BaseSuite[Env], FakeInta
 		})
 
 		hostPayloads := cnx.GetPayloadsByName(targetHostnameNetID)
-		lenHostPayloads := len(hostPayloads)
-		if !assert.Equalf(c, len(hostPayloads[lenHostPayloads-2].Connections), 600, "can't found enough connections 600+") {
-			return
-		}
+		lastTwoPayloads := hostPayloads[len(hostPayloads)-2:]
 
-		cnx600PayloadTime := hostPayloads[lenHostPayloads-2].GetCollectedTime()
-		latestPayloadTime := hostPayloads[lenHostPayloads-1].GetCollectedTime()
+		totalConnections := 0
+		// the last two should have 600+ connections. The benchmark is set to send 1500 connections,
+		// so if the connections check happens to occur exactly at the same time as the benchmark,
+		// one side or the other will have 600+ connections.
+		for _, payload := range lastTwoPayloads {
+			totalConnections += len(payload.Connections)
+		}
+		assert.GreaterOrEqualf(c, totalConnections, 600, "can't find enough connections 600+")
+		cnx600PayloadTime := lastTwoPayloads[0].GetCollectedTime()
+		latestPayloadTime := lastTwoPayloads[1].GetCollectedTime()
 
 		dt := latestPayloadTime.Sub(cnx600PayloadTime).Seconds()
 		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -154,7 +154,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM600cnxBucket_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("ab -n 1500 -c 1500 " + testURL)
+	v.Env().RemoteHost.MustExecute("ab -n 1500 -c 600 " + testURL)
 
 	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }
@@ -167,7 +167,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM600cnxBucket_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("docker run --rm ghcr.io/datadog/apps-npm-tools:" + apps.Version + " ab -n 1500 -c 1500 " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run --rm ghcr.io/datadog/apps-npm-tools:" + apps.Version + " ab -n 1500 -c 600 " + testURL)
 
 	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_test.go
@@ -154,7 +154,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM600cnxBucket_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("ab -n 600 -c 600 " + testURL)
+	v.Env().RemoteHost.MustExecute("ab -n 1500 -c 1500 " + testURL)
 
 	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }
@@ -167,7 +167,7 @@ func (v *ec2VMSuite) TestFakeIntakeNPM600cnxBucket_DockerRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("docker run --rm ghcr.io/datadog/apps-npm-tools:" + apps.Version + " ab -n 600 -c 600 " + testURL)
+	v.Env().RemoteHost.MustExecute("docker run --rm ghcr.io/datadog/apps-npm-tools:" + apps.Version + " ab -n 1500 -c 1500 " + testURL)
 
 	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_wkit_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_wkit_test.go
@@ -135,7 +135,7 @@ func (v *ec2VMWKitSuite) TestFakeIntakeNPM600cnxBucket_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("C:\\Users\\Administrator\\httpd\\Apache24\\bin\\ab.exe -n 600 -c 600 " + testURL)
+	v.Env().RemoteHost.MustExecute("C:\\Users\\Administrator\\httpd\\Apache24\\bin\\ab.exe -n 1500 -c 1500 " + testURL)
 
 	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_wkit_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_wkit_test.go
@@ -135,7 +135,7 @@ func (v *ec2VMWKitSuite) TestFakeIntakeNPM600cnxBucket_HostRequests() {
 	testURL := "http://" + v.Env().HTTPBinHost.Address + "/"
 
 	// generate connections
-	v.Env().RemoteHost.MustExecute("C:\\Users\\Administrator\\httpd\\Apache24\\bin\\ab.exe -n 1500 -c 1500 " + testURL)
+	v.Env().RemoteHost.MustExecute("C:\\Users\\Administrator\\httpd\\Apache24\\bin\\ab.exe -n 1500 -c 600 " + testURL)
 
 	test1HostFakeIntakeNPM600cnxBucket(&v.BaseSuite, v.Env().FakeIntake)
 }


### PR DESCRIPTION
### What does this PR do?
This PR (hopefully) fixes flakes that happen about 0.05% of the time with the 1host e2e tests. I think what's happening is, it expects to see 600+ connections, but tells `ab` to create exactly 600 connections, meaning if it's very unlucky, the connections check could run smack dab in the middle of `ab`, splitting each side (before vs after) into ~300 connections each. Then the test would fail.

### Motivation
Test flakes are bad

### Describe how you validated your changes
e2e tests should pass in CI