### PR TITLE
[CWS] Do not run security-agent tests on suse 12

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -154,7 +154,6 @@ kmt_run_secagent_tests_x64:
           - "rocky_9.4"
           - "opensuse_15.3"
           - "opensuse_15.5"
-          - "suse_12.5"
         TEST_SET: [cws_host]
   after_script:
     - !reference [.collect_outcomes_kmt]
@@ -197,7 +196,6 @@ kmt_run_secagent_tests_x64_peds:
           - "rocky_9.4"
           - "opensuse_15.3"
           - "opensuse_15.5"
-          - "suse_12.5"
         TEST_SET: [cws_peds]
   after_script:
     - !reference [.collect_outcomes_kmt]


### PR DESCRIPTION
### What does this PR do?

Suse 12 is EOL since 2024.

### Motivation

### Describe how you validated your changes

### Additional Notes
