### PR TITLE
[USMON-1507] usm: debugtool: add symbols ls command to list binary symbols

### DIFF
--- a/cmd/system-probe/subcommands/usm/command.go
+++ b/cmd/system-probe/subcommands/usm/command.go
@@ -32,5 +32,16 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		usmCmd.AddCommand(checkMapsCmd)
 	}
 
+	// Add symbols command if available on this platform
+	if symbolsLsCmd := makeSymbolsLsCommand(globalParams); symbolsLsCmd != nil {
+		symbolsCmd := &cobra.Command{
+			Use:          "symbols",
+			Short:        "Symbol inspection commands",
+			SilenceUsage: true,
+		}
+		symbolsCmd.AddCommand(symbolsLsCmd)
+		usmCmd.AddCommand(symbolsCmd)
+	}
+
 	return []*cobra.Command{usmCmd}
 }

--- a/cmd/system-probe/subcommands/usm/symbols_ls_linux.go
+++ b/cmd/system-probe/subcommands/usm/symbols_ls_linux.go
@@ -152,6 +152,10 @@ func runSymbolsLs(_ sysconfigcomponent.Component, _ *command.GlobalParams, dynam
 	return nil
 }
 
+const (
+	sizeOfUint16 = 2
+)
+
 // getSymbolVersions extracts version information for dynamic symbols.
 // Returns a map from symbol index to version string (e.g., "@GLIBC_2.17").
 func getSymbolVersions(elfFile *safeelf.File) map[int]string {
@@ -214,9 +218,9 @@ func getSymbolVersions(elfFile *safeelf.File) map[int]string {
 	// Map each symbol to its version
 	// Note: DynamicSymbols() skips the null symbol at index 0, but .gnu.version includes it
 	// So .gnu.version[0] is for null, .gnu.version[1] is for DynamicSymbols()[0], etc.
-	for i := 0; i < len(versionData)/2; i++ {
+	for i := 0; i < len(versionData)/sizeOfUint16; i++ {
 		// Each entry is 2 bytes (uint16)
-		versionIdx := uint16(versionData[i*2]) | (uint16(versionData[i*2+1]) << 8)
+		versionIdx := uint16(versionData[i*sizeOfUint16]) | (uint16(versionData[i*sizeOfUint16+1]) << 8)
 
 		// Version index 0 and 1 are special (local and global)
 		if versionIdx > 1 {

--- a/cmd/system-probe/subcommands/usm/symbols_ls_unsupported.go
+++ b/cmd/system-probe/subcommands/usm/symbols_ls_unsupported.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package usm
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+)
+
+// makeSymbolsLsCommand returns nil on unsupported platforms
+func makeSymbolsLsCommand(_ *command.GlobalParams) *cobra.Command {
+	return nil
+}

--- a/pkg/util/safeelf/types.go
+++ b/pkg/util/safeelf/types.go
@@ -10,6 +10,8 @@ import "debug/elf" //nolint:depguard
 
 type Prog = elf.Prog
 type Symbol = elf.Symbol
+type SymType = elf.SymType
+type SymBind = elf.SymBind
 type Section = elf.Section
 type SectionHeader = elf.SectionHeader
 type SectionType = elf.SectionType
@@ -43,6 +45,17 @@ const PF_X = elf.PF_X
 const PF_W = elf.PF_W
 
 const STB_GLOBAL = elf.STB_GLOBAL
+const STB_WEAK = elf.STB_WEAK
+const STT_OBJECT = elf.STT_OBJECT
 const STT_FUNC = elf.STT_FUNC
+const STT_FILE = elf.STT_FILE
+const SHN_UNDEF = elf.SHN_UNDEF
+const SHF_WRITE = elf.SHF_WRITE
+const SHT_NOBITS = elf.SHT_NOBITS
+const SHN_ABS = elf.SHN_ABS
+const SHN_COMMON = elf.SHN_COMMON
 
 const SHF_COMPRESSED = elf.SHF_COMPRESSED
+
+func ST_TYPE(info uint8) SymType { return elf.ST_TYPE(info) }
+func ST_BIND(info uint8) SymBind { return elf.ST_BIND(info) }


### PR DESCRIPTION
### What does this PR do?

Adds a new `symbols ls` subcommand to `system-probe usm` that lists symbols from ELF binaries. This debugging tool helps analyze binary symbols, which is particularly useful for USM troubleshooting and binary analysis.

The command uses a hierarchical structure (`usm symbols ls`) and supports both static and dynamic symbol tables with proper version information parsing from ELF files.

### Motivation

USM developers and support engineers need to inspect symbols in binaries to:
- Debug symbol resolution issues in monitored applications
- Verify library versions being used (e.g., GLIBC versions)
- Analyze symbol visibility and linkage for troubleshooting
- Understand which symbols are being imported/exported by binaries

Having this tool integrated into `system-probe usm` provides a consistent debugging experience without requiring additional external tools. The hierarchical command structure (`usm symbols ls`) allows for future symbol-related subcommands.

### Describe how you validated your changes

1. **Comprehensive comparison testing**: Compared output against GNU `nm` utility using the envoy-1.24.6-solo binary (large production binary with ~870K symbols)
   - Dynamic symbols: `diff <(system-probe usm symbols ls --dynamic envoy) <(nm -D envoy | sort)` → 0 differences
   - Static symbols: `diff <(system-probe usm symbols ls envoy) <(nm envoy | sort)` → 0 differences

2. **Tested specific edge cases**:
   - Symbol version information (e.g., `abort@GLIBC_2.17`)
   - Weak undefined symbols (showing as 'w' not 'U')
   - Absolute symbols with value 0 (showing `0000000000000000` not blank)
   - FILE symbol filtering (excluded by default, matching nm behavior)
   - Symbol type detection (text, data, BSS, undefined, weak, etc.)

3. **Verified command structure**:
   - Parent command: `system-probe usm symbols`
   - Subcommand: `system-probe usm symbols ls`
   - Help output for both levels

### Additional Notes

- Uses existing `pkg/util/safeelf` package for safe ELF parsing
- Platform-specific: Linux implementation only (returns nil on other platforms)
- Handles complex ELF structures: `.gnu.version`, `.gnu.version_r`, `.gnu.version_d`
- Correctly handles Go's `DynamicSymbols()` off-by-one indexing vs `.gnu.version` array
- Hierarchical command structure allows for future expansion (e.g., `symbols search`, `symbols diff`)