### PR TITLE
[CWS] do not follow inheritance of variables in status output

### DIFF
--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -239,7 +239,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 		switch v := v.(type) {
 		case string:
 			if rules.IsScopeVariable(k) {
-				variables[k] = eval.NewScopedStringVariable(func(_ *eval.Context) (string, bool) {
+				variables[k] = eval.NewScopedStringVariable(func(_ *eval.Context, _ bool) (string, bool) {
 					return v, true
 				}, nil)
 			} else {
@@ -253,7 +253,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 					values[i] = value.(string)
 				}
 				if rules.IsScopeVariable(k) {
-					variables[k] = eval.NewScopedStringArrayVariable(func(_ *eval.Context) ([]string, bool) {
+					variables[k] = eval.NewScopedStringArrayVariable(func(_ *eval.Context, _ bool) ([]string, bool) {
 						return values, true
 					}, nil)
 				} else {
@@ -270,7 +270,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 				}
 
 				if rules.IsScopeVariable(k) {
-					variables[k] = eval.NewScopedIntArrayVariable(func(_ *eval.Context) ([]int, bool) {
+					variables[k] = eval.NewScopedIntArrayVariable(func(_ *eval.Context, _ bool) ([]int, bool) {
 						return values, true
 					}, nil)
 				} else {
@@ -285,7 +285,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 				return nil, fmt.Errorf("failed to convert %s to int: %w", v, err)
 			}
 			if rules.IsScopeVariable(k) {
-				variables[k] = eval.NewScopedIntVariable(func(_ *eval.Context) (int, bool) {
+				variables[k] = eval.NewScopedIntVariable(func(_ *eval.Context, _ bool) (int, bool) {
 					return int(value), true
 				}, nil)
 			} else {
@@ -293,7 +293,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 			}
 		case bool:
 			if rules.IsScopeVariable(k) {
-				variables[k] = eval.NewScopedBoolVariable(func(_ *eval.Context) (bool, bool) {
+				variables[k] = eval.NewScopedBoolVariable(func(_ *eval.Context, _ bool) (bool, bool) {
 					return v, true
 				}, nil)
 			} else {

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -440,7 +440,7 @@ func (e *RuleEngine) fillCommonSECLVariables(rsVariables map[string]eval.SECLVar
 				})
 				defer preparator.put(ctx)
 
-				value, found := scopedVariable.GetValue(ctx)
+				value, found := scopedVariable.GetValue(ctx, true) // for status, let's not follow inheritance
 				if !found {
 					return
 				}

--- a/pkg/security/rules/engine_linux.go
+++ b/pkg/security/rules/engine_linux.go
@@ -51,7 +51,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 				})
 				defer preparator.put(ctx)
 
-				value, found := scopedVariable.GetValue(ctx)
+				value, found := scopedVariable.GetValue(ctx, true) // for status, let's not follow inheritance
 				if !found {
 					return
 				}
@@ -83,7 +83,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 				})
 				defer preparator.put(ctx)
 
-				value, found := scopedVariable.GetValue(ctx)
+				value, found := scopedVariable.GetValue(ctx, true) // for status, let's not follow inheritance
 				if !found {
 					return
 				}

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -30,10 +30,10 @@ func newOptsWithParams(constants map[string]interface{}, legacyFields map[Field]
 	}
 
 	variables := map[string]SECLVariable{
-		"pid": NewScopedIntVariable(func(_ *Context) (int, bool) {
+		"pid": NewScopedIntVariable(func(_ *Context, _ bool) (int, bool) {
 			return os.Getpid(), true
 		}, nil),
-		"str": NewScopedStringVariable(func(_ *Context) (string, bool) {
+		"str": NewScopedStringVariable(func(_ *Context, _ bool) (string, bool) {
 			return "aaa", true
 		}, nil),
 	}
@@ -502,7 +502,7 @@ func TestPartial(t *testing.T) {
 
 	variables := make(map[string]SECLVariable)
 	variables["var"] = NewScopedBoolVariable(
-		func(_ *Context) (bool, bool) {
+		func(_ *Context, _ bool) (bool, bool) {
 			return false, true
 		},
 		func(_ *Context, _ interface{}) error {

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -52,7 +52,7 @@ type Variable interface {
 
 // ScopedVariable is the interface implemented by scoped variables
 type ScopedVariable interface {
-	GetValue(ctx *Context) (interface{}, bool)
+	GetValue(ctx *Context, noFollowInheritance bool) (interface{}, bool)
 	IsMutable() bool
 }
 
@@ -106,26 +106,26 @@ func (v *settableVariable) SetVariableOpts(opts VariableOpts) {
 // ScopedIntVariable describes a scoped integer variable
 type ScopedIntVariable struct {
 	settableVariable
-	intFnc func(ctx *Context) (int, bool)
+	intFnc func(ctx *Context, noFollowInheritance bool) (int, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (i *ScopedIntVariable) GetEvaluator() interface{} {
 	return &IntEvaluator{
 		EvalFnc: func(ctx *Context) int {
-			i, _ := i.intFnc(ctx)
+			i, _ := i.intFnc(ctx, false)
 			return i
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (i *ScopedIntVariable) GetValue(ctx *Context) (interface{}, bool) {
-	return i.intFnc(ctx)
+func (i *ScopedIntVariable) GetValue(ctx *Context, noFollowInheritance bool) (interface{}, bool) {
+	return i.intFnc(ctx, noFollowInheritance)
 }
 
 // NewScopedIntVariable returns a new integer variable
-func NewScopedIntVariable(intFnc func(ctx *Context) (int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntVariable {
+func NewScopedIntVariable(intFnc func(ctx *Context, noFollowInheritance bool) (int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntVariable {
 	return &ScopedIntVariable{
 		settableVariable: settableVariable{
 			setFnc: setFnc,
@@ -140,7 +140,7 @@ func NewScopedIntVariable(intFnc func(ctx *Context) (int, bool), setFnc func(ctx
 // ScopedStringVariable describes a string variable
 type ScopedStringVariable struct {
 	settableVariable
-	strFnc func(ctx *Context) (string, bool)
+	strFnc func(ctx *Context, noFollowInheritance bool) (string, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
@@ -148,19 +148,19 @@ func (s *ScopedStringVariable) GetEvaluator() interface{} {
 	return &StringEvaluator{
 		ValueType: VariableValueType,
 		EvalFnc: func(ctx *Context) string {
-			v, _ := s.strFnc(ctx)
+			v, _ := s.strFnc(ctx, false)
 			return v
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (s *ScopedStringVariable) GetValue(ctx *Context) (interface{}, bool) {
-	return s.strFnc(ctx)
+func (s *ScopedStringVariable) GetValue(ctx *Context, noFollowInheritance bool) (interface{}, bool) {
+	return s.strFnc(ctx, noFollowInheritance)
 }
 
 // NewScopedStringVariable returns a new scoped string variable
-func NewScopedStringVariable(strFnc func(ctx *Context) (string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringVariable {
+func NewScopedStringVariable(strFnc func(ctx *Context, noFollowInheritance bool) (string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringVariable {
 	return &ScopedStringVariable{
 		strFnc: strFnc,
 		settableVariable: settableVariable{
@@ -175,26 +175,26 @@ func NewScopedStringVariable(strFnc func(ctx *Context) (string, bool), setFnc fu
 // ScopedBoolVariable describes a boolean variable
 type ScopedBoolVariable struct {
 	settableVariable
-	boolFnc func(ctx *Context) (bool, bool)
+	boolFnc func(ctx *Context, noFollowInheritance bool) (bool, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (b *ScopedBoolVariable) GetEvaluator() interface{} {
 	return &BoolEvaluator{
 		EvalFnc: func(ctx *Context) bool {
-			v, _ := b.boolFnc(ctx)
+			v, _ := b.boolFnc(ctx, false)
 			return v
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (b *ScopedBoolVariable) GetValue(ctx *Context) (interface{}, bool) {
-	return b.boolFnc(ctx)
+func (b *ScopedBoolVariable) GetValue(ctx *Context, noFollowInheritance bool) (interface{}, bool) {
+	return b.boolFnc(ctx, noFollowInheritance)
 }
 
 // NewScopedBoolVariable returns a new boolean variable
-func NewScopedBoolVariable(boolFnc func(ctx *Context) (bool, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedBoolVariable {
+func NewScopedBoolVariable(boolFnc func(ctx *Context, noFollowInheritance bool) (bool, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedBoolVariable {
 	return &ScopedBoolVariable{
 		boolFnc: boolFnc,
 		settableVariable: settableVariable{
@@ -209,26 +209,26 @@ func NewScopedBoolVariable(boolFnc func(ctx *Context) (bool, bool), setFnc func(
 // ScopedIPVariable describes a scoped IP variable
 type ScopedIPVariable struct {
 	settableVariable
-	ipFnc func(ctx *Context) (net.IPNet, bool)
+	ipFnc func(ctx *Context, noFollowInheritance bool) (net.IPNet, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (i *ScopedIPVariable) GetEvaluator() interface{} {
 	return &CIDREvaluator{
 		EvalFnc: func(ctx *Context) net.IPNet {
-			i, _ := i.ipFnc(ctx)
+			i, _ := i.ipFnc(ctx, false)
 			return i
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (i *ScopedIPVariable) GetValue(ctx *Context) (interface{}, bool) {
-	return i.ipFnc(ctx)
+func (i *ScopedIPVariable) GetValue(ctx *Context, noFollowInheritance bool) (interface{}, bool) {
+	return i.ipFnc(ctx, noFollowInheritance)
 }
 
 // NewScopedIPVariable returns a new scoped IP variable
-func NewScopedIPVariable(ipFnc func(ctx *Context) (net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIPVariable {
+func NewScopedIPVariable(ipFnc func(ctx *Context, noFollowInheritance bool) (net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIPVariable {
 	return &ScopedIPVariable{
 		ipFnc: ipFnc,
 		settableVariable: settableVariable{
@@ -243,22 +243,22 @@ func NewScopedIPVariable(ipFnc func(ctx *Context) (net.IPNet, bool), setFnc func
 // ScopedStringArrayVariable describes a scoped string array variable
 type ScopedStringArrayVariable struct {
 	settableVariable
-	strFnc func(ctx *Context) ([]string, bool)
+	strFnc func(ctx *Context, noFollowInheritance bool) ([]string, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (s *ScopedStringArrayVariable) GetEvaluator() interface{} {
 	return &StringArrayEvaluator{
 		EvalFnc: func(ctx *Context) []string {
-			v, _ := s.strFnc(ctx)
+			v, _ := s.strFnc(ctx, false)
 			return v
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (s *ScopedStringArrayVariable) GetValue(ctx *Context) (interface{}, bool) {
-	return s.strFnc(ctx)
+func (s *ScopedStringArrayVariable) GetValue(ctx *Context, noFollowInheritance bool) (interface{}, bool) {
+	return s.strFnc(ctx, noFollowInheritance)
 }
 
 // Set the array values
@@ -274,12 +274,12 @@ func (s *ScopedStringArrayVariable) Append(ctx *Context, value interface{}) erro
 	if val, ok := value.(string); ok {
 		value = []string{val}
 	}
-	values, _ := s.strFnc(ctx)
+	values, _ := s.strFnc(ctx, false)
 	return s.Set(ctx, append(values, value.([]string)...))
 }
 
 // NewScopedStringArrayVariable returns a new scoped string array variable
-func NewScopedStringArrayVariable(strFnc func(ctx *Context) ([]string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringArrayVariable {
+func NewScopedStringArrayVariable(strFnc func(ctx *Context, noFollowInheritance bool) ([]string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringArrayVariable {
 	return &ScopedStringArrayVariable{
 		strFnc: strFnc,
 		settableVariable: settableVariable{
@@ -294,22 +294,22 @@ func NewScopedStringArrayVariable(strFnc func(ctx *Context) ([]string, bool), se
 // ScopedIntArrayVariable describes a scoped integer array variable
 type ScopedIntArrayVariable struct {
 	settableVariable
-	intFnc func(ctx *Context) ([]int, bool)
+	intFnc func(ctx *Context, noFollowInheritance bool) ([]int, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (v *ScopedIntArrayVariable) GetEvaluator() interface{} {
 	return &IntArrayEvaluator{
 		EvalFnc: func(ctx *Context) []int {
-			s, _ := v.intFnc(ctx)
+			s, _ := v.intFnc(ctx, false)
 			return s
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (v *ScopedIntArrayVariable) GetValue(ctx *Context) (interface{}, bool) {
-	return v.intFnc(ctx)
+func (v *ScopedIntArrayVariable) GetValue(ctx *Context, noFollowInheritance bool) (interface{}, bool) {
+	return v.intFnc(ctx, noFollowInheritance)
 }
 
 // Set the array values
@@ -325,12 +325,12 @@ func (v *ScopedIntArrayVariable) Append(ctx *Context, value interface{}) error {
 	if val, ok := value.(int); ok {
 		value = []int{val}
 	}
-	values, _ := v.intFnc(ctx)
+	values, _ := v.intFnc(ctx, false)
 	return v.Set(ctx, append(values, value.([]int)...))
 }
 
 // NewScopedIntArrayVariable returns a new integer array variable
-func NewScopedIntArrayVariable(intFnc func(ctx *Context) ([]int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntArrayVariable {
+func NewScopedIntArrayVariable(intFnc func(ctx *Context, noFollowInheritance bool) ([]int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntArrayVariable {
 	return &ScopedIntArrayVariable{
 		intFnc: intFnc,
 		settableVariable: settableVariable{
@@ -345,22 +345,22 @@ func NewScopedIntArrayVariable(intFnc func(ctx *Context) ([]int, bool), setFnc f
 // ScopedIPArrayVariable describes a scoped IP array variable
 type ScopedIPArrayVariable struct {
 	settableVariable
-	ipFnc func(ctx *Context) ([]net.IPNet, bool)
+	ipFnc func(ctx *Context, noFollowInheritance bool) ([]net.IPNet, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (i *ScopedIPArrayVariable) GetEvaluator() interface{} {
 	return &CIDRArrayEvaluator{
 		EvalFnc: func(ctx *Context) []net.IPNet {
-			i, _ := i.ipFnc(ctx)
+			i, _ := i.ipFnc(ctx, false)
 			return i
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (i *ScopedIPArrayVariable) GetValue(ctx *Context) (interface{}, bool) {
-	return i.ipFnc(ctx)
+func (i *ScopedIPArrayVariable) GetValue(ctx *Context, noFollowInheritance bool) (interface{}, bool) {
+	return i.ipFnc(ctx, noFollowInheritance)
 }
 
 // Set the array values
@@ -376,12 +376,12 @@ func (i *ScopedIPArrayVariable) Append(ctx *Context, value interface{}) error {
 	if val, ok := value.(net.IPNet); ok {
 		value = []net.IPNet{val}
 	}
-	values, _ := i.ipFnc(ctx)
+	values, _ := i.ipFnc(ctx, false)
 	return i.Set(ctx, append(values, value.([]net.IPNet)...))
 }
 
 // NewScopedIPArrayVariable returns a new IP array variable
-func NewScopedIPArrayVariable(ipFnc func(ctx *Context) ([]net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIPArrayVariable {
+func NewScopedIPArrayVariable(ipFnc func(ctx *Context, noFollowInheritance bool) ([]net.IPNet, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIPArrayVariable {
 	return &ScopedIPArrayVariable{
 		ipFnc: ipFnc,
 		settableVariable: settableVariable{
@@ -1098,7 +1098,7 @@ func (v *ScopedVariables) Len() int {
 
 // NewSECLVariable returns new variable of the type of the specified value
 func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName string, opts VariableOpts) (SECLVariable, error) {
-	getVariable := func(ctx *Context) MutableSECLVariable {
+	getVariable := func(ctx *Context, noFollowInheritance bool) MutableSECLVariable {
 		v.varsLock.RLock()
 		defer v.varsLock.RUnlock()
 		scope := v.scoper(ctx)
@@ -1107,7 +1107,7 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 		}
 		key := scope.Hash()
 		vars := v.vars[key]
-		if (vars == nil || vars[name] == nil) && opts.Inherited {
+		if (vars == nil || vars[name] == nil) && opts.Inherited && !noFollowInheritance {
 			var ok bool
 			scope, ok = scope.ParentScope()
 			for vars == nil && ok {
@@ -1164,48 +1164,48 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 
 	switch value.(type) {
 	case int:
-		return NewScopedIntVariable(func(ctx *Context) (int, bool) {
-			if v := getVariable(ctx); v != nil {
+		return NewScopedIntVariable(func(ctx *Context, noFollowInheritance bool) (int, bool) {
+			if v := getVariable(ctx, noFollowInheritance); v != nil {
 				value, set := v.GetValue()
 				return value.(int), set
 			}
 			return 0, false
 		}, setVariable), nil
 	case bool:
-		return NewScopedBoolVariable(func(ctx *Context) (bool, bool) {
-			if v := getVariable(ctx); v != nil {
+		return NewScopedBoolVariable(func(ctx *Context, noFollowInheritance bool) (bool, bool) {
+			if v := getVariable(ctx, noFollowInheritance); v != nil {
 				value, set := v.GetValue()
 				return value.(bool), set
 			}
 			return false, false
 		}, setVariable), nil
 	case string:
-		return NewScopedStringVariable(func(ctx *Context) (string, bool) {
-			if v := getVariable(ctx); v != nil {
+		return NewScopedStringVariable(func(ctx *Context, noFollowInheritance bool) (string, bool) {
+			if v := getVariable(ctx, noFollowInheritance); v != nil {
 				value, set := v.GetValue()
 				return value.(string), set
 			}
 			return "", false
 		}, setVariable), nil
 	case net.IPNet:
-		return NewScopedIPVariable(func(ctx *Context) (net.IPNet, bool) {
-			if v := getVariable(ctx); v != nil {
+		return NewScopedIPVariable(func(ctx *Context, noFollowInheritance bool) (net.IPNet, bool) {
+			if v := getVariable(ctx, noFollowInheritance); v != nil {
 				value, set := v.GetValue()
 				return value.(net.IPNet), set
 			}
 			return net.IPNet{}, false
 		}, setVariable), nil
 	case []string:
-		return NewScopedStringArrayVariable(func(ctx *Context) ([]string, bool) {
-			if v := getVariable(ctx); v != nil {
+		return NewScopedStringArrayVariable(func(ctx *Context, noFollowInheritance bool) ([]string, bool) {
+			if v := getVariable(ctx, noFollowInheritance); v != nil {
 				value, set := v.GetValue()
 				return value.([]string), set
 			}
 			return nil, false
 		}, setVariable), nil
 	case []int:
-		return NewScopedIntArrayVariable(func(ctx *Context) ([]int, bool) {
-			if v := getVariable(ctx); v != nil {
+		return NewScopedIntArrayVariable(func(ctx *Context, noFollowInheritance bool) ([]int, bool) {
+			if v := getVariable(ctx, noFollowInheritance); v != nil {
 				value, set := v.GetValue()
 				return value.([]int), set
 			}
@@ -1213,8 +1213,8 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 
 		}, setVariable), nil
 	case []net.IPNet:
-		return NewScopedIPArrayVariable(func(ctx *Context) ([]net.IPNet, bool) {
-			if v := getVariable(ctx); v != nil {
+		return NewScopedIPArrayVariable(func(ctx *Context, noFollowInheritance bool) ([]net.IPNet, bool) {
+			if v := getVariable(ctx, noFollowInheritance); v != nil {
 				value, set := v.GetValue()
 				return value.([]net.IPNet), set
 			}

--- a/pkg/security/secl/model/variables.go
+++ b/pkg/security/secl/model/variables.go
@@ -14,14 +14,14 @@ import (
 var (
 	// SECLVariables set of variables
 	SECLVariables = map[string]eval.SECLVariable{
-		"process.pid": eval.NewScopedIntVariable(func(ctx *eval.Context) (int, bool) {
+		"process.pid": eval.NewScopedIntVariable(func(ctx *eval.Context, _ bool) (int, bool) {
 			pc := ctx.Event.(*Event).ProcessContext
 			if pc == nil {
 				return 0, false
 			}
 			return int(pc.Process.Pid), true
 		}, nil),
-		"builtins.uuid4": eval.NewScopedStringVariable(func(_ *eval.Context) (string, bool) {
+		"builtins.uuid4": eval.NewScopedStringVariable(func(_ *eval.Context, _ bool) (string, bool) {
 			return uuid.New().String(), true
 		}, nil),
 	}

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -458,7 +458,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 	stringArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
 	assert.NotNil(t, stringArrayScopedVar)
 	assert.True(t, ok)
-	value, _ = stringArrayScopedVar.GetValue(ctx)
+	value, _ = stringArrayScopedVar.GetValue(ctx, false)
 	assert.NotNil(t, value)
 	assert.Contains(t, value, "bar")
 	assert.IsType(t, value, []string{})
@@ -468,7 +468,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 	intArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
 	assert.NotNil(t, intArrayScopedVar)
 	assert.True(t, ok)
-	value, _ = intArrayScopedVar.GetValue(ctx)
+	value, _ = intArrayScopedVar.GetValue(ctx, false)
 	assert.NotNil(t, value)
 	assert.Contains(t, value, 123)
 	assert.IsType(t, value, []int{})
@@ -478,7 +478,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 	intVarScopedVar, ok := existingContainerScopedVariable.(eval.ScopedVariable)
 	assert.NotNil(t, intVarScopedVar)
 	assert.True(t, ok)
-	value, isSet := intVarScopedVar.GetValue(ctx)
+	value, isSet := intVarScopedVar.GetValue(ctx, false)
 	assert.True(t, isSet)
 	assert.NotNil(t, value)
 	assert.Equal(t, 456, value)
@@ -494,15 +494,15 @@ func TestActionSetVariableTTL(t *testing.T) {
 	assert.NotContains(t, value, 123)
 	assert.Len(t, value, 0)
 
-	value, _ = stringArrayScopedVar.GetValue(ctx)
+	value, _ = stringArrayScopedVar.GetValue(ctx, false)
 	assert.NotContains(t, value, "foo")
 	assert.Len(t, value, 0)
 
-	value, _ = intArrayScopedVar.GetValue(ctx)
+	value, _ = intArrayScopedVar.GetValue(ctx, false)
 	assert.NotContains(t, value, 123)
 	assert.Len(t, value, 0)
 
-	value, isSet = intVarScopedVar.GetValue(ctx)
+	value, isSet = intVarScopedVar.GetValue(ctx, false)
 	assert.False(t, isSet)
 	assert.Equal(t, 0, value)
 }
@@ -608,10 +608,10 @@ func TestActionSetVariableSize(t *testing.T) {
 
 	ctx := eval.NewContext(event)
 
-	_, set = stringArrayScopedVar.GetValue(ctx)
+	_, set = stringArrayScopedVar.GetValue(ctx, false)
 	assert.False(t, set)
 
-	_, set = intArrayScopedVar.GetValue(ctx)
+	_, set = intArrayScopedVar.GetValue(ctx, false)
 	assert.False(t, set)
 
 	if !rs.Evaluate(event) {
@@ -633,14 +633,14 @@ func TestActionSetVariableSize(t *testing.T) {
 	assert.Len(t, value, 1)
 	assert.True(t, set)
 
-	value, set = stringArrayScopedVar.GetValue(ctx)
+	value, set = stringArrayScopedVar.GetValue(ctx, false)
 	assert.NotNil(t, value)
 	assert.Contains(t, value, "bar")
 	assert.IsType(t, value, []string{})
 	assert.Len(t, value, 1)
 	assert.True(t, set)
 
-	value, set = intArrayScopedVar.GetValue(ctx)
+	value, set = intArrayScopedVar.GetValue(ctx, false)
 	assert.NotNil(t, value)
 	assert.Contains(t, value, 123)
 	assert.IsType(t, value, []int{})
@@ -701,7 +701,7 @@ func TestActionSetEmptyScope(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	value, set := stringArrayScopedVar.GetValue(ctx)
+	value, set := stringArrayScopedVar.GetValue(ctx, false)
 	assert.Nil(t, value)
 	assert.False(t, set)
 }
@@ -907,7 +907,7 @@ func TestActionSetVariableInherited(t *testing.T) {
 	assert.NotNil(t, stringScopedVar)
 	assert.True(t, ok)
 
-	value, set := stringScopedVar.GetValue(ctx)
+	value, set := stringScopedVar.GetValue(ctx, false)
 	assert.NotNil(t, value)
 	// TODO(lebauce): should be 123. default_value are not properly handled
 	assert.Equal(t, 0, value)
@@ -917,7 +917,7 @@ func TestActionSetVariableInherited(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	value, set = stringScopedVar.GetValue(ctx)
+	value, set = stringScopedVar.GetValue(ctx, false)
 	assert.NotNil(t, value)
 	assert.Equal(t, 456, value)
 	assert.True(t, set)
@@ -942,7 +942,7 @@ func TestActionSetVariableInherited(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	value, set = stringScopedVar.GetValue(ctx)
+	value, set = stringScopedVar.GetValue(ctx, false)
 	assert.NotNil(t, value)
 	assert.Equal(t, 1000, value)
 	assert.True(t, set)
@@ -1082,7 +1082,7 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	ctx := eval.NewContext(event)
 
 	// test correlation key initial value
-	correlationKeyValue, set := correlationKeyScopedVariable.GetValue(ctx)
+	correlationKeyValue, set := correlationKeyScopedVariable.GetValue(ctx, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, "", correlationKeyValue)
 	assert.False(t, set)
@@ -1091,12 +1091,12 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.True(t, strings.HasPrefix(correlationKeyValue.(string), "first_"))
 	assert.True(t, set)
 
-	parentCorrelationKeysValue, _ := parentCorrelationKeysScopedVariable.GetValue(ctx)
+	parentCorrelationKeysValue, _ := parentCorrelationKeysScopedVariable.GetValue(ctx, false)
 	assert.Equal(t, len(parentCorrelationKeysValue.([]string)), 0)
 
 	correlationKeyFromFirstRule := correlationKeyValue.(string)
@@ -1105,7 +1105,7 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	event2 := fakeOpenEvent("/tmp/first", 2, event.ProcessCacheEntry)
 	ctx = eval.NewContext(event2)
 
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
 	assert.True(t, set)
@@ -1114,12 +1114,12 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 		t.Errorf("Didn't expected event to match rule")
 	}
 
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
 	assert.True(t, set)
 
-	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx, false)
 	assert.Equal(t, len(parentCorrelationKeysValue.([]string)), 0)
 
 	// jump to the third rule, check:
@@ -1128,7 +1128,7 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	event3 := fakeOpenEvent("/tmp/third", 3, event2.ProcessCacheEntry)
 	ctx = eval.NewContext(event3)
 
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
 	assert.True(t, set)
@@ -1137,12 +1137,12 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 		t.Errorf("Expected event to match rule")
 	}
 
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.True(t, strings.HasPrefix(correlationKeyValue.(string), "third_"))
 	assert.True(t, set)
 
-	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx, false)
 	assert.True(t, len(parentCorrelationKeysValue.([]string)) == 1 && slices.Contains(parentCorrelationKeysValue.([]string), correlationKeyFromFirstRule))
 
 	correlationKeyFromThirdRule := correlationKeyValue.(string)
@@ -1151,7 +1151,7 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	event4 := fakeOpenEvent("/tmp/second", 4, event3.ProcessCacheEntry)
 	ctx = eval.NewContext(event4)
 
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, correlationKeyValue, correlationKeyFromThirdRule)
 	assert.True(t, set)
@@ -1160,12 +1160,12 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 		t.Errorf("Didn't expected event to match rule")
 	}
 
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, correlationKeyValue, correlationKeyFromThirdRule)
 	assert.True(t, set)
 
-	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx, false)
 	assert.True(t, len(parentCorrelationKeysValue.([]string)) == 1 && slices.Contains(parentCorrelationKeysValue.([]string), correlationKeyFromFirstRule))
 }
 
@@ -1352,13 +1352,13 @@ func TestActionSetVariableScopeField(t *testing.T) {
 	}
 
 	// check the correlation_key of the current process
-	correlationKeyValue, set := correlationKeyScopedVariable.GetValue(ctx1)
+	correlationKeyValue, set := correlationKeyScopedVariable.GetValue(ctx1, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, "cgroup_write_first", correlationKeyValue.(string))
 	assert.True(t, set)
 
 	// check the correlation key of the PID from the cgroup_write
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, "first", correlationKeyValue.(string))
 	assert.True(t, set)
@@ -1368,23 +1368,23 @@ func TestActionSetVariableScopeField(t *testing.T) {
 	}
 
 	// check the correlation_key of the current process
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx1)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx1, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, "cgroup_write_second", correlationKeyValue.(string))
 	assert.True(t, set)
 
 	// check the parent_correlation_keys of the current process
-	parentCorrelationKeysValue, _ := parentCorrelationKeysScopedVariable.GetValue(ctx1)
+	parentCorrelationKeysValue, _ := parentCorrelationKeysScopedVariable.GetValue(ctx1, false)
 	assert.Equal(t, []string{"cgroup_write_first"}, parentCorrelationKeysValue.([]string))
 
 	// check the correlation key of the PID from the cgroup_write
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, "second", correlationKeyValue.(string))
 	assert.True(t, set)
 
 	// check the parent_correlation_keys of the PID from the cgroup_write
-	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx3)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx3, false)
 	assert.Equal(t, []string{"first"}, parentCorrelationKeysValue.([]string))
 
 	if !rs.Evaluate(event3) {
@@ -1392,23 +1392,23 @@ func TestActionSetVariableScopeField(t *testing.T) {
 	}
 
 	// check the correlation_key of the current process
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx1)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx1, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, "cgroup_write_second", correlationKeyValue.(string))
 	assert.True(t, set)
 
 	// check the parent_correlation_keys of the current process
-	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx1)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx1, false)
 	assert.Equal(t, []string{"cgroup_write_first"}, parentCorrelationKeysValue.([]string))
 
 	// check the correlation key of the PID from the cgroup_write
-	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3)
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx3, false)
 	assert.NotNil(t, correlationKeyValue)
 	assert.Equal(t, "third", correlationKeyValue.(string))
 	assert.True(t, set)
 
 	// check the parent_correlation_keys of the PID from the cgroup_write
-	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx3)
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx3, false)
 	assert.ElementsMatch(t, []string{"first", "second"}, parentCorrelationKeysValue.([]string))
 }
 


### PR DESCRIPTION
### What does this PR do?

When displaying the value of each variables in status, we currently iterate on all PCEs to display process scoped variables. If a variable is inherited, we end up walking the whole ancestor tree, for each PCE. Quite wasteful. It's also not really needed, and creates a lot of noise in the status output.

This PR adds a boolean when querying the value, used to say "skip the inheritance part" and just get the direct value, and uses it for the status part.

### Motivation

### Describe how you validated your changes

### Additional Notes
