### PR TITLE
DJM Installer: workspace prefixed REDAPL resources

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -213,8 +213,9 @@ func setupCommonHostTags(s *common.Setup) {
 	if isJobCluster == "TRUE" && ok {
 		setHostTag(s, "dd.internal.resource:databricks_cluster", prefixWithWorkspace(normalizedWorkspace, jobID))
 	} else {
-		clusterID, _ := os.LookupEnv("DB_CLUSTER_ID")
-		setHostTag(s, "dd.internal.resource:databricks_cluster", prefixWithWorkspace(normalizedWorkspace, clusterID))
+		if clusterID, ok := os.LookupEnv("DB_CLUSTER_ID"); ok {
+			setHostTag(s, "dd.internal.resource:databricks_cluster", prefixWithWorkspace(normalizedWorkspace, clusterID))
+		}
 	}
 
 	addCustomHostTags(s)

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -255,9 +255,9 @@ func TestNormalizeTagValue(t *testing.T) {
 			expected: "example_workspace",
 		},
 		{
-			name:     "remove leading and trailing underscores and other special characters except for colons",
-			input:    "_!:_example_workspace!!",
-			expected: ":_example_workspace",
+			name:     "remove leading and trailing underscores and other special characters except for colons and slash",
+			input:    "_!:_/example_workspace!!",
+			expected: ":_/example_workspace",
 		},
 		{
 			name:     "remove leading digits",
@@ -265,9 +265,9 @@ func TestNormalizeTagValue(t *testing.T) {
 			expected: "workspace123",
 		},
 		{
-			name:     "allow  numbers if surrounded by alpha",
-			input:    "___123_workspace123workspace",
-			expected: "workspace123workspace",
+			name:     "allow  numbers if surrounded by alpha and non-ascii characters",
+			input:    "___123_workspàce123workspacé",
+			expected: "workspàce123workspacé",
 		},
 		{
 			name:     "truncate to 200 characters",

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -49,7 +49,7 @@ func TestSetupCommonHostTags(t *testing.T) {
 				"cluster_name:example_job_name",
 				"databricks_workspace:example_workspace",
 				"workspace:example_workspace",
-				"dd.internal.resource:databricks_cluster:cluster123",
+				"dd.internal.resource:databricks_cluster:example_workspace-cluster123",
 				"workspace_url:https://dbc-12345678-a1b2.cloud.databricks.com/",
 			},
 		},
@@ -57,14 +57,18 @@ func TestSetupCommonHostTags(t *testing.T) {
 			name: "with job, run ids but not job cluster",
 			env: map[string]string{
 				"DB_CLUSTER_NAME": "job-123-run-456",
+				"DB_CLUSTER_ID":   "cluster123",
 			},
 			wantTags: []string{
 				"data_workload_monitoring_trial:true",
 				"databricks_cluster_name:job-123-run-456",
 				"cluster_name:job-123-run-456",
+				"databricks_cluster_id:cluster123",
+				"cluster_id:cluster123",
 				"jobid:123",
 				"runid:456",
 				"dd.internal.resource:databricks_job:123",
+				"dd.internal.resource:databricks_cluster:cluster123",
 			},
 		},
 		{
@@ -114,7 +118,7 @@ func TestSetupCommonHostTags(t *testing.T) {
 				"cluster_name:example_job_name",
 				"databricks_workspace:\"example_workspace\"",
 				"workspace:example_workspace",
-				"dd.internal.resource:databricks_cluster:cluster123",
+				"dd.internal.resource:databricks_cluster:example_workspace-cluster123",
 			},
 		},
 		{
@@ -140,7 +144,7 @@ func TestSetupCommonHostTags(t *testing.T) {
 				"cluster_name:example_job_name",
 				"databricks_workspace:Example Workspace",
 				"workspace:example_workspace",
-				"dd.internal.resource:databricks_cluster:cluster123",
+				"dd.internal.resource:databricks_cluster:example_workspace-cluster123",
 			},
 		},
 		{

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -255,14 +255,19 @@ func TestNormalizeTagValue(t *testing.T) {
 			expected: "example_workspace",
 		},
 		{
-			name:     "remove leading and trailing underscores and colons",
-			input:    "_:_example_workspace!!",
-			expected: "example_workspace",
+			name:     "remove leading and trailing underscores and other special characters except for colons",
+			input:    "_!:_example_workspace!!",
+			expected: ":_example_workspace",
 		},
 		{
-			name:     "allow starting with numbers",
-			input:    "___123_workspace",
-			expected: "123_workspace",
+			name:     "remove leading digits",
+			input:    "___123_[]workspace123",
+			expected: "workspace123",
+		},
+		{
+			name:     "allow  numbers if surrounded by alpha",
+			input:    "___123_workspace123workspace",
+			expected: "workspace123workspace",
 		},
 		{
 			name:     "truncate to 200 characters",
@@ -278,7 +283,7 @@ func TestNormalizeTagValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeTagValue(tt.input)
+			result := normalizeWorkspaceName(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Write REDAPL resource tags with workspace name as prefix.

### Motivation

Changes to the Databricks crawler: https://github.com/DataDog/dogweb/pull/147650

### Describe how you validated your changes

### Additional Notes
