### PR TITLE
[CWS] do not share zeroer between probe event and related events

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1047,11 +1047,13 @@ func (p *EBPFProbe) getPoolEvent() *model.Event {
 	return event
 }
 
+var relatedEventZeroer = model.NewEventZeroer()
+
 func (p *EBPFProbe) putBackPoolEvent(event *model.Event) {
 	if event.ProcessCacheEntry != nil {
 		event.ProcessCacheEntry.Release()
 	}
-	probeEventZeroer(event)
+	relatedEventZeroer(event)
 	p.eventPool.Put(event)
 }
 


### PR DESCRIPTION
### What does this PR do?

The probe event (use for event evaluation) and the pool of event used in related events should not use the same zeroer. This PR splits those.

### Motivation

### Describe how you validated your changes

### Additional Notes
