### PR TITLE
[CWS-5648] disable sysctl events and snapshot when only PEDS is enabled

### DIFF
--- a/pkg/security/module/cws_linux.go
+++ b/pkg/security/module/cws_linux.go
@@ -24,6 +24,7 @@ func DisableRuntimeSecurity(config *config.Config) {
 	config.Probe.NetworkEnabled = false
 	config.RuntimeSecurity.ActivityDumpEnabled = false
 	config.RuntimeSecurity.SecurityProfileEnabled = false
+	config.RuntimeSecurity.SysCtlEnabled = false
 }
 
 // platform specific init function


### PR DESCRIPTION
### What does this PR do?

When running in PEDS mode, we should disable sysctl events. This PR does exactly that.

### Motivation

### Describe how you validated your changes

### Additional Notes
