### PR TITLE
[OTAGENT-591] Add DDOT gateway e2e test

### DIFF
--- a/test/e2e-framework/components/datadog/agent/helm/kubernetes_agent.go
+++ b/test/e2e-framework/components/datadog/agent/helm/kubernetes_agent.go
@@ -40,6 +40,7 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 			DualShipping:                   params.DualShipping,
 			DisableLogsContainerCollectAll: params.DisableLogsContainerCollectAll,
 			OTelAgent:                      params.OTelAgent,
+			OTelAgentGateway:               params.OTelAgentGateway,
 			OTelConfig:                     params.OTelConfig,
 			GKEAutopilot:                   params.GKEAutopilot,
 			FIPS:                           params.FIPS,

--- a/test/e2e-framework/components/datadog/agent/helm/kubernetes_agent.go
+++ b/test/e2e-framework/components/datadog/agent/helm/kubernetes_agent.go
@@ -42,6 +42,7 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 			OTelAgent:                      params.OTelAgent,
 			OTelAgentGateway:               params.OTelAgentGateway,
 			OTelConfig:                     params.OTelConfig,
+			OTelGatewayConfig:              params.OTelGatewayConfig,
 			GKEAutopilot:                   params.GKEAutopilot,
 			FIPS:                           params.FIPS,
 			JMX:                            params.JMX,

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -57,8 +57,12 @@ type HelmInstallationArgs struct {
 	DualShipping bool
 	// OTelAgent is used to deploy the OTel agent instead of the classic agent
 	OTelAgent bool
+	// OTelAgentGateway is used to deploy the OTel agent with gateway enabled
+	OTelAgentGateway bool
 	// OTelConfig is used to provide a custom OTel configuration
 	OTelConfig string
+	// OTelGatewayConfig is used to provide a custom OTel configuration for the gateway collector
+	OTelGatewayConfig string
 	// GKEAutopilot is used to enable the GKE Autopilot mode and keep only compatible values
 	GKEAutopilot bool
 	// FIPS is used to deploy the agent with the FIPS agent image
@@ -171,7 +175,10 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	var valuesYAML pulumi.AssetOrArchiveArray
 	valuesYAML = append(valuesYAML, defaultYAMLValues)
 	valuesYAML = append(valuesYAML, args.ValuesYAML...)
-	if args.OTelAgent {
+	if args.OTelAgentGateway {
+		valuesYAML = append(valuesYAML, buildOTelAgentGatewayConfigWithFakeintake(args.OTelGatewayConfig, args.Fakeintake))
+	}
+	if args.OTelAgent && !args.OTelAgentGateway {
 		valuesYAML = append(valuesYAML, buildOTelConfigWithFakeintake(args.OTelConfig, args.Fakeintake))
 	}
 
@@ -894,6 +901,43 @@ datadog:
     config: |
 %s
 `, utils.IndentMultilineString(string(mergedConfigYAML), 6))
+		return pulumi.NewStringAsset(otelConfigValues), nil
+
+	}).(pulumi.AssetOutput)
+}
+
+func buildOTelAgentGatewayConfigWithFakeintake(otelConfig string, fakeintake *fakeintake.Fakeintake) pulumi.AssetOutput {
+	return fakeintake.URL.ApplyT(func(url string) (pulumi.Asset, error) {
+		defaultConfig := map[string]any{
+			"exporters": map[string]any{
+				"datadog": map[string]any{
+					"metrics": map[string]any{
+						"endpoint": url,
+					},
+					"traces": map[string]any{
+						"endpoint": url,
+					},
+					"logs": map[string]any{
+						"endpoint": url,
+					},
+				},
+			},
+		}
+		config := map[string]any{}
+		if err := yaml.Unmarshal([]byte(otelConfig), &config); err != nil {
+			return nil, err
+		}
+		mergeSlices := false
+		mergedConfig := utils.MergeMaps(config, defaultConfig, mergeSlices)
+		mergedConfigYAML, err := yaml.Marshal(mergedConfig)
+		if err != nil {
+			return nil, err
+		}
+		otelConfigValues := fmt.Sprintf(`
+otelAgentGateway:
+  config: |
+%s
+`, utils.IndentMultilineString(string(mergedConfigYAML), 4))
 		return pulumi.NewStringAsset(otelConfigValues), nil
 
 	}).(pulumi.AssetOutput)

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	HelmVersion = "3.135.4"
+	HelmVersion = "3.155.1"
 )
 
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component
@@ -164,6 +164,8 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 
 	if args.GKEAutopilot {
 		values = buildLinuxHelmValuesAutopilot(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result)
+	} else if args.OTelAgentGateway {
+		values = buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result, !args.DisableLogsContainerCollectAll, false, args.FIPS)
 	} else {
 		values = buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result, !args.DisableLogsContainerCollectAll, e.TestingWorkloadDeploy(), args.FIPS)
 	}

--- a/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
+++ b/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
@@ -219,13 +219,11 @@ datadog:
 
 func WithOTelAgentGateway() func(*Params) error {
 	return func(p *Params) error {
-		p.OTelAgent = true
+		p.OTelAgentGateway = true
 		otelAgentGatewayValues := `
 otelAgentGateway:
   enabled: true
-  replicas: 1
-  nodeSelector:
-    gateway: "true"`
+  replicas: 1`
 
 		p.HelmValues = append(p.HelmValues, pulumi.NewStringAsset(otelAgentGatewayValues))
 		return nil

--- a/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
+++ b/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
@@ -7,9 +7,9 @@ package kubernetesagentparams
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
 	"gopkg.in/yaml.v3"
@@ -65,8 +65,12 @@ type Params struct {
 	DualShipping bool
 	// OTelAgent is a flag to deploy the OTel agent.
 	OTelAgent bool
+	// OTelAgentGateway is a flag to deploy the OTel agent with gateway enabled.
+	OTelAgentGateway bool
 	// OTelConfig is the OTel configuration to use for the agent installation.
 	OTelConfig string
+	// OTelGatewayConfig is the OTel configuration to use for the gateway collector installation.
+	OTelGatewayConfig string
 	// GKEAutopilot is a flag to deploy the agent with only GKE Autopilot compatible values.
 	GKEAutopilot bool
 	// FIPS is a flag to deploy the agent with FIPS agent image.
@@ -213,10 +217,33 @@ datadog:
 	}
 }
 
+func WithOTelAgentGateway() func(*Params) error {
+	return func(p *Params) error {
+		p.OTelAgent = true
+		otelAgentGatewayValues := `
+otelAgentGateway:
+  enabled: true
+  replicas: 1
+  nodeSelector:
+    gateway: "true"`
+
+		p.HelmValues = append(p.HelmValues, pulumi.NewStringAsset(otelAgentGatewayValues))
+		return nil
+	}
+}
+
 func WithOTelConfig(config string) func(*Params) error {
 	return func(p *Params) error {
 		var err error
 		p.OTelConfig, err = utils.MergeYAML(p.OTelConfig, config)
+		return err
+	}
+}
+
+func WithOTelGatewayConfig(config string) func(*Params) error {
+	return func(p *Params) error {
+		var err error
+		p.OTelGatewayConfig, err = utils.MergeYAML(p.OTelGatewayConfig, config)
 		return err
 	}
 }

--- a/test/new-e2e/tests/otel/otel-agent/config/gateway.yml
+++ b/test/new-e2e/tests/otel/otel-agent/config/gateway.yml
@@ -2,19 +2,29 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: "localhost:5317"
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
 exporters:
   datadog:
+    metrics:
+      resource_attributes_as_tags: true
     api:
       key: ${env:DD_API_KEY}
+processors:
+  batch:
+    timeout: 10s
 service:
   pipelines:
     traces:
       receivers: [otlp]
+      processors: [batch]
       exporters: [datadog]
     metrics:
       receivers: [otlp]
+      processors: [batch]
       exporters: [datadog]
     logs:
       receivers: [otlp]
+      processors: [batch]
       exporters: [datadog]

--- a/test/new-e2e/tests/otel/otel-agent/config/gateway.yml
+++ b/test/new-e2e/tests/otel/otel-agent/config/gateway.yml
@@ -1,0 +1,20 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:5317"
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [datadog]
+    metrics:
+      receivers: [otlp]
+      exporters: [datadog]
+    logs:
+      receivers: [otlp]
+      exporters: [datadog]

--- a/test/new-e2e/tests/otel/otel-agent/gateway_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/gateway_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package otelagent contains e2e otel agent tests
+package otelagent
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	scenkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/otel/utils"
+)
+
+type gatewayTestSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+//go:embed config/gateway.yml
+var gatewayConfig string
+
+func TestOTelAgentGateway(t *testing.T) {
+	values := `
+datadog:
+  otelCollector:
+    useStandaloneImage: false
+  logs:
+    containerCollectAll: false
+    containerCollectUsingFiles: false
+agents:
+  containers:
+    otelAgent:
+      env:
+        - name: DD_APM_FEATURES
+          value: 'disable_operation_and_resource_name_logic_v2'
+`
+	t.Parallel()
+	e2e.Run(t, &gatewayTestSuite{},
+		e2e.WithProvisioner(provkindvm.Provisioner(
+			provkindvm.WithRunOptions(
+				scenkindvm.WithAgentOptions(
+					kubernetesagentparams.WithHelmValues(values),
+					kubernetesagentparams.WithOTelAgent(),
+					kubernetesagentparams.WithOTelGatewayConfig(gatewayConfig),
+					kubernetesagentparams.WithOTelAgentGateway(),
+				),
+			),
+		)),
+	)
+}
+
+var gatewayParams = utils.IAParams{
+	InfraAttributes: true,
+	EKS:             false,
+	Cardinality:     types.LowCardinality,
+}
+
+func (s *gatewayTestSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	// SetupSuite needs to defer CleanupOnSetupFailure() if what comes after BaseSuite.SetupSuite() can fail.
+	defer s.CleanupOnSetupFailure()
+
+	utils.TestCalendarApp(s, false, utils.CalendarService)
+}
+
+func (s *gatewayTestSuite) TestOTLPTraces() {
+	utils.TestTraces(s, gatewayParams)
+}
+
+func (s *gatewayTestSuite) TestOTLPMetrics() {
+	utils.TestMetrics(s, gatewayParams)
+}
+
+func (s *gatewayTestSuite) TestOTLPLogs() {
+	utils.TestLogs(s, gatewayParams)
+}
+
+func (s *gatewayTestSuite) TestHosts() {
+	utils.TestHosts(s)
+}
+
+func (s *gatewayTestSuite) TestOTelAgentInstalled() {
+	utils.TestOTelAgentInstalled(s)
+}

