### PR TITLE
[EBPF] kmt: do not retry downloading test results on test failure

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -281,7 +281,7 @@
     - ${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "scp /home/ubuntu/job_env-${ARCH}-${TAG}-${TEST_SET}.txt ${MICRO_VM_IP}:/job_env.txt"
     - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'mount -o remount,size=5G /opt/kmt-ramfs && CI=true /root/fetch_dependencies.sh ${ARCH} && COLLECT_COMPLEXITY=${COLLECT_COMPLEXITY} /opt/micro-vm-init.sh -test-tools /opt/testing-tools -retry ${RETRY} -test-root /opt/${TEST_COMPONENT}-tests -packages-run-config /opt/${TEST_SET}.json'"
     - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}" -send-env-vars CI_COMMIT_SHA,DD_API_KEY # Allow DD_API_KEY to be passed to the metal instance, so we can use it to send metrics from the connector.
-    - NO_RETRY_EXIT_CODE=42${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml -codeowners /opt/testing-tools/CODEOWNERS -test-root /opt/${TEST_COMPONENT}-tests'"
+    - NO_RETRY_EXIT_CODE=42 ${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml -codeowners /opt/testing-tools/CODEOWNERS -test-root /opt/${TEST_COMPONENT}-tests'"
     - "[ ! -f $CI_PROJECT_DIR/daemon-${ARCH}.log ] && ${CI_PROJECT_DIR}/tools/ci/retry.sh scp metal_instance:/home/ubuntu/daemon.log $CI_PROJECT_DIR/vm-metrics-daemon-${ARCH}.log"
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -281,7 +281,7 @@
     - ${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "scp /home/ubuntu/job_env-${ARCH}-${TAG}-${TEST_SET}.txt ${MICRO_VM_IP}:/job_env.txt"
     - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'mount -o remount,size=5G /opt/kmt-ramfs && CI=true /root/fetch_dependencies.sh ${ARCH} && COLLECT_COMPLEXITY=${COLLECT_COMPLEXITY} /opt/micro-vm-init.sh -test-tools /opt/testing-tools -retry ${RETRY} -test-root /opt/${TEST_COMPONENT}-tests -packages-run-config /opt/${TEST_SET}.json'"
     - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}" -send-env-vars CI_COMMIT_SHA,DD_API_KEY # Allow DD_API_KEY to be passed to the metal instance, so we can use it to send metrics from the connector.
-    - ${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml -codeowners /opt/testing-tools/CODEOWNERS -test-root /opt/${TEST_COMPONENT}-tests'"
+    - NO_RETRY_EXIT_CODE=42${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml -codeowners /opt/testing-tools/CODEOWNERS -test-root /opt/${TEST_COMPONENT}-tests'"
     - "[ ! -f $CI_PROJECT_DIR/daemon-${ARCH}.log ] && ${CI_PROJECT_DIR}/tools/ci/retry.sh scp metal_instance:/home/ubuntu/daemon.log $CI_PROJECT_DIR/vm-metrics-daemon-${ARCH}.log"
   artifacts:
     expire_in: 2 weeks

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -61,9 +61,11 @@ func main() {
 	}
 	if out.Failed != "" {
 		fmt.Println(color.RedString(out.Failed))
-		// We want to make sure the exit code is correctly set to
-		// failed here, so that the CI job also fails.
-		os.Exit(1)
+		// We want to make sure the exit code is correctly set to failed here,
+		// so that the CI job also fails. Return 42 specifically so that the
+		// retry tool doesn't retry the command, since it's not an infra failure
+		// but a exit code used to signal that the tests failed.
+		os.Exit(42)
 	}
 }
 

--- a/tools/ci/retry.sh
+++ b/tools/ci/retry.sh
@@ -17,7 +17,13 @@ fi
 
 for i in $(seq 1 $((NB_ATTEMPTS - 1))); do
     "$@" && exit 0
-    >&2 echo "Attempt #$i/$NB_ATTEMPTS failed with error code $?"
+    exitCode=$?
+    if [ ! -z "$NO_RETRY_EXIT_CODE" ] && [ "$exitCode" = "$NO_RETRY_EXIT_CODE" ]; then
+        >&2 echo "Attempt #$i/$NB_ATTEMPTS failed with error code $exitCode, but not retrying since NO_RETRY_EXIT_CODE is set to $NO_RETRY_EXIT_CODE"
+        exit $exitCode
+    fi
+
+    >&2 echo "Attempt #$i/$NB_ATTEMPTS failed with error code $exitCode"
     sleep $((i ** 2))
 done
 


### PR DESCRIPTION
### What does this PR do?

This PR changes the `retry.sh` code to avoid retrying commands that failed because of a non-retryable error, and applies that to the `test-json-review` command, which fails if the test results have failures in them.

### Motivation

Improve output in test failures

### Describe how you validated your changes

Job with no failures: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1295034871
Job with failures: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1295034755

### Additional Notes