### PR TITLE
Improve error handling and log limits for container store

### DIFF
--- a/pkg/network/containers/container_item_linux_test.go
+++ b/pkg/network/containers/container_item_linux_test.go
@@ -8,11 +8,19 @@
 package containers
 
 import (
+	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/require"
+	"go4.org/intern"
+
+	"github.com/DataDog/datadog-agent/pkg/network/events"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestStripResolvConf(t *testing.T) {
@@ -39,6 +47,16 @@ type errorReader struct {
 
 func (er *errorReader) Read(_ []byte) (n int, err error) {
 	return 0, er.err
+}
+
+// mockResolvConfReader is a mock implementation of resolvConfReader for testing
+type mockResolvConfReader struct {
+	result string
+	err    error
+}
+
+func (m *mockResolvConfReader) readResolvConf(_ *events.Process) (string, error) {
+	return m.result, m.err
 }
 func TestStripResolvConfReaderError(t *testing.T) {
 	customErr := errors.New("custom read error")
@@ -69,4 +87,214 @@ func TestStripResolvConfTooBigOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "<too big: kind=output size=2000>", stripped)
+}
+
+func TestCheckProcessNotRunning(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "ErrorProcessNotRunning",
+			err:      process.ErrorProcessNotRunning,
+			expected: true,
+		},
+		{
+			name:     "ErrProcessDone",
+			err:      os.ErrProcessDone,
+			expected: true,
+		},
+		{
+			name:     "ErrNotExist",
+			err:      os.ErrNotExist,
+			expected: true,
+		},
+		{
+			name:     "wrapped ErrorProcessNotRunning",
+			err:      errors.Join(errors.New("context"), process.ErrorProcessNotRunning),
+			expected: true,
+		},
+		{
+			name:     "wrapped ErrProcessDone",
+			err:      errors.Join(errors.New("context"), os.ErrProcessDone),
+			expected: true,
+		},
+		{
+			name:     "other error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := errIsProcessNotRunning(tt.err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReadContainerItemProcessRunningVsNotRunning(t *testing.T) {
+	tests := []struct {
+		name                     string
+		isProcessRunning         bool
+		isProcessStillRunningErr error
+		readResolvConfResult     string
+		readResolvConfErr        error
+		expectedNoDataReason     string
+		expectedError            bool
+		expectedResolvConf       string
+	}{
+		{
+			name:                     "process not running - should return noDataReason",
+			isProcessRunning:         false,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "nameserver 8.8.8.8",
+			readResolvConfErr:        nil,
+			expectedNoDataReason:     "process not running",
+			expectedError:            false,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "process running - should return resolv.conf data",
+			isProcessRunning:         true,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "nameserver 8.8.8.8",
+			readResolvConfErr:        nil,
+			expectedNoDataReason:     "",
+			expectedError:            false,
+			expectedResolvConf:       "nameserver 8.8.8.8",
+		},
+		{
+			name:                     "process running but resolv.conf read failed",
+			isProcessRunning:         true,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "",
+			readResolvConfErr:        errors.New("permission denied"),
+			expectedNoDataReason:     "",
+			expectedError:            true,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "isProcessStillRunning returns error",
+			isProcessRunning:         false,
+			isProcessStillRunningErr: errors.New("process check failed"),
+			readResolvConfResult:     "nameserver 8.8.8.8",
+			readResolvConfErr:        nil,
+			expectedNoDataReason:     "",
+			expectedError:            true,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "process running with empty resolv.conf",
+			isProcessRunning:         true,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "",
+			readResolvConfErr:        nil,
+			expectedNoDataReason:     "",
+			expectedError:            false,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "readResolvConf ErrorProcessNotRunning + process not running",
+			isProcessRunning:         false,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "",
+			readResolvConfErr:        process.ErrorProcessNotRunning,
+			expectedNoDataReason:     "process not running",
+			expectedError:            false,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "readResolvConf ErrProcessDone + process not running",
+			isProcessRunning:         false,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "",
+			readResolvConfErr:        os.ErrProcessDone,
+			expectedNoDataReason:     "process not running",
+			expectedError:            false,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "readResolvConf wrapped ErrorProcessNotRunning + process not running",
+			isProcessRunning:         false,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "",
+			readResolvConfErr:        errors.Join(errors.New("context"), process.ErrorProcessNotRunning),
+			expectedNoDataReason:     "process not running",
+			expectedError:            false,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "readResolvConf wrapped ErrProcessDone + process not running",
+			isProcessRunning:         false,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "",
+			readResolvConfErr:        errors.Join(errors.New("wrapped"), os.ErrProcessDone),
+			expectedNoDataReason:     "process not running",
+			expectedError:            false,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "readResolvConf ErrNotExist + process running should propagate",
+			isProcessRunning:         true,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "",
+			readResolvConfErr:        os.ErrNotExist,
+			expectedNoDataReason:     "",
+			expectedError:            true,
+			expectedResolvConf:       "",
+		},
+		{
+			name:                     "readResolvConf ErrNotExist + process not running should not propagate",
+			isProcessRunning:         false,
+			isProcessStillRunningErr: nil,
+			readResolvConfResult:     "",
+			readResolvConfErr:        os.ErrNotExist,
+			expectedNoDataReason:     "process not running",
+			expectedError:            false,
+			expectedResolvConf:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := newContainerReader(
+				&mockResolvConfReader{
+					result: tt.readResolvConfResult,
+					err:    tt.readResolvConfErr,
+				},
+				log.NewLogLimit(999, time.Second),
+			)
+			// Override isProcessStillRunning for mocking
+			cr.isProcessStillRunning = func(_ context.Context, _ *events.Process) (bool, error) {
+				return tt.isProcessRunning, tt.isProcessStillRunningErr
+			}
+
+			processEvent := &events.Process{
+				Pid:         12345,
+				ContainerID: intern.GetByString("test-container"),
+			}
+
+			result, err := cr.readContainerItem(context.Background(), processEvent)
+
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedNoDataReason, result.noDataReason)
+				if tt.expectedResolvConf != "" {
+					require.Equal(t, tt.expectedResolvConf, result.item.resolvConf.Get())
+				} else {
+					require.Empty(t, result.item.resolvConf)
+				}
+			}
+		})
+	}
 }