--- a/test/new-e2e/tests/otel/otel-agent/gateway_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/gateway_test.go
@@ -57,7 +57,7 @@ agents:
 }
 
 var gatewayParams = utils.IAParams{
-	InfraAttributes: true,
+	InfraAttributes: false,
 	EKS:             false,
 	Cardinality:     types.LowCardinality,
 }
@@ -88,4 +88,8 @@ func (s *gatewayTestSuite) TestHosts() {
 
 func (s *gatewayTestSuite) TestOTelAgentInstalled() {
 	utils.TestOTelAgentInstalled(s)
+}
+
+func (s *gatewayTestSuite) TestOTelGatewayInstalled() {
+	utils.TestOTelGatewayInstalled(s)
 }

--- a/test/new-e2e/tests/otel/utils/config_utils.go
+++ b/test/new-e2e/tests/otel/utils/config_utils.go
@@ -47,6 +47,12 @@ func TestOTelAgentInstalled(s OTelTestSuite) {
 	assert.Contains(s.T(), agent.ObjectMeta.String(), "otel-agent")
 }
 
+// TestOTelGatewayInstalled checks that the OTel Gateway collector is installed in the test suite
+func TestOTelGatewayInstalled(s OTelTestSuite) {
+	agent := getGatewayPod(s)
+	assert.Contains(s.T(), agent.ObjectMeta.String(), "otel-agent-gateway")
+}
+
 var otelFlareFilesCommon = []string{
 	"otel/otel-response.json",
 	"otel/otel-flare/customer.cfg",
@@ -180,6 +186,15 @@ func TestOTelRemoteConfigPayload(s OTelTestSuite, providedCfg string, fullCfg st
 func getAgentPod(s OTelTestSuite) corev1.Pod {
 	res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.Background(), metav1.ListOptions{
 		LabelSelector: fields.OneTermEqualSelector("app", s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]).String(),
+	})
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), res.Items)
+	return res.Items[0]
+}
+
+func getGatewayPod(s OTelTestSuite) corev1.Pod {
+	res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.Background(), metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("app", "dda-linux-datadog-otel-agent-gateway").String(),
 	})
 	require.NoError(s.T(), err)
 	require.NotEmpty(s.T(), res.Items)


### PR DESCRIPTION
### What does this PR do?
Adds e2e test for DDOT Gateway. This PR adds new e2e test options to enable e2e testing for DDOT gateway deployments:
- `WithOTelAgentGateway` adds `otelAgentGateway` helm values and enables gateway collector
- `WithOTelGatewayConfig` allows you to pass in a collector config for the gateway collector (see `gateway.yml`)

This PR also has two relevant changes in the e2e test framework:
- Updates datadog-agent helm chart version from `3.135.4` to `3.155.1` (previous version didn't include gateway changes)
- Disables `testingWorkloads` in `buildLinuxHelmValues` for gateway tests, since `agents.useConfigMap` was causing errors in gateway deployment

### Motivation

### Describe how you validated your changes
Running e2e tests

### Additional Notes
`WithOTelAgentConfig` (daemonset DDOT otel config param) cannot be used with Gateway e2e tests yet because these tests depend on the default daemonset otel config which automatically points to the gateway collector address: https://github.com/DataDog/helm-charts/blob/12f196db60526a0b67bbe77bc6b61a8c934d5d62/charts/datadog/templates/_otel_agent_config.yaml#L15.

This can be implemented in a future PR but might require some legwork.
