### PR TITLE
[CWS] Do not trigger chmod event for unchanged mode

### DIFF
--- a/pkg/security/secl/rules/fim_test.go
+++ b/pkg/security/secl/rules/fim_test.go
@@ -30,7 +30,7 @@ func TestExpandFIM(t *testing.T) {
 				},
 				{
 					id:   "__fim_expanded_chmod__test",
-					expr: "chmod.file.path == \"/tmp/test\"",
+					expr: "(chmod.file.path == \"/tmp/test\") && (chmod.file.destination.mode != chmod.file.mode)",
 				},
 				{
 					id:   "__fim_expanded_chown__test",
@@ -68,7 +68,7 @@ func TestExpandFIM(t *testing.T) {
 				},
 				{
 					id:   "__fim_expanded_chmod__complex",
-					expr: "(chmod.file.path == \"/tmp/test\" || chmod.file.name == \"abc\") && process.file.name == \"def\" && container.id != \"\"",
+					expr: "((chmod.file.path == \"/tmp/test\" || chmod.file.name == \"abc\") && process.file.name == \"def\" && container.id != \"\") && (chmod.file.destination.mode != chmod.file.mode)",
 				},
 				{
 					id:   "__fim_expanded_chown__complex",

--- a/pkg/security/secl/rules/fim_unix.go
+++ b/pkg/security/secl/rules/fim_unix.go
@@ -36,6 +36,8 @@ func expandFim(baseID, groupID, baseExpr string) []expandedRule {
 			expr = fmt.Sprintf("(%s) && open.flags & (O_CREAT|O_TRUNC|O_APPEND|O_RDWR|O_WRONLY) > 0", expr)
 		case "chown":
 			expr = fmt.Sprintf("(%s) && ((chown.file.destination.uid != -1 && chown.file.destination.uid != chown.file.uid) || (chown.file.destination.gid != -1 && chown.file.destination.gid != chown.file.gid))", expr)
+		case "chmod":
+			expr = fmt.Sprintf("(%s) && (chmod.file.destination.mode != chmod.file.mode)", expr)
 		}
 
 		id := fmt.Sprintf("__fim_expanded_%s_%s_%s", eventType, groupID, baseID)


### PR DESCRIPTION
### What does this PR do?

Do not trigger "fim" event for unchanged mode.

### Motivation

chmod 755 caused a `fim` rule to trigger even if the file mode is already 755

### Describe how you validated your changes

### Additional Notes
