### PR TITLE
[CWS] do not release PCE in related events

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -838,6 +838,9 @@ func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 
 	for _, event := range events {
 		p.DispatchEvent(event, notifyConsumers)
+		if event.ProcessCacheEntry != nil {
+			event.ProcessCacheEntry.Release()
+		}
 		p.putBackPoolEvent(event)
 	}
 }
@@ -1050,9 +1053,6 @@ func (p *EBPFProbe) getPoolEvent() *model.Event {
 var relatedEventZeroer = model.NewEventZeroer()
 
 func (p *EBPFProbe) putBackPoolEvent(event *model.Event) {
-	if event.ProcessCacheEntry != nil {
-		event.ProcessCacheEntry.Release()
-	}
 	relatedEventZeroer(event)
 	p.eventPool.Put(event)
 }

--- a/pkg/security/probe/probe_ebpf_test.go
+++ b/pkg/security/probe/probe_ebpf_test.go
@@ -86,8 +86,8 @@ func TestPutBackPoolEvent(t *testing.T) {
 
 		p.putBackPoolEvent(event)
 
-		// Verify that Release was called (since refCount was 1, coreRelease callback should be called)
-		assert.True(t, releaseCalled, "Release callback should have been called")
+		// Verify that Release was not called
+		assert.False(t, releaseCalled, "Release callback should not have been called")
 
 		// Get a new event from the pool (should be the one we just put back)
 		newEvent := p.getPoolEvent()


### PR DESCRIPTION
### What does this PR do?

In related events we don't want to release the process cache entry because the entry needs to be retained. 

Reverts this change https://github.com/DataDog/datadog-agent/pull/44096/files#diff-cbb7fffd6c75f4a7fbb99f763ab3db5b1078d9ec582502c00295dff1e8db54ceL1162

### Motivation

### Describe how you validated your changes

### Additional Notes
