### PR TITLE
[incident-47030] Disable ci viz in orchestrion

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -53,7 +53,7 @@
     # Generate external links to CI VISIBILITY, used by artifacts:reports:annotations
     - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - export DD_ENV=nativetest # TODO: Remove after testing native instrumentation
-    - export DD_CIVISIBILITY_ENABLED=true
+    # - export DD_CIVISIBILITY_ENABLED=true
     - export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     # set the environment variables for the windows test signing


### PR DESCRIPTION
### What does this PR do?
Disable CI visibility in orchestrion.

### Motivation
There is a bad interaction between Go 1.25 and CI viz, and some logs end up missing in tests, which makes it impossible to debug and also causes some failures related to the flake marker. 

### Describe how you validated your changes
CI

### Additional Notes
