### PR TITLE
[CSPM] dbbenchs: second iteration, robustness and new capabilities

### DIFF
--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -11,9 +11,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/xml"
 	"fmt"
-	"io"
-	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,31 +32,6 @@ const (
 
 	mongoDBConfigPath = "/etc/mongod.conf"
 )
-
-func relPath(hostroot, configPath string) string {
-	if hostroot == "" {
-		return configPath
-	}
-	path, err := filepath.Rel(hostroot, configPath)
-	if err != nil {
-		path = configPath
-	}
-	return filepath.Join("/", path)
-}
-
-func readFileLimit(name string) ([]byte, error) {
-	f, err := os.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	r := io.LimitReader(f, maxFileSize)
-	b, err := io.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
-}
 
 // GetProcResourceType returns the type of database resource associated with
 // the given process.
@@ -113,10 +87,13 @@ func LoadDBResourceFromPID(ctx context.Context, pid int32) (*DBResource, bool) {
 	if !ok {
 		return nil, false
 	}
+	if !checkProcExe(proc) {
+		return nil, false
+	}
 
 	containerID, _ := utils.GetProcessContainerID(pid)
 	hostroot, ok := utils.GetProcessRootPath(pid)
-	if !ok {
+	if !ok || !filepath.IsAbs(hostroot) {
 		return nil, false
 	}
 
@@ -141,18 +118,17 @@ func LoadDBResourceFromPID(ctx context.Context, pid int32) (*DBResource, bool) {
 	}, true
 }
 
+func checkProcExe(proc *process.Process) bool {
+	name, _ := proc.Name()
+	exe, _ := proc.Exe()
+	return name == filepath.Base(exe)
+}
+
 // LoadMongoDBConfig loads and extracts the MongoDB configuration data found
 // on the system.
 func LoadMongoDBConfig(ctx context.Context, hostroot string, proc *process.Process) (*DBConfig, bool) {
 	configLocalPath := mongoDBConfigPath
-	var result DBConfig
-	result.ProcessUser, _ = proc.UsernameWithContext(ctx)
-	result.ProcessName, _ = proc.NameWithContext(ctx)
-	if result.ProcessUser == "" {
-		if uids, _ := proc.UidsWithContext(ctx); len(uids) > 0 {
-			result.ProcessUser = fmt.Sprintf("uid:%d", uids[0]) // RUID
-		}
-	}
+	result := newDBConfig(ctx, proc)
 	cmdline, _ := proc.CmdlineSlice()
 	for i, arg := range cmdline {
 		if arg == "--config" && i+1 < len(cmdline) {
@@ -171,81 +147,65 @@ func LoadMongoDBConfig(ctx context.Context, hostroot string, proc *process.Proce
 		}
 	})
 
-	configPath := filepath.Join(hostroot, configLocalPath)
-	fi, err := os.Stat(configPath)
-	if err != nil || fi.IsDir() {
-		result.ConfigFileUser = "<none>"
-		result.ConfigFileGroup = "<none>"
-		result.ConfigData = map[string]interface{}{}
-		return &result, true
-	}
-
-	var configData mongoDBConfig
-	result.ConfigFileUser = utils.GetFileUser(fi)
-	result.ConfigFileGroup = utils.GetFileGroup(fi)
-	result.ConfigFileMode = uint32(fi.Mode())
-	result.ConfigFilePath = relPath(hostroot, configPath)
-	configRaw, err := readFileLimit(configPath)
+	root, err := os.OpenRoot(hostroot)
 	if err != nil {
 		return nil, false
 	}
+	defer root.Close()
+
+	configRaw, fi, err := utils.ReadProcessFileLimit(proc, root, configLocalPath, maxFileSize)
+	if err != nil {
+		return nil, false
+	}
+	var configData mongoDBConfig
 	if err := yaml.Unmarshal(configRaw, &configData); err != nil {
 		return nil, false
 	}
-	result.ConfigData = &configData
+	setConfigFileMetadata(&result, fi, configLocalPath, &configData)
 	return &result, true
 }
 
 // LoadCassandraConfig loads and extracts the Cassandra configuration data
 // found on the system.
 func LoadCassandraConfig(ctx context.Context, hostroot string, proc *process.Process) (*DBConfig, bool) {
-	var result DBConfig
-	if proc != nil {
-		result.ProcessUser, _ = proc.UsernameWithContext(ctx)
-		result.ProcessName, _ = proc.NameWithContext(ctx)
-	}
-
+	result := newDBConfig(ctx, proc)
 	var configData *cassandraDBConfig
-	matches, _ := filepath.Glob(filepath.Join(hostroot, cassandraConfigGlob))
+	root, err := os.OpenRoot(hostroot)
+	if err != nil {
+		return nil, false
+	}
+	defer root.Close()
+	matches := utils.RootedGlob(hostroot, cassandraConfigGlob)
 	for _, configPath := range matches {
-		fi, err := os.Stat(configPath)
-		if err != nil || fi.IsDir() {
-			continue
-		}
-		result.ConfigFileUser = utils.GetFileUser(fi)
-		result.ConfigFileGroup = utils.GetFileGroup(fi)
-		result.ConfigFileMode = uint32(fi.Mode())
-		result.ConfigFilePath = relPath(hostroot, configPath)
-		configRaw, err := readFileLimit(configPath)
+		configRaw, fi, err := utils.ReadProcessFileLimit(proc, root, configPath, maxFileSize)
 		if err != nil {
 			continue
 		}
 		if err := yaml.Unmarshal(configRaw, &configData); err == nil {
+			setConfigFileMetadata(&result, fi, configPath, configData)
 			break
 		}
 	}
-
 	if configData == nil {
 		return nil, false
 	}
-
-	logback, err := readFileLimit(filepath.Join(hostroot, cassandraLogbackPath))
+	logbackRaw, _, err := utils.ReadProcessFileLimit(proc, root, cassandraLogbackPath, maxFileSize)
 	if err == nil {
 		configData.LogbackFilePath = cassandraLogbackPath
-		configData.LogbackFileContent = string(logback)
+		var logbackConfig cassandraLogback
+		if err := xml.Unmarshal(logbackRaw, &logbackConfig); err == nil {
+			configData.Logback = &logbackConfig
+		}
 	}
-	result.ConfigData = configData
 	return &result, true
 }
 
 // LoadPostgreSQLConfig loads and extracts the PostgreSQL configuration data found on the system.
 func LoadPostgreSQLConfig(ctx context.Context, hostroot string, proc *process.Process) (*DBConfig, bool) {
-	var result DBConfig
+	result := newDBConfig(ctx, proc)
 
 	// Let's try to parse the -D command line argument containing the data
 	// directory of PG. Configuration file may be located in this directory.
-	result.ProcessUser, _ = proc.UsernameWithContext(ctx)
-	result.ProcessName, _ = proc.NameWithContext(ctx)
 
 	var hintPath string
 	cmdline, _ := proc.CmdlineSlice()
@@ -264,31 +224,78 @@ func LoadPostgreSQLConfig(ctx context.Context, hostroot string, proc *process.Pr
 		}
 	}
 
-	configPath, ok := locatePGConfigFile(hostroot, hintPath)
-	if !ok {
-		// postgres can be setup without a configuration file.
-		result.ConfigFileUser = "<none>"
-		result.ConfigFileGroup = "<none>"
-		result.ConfigData = map[string]interface{}{}
-		return &result, true
-	}
-	fi, err := os.Stat(filepath.Join(hostroot, configPath))
-	if err != nil || fi.IsDir() {
+	root, err := os.OpenRoot(hostroot)
+	if err != nil {
 		return nil, false
 	}
-	result.ConfigFileUser = utils.GetFileUser(fi)
-	result.ConfigFileGroup = utils.GetFileGroup(fi)
-	result.ConfigFileMode = uint32(fi.Mode())
-	result.ConfigFilePath = configPath
-	configData, ok := parsePGConfig(hostroot, configPath, 0)
-	if ok {
+	defer root.Close()
+
+	configData := make(map[string]string)
+	parseCmdline := func(configData map[string]string) {
+		foreachFlags(cmdline, func(k, v string) {
+			if name, ok := strings.CutPrefix(k, "--"); ok {
+				if _, ok := postgresKnownConfigKeys[name]; ok {
+					configData[name] = v
+				}
+			}
+		})
+	}
+
+	configPath, ok := locatePGConfigFile(root, proc, hintPath)
+	if !ok {
+		// postgres can be setup without a configuration file.
+		parseCmdline(configData)
 		result.ConfigData = configData
 		return &result, true
 	}
-	return nil, false
+	fi, ok := parsePGConfig(proc, root, configPath, configData, 0)
+	if !ok {
+		return nil, false
+	}
+	parseCmdline(configData)
+	setConfigFileMetadata(&result, fi, configPath, configData)
+	return &result, true
 }
 
-func locatePGConfigFile(hostroot, hintPath string) (string, bool) {
+func newDBConfig(ctx context.Context, proc *process.Process) DBConfig {
+	user, _ := proc.UsernameWithContext(ctx)
+	name, _ := proc.NameWithContext(ctx)
+	if user == "" {
+		if uids, _ := proc.UidsWithContext(ctx); len(uids) > 0 {
+			user = fmt.Sprintf("uid:%d", uids[0]) // RUID
+		}
+	}
+	if user == "" {
+		user = "<unknown>"
+	}
+	if name == "" {
+		name = "<unknown>"
+	}
+	return DBConfig{
+		ProcessUser: user,
+		ProcessName: name,
+	}
+}
+
+func setConfigFileMetadata(dbconfig *DBConfig, fi os.FileInfo, configPath string, configData interface{}) {
+	fileUser := utils.GetFileUser(fi)
+	fileGroup := utils.GetFileGroup(fi)
+	fileMode := uint32(fi.Mode())
+	dbconfig.ConfigFileUser = fileUser
+	dbconfig.ConfigFileGroup = fileGroup
+	dbconfig.ConfigFileMode = fileMode
+	dbconfig.ConfigFilePath = configPath
+	dbconfig.ConfigData = configData
+}
+
+func locatePGConfigFile(root *os.Root, proc *process.Process, hintPath string) (string, bool) {
+	if hintPath != "" {
+		if !filepath.IsAbs(hintPath) {
+			cwd, _ := proc.Cwd()
+			hintPath = filepath.Join(cwd, hintPath)
+		}
+		return hintPath, true
+	}
 	var pgConfigGlobs = []string{
 		"/etc/postgresql/postgresql.conf",
 		"/etc/postgresql/*/*/postgresql.conf",
@@ -296,13 +303,10 @@ func locatePGConfigFile(hostroot, hintPath string) (string, bool) {
 		"/var/lib/pgsql/data/postgresql.conf",
 		"/var/lib/postgresql/*/data/postgresql.conf",
 	}
-	if hintPath != "" {
-		pgConfigGlobs = append([]string{hintPath}, pgConfigGlobs...)
-	}
 	for _, pattern := range pgConfigGlobs {
-		files, _ := filepath.Glob(filepath.Join(hostroot, pattern))
+		files := utils.RootedGlob(root.Name(), pattern)
 		if len(files) > 0 {
-			return relPath(hostroot, files[0]), true
+			return files[0], true
 		}
 	}
 	return "", false
@@ -317,23 +321,22 @@ func locatePGConfigFile(hostroot, hintPath string) (string, bool) {
 // references:
 //   - https://www.postgresql.org/docs/current/config-setting.html
 //   - https://github.com/postgres/postgres/blob/5abbd97fef6f18eef91bfed7d2057c39bd204702/src/backend/utils/misc/guc-file.l#L317-L349
-func parsePGConfig(hostroot, configPath string, includeDepth int) (map[string]interface{}, bool) {
+func parsePGConfig(proc *process.Process, root *os.Root, configPath string, config map[string]string, includeDepth int) (os.FileInfo, bool) {
+	if filepath.Ext(configPath) != ".conf" {
+		return nil, false
+	}
+
 	// Let's protect ourselves from circular "includes" by limiting the number
 	//	of possible include to 10. This is the same parameter as postgresql:
 	//	https://github.com/postgres/postgres/blob/5abbd97fef6f18eef91bfed7d2057c39bd204702/src/include/utils/conffiles.h#L18
 	if includeDepth > 10 {
 		return nil, false
 	}
-	if configPath == "" {
-		return nil, false
-	}
 
-	b, err := readFileLimit(filepath.Join(hostroot, configPath))
+	b, fi, err := utils.ReadProcessFileLimit(proc, root, configPath, maxFileSize)
 	if err != nil {
 		return nil, false
 	}
-
-	config := make(map[string]interface{})
 
 	s := bufio.NewScanner(bytes.NewReader(b))
 	s.Split(bufio.ScanLines)
@@ -349,40 +352,35 @@ func parsePGConfig(hostroot, configPath string, includeDepth int) (map[string]in
 				if !filepath.IsAbs(includedPath) {
 					includedPath = filepath.Join(filepath.Dir(configPath), includedPath)
 				}
-				included, ok := parsePGConfig(hostroot, includedPath, includeDepth+1)
-				if ok {
-					maps.Copy(config, included)
-				}
+				_, _ = parsePGConfig(proc, root, includedPath, config, includeDepth+1)
 			} else if key == "include_dir" {
 				includedPath := val
 				if !filepath.IsAbs(includedPath) {
 					includedPath = filepath.Join(filepath.Dir(configPath), includedPath)
 				}
-				glob := filepath.Join(hostroot, includedPath, "*.conf")
-				matches, _ := filepath.Glob(glob)
-				for _, match := range matches {
-					includedFile := relPath(hostroot, match)
-					included, ok := parsePGConfig(hostroot, includedFile, includeDepth+1)
-					if ok {
-						maps.Copy(config, included)
-					}
+				glob := filepath.Join(includedPath, "*.conf")
+				matches := utils.RootedGlob(root.Name(), glob)
+				for _, includedPath := range matches {
+					_, _ = parsePGConfig(proc, root, includedPath, config, includeDepth+1)
 				}
 			} else {
 				if val == "=" { // skip optional equal token
 					val, _ = t.next()
 				}
-				if val == "on" || val == "true" || val == "yes" {
-					config[key] = "on"
-				} else if val == "off" || val == "false" || val == "no" {
-					config[key] = "off"
-				} else {
-					config[key] = val
+				if _, ok := postgresKnownConfigKeys[key]; ok {
+					if val == "on" || val == "true" || val == "yes" {
+						config[key] = "on"
+					} else if val == "off" || val == "false" || val == "no" {
+						config[key] = "off"
+					} else {
+						config[key] = val
+					}
 				}
 			}
 		}
 	}
 
-	return config, true
+	return fi, true
 }
 
 // Simple ASCII lexer for postgresql configuration files (aka. GUC)
@@ -512,7 +510,7 @@ func foreachFlags(cmdline []string, f func(k, v string)) {
 				f(parts[0], "")
 				pendingFlagValue = true
 			}
-		} else {
+		} else if arg != "--" {
 			if pendingFlagValue {
 				pendingFlagValue = false
 				f(cmdline[i-1], arg)

--- a/pkg/compliance/dbconfig/types.go
+++ b/pkg/compliance/dbconfig/types.go
@@ -5,7 +5,11 @@
 
 package dbconfig
 
-import "github.com/DataDog/datadog-agent/pkg/compliance/types"
+import (
+	"encoding/xml"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/types"
+)
 
 // DBResource holds a database configuration data and the resource type
 // associated with it.
@@ -231,11 +235,11 @@ type mongoDBConfig struct {
 }
 
 type cassandraDBConfig struct {
-	Authenticator           string `yaml:"authenticator" json:"authenticator"`
-	LogbackFilePath         string `yaml:"logback_file_path" json:"logback_file_path"`
-	LogbackFileContent      string `yaml:"logback_file_content" json:"logback_file_content"`
-	Authorizer              string `yaml:"authorizer" json:"authorizer"`
-	ListenAddress           string `yaml:"listen_address" json:"listen_address"`
+	Authenticator           string            `yaml:"authenticator" json:"authenticator"`
+	LogbackFilePath         string            `yaml:"logback_file_path" json:"logback_file_path"`
+	Logback                 *cassandraLogback `yaml:"logback_filter" json:"logback_filter"`
+	Authorizer              string            `yaml:"authorizer" json:"authorizer"`
+	ListenAddress           string            `yaml:"listen_address" json:"listen_address"`
 	ClientEncryptionOptions struct {
 		Enabled  bool `yaml:"enabled" json:"enabled"`
 		Optional bool `yaml:"optional" json:"optional"`
@@ -243,4 +247,125 @@ type cassandraDBConfig struct {
 	ServerEncryptionOptions struct {
 		InternodeEncryption string `yaml:"internode_encryption" json:"internode_encryption"`
 	} `yaml:"server_encryption_options" json:"server_encryption_options"`
+}
+
+type cassandraLogback struct {
+	XMLName   xml.Name `xml:"configuration"`
+	Appenders []struct {
+		Name  string `xml:"name,attr"`
+		Class string `xml:"class,attr"`
+	} `xml:"appender"`
+	Loggers []struct {
+		Name         string `xml:"name,attr"`
+		Level        string `xml:"level,attr"`
+		Additivity   string `xml:"additivity,attr,omitempty"`
+		AppenderRefs []struct {
+			Ref string `xml:"ref,attr"`
+		} `xml:"appender-ref"`
+	} `xml:"logger"`
+	Root struct {
+		Level        string `xml:"level,attr"`
+		AppenderRefs []struct {
+			Ref string `xml:"ref,attr"`
+		} `xml:"appender-ref"`
+	} `xml:"root"`
+}
+
+var postgresKnownConfigKeys = map[string]struct{}{
+	"archive_command":                     {},
+	"archive_mode":                        {},
+	"archive_timeout":                     {},
+	"autovacuum":                          {},
+	"autovacuum_analyze_scale_factor":     {},
+	"autovacuum_max_workers":              {},
+	"autovacuum_naptime":                  {},
+	"autovacuum_vacuum_cost_delay":        {},
+	"autovacuum_vacuum_cost_limit":        {},
+	"autovacuum_vacuum_scale_factor":      {},
+	"checkpoint_timeout":                  {},
+	"cluster_name":                        {},
+	"debug_pretty_print":                  {},
+	"debug_print_parse":                   {},
+	"debug_print_plan":                    {},
+	"debug_print_rewritten":               {},
+	"default_statistics_target":           {},
+	"dynamic_shared_memory_type":          {},
+	"effective_cache_size":                {},
+	"effective_io_concurrency":            {},
+	"fsync":                               {},
+	"hba_file":                            {},
+	"hot_standby":                         {},
+	"hot_standby_feedback":                {},
+	"ident_file":                          {},
+	"idle_in_transaction_session_timeout": {},
+	"idle_session_timeout":                {},
+	"ignore_system_indexes":               {},
+	"jit_debugging_support":               {},
+	"jit_profiling_support":               {},
+	"listen_addresses":                    {},
+	"log_autovacuum_min_duration":         {},
+	"log_checkpoints":                     {},
+	"log_connections":                     {},
+	"log_destination":                     {},
+	"log_directory":                       {},
+	"log_disconnections":                  {},
+	"log_error_verbosity":                 {},
+	"log_file_mode":                       {},
+	"log_filename":                        {},
+	"log_hostname":                        {},
+	"log_line_prefix":                     {},
+	"log_lock_waits":                      {},
+	"log_min_duration_sample":             {},
+	"log_min_error_statement":             {},
+	"log_min_messages":                    {},
+	"log_rotation_age":                    {},
+	"log_rotation_size":                   {},
+	"log_statement":                       {},
+	"log_statement_sample_rate":           {},
+	"log_timezone":                        {},
+	"log_truncate_on_rotation":            {},
+	"logging_collector":                   {},
+	"maintenance_work_mem":                {},
+	"max_connections":                     {},
+	"max_locks_per_transaction":           {},
+	"max_parallel_workers":                {},
+	"max_prepared_transactions":           {},
+	"max_replication_slots":               {},
+	"max_wal_senders":                     {},
+	"max_wal_size":                        {},
+	"max_worker_processes":                {},
+	"password_encryption":                 {},
+	"pg_stat_statements.max":              {},
+	"pg_stat_statements.track":            {},
+	"pg_stat_statements.track_utility":    {},
+	"port":                                {},
+	"post_auth_delay":                     {},
+	"random_page_cost":                    {},
+	"seq_page_cost":                       {},
+	"shared_buffers":                      {},
+	"shared_preload_libraries":            {},
+	"ssl":                                 {},
+	"ssl_ca_file":                         {},
+	"ssl_cert_file":                       {},
+	"ssl_ciphers":                         {},
+	"ssl_key_file":                        {},
+	"ssl_min_protocol_version":            {},
+	"statement_timeout":                   {},
+	"syslog_facility":                     {},
+	"syslog_ident":                        {},
+	"syslog_sequence_numbers":             {},
+	"syslog_split_messages":               {},
+	"tcp_keepalives_idle":                 {},
+	"tcp_keepalives_interval":             {},
+	"track_activities":                    {},
+	"track_activity_query_size":           {},
+	"track_commit_timestamp":              {},
+	"track_functions":                     {},
+	"track_io_timing":                     {},
+	"wal_buffers":                         {},
+	"wal_compression":                     {},
+	"wal_keep_size":                       {},
+	"wal_level":                           {},
+	"wal_log_hints":                       {},
+	"work_mem":                            {},
 }

--- a/pkg/compliance/utils/inputs_files.go
+++ b/pkg/compliance/utils/inputs_files.go
@@ -9,6 +9,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"strconv"
@@ -22,6 +23,7 @@ func GetFileUser(fi os.FileInfo) string {
 		if user, err := user.LookupId(u); err == nil {
 			return user.Username
 		}
+		return fmt.Sprintf("uid:%d", statt.Uid)
 	}
 	return ""
 }
@@ -33,6 +35,7 @@ func GetFileGroup(fi os.FileInfo) string {
 		if group, err := user.LookupGroupId(g); err == nil {
 			return group.Name
 		}
+		return fmt.Sprintf("gid:%d", statt.Gid)
 	}
 	return ""
 }

--- a/pkg/compliance/utils/proc_check_perms_nounix.go
+++ b/pkg/compliance/utils/proc_check_perms_nounix.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package utils
+
+import "os"
+
+func checkFilePermissions(_ os.FileInfo, _, _ []uint32) error {
+	return nil
+}

--- a/pkg/compliance/utils/proc_check_perms_unix.go
+++ b/pkg/compliance/utils/proc_check_perms_unix.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func checkFilePermissions(fi os.FileInfo, uids, gids []uint32) error {
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("failed to get file info")
+	}
+	perms := fi.Mode().Perm()
+	euid := uids[1] // effective UID
+	egid := gids[1] // effective GID
+	fileUID := stat.Uid
+	fileGID := stat.Gid
+	canRead := false
+	if fileUID == 0 && perms&0004 == 0 {
+		canRead = false // do not allow to read non world-readable files owned by root
+	} else if euid == 0 {
+		canRead = true
+	} else if fileUID == euid {
+		canRead = perms&0400 != 0
+	} else if fileGID == egid {
+		canRead = perms&0040 != 0 // NOTE: does not check supplementary groups
+	} else {
+		canRead = perms&0004 != 0
+	}
+	if !canRead {
+		return fmt.Errorf(
+			"file %s is not readable by process (euid=%d, egid=%d, file_uid=%d, file_gid=%d, perms=%04o)",
+			fi.Name(), euid, egid, fileUID, fileGID, perms,
+		)
+	}
+	return nil
+}

--- a/pkg/compliance/utils/proc_read_file.go
+++ b/pkg/compliance/utils/proc_read_file.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Process interface {
+	Uids() ([]uint32, error)
+	Gids() ([]uint32, error)
+}
+
+// ReadProcessFileLimit reads a file from a process's file system. It will
+// resolve it using the provided *os.Root, and check that the file is properly
+// accessible by the process.
+func ReadProcessFileLimit(proc Process, root *os.Root, name string, maxFileSize int64) ([]byte, os.FileInfo, error) {
+	name = filepath.Clean(name)
+	if filepath.IsAbs(name) {
+		// when receiving an absolute path, we consider it as relative to the root
+		name = strings.TrimPrefix(name, string(os.PathSeparator))
+	}
+	uids, err := proc.Uids()
+	if err != nil {
+		return nil, nil, err
+	}
+	gids, err := proc.Gids()
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(uids) < 2 || len(gids) < 2 {
+		return nil, nil, errors.New("invalid process IDs")
+	}
+	f, err := root.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	if fi.IsDir() {
+		return nil, nil, fmt.Errorf("file %s is a directory", f.Name())
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("file %s is not a regular file", f.Name())
+	}
+	isExecutable := fi.Mode().Perm()&0111 > 0
+	if isExecutable {
+		return nil, nil, fmt.Errorf("file %s is executable", f.Name())
+	}
+	if err := checkFilePermissions(fi, uids, gids); err != nil {
+		return nil, nil, err
+	}
+	r := io.LimitReader(f, maxFileSize)
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return b, fi, nil
+}
+
+func RootedGlob(hostroot string, glob string) []string {
+	glob = filepath.Clean(glob)
+	if !filepath.IsAbs(glob) && glob != "" {
+		return nil
+	}
+	path := filepath.Join(hostroot, glob)
+	matches, _ := filepath.Glob(path)
+	var allMatches []string
+	for _, m := range matches {
+		if m, ok := strings.CutPrefix(m, hostroot); ok && m != "" {
+			allMatches = append(allMatches, m)
+		}
+	}
+	return allMatches
+}

--- a/pkg/compliance/utils/proc_read_file_test.go
+++ b/pkg/compliance/utils/proc_read_file_test.go
@@ -1,0 +1,423 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockProcess struct {
+	uids []uint32
+	gids []uint32
+	err  error
+}
+
+func (m *mockProcess) Uids() ([]uint32, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.uids, nil
+}
+
+func (m *mockProcess) Gids() ([]uint32, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.gids, nil
+}
+
+func newMockProcess(uid, gid uint32) *mockProcess {
+	return &mockProcess{
+		uids: []uint32{uid, uid, uid},
+		gids: []uint32{gid, gid, gid},
+	}
+}
+
+func TestReadProcessFileLimit(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test requires root privileges to chown files")
+	}
+
+	tempDir := t.TempDir()
+	root, err := os.OpenRoot(tempDir)
+	require.NoError(t, err)
+
+	// Use non-root UIDs for testing to avoid the root-owned security policy
+	testUID := uint32(1000)
+	testGID := uint32(1000)
+	otherUID := uint32(2000)
+	otherGID := uint32(2000)
+
+	createTestFile := func(t *testing.T, name string, content string, uid, gid uint32, mode os.FileMode) string {
+		path := filepath.Join(tempDir, name)
+		dir := filepath.Dir(path)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(path, []byte(content), mode))
+		require.NoError(t, os.Chown(path, int(uid), int(gid)))
+		return name
+	}
+
+	tests := []struct {
+		name        string
+		setupFile   func(t *testing.T) string
+		proc        *mockProcess
+		maxSize     int64
+		expectError string
+		expectData  string
+	}{
+		{
+			name: "successful read - owner with read permission",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "owner_readable.txt", "owner content", testUID, testGID, 0400)
+			},
+			proc:       newMockProcess(testUID, testGID),
+			maxSize:    1024,
+			expectData: "owner content",
+		},
+		{
+			name: "successful read - owner with rw permission",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "owner_rw.txt", "owner rw", testUID, testGID, 0600)
+			},
+			proc:       newMockProcess(testUID, testGID),
+			maxSize:    1024,
+			expectData: "owner rw",
+		},
+		{
+			name: "successful read - group with read permission",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "group_readable.txt", "group content", otherUID, testGID, 0040)
+			},
+			proc:       newMockProcess(testUID, testGID),
+			maxSize:    1024,
+			expectData: "group content",
+		},
+		{
+			name: "successful read - world readable (non-root owned)",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "world_readable.txt", "world content", otherUID, otherGID, 0004)
+			},
+			proc:       newMockProcess(testUID, testGID),
+			maxSize:    1024,
+			expectData: "world content",
+		},
+		{
+			name: "successful read - root process can read any file",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "root_process.txt", "root reads all", otherUID, otherGID, 0000)
+			},
+			proc:       newMockProcess(0, 0),
+			maxSize:    1024,
+			expectData: "root reads all",
+		},
+		{
+			name: "file size limit enforced",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "large_file.txt", "this is a long content that exceeds limit", testUID, testGID, 0400)
+			},
+			proc:       newMockProcess(testUID, testGID),
+			maxSize:    10,
+			expectData: "this is a ",
+		},
+		{
+			name: "permission denied - root-owned non-world-readable",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "root_owned_not_world.txt", "root file", 0, 0, 0600)
+			},
+			proc:        newMockProcess(0, 0),
+			maxSize:     1024,
+			expectError: "is not readable by process",
+		},
+		{
+			name: "permission denied - no read permission",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "no_read.txt", "cannot read", otherUID, otherGID, 0000)
+			},
+			proc:        newMockProcess(testUID, testGID),
+			maxSize:     1024,
+			expectError: "is not readable by process",
+		},
+		{
+			name: "permission denied - owner without read",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "owner_no_read.txt", "no read", testUID, testGID, 0200)
+			},
+			proc:        newMockProcess(testUID, testGID),
+			maxSize:     1024,
+			expectError: "is not readable by process",
+		},
+		{
+			name: "permission denied - group without read",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "group_no_read.txt", "no read", otherUID, testGID, 0020)
+			},
+			proc:        newMockProcess(testUID, testGID),
+			maxSize:     1024,
+			expectError: "is not readable by process",
+		},
+		{
+			name: "successful read - root-owned world-readable by non-root",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "root_world_readable.txt", "world readable", 0, 0, 0644)
+			},
+			proc:       newMockProcess(testUID, testGID),
+			maxSize:    1024,
+			expectData: "world readable",
+		},
+		{
+			name: "permission denied - root-owned non-world-readable blocked by security policy",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "root_owned_secret.txt", "secret", 0, 0, 0600)
+			},
+			proc:        newMockProcess(testUID, testGID),
+			maxSize:     1024,
+			expectError: "is not readable by process",
+		},
+		{
+			name: "permission denied - root-owned 0400 blocked by security policy",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "root_owned_0400.txt", "secret", 0, 0, 0400)
+			},
+			proc:        newMockProcess(testUID, testGID),
+			maxSize:     1024,
+			expectError: "is not readable by process",
+		},
+		{
+			name: "error - file is executable",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "executable.sh", "#!/bin/bash\necho test", testUID, testGID, 0755)
+			},
+			proc:        newMockProcess(testUID, testGID),
+			maxSize:     1024,
+			expectError: "is executable",
+		},
+		{
+			name: "error - file is a directory",
+			setupFile: func(t *testing.T) string {
+				dir := "testdir"
+				require.NoError(t, os.MkdirAll(filepath.Join(tempDir, dir), 0755))
+				return dir
+			},
+			proc:        newMockProcess(testUID, testGID),
+			maxSize:     1024,
+			expectError: "is a directory",
+		},
+		{
+			name: "error - file does not exist",
+			setupFile: func(_ *testing.T) string {
+				return "nonexistent.txt"
+			},
+			proc:        newMockProcess(testUID, testGID),
+			maxSize:     1024,
+			expectError: "no such file or directory",
+		},
+		{
+			name: "absolute path handling",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "abs_path.txt", "absolute", testUID, testGID, 0400)
+			},
+			proc:       newMockProcess(testUID, testGID),
+			maxSize:    1024,
+			expectData: "absolute",
+		},
+		{
+			name: "empty file",
+			setupFile: func(t *testing.T) string {
+				return createTestFile(t, "empty.txt", "", testUID, testGID, 0400)
+			},
+			proc:       newMockProcess(testUID, testGID),
+			maxSize:    1024,
+			expectData: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filename := tt.setupFile(t)
+
+			data, fileInfo, err := ReadProcessFileLimit(tt.proc, root, filename, tt.maxSize)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Nil(t, data)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectData, string(data))
+			assert.NotNil(t, fileInfo)
+			assert.False(t, fileInfo.IsDir())
+		})
+	}
+}
+
+func TestReadProcessFileLimit_ProcessErrors(t *testing.T) {
+	tempDir := t.TempDir()
+	root, err := os.OpenRoot(tempDir)
+	require.NoError(t, err)
+
+	// Create a test file
+	testFile := filepath.Join(tempDir, "test.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("content"), 0644))
+
+	tests := []struct {
+		name        string
+		proc        *mockProcess
+		expectError bool
+	}{
+		{
+			name: "error getting UIDs",
+			proc: &mockProcess{
+				err: assert.AnError,
+			},
+			expectError: true,
+		},
+		{
+			name: "empty UIDs slice - returns error",
+			proc: &mockProcess{
+				uids: []uint32{},
+				gids: []uint32{1000, 1000, 1000},
+			},
+			expectError: true,
+		},
+		{
+			name: "empty GIDs slice - returns error",
+			proc: &mockProcess{
+				uids: []uint32{1000, 1000, 1000},
+				gids: []uint32{},
+			},
+			expectError: true,
+		},
+		{
+			name: "single UID - returns error (needs at least 2)",
+			proc: &mockProcess{
+				uids: []uint32{1000},
+				gids: []uint32{1000, 1000, 1000},
+			},
+			expectError: true,
+		},
+		{
+			name: "single GID - returns error (needs at least 2)",
+			proc: &mockProcess{
+				uids: []uint32{1000, 1000, 1000},
+				gids: []uint32{1000},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, fileInfo, err := ReadProcessFileLimit(tt.proc, root, "test.txt", 1024)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, data)
+				assert.Nil(t, fileInfo)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, data)
+				assert.NotNil(t, fileInfo)
+			}
+		})
+	}
+}
+
+func TestReadProcessFileLimit_PathHandling(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test requires root privileges to chown files")
+	}
+
+	tempDir := t.TempDir()
+	root, err := os.OpenRoot(tempDir)
+	require.NoError(t, err)
+
+	testUID := uint32(1000)
+	testGID := uint32(1000)
+
+	// Create test file in subdirectory
+	subDir := filepath.Join(tempDir, "subdir")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+	testFile := filepath.Join(subDir, "test.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("path test"), 0400))
+	require.NoError(t, os.Chown(testFile, int(testUID), int(testGID)))
+
+	proc := newMockProcess(testUID, testGID)
+
+	tests := []struct {
+		name        string
+		path        string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "relative path",
+			path:        "subdir/test.txt",
+			expected:    "path test",
+			expectError: false,
+		},
+		{
+			name:        "absolute path",
+			path:        "/subdir/test.txt",
+			expected:    "path test",
+			expectError: false,
+		},
+		{
+			name:        "path with dots",
+			path:        "./subdir/./test.txt",
+			expected:    "path test",
+			expectError: false,
+		},
+		{
+			name:        "path traversal - parent directory",
+			path:        "../out",
+			expectError: true,
+		},
+		{
+			name:        "path traversal - multiple levels up",
+			path:        "../../out",
+			expectError: true,
+		},
+		{
+			name:        "path traversal - from subdirectory",
+			path:        "subdir/../../out",
+			expectError: true,
+		},
+		{
+			name:        "path traversal - absolute with parent",
+			path:        "/../out",
+			expectError: true,
+		},
+		{
+			name:        "path traversal - complex",
+			path:        "/subdir/../../../out",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, fileInfo, err := ReadProcessFileLimit(proc, root, tt.path, 1024)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, data)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, string(data))
+				assert.NotNil(t, fileInfo)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is a second round of changes for the DB benchmarks. The module is still experimental and deactivated.

Robustness:
 - using *os.Root to get configuration file relative to PID's mount namespace
 - introducing a dedicated method ReadProcessFileLimit to read config files using the PID uid/gid
 - allowlist of known and useful configuration keys for PostgreSQL configs
 - more tests

Features:
 - exposing cassandra logback XML configuration file
 - exposing PostgreSQL CLI flags

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
