### PR TITLE
feat(opso): Remove the `waiting on author` label on external comments

### DIFF
--- a/.github/workflows/check_issue_status.yml
+++ b/.github/workflows/check_issue_status.yml
@@ -85,6 +85,30 @@ jobs:
                 });
               }
             }
+      - name: Remove the "waiting on author" label when issue is commented
+        if: steps.datadog-comment.outputs.result == 'false'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
+          script: |
+            const issueNumber = context.eventName === 'issue_comment'
+              ? context.issue.number
+              : parseInt(context.payload.inputs.issue_number);
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            for (const label of labels.data) {
+              if (label.name === 'waiting on author') {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label.name
+                });
+              }
+            }
       - name: Remove the team/triage label if another team label exists
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:

--- a/.github/workflows/check_issue_status.yml
+++ b/.github/workflows/check_issue_status.yml
@@ -26,7 +26,7 @@ jobs:
           scope: DataDog/datadog-agent
           policy: self.assign-issue.label-issue
 
-      - name: Check if there is a comment from a datadog member
+      - name: Check if the latest comment is from a datadog member
         id: datadog-comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -36,31 +36,47 @@ jobs:
             const issueNumber = context.eventName === 'issue_comment'
               ? context.issue.number
               : parseInt(context.payload.inputs.issue_number);
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber
-            });
-            let commented = "false";
-            for (const comment of comments.data) {
-              try {
-                const membership = await github.rest.orgs.checkMembershipForUser({
-                  org: 'datadog',
-                  username: comment.user.login
-                });
-                if (membership.status === 204) {
-                  commented = "true";
-                  break;
-                }
-              } catch (error) {
-                if (error.name === 'HttpError') {
-                  // User is not a datadog member
-                  continue;
-                }
-                throw error;
+
+            // Determine the username of the current comment's author depending on event type
+            let username = null;
+            if (context.eventName === 'issue_comment') {
+              username = context.payload.comment.user.login;
+            } else if (context.payload.inputs && context.payload.inputs.issue_number) {
+              // For workflow_dispatch, fetch the latest comment's author on the issue
+
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 1,
+                sort: 'created',
+                direction: 'desc'
+              });
+              if (comments.data.length === 0) {
+                // no comments, cannot determine user
+                return "false";
               }
+              username = comments.data[0].user.login;
+            } else {
+              return "false";
             }
-            return commented;
+
+            try {
+              const membership = await github.rest.orgs.checkMembershipForUser({
+                org: 'datadog',
+                username: username
+              });
+              if (membership.status === 204) {
+                return "true";
+              }
+              return "false";
+            } catch (error) {
+              if (error.name === 'HttpError') {
+                // User is not a datadog member
+                return "false";
+              }
+              throw error;
+            }
       - name: Remove the pending label when issue is commented
         if: steps.datadog-comment.outputs.result == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/check_issue_status.yml
+++ b/.github/workflows/check_issue_status.yml
@@ -48,15 +48,12 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
-                per_page: 1,
-                sort: 'created',
-                direction: 'desc'
               });
               if (comments.data.length === 0) {
                 // no comments, cannot determine user
                 return "false";
               }
-              username = comments.data[0].user.login;
+              username = comments.data[comments.data.length - 1].user.login;
             } else {
               return "false";
             }
@@ -71,7 +68,7 @@ jobs:
               }
               return "false";
             } catch (error) {
-              if (error.name === 'HttpError') {
+              if (error.message.startsWith('User does not exist or is not a member')) {
                 // User is not a datadog member
                 return "false";
               }


### PR DESCRIPTION
### What does this PR do?
Removes the `waiting on author` label if present when an issue is commented by an external contributor

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-1151

### Describe how you validated your changes
n/a. Same code as the one removing the `pending` label

### Additional Notes