--- a/pkg/network/containers/container_store_linux.go
+++ b/pkg/network/containers/container_store_linux.go
@@ -62,6 +62,7 @@ type ContainerStore struct {
 
 	warnLimit  *log.Limit
 	errorLimit *log.Limit
+	debugLimit *log.Limit
 
 	containerReader containerReader
 
@@ -77,8 +78,9 @@ func (csi containerStoreItem) isExpired() bool {
 
 // NewContainerStore initializes the container store
 func NewContainerStore(maxContainers int) (*ContainerStore, error) {
-	warnLimit := log.NewLogLimit(5, 10*time.Second)
-	errorLimit := log.NewLogLimit(5, 10*time.Second)
+	warnLimit := log.NewLogLimit(5, 10*time.Minute)
+	errorLimit := log.NewLogLimit(5, 10*time.Minute)
+	debugLimit := log.NewLogLimit(5, time.Minute)
 
 	cache, err := lru.NewWithEvict(maxContainers, func(key *intern.Value, item containerStoreItem) {
 		if log.ShouldLog(log.TraceLvl) {
@@ -103,11 +105,11 @@ func NewContainerStore(maxContainers int) (*ContainerStore, error) {
 
 		warnLimit:  warnLimit,
 		errorLimit: errorLimit,
+		debugLimit: debugLimit,
 
-		containerReader: containerReader{
-			resolvStripper: makeResolvStripper(resolvConfInputMaxSizeBytes),
-		},
+		containerReader: newContainerReader(makeResolvStripper(resolvConfInputMaxSizeBytes), debugLimit),
 	}
+	// this function is only ever replaced in tests for mocking purposes
 	cs.readContainerItem = cs.containerReader.readContainerItem
 
 	cleanTicker := time.NewTicker(cleanerInterval)
@@ -151,7 +153,7 @@ func (cs *ContainerStore) addProcess(entry *events.Process) {
 	}
 
 	result, err := cs.readContainerItem(cs.ctx, entry)
-	if log.ShouldLog(log.DebugLvl) {
+	if log.ShouldLog(log.DebugLvl) && cs.debugLimit.ShouldLog() {
 		logHandledID(entry.ContainerID, result, err)
 	}
 	if cs.ctx.Err() != nil {
@@ -171,7 +173,7 @@ func (cs *ContainerStore) addProcess(entry *events.Process) {
 		return
 	}
 	if result.noDataReason != "" {
-		if log.ShouldLog(log.DebugLvl) {
+		if log.ShouldLog(log.DebugLvl) && cs.debugLimit.ShouldLog() {
 			logNoData(entry.ContainerID, result.noDataReason)
 		}
 		return
@@ -179,7 +181,7 @@ func (cs *ContainerStore) addProcess(entry *events.Process) {
 
 	item := result.item
 
-	if log.ShouldLog(log.DebugLvl) {
+	if log.ShouldLog(log.DebugLvl) && cs.debugLimit.ShouldLog() {
 		logResolvConfRead(len(item.resolvConf.Get()))
 	}
 
@@ -256,6 +258,7 @@ func (cs *ContainerStore) GetResolvConfMap(conns []network.ConnectionStats) map[
 		}
 	}
 
+	// we know this one will only run once per 30s connections check, so no need to use log.Limit
 	log.Debugf("CNM ContainerStore mapped %d out of %d containerIDs", len(resolvConfs), len(allContainers))
 
 	return resolvConfs


### PR DESCRIPTION
### What does this PR do?
This PR suppresses some spurious errors that were getting logged when PIDs were no longer running. It also sets more aggressive log limits to avoid spamming system-probe.

### Motivation
Too much non-useful logs in system-probe

### Describe how you validated your changes
Added tests to `container_item_test.go`:
```
go test -tags linux_bpf github.com/DataDog/datadog-agent/pkg/network/containers
```