### PR TITLE
Add missing `TestPodAutoscalerLocalOwnerObjectsLimit` mock setup

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -555,6 +555,9 @@ func TestPodAutoscalerLocalOwnerObjectsLimit(t *testing.T) {
 	dpa1, dpaTyped1 := newFakePodAutoscaler(currentNs, "dpa-1", 1, dpa1Time, dpaSpec, datadoghqcommon.DatadogPodAutoscalerStatus{})
 	dpa2, dpaTyped2 := newFakePodAutoscaler(currentNs, "dpa-2", 1, dpa2Time, dpaSpec, datadoghqcommon.DatadogPodAutoscalerStatus{})
 
+	// Setup scaler mock to handle any get calls during concurrent processing
+	f.scaler.On("get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&autoscalingv1.Scale{}, schema.GroupResource{}, nil).Maybe()
+
 	f.InformerObjects = append(f.InformerObjects, dpa, dpa1)
 	f.Objects = append(f.Objects, dpaTyped, dpaTyped1)
 


### PR DESCRIPTION
### What does this PR do?
Add missing mock scaler setup to `TestPodAutoscalerLocalOwnerObjectsLimit` to prevent panic when the horizontal controller attempts to fetch the target deployment's scale.

### Motivation
#43202 addressed `TestPodAutoscalerRemoteOwnerObjectsLimit` but didn't tranpose the mock scaler setup to `TestPodAutoscalerLocalOwnerObjectsLimit`, leading it to fail on the 7.73.x branch ([tests_macos_gitlab_arm64](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1294411635)):
```
panic: mock: I don't know what to return because the method call was unexpected.
    This method was unexpected:
        get(<nil>,string,string,schema.GroupVersionKind)
```

When `RunControllerSync` processes a DatadogPodAutoscaler with `Owner: DatadogPodAutoscalerLocalOwner`, the controller calls `handleScaling` which invokes `horizontalController.sync`.
This method always calls `scaler.get` to fetch the current scale of the target resource.
Without mock expectations configured, the fake scaler panics.

### Additional Notes
This test passes most of the time without the fix, but adding the mock makes the test robust regardless.