### PR TITLE
[Backport 7.74.x] privileged logs: Handle unsearchable directories

### DIFF
--- a/pkg/logs/internal/util/opener/open_linux.go
+++ b/pkg/logs/internal/util/opener/open_linux.go
@@ -16,3 +16,8 @@ import (
 func OpenLogFile(path string) (*os.File, error) {
 	return privilegedlogsclient.Open(path)
 }
+
+// StatLogFile stats a log file with the privileged logs client
+func StatLogFile(path string) (os.FileInfo, error) {
+	return privilegedlogsclient.Stat(path)
+}

--- a/pkg/logs/internal/util/opener/open_other.go
+++ b/pkg/logs/internal/util/opener/open_other.go
@@ -18,3 +18,8 @@ import (
 func OpenLogFile(path string) (*os.File, error) {
 	return filesystem.OpenShared(path)
 }
+
+// StatLogFile stats a log file
+func StatLogFile(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/opener"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
@@ -267,7 +268,7 @@ func (p *FileProvider) FilesToTail(ctx context.Context, validatePodContainerID b
 // with ordering defined by 'wildcardOrder'
 func (p *FileProvider) CollectFiles(source *sources.LogSource) ([]*tailer.File, error) {
 	path := source.Config.Path
-	_, err := os.Stat(path)
+	_, err := opener.StatLogFile(path)
 	switch {
 	case err == nil:
 		return []*tailer.File{

--- a/pkg/privileged-logs/client/open.go
+++ b/pkg/privileged-logs/client/open.go
@@ -111,6 +111,24 @@ func OpenPrivileged(socketPath string, filePath string) (*os.File, error) {
 	return nil, fmt.Errorf("no file descriptor received")
 }
 
+func maybeOpenPrivileged(path string, originalError error) (*os.File, error) {
+	enabled := pkgconfigsetup.SystemProbe().GetBool("privileged_logs.enabled")
+	if !enabled {
+		return nil, originalError
+	}
+
+	log.Debugf("Permission denied, opening file with system-probe: %v", path)
+
+	socketPath := pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")
+	file, spErr := OpenPrivileged(socketPath, path)
+	log.Tracef("Opened file with system-probe: %v, err: %v", path, spErr)
+	if spErr != nil {
+		return nil, fmt.Errorf("failed to open file with system-probe: %w, original error: %w", spErr, originalError)
+	}
+
+	return file, nil
+}
+
 // Open attempts to open a file, and if it fails due to permissions, it opens
 // the file using system-probe if the privileged logs module is available.
 func Open(path string) (*os.File, error) {
@@ -119,19 +137,33 @@ func Open(path string) (*os.File, error) {
 		return file, err
 	}
 
-	enabled := pkgconfigsetup.SystemProbe().GetBool("privileged_logs.enabled")
-	if !enabled {
-		return file, err
+	file, err = maybeOpenPrivileged(path, err)
+	if err != nil {
+		return nil, err
 	}
 
-	log.Debugf("Permission denied, opening file with system-probe: %v", path)
+	return file, nil
+}
 
-	socketPath := pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")
-	fd, spErr := OpenPrivileged(socketPath, path)
-	log.Tracef("Opened file with system-probe: %v, err: %v", path, spErr)
-	if spErr != nil {
-		return file, fmt.Errorf("failed to open file with system-probe: %w, original error: %w", spErr, err)
+// Stat attempts to stat a file, and if it fails due to permissions, it opens
+// the file using system-probe if the privileged logs module is available and
+// stats the opened file.
+func Stat(path string) (os.FileInfo, error) {
+	info, err := os.Stat(path)
+	if err == nil || !errors.Is(err, os.ErrPermission) {
+		return info, err
 	}
 
-	return fd, nil
+	file, err := maybeOpenPrivileged(path, err)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err = file.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }

--- a/pkg/privileged-logs/client/open_other.go
+++ b/pkg/privileged-logs/client/open_other.go
@@ -16,3 +16,8 @@ import (
 func Open(path string) (*os.File, error) {
 	return os.Open(path)
 }
+
+// Stat provides a fallback for non-Linux platforms where the privileged logs module is not available.
+func Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}

--- a/pkg/privileged-logs/test/privileged_logs_test.go
+++ b/pkg/privileged-logs/test/privileged_logs_test.go
@@ -25,7 +25,20 @@ import (
 
 func createTestFile(t *testing.T, dir, filename, content string) string {
 	filePath := filepath.Join(dir, filename)
-	err := os.WriteFile(filePath, []byte(content), 0000)
+	WithParentPermFixup(t, filePath, func() error {
+		err := os.WriteFile(filePath, []byte(content), 0000)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.Remove(filePath)
+		})
+		return err
+	})
+	return filePath
+}
+
+func createAccessibleTestFile(t *testing.T, dir, filename, content string) string {
+	filePath := filepath.Join(dir, filename)
+	err := os.WriteFile(filePath, []byte(content), 0644)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.Remove(filePath)
@@ -66,6 +79,20 @@ func assertClientOpenContent(t *testing.T, filePath, expectedContent string) {
 	assert.Equal(t, expectedContent, string(data))
 }
 
+func assertClientStatInfo(t *testing.T, filePath string, expectedSize int64) {
+	info, err := client.Stat(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, expectedSize, info.Size())
+}
+
+func assertClientStatError(t *testing.T, filePath, expectedErrorMsg string) {
+	info, err := client.Stat(filePath)
+	require.Error(t, err)
+	assert.Nil(t, info)
+	assert.Contains(t, err.Error(), expectedErrorMsg)
+}
+
 func assertOpenPrivilegedError(t *testing.T, socketPath, filePath, expectedErrorMsg string) {
 	file, err := client.OpenPrivileged(socketPath, filePath)
 	require.Error(t, err)
@@ -75,13 +102,22 @@ func assertOpenPrivilegedError(t *testing.T, socketPath, filePath, expectedError
 
 type PrivilegedLogsSuite struct {
 	suite.Suite
-	handler *Handler
-	tempDir string
+	handler          *Handler
+	searchableTmpDir string
+	tempDir          string
 }
 
 func (s *PrivilegedLogsSuite) SetupSuite() {
 	s.handler = Setup(s.T(), func() {
-		s.tempDir = s.T().TempDir()
+		s.searchableTmpDir = s.T().TempDir()
+
+		unsearchableDir := filepath.Join(s.searchableTmpDir, "unsearchable")
+		err := os.Mkdir(unsearchableDir, 0000)
+		require.NoError(s.T(), err)
+		s.T().Cleanup(func() {
+			os.Remove(unsearchableDir)
+		})
+		s.tempDir = unsearchableDir
 	})
 }
 
@@ -114,7 +150,9 @@ func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_Symlink() {
 	realLogFile := createTestFile(s.T(), s.tempDir, "real.log", testContent)
 
 	symlinkPath := filepath.Join(s.tempDir, "fake.log")
-	err := os.Symlink(realLogFile, symlinkPath)
+	err := WithParentPermFixup(s.T(), symlinkPath, func() error {
+		return os.Symlink(realLogFile, symlinkPath)
+	})
 	require.NoError(s.T(), err)
 
 	assertOpenPrivilegedContent(s.T(), s.handler.SocketPath, symlinkPath, testContent)
@@ -124,7 +162,9 @@ func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_SymlinkToNonLogFile() {
 	nonLogFile := createTestFile(s.T(), s.tempDir, "secret_nonlog.txt", "secret content")
 
 	symlinkPath := filepath.Join(s.tempDir, "fake_nonlog.log")
-	err := os.Symlink(nonLogFile, symlinkPath)
+	err := WithParentPermFixup(s.T(), symlinkPath, func() error {
+		return os.Symlink(nonLogFile, symlinkPath)
+	})
 	require.NoError(s.T(), err)
 
 	assertOpenPrivilegedError(s.T(), s.handler.SocketPath, symlinkPath, "non-log file not allowed")
@@ -146,6 +186,7 @@ func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenFallback() {
 	setupSystemProbeConfig(s.T(), s.handler.SocketPath, true)
 
 	assertClientOpenContent(s.T(), upperLogFile, testContent)
+	assertClientStatInfo(s.T(), upperLogFile, int64(len(testContent)))
 }
 
 func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenFallbackError() {
@@ -155,6 +196,7 @@ func (s *PrivilegedLogsSuite) TestPrivilegedLogsModule_OpenFallbackError() {
 	setupSystemProbeConfig(s.T(), s.handler.SocketPath, true)
 
 	assertClientOpenError(s.T(), upperLogFile, "non-log file not allowed")
+	assertClientStatError(s.T(), upperLogFile, "non-log file not allowed")
 }
 
 func TestPrivilegedLogsSuite(t *testing.T) {
@@ -170,12 +212,13 @@ func TestPrivilegedLogsModule_Close(t *testing.T) {
 
 func (s *PrivilegedLogsSuite) TestOpen_SuccessfulNormalOpen() {
 	testContent := "Hello, privileged logs transfer!"
-	testFile := createTestFile(s.T(), s.tempDir, "test.log", testContent)
+	testFile := createAccessibleTestFile(s.T(), s.searchableTmpDir, "test.log", testContent)
 
-	// Force the file to be accesssible from the non-privileged user
+	// Force the file to be accessible from the non-privileged user
 	require.NoError(s.T(), os.Chmod(testFile, 0644))
 
 	assertClientOpenContent(s.T(), testFile, testContent)
+	assertClientStatInfo(s.T(), testFile, int64(len(testContent)))
 }
 
 func (s *PrivilegedLogsSuite) TestOpen_PermissionErrorWithModuleDisabled() {
@@ -184,6 +227,7 @@ func (s *PrivilegedLogsSuite) TestOpen_PermissionErrorWithModuleDisabled() {
 	setupSystemProbeConfig(s.T(), s.handler.SocketPath, false)
 
 	assertClientOpenError(s.T(), testFile, "permission denied")
+	assertClientStatError(s.T(), testFile, "permission denied")
 }
 
 func (s *PrivilegedLogsSuite) TestOpen_PermissionErrorWithModuleFailure() {
@@ -197,6 +241,12 @@ func (s *PrivilegedLogsSuite) TestOpen_PermissionErrorWithModuleFailure() {
 	assert.Nil(t, file)
 	assert.Contains(t, err.Error(), "failed to open file with system-probe")
 	assert.Contains(t, err.Error(), "permission denied")
+
+	stat, err := client.Stat(testFile)
+	require.Error(t, err)
+	assert.Nil(t, stat)
+	assert.Contains(t, err.Error(), "failed to open file with system-probe")
+	assert.Contains(t, err.Error(), "permission denied")
 }
 
 func (s *PrivilegedLogsSuite) TestOpen_NonPermissionError() {
@@ -204,5 +254,10 @@ func (s *PrivilegedLogsSuite) TestOpen_NonPermissionError() {
 	t := s.T()
 	require.Error(t, err)
 	assert.Nil(t, file)
+	assert.NotContains(t, err.Error(), "system-probe")
+
+	stat, err := client.Stat("/nonexistent/file.log")
+	require.Error(t, err)
+	assert.Nil(t, stat)
 	assert.NotContains(t, err.Error(), "system-probe")
 }


### PR DESCRIPTION
Backports #43747. The backport had to be performed manually since there was a conflict in `pkg/logs/launchers/file/launcher_test.go` due to "Replace uses of `fmt.Sprintf` and `fmt.Errorf` with better alternatives" (#43413) not being present on 7.74.x. No other files had conflicts.

In any directory in the path of a configured log file does not have executable (search) permissions, it does not get tailed even with privileged logs enabled since a stat(2) call from the file launcher fails and the logs agent never gets to the point where it calls into system-probe.  Fix this by having that stat(2) call too fallback to system-probe if privileged logs is enabled.

https://datadoghq.atlassian.net/browse/DSCVR-288

Unit and E2E tests have been modified to test this case.


(cherry picked from commit d81746c60fffaf5ef00426aa12f11531e761ff68)
(Manually fixed conflict in pkg/logs/launchers/file/launcher_test.go
 due to "Replace uses of `fmt.Sprintf` and `fmt.Errorf` with better
 alternatives (#43413) not being present on 7.74.x)