### PR TITLE
Use module name in fx tracing when event name is reflect

### DIFF
--- a/pkg/util/fxutil/logging/tracer.go
+++ b/pkg/util/fxutil/logging/tracer.go
@@ -6,6 +6,7 @@
 package logging
 
 import (
+	"fmt"
 	"io"
 	"math/rand"
 	"os"
@@ -115,7 +116,10 @@ func (l *FxTracingLogger) handleRun(e *fxevent.Run) {
 	startTime := time.Now().Add(-e.Runtime).UnixNano()
 
 	name := extractShortPathFromFullPath(e.Name)
-
+	if name == "reflect.makeFuncStub()" {
+		// fallback to the module to at least know where this comes from
+		name = fmt.Sprintf("%s(%s)", e.Kind, e.ModuleName) // eg. "provide(comp/core/ipc)"
+	}
 	span := &Span{
 		Service:  serviceName,
 		Name:     constructorName,


### PR DESCRIPTION
### What does this PR do?
Update fx tracing to use the module name when the event name is from reflect.

### Motivation
We currently have many spans named `reflect.makeFuncStub()`, which doesn't let us know where the event comes from.
Using the module name and event type instead gives us a lot more information.
Eg. `reflect.makeFuncStub()` -> `provide(comp/core/ipc)`.

### Describe how you validated your changes
Manual testing.

### Additional Notes
