### PR TITLE
switch to ebpf-platform slack channel for reviews

### DIFF
--- a/tasks/libs/pipeline/github_slack_review_map.yaml
+++ b/tasks/libs/pipeline/github_slack_review_map.yaml
@@ -38,7 +38,7 @@
 '@datadog/database-monitoring': '#database-monitoring'
 '@datadog/debugger-go': '#debugger-go'
 '@datadog/documentation': '#documentation'
-'@datadog/ebpf-platform': '#ebpf-platform-reviews'
+'@datadog/ebpf-platform': '#ebpf-platform'
 '@datadog/fleet': '#fleet-automation'
 '@datadog/injection-platform': '#injection-platform'
 '@datadog/kubernetes-experiences': '#kubernetes-experiences'


### PR DESCRIPTION
### What does this PR do?

Moves ebpf-platform reviews back to #ebpf-platform channel.

### Motivation

The review requests were getting lost in the noise of the Github reminders

### Describe how you validated your changes

### Additional Notes
