### PR TITLE
[ABLD-46] Better PURLs

### DIFF
--- a/compliance/rules/BUILD
+++ b/compliance/rules/BUILD
@@ -1,6 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
+    name = "purl",
+    srcs = ["purl.bzl"],
+)
+
+bzl_library(
     name = "ship_source_offer",
     srcs = ["ship_source_offer.bzl"],
 )

--- a/compliance/rules/purl.bzl
+++ b/compliance/rules/purl.bzl
@@ -1,0 +1,14 @@
+"""Functions for creating PURLs.
+
+If these work well for us, we'll propose them for inclusion in bazel-contrib/supply_chain
+"""
+
+def purl_for_generic(package, version, download_url):
+    # TODO: This must be http-encoded. Do that once the function is available from
+    # supply_chain
+    url = download_url.format(version = version)
+    return "pkg:generic/{package}@{version}?download_url={url}".format(
+        package = package,
+        version = version,
+        url = url,
+    )

--- a/deps/acl/overlay/overlay.BUILD.bazel
+++ b/deps/acl/overlay/overlay.BUILD.bazel
@@ -1,6 +1,7 @@
 """libacl"""
 
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@@//compliance/rules:purl.bzl", "purl_for_generic")
 load("@@//compliance/rules:ship_source_offer.bzl", "ship_source_offer")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
@@ -13,17 +14,17 @@ package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
 
 VERSION = "2.3.1"
 
-PURL = "pkg:generic/acl@{version}?download_url=https://download.savannah.nongnu.org/releases/acl/acl-{version}.tar.xz".format(
-    version = VERSION,
-)
-
 package_metadata(
     name = "package_metadata",
     attributes = [
         ":license",
         ":ship_source_offer",
     ],
-    purl = PURL,
+    purl = purl_for_generic(
+        package = "acl",
+        version = VERSION,
+        download_url = "https://download.savannah.nongnu.org/releases/acl/acl-{version}.tar.xz",
+    ),
 )
 
 ship_source_offer(name = "ship_source_offer")

--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -1,4 +1,5 @@
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@@//compliance/rules:purl.bzl", "purl_for_generic")
 load("@@//compliance/rules:ship_source_offer.bzl", "ship_source_offer")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
@@ -12,18 +13,17 @@ package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
 
 _VERSION = "2.5.1"
 
-# This is going to change in the future. Debate the syntax in https://github.com/bazel-contrib/supply-chain/issues/124
-PURL = "pkg:https/download.savannah.nongnu.org/attr@{version}?url=https://download.savannah.nongnu.org/releases/attr/attr-%{version}.tar.xz".format(
-    version = _VERSION,
-)
-
 package_metadata(
     name = "package_metadata",
     attributes = [
         ":license",
         ":ship_source_offer",
     ],
-    purl = PURL,
+    purl = purl_for_generic(
+        package = "attr",
+        version = _VERSION,
+        download_url = "https://download.savannah.nongnu.org/releases/attr/attr-{version}.tar.xz",
+    ),
 )
 
 license(

--- a/deps/libpcap/overlay/overlay.BUILD.bazel
+++ b/deps/libpcap/overlay/overlay.BUILD.bazel
@@ -1,3 +1,4 @@
+load("@@//compliance/rules:purl.bzl", "purl_for_generic")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
@@ -7,17 +8,16 @@ package(default_package_metadata = [":package_metadata"])
 
 VERSION = "1.10.5"
 
-# This is going to change in the future. Debate the syntax in https://github.com/bazel-contrib/supply-chain/issues/124
-PURL = "pkg:https/www.tcpdump.org/libpcap@{version}?url=https://www.tcpdump.org/release/libpcap-#{version}.tar.xz".format(
-    version = VERSION,
-)
-
 package_metadata(
     name = "package_metadata",
     attributes = [
         ":license",
     ],
-    purl = PURL,
+    purl = purl_for_generic(
+        package = "libpcap",
+        version = VERSION,
+        download_url = "https://www.tcpdump.org/release/libpcap-{version}.tar.xz",
+    ),
 )
 
 license(


### PR DESCRIPTION
- create a function to generate a correctly formatted PURL for a generic http download
- use that function in the places we create PURLs

### test plan
```
$ bazel cquery --output=build @libpcap//:all | grep purl
...
  purl = "pkg:generic/libpcap@1.10.5?download_url=https://www.tcpdump.org/release/libpcap-1.10.5.tar.xz",
```
That's exactly what I expect.