### PR TITLE
chore(fleet): Support sudo-rs in install.sh

### DIFF
--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -38,10 +38,32 @@ tmp_bin="${tmp_dir}/installer"
 
 if ((UID == 0)); then
   sudo_cmd=()
-  sudo_env_cmd=()
+  # When running as root, no sudo needed
+  sudo_env_cmd() {
+    "$@"
+  }
 else
   sudo_cmd=(sudo)
-  sudo_env_cmd=(sudo -E)
+  # sudo-rs (used in Ubuntu 25) doesn't support -E flag
+  # Detect sudo-rs and use explicit env passing instead
+  if sudo --version 2>&1 | sed -n '1p' | grep -q 'sudo-rs'; then
+    sudo_env_cmd() {
+      local env_args=()
+      while IFS='=' read -r name value; do
+        case "$name" in
+          DD_*|HTTP_PROXY|HTTPS_PROXY|NO_PROXY|http_proxy|https_proxy|no_proxy)
+            env_args+=("$name=$value")
+            ;;
+        esac
+      done < <(env)
+      sudo env "${env_args[@]}" "$@"
+    }
+  else
+    # Traditional sudo supports -E flag
+    sudo_env_cmd() {
+      sudo -E "$@"
+    }
+  fi
 fi
 
 # This migrates legacy installs by removing the legacy deb / rpm installer package
@@ -57,12 +79,12 @@ fi
 
 echo "Downloading the Datadog installer..."
 if command -v curl >/dev/null; then
-  if ! "${sudo_env_cmd[@]+"${sudo_env_cmd[@]}"}" curl -L --retry 3 "$installer_url" --output "$tmp_bin" >/dev/null; then
+  if ! sudo_env_cmd curl -L --retry 3 "$installer_url" --output "$tmp_bin" >/dev/null; then
     echo "Error: Download failed with curl." >&2
     exit 1
   fi
 else
-  if ! "${sudo_env_cmd[@]+"${sudo_env_cmd[@]}"}" wget --tries=3 -O "$tmp_bin" "$installer_url" >/dev/null; then
+  if ! sudo_env_cmd wget --tries=3 -O "$tmp_bin" "$installer_url" >/dev/null; then
     echo "Error: Download failed with wget." >&2
     exit 1
   fi
@@ -74,7 +96,7 @@ sha256sum -c <<<"$installer_sha256  $tmp_bin" >/dev/null
 echo "Installer integrity verified."
 
 echo "Starting the Datadog installer..."
-"${sudo_env_cmd[@]+"${sudo_env_cmd[@]}"}" "$tmp_bin" setup --flavor "$flavor" "$@"
+sudo_env_cmd "$tmp_bin" setup --flavor "$flavor" "$@"
 
 "${sudo_cmd[@]+"${sudo_cmd[@]}"}" rm -f "$tmp_bin"
 


### PR DESCRIPTION
### What does this PR do?
Ubuntu 25.05 and sudo-rs (issue 1299) stopped supporting sudo -E. This PR fixes it by passing environment variables from an allowlist instead.

### Motivation

### Describe how you validated your changes
Manual test on an ubuntu 25.10 VM as we don't have it available in the E2E tests.

### Additional Notes
