### PR TITLE
feat(ssi): Implement APM libraries injection using CSI driver

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/csi.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/csi.go
@@ -1,0 +1,152 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package libraryinjection
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+)
+
+// CSI driver constants.
+const (
+	// CSIDriverName is the name of the Datadog CSI driver.
+	CSIDriverName = "k8s.csi.datadoghq.com"
+
+	// CSIVolumeAttributeType is the key for the volume type attribute.
+	CSIVolumeAttributeType = "type"
+
+	// CSIVolumeTypeLibrary is the volume type for mounting OCI image contents.
+	// This is used for both the APM injector and language-specific libraries.
+	CSIVolumeTypeLibrary = "DatadogLibrary"
+
+	// CSIVolumeTypeInjectorPreload is the volume type for mounting the injector preload file.
+	CSIVolumeTypeInjectorPreload = "DatadogInjectorPreload"
+
+	// CSIVolumeAttributeImage is the key for the OCI image to mount.
+	CSIVolumeAttributeImage = "dd.csi.datadog.com/library.image"
+
+	// CSIVolumeAttributeSource is the key for the source path within the OCI image.
+	CSIVolumeAttributeSource = "dd.csi.datadog.com/library.source"
+
+	// CSIInjectorSourcePath is the source path for the APM injector within its OCI image.
+	CSIInjectorSourcePath = "/opt/datadog-packages/datadog-apm-inject"
+
+	// CSILibrarySourcePath is the source path for language libraries within their OCI images.
+	CSILibrarySourcePath = "/datadog-init/package"
+)
+
+// CSIProvider implements LibraryInjectionProvider using a CSI driver.
+// This provider mounts library files directly via CSI volumes without using init containers.
+type CSIProvider struct {
+	cfg ProviderConfig
+}
+
+// NewCSIProvider creates a new CSIProvider.
+func NewCSIProvider(cfg ProviderConfig) *CSIProvider {
+	return &CSIProvider{
+		cfg: cfg,
+	}
+}
+
+// InjectInjector mutates the pod to add the APM injector using CSI volumes.
+func (p *CSIProvider) InjectInjector(pod *corev1.Pod, cfg InjectorConfig) MutationResult {
+	mutator := NewPodMutator(pod, p.cfg)
+
+	// CSI volume for the injector image contents
+	injectorVolume := corev1.Volume{
+		Name: VolumeName,
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver:   CSIDriverName,
+				ReadOnly: pointer.Ptr(true),
+				VolumeAttributes: map[string]string{
+					CSIVolumeAttributeType:   CSIVolumeTypeLibrary,
+					CSIVolumeAttributeImage:  cfg.Image,
+					CSIVolumeAttributeSource: CSIInjectorSourcePath,
+				},
+			},
+		},
+	}
+	mutator.AddVolume(injectorVolume)
+	mutator.AddVolumeMount(corev1.VolumeMount{
+		Name:      VolumeName,
+		MountPath: AsAbsPath(InjectPackageDir),
+		ReadOnly:  true,
+	})
+
+	// CSI volume for /etc/ld.so.preload
+	ldPreloadVolume := corev1.Volume{
+		Name: EtcVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver:   CSIDriverName,
+				ReadOnly: pointer.Ptr(true),
+				VolumeAttributes: map[string]string{
+					CSIVolumeAttributeType: CSIVolumeTypeInjectorPreload,
+				},
+			},
+		},
+	}
+	mutator.AddVolume(ldPreloadVolume)
+	mutator.AddVolumeMount(corev1.VolumeMount{
+		Name:      EtcVolumeName,
+		MountPath: "/etc/ld.so.preload",
+		ReadOnly:  true,
+	})
+
+	return MutationResult{
+		Status: MutationStatusInjected,
+	}
+}
+
+// InjectLibrary mutates the pod to add a language-specific tracing library using CSI volumes.
+func (p *CSIProvider) InjectLibrary(pod *corev1.Pod, cfg LibraryConfig) MutationResult {
+	if !IsLanguageSupported(cfg.Language) {
+		return MutationResult{
+			Status:  MutationStatusError,
+			Message: fmt.Sprintf("language %s is not supported", cfg.Language),
+		}
+	}
+
+	mutator := NewPodMutator(pod, p.cfg)
+
+	// CSI volume for the library (uses DatadogLibrary type to mount OCI image contents)
+	volumeName := fmt.Sprintf("dd-lib-%s", cfg.Language)
+	libraryVolume := corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver:   CSIDriverName,
+				ReadOnly: pointer.Ptr(true),
+				VolumeAttributes: map[string]string{
+					CSIVolumeAttributeType:   CSIVolumeTypeLibrary,
+					CSIVolumeAttributeImage:  cfg.Image,
+					CSIVolumeAttributeSource: CSILibrarySourcePath,
+				},
+			},
+		},
+	}
+	mutator.AddVolume(libraryVolume)
+
+	// Volume mount for application containers
+	mutator.AddVolumeMount(corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: AsAbsPath(LibraryPackagesDir) + "/" + cfg.Language,
+		ReadOnly:  true,
+	})
+
+	return MutationResult{
+		Status: MutationStatusInjected,
+	}
+}
+
+// Verify that CSIProvider implements LibraryInjectionProvider.
+var _ LibraryInjectionProvider = (*CSIProvider)(nil)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/init_container.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/init_container.go
@@ -1,0 +1,348 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package libraryinjection
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+	// minimumCPULimit is the minimum CPU limit required for init containers.
+	// Below this, copying + library initialization would take too long.
+	minimumCPULimit = resource.MustParse("0.05") // 0.05 core
+
+	// minimumMemoryLimit is the minimum memory limit required for init containers.
+	// This is the recommended minimum by Alpine.
+	minimumMemoryLimit = resource.MustParse("100Mi") // 100 MB
+)
+
+// InitContainerProvider implements LibraryInjectionProvider using init containers
+// and EmptyDir volumes. This is the traditional injection method where init containers
+// copy library files from images into a shared EmptyDir volume.
+type InitContainerProvider struct {
+	cfg ProviderConfig
+	// cachedRequirements stores the computed resource requirements for init containers.
+	// This is computed once during InjectInjector and reused for InjectLibrary calls.
+	cachedRequirements corev1.ResourceRequirements
+}
+
+// NewInitContainerProvider creates a new InitContainerProvider.
+func NewInitContainerProvider(cfg ProviderConfig) *InitContainerProvider {
+	return &InitContainerProvider{
+		cfg: cfg,
+	}
+}
+
+// InjectInjector mutates the pod to add the APM injector using init containers.
+func (p *InitContainerProvider) InjectInjector(pod *corev1.Pod, cfg InjectorConfig) MutationResult {
+	// First, validate that the pod has sufficient resources
+	requirements, shouldSkip, message := p.computeResourceRequirements(pod)
+	if shouldSkip {
+		return MutationResult{
+			Status:  MutationStatusSkipped,
+			Message: message,
+		}
+	}
+	p.cachedRequirements = requirements
+
+	mutator := NewPodMutator(pod, p.cfg)
+
+	// Main volume for library files (EmptyDir)
+	sourceVolume := NewEmptyDirVolume(VolumeName)
+	mutator.AddVolume(sourceVolume)
+
+	// Volume for /etc/ld.so.preload
+	etcVolume := NewEmptyDirVolume(EtcVolumeName)
+	mutator.AddVolume(etcVolume)
+
+	// Volume mount for the injector files
+	injectorMount := corev1.VolumeMount{
+		Name:      VolumeName,
+		MountPath: "/datadog-inject",
+		SubPath:   InjectPackageDir,
+	}
+
+	// Volume mount for /etc directory in init container
+	etcMountInitContainer := corev1.VolumeMount{
+		Name:      EtcVolumeName,
+		MountPath: "/datadog-etc",
+	}
+
+	// Volume mount for /etc/ld.so.preload in app containers
+	etcMountAppContainer := corev1.VolumeMount{
+		Name:      EtcVolumeName,
+		MountPath: "/etc/ld.so.preload",
+		SubPath:   "ld.so.preload",
+		ReadOnly:  true,
+	}
+
+	// Add volume mounts to app containers
+	mutator.AddVolumeMount(etcMountAppContainer)
+	mutator.AddVolumeMount(corev1.VolumeMount{
+		Name:      VolumeName,
+		MountPath: AsAbsPath(InjectPackageDir),
+		SubPath:   InjectPackageDir,
+	})
+
+	// Timestamp file path for tracking init container completion
+	tsFilePath := injectorMount.MountPath + "/c-init-time." + InjectorInitContainerName
+
+	// Init container that copies injector files
+	initContainer := corev1.Container{
+		Name:    InjectorInitContainerName,
+		Image:   cfg.Image,
+		Command: []string{"/bin/sh", "-c", "--"},
+		Args: []string{
+			fmt.Sprintf(
+				`cp -r /%s/* %s && echo %s > /datadog-etc/ld.so.preload && echo $(date +%%s) >> %s`,
+				injectorMount.SubPath,
+				injectorMount.MountPath,
+				AsAbsPath(InjectorFilePath("launcher.preload.so")),
+				tsFilePath,
+			),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			injectorMount,
+			etcMountInitContainer,
+		},
+		Resources: requirements,
+	}
+
+	// Apply security context - prefer the one from InjectorConfig (namespace-specific),
+	// fall back to the one from ProviderConfig (global default)
+	if cfg.InitSecurityContext != nil {
+		initContainer.SecurityContext = cfg.InitSecurityContext
+	} else if p.cfg.InitSecurityContext != nil {
+		initContainer.SecurityContext = p.cfg.InitSecurityContext
+	}
+
+	mutator.AddInitContainer(initContainer)
+
+	return MutationResult{
+		Status: MutationStatusInjected,
+	}
+}
+
+// InjectLibrary mutates the pod to add a language-specific tracing library using init containers.
+func (p *InitContainerProvider) InjectLibrary(pod *corev1.Pod, cfg LibraryConfig) MutationResult {
+	if !IsLanguageSupported(cfg.Language) {
+		return MutationResult{
+			Status:  MutationStatusError,
+			Message: fmt.Sprintf("language %s is not supported", cfg.Language),
+		}
+	}
+
+	mutator := NewPodMutator(pod, p.cfg)
+
+	// Main volume (should already exist from injector, but we add it for completeness)
+	sourceVolume := NewEmptyDirVolume(VolumeName)
+	mutator.AddVolume(sourceVolume)
+
+	// Mount path for this language's library files
+	libraryMountPath := MountPath
+	librarySubPath := LibraryPackagesDir + "/" + cfg.Language
+
+	// Volume mount for the library files in the init container
+	initContainerMount := corev1.VolumeMount{
+		Name:      VolumeName,
+		MountPath: libraryMountPath,
+		SubPath:   librarySubPath,
+	}
+
+	// Volume mount for injector (to write timestamp)
+	injectorMount := corev1.VolumeMount{
+		Name:      VolumeName,
+		MountPath: AsAbsPath(InjectPackageDir),
+		SubPath:   InjectPackageDir,
+	}
+
+	// Init container name
+	containerName := LibraryInitContainerName(cfg.Language)
+
+	// Timestamp file path
+	tsFilePath := injectorMount.MountPath + "/c-init-time." + containerName
+
+	// Init container that copies library files
+	initContainer := corev1.Container{
+		Name:    containerName,
+		Image:   cfg.Image,
+		Command: []string{"/bin/sh", "-c", "--"},
+		Args: []string{
+			fmt.Sprintf(
+				`sh copy-lib.sh %s && echo $(date +%%s) >> %s`,
+				initContainerMount.MountPath,
+				tsFilePath,
+			),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			initContainerMount,
+			injectorMount,
+		},
+		Resources: p.cachedRequirements,
+	}
+
+	// Apply security context - prefer the one from LibraryConfig (namespace-specific),
+	// fall back to the one from ProviderConfig (global default)
+	if cfg.InitSecurityContext != nil {
+		initContainer.SecurityContext = cfg.InitSecurityContext
+	} else if p.cfg.InitSecurityContext != nil {
+		initContainer.SecurityContext = p.cfg.InitSecurityContext
+	}
+
+	mutator.AddInitContainer(initContainer)
+
+	// Volume mount for application containers
+	mutator.AddVolumeMount(corev1.VolumeMount{
+		Name:      VolumeName,
+		MountPath: AsAbsPath(LibraryPackagesDir),
+		SubPath:   LibraryPackagesDir,
+	})
+
+	return MutationResult{
+		Status: MutationStatusInjected,
+	}
+}
+
+// computeResourceRequirements computes the resource requirements for init containers.
+// It returns the requirements, whether injection should be skipped, and an optional message.
+func (p *InitContainerProvider) computeResourceRequirements(pod *corev1.Pod) (corev1.ResourceRequirements, bool, string) {
+	requirements := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+
+	podRequirements := podSumResourceRequirements(pod)
+	insufficientResourcesMessage := "The overall pod's containers limit is too low"
+	shouldSkip := false
+
+	for _, k := range [2]corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		// If a resource quantity was set in config, use it
+		if q, ok := p.cfg.DefaultResourceRequirements[k]; ok {
+			requirements.Limits[k] = q
+			requirements.Requests[k] = q
+		} else {
+			// Otherwise, try to use as much of the resource as we can without impacting pod scheduling
+			if maxPodLim, ok := podRequirements.Limits[k]; ok {
+				// Check if the pod has sufficient resources
+				switch k {
+				case corev1.ResourceMemory:
+					if minimumMemoryLimit.Cmp(maxPodLim) == 1 {
+						shouldSkip = true
+						insufficientResourcesMessage += fmt.Sprintf(", %v pod_limit=%v needed=%v", k, maxPodLim.String(), minimumMemoryLimit.String())
+					}
+				case corev1.ResourceCPU:
+					if minimumCPULimit.Cmp(maxPodLim) == 1 {
+						shouldSkip = true
+						insufficientResourcesMessage += fmt.Sprintf(", %v pod_limit=%v needed=%v", k, maxPodLim.String(), minimumCPULimit.String())
+					}
+				}
+				requirements.Limits[k] = maxPodLim
+			}
+			if maxPodReq, ok := podRequirements.Requests[k]; ok {
+				requirements.Requests[k] = maxPodReq
+			}
+		}
+	}
+
+	if shouldSkip {
+		return requirements, true, insufficientResourcesMessage
+	}
+	return requirements, false, ""
+}
+
+// podSumResourceRequirements computes the sum of cpu/memory necessary for the whole pod.
+// This is computed as max(max(initContainer resources), sum(container resources) + sum(sidecar containers))
+// for both limit and request.
+// See: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#resource-sharing-within-containers
+func podSumResourceRequirements(pod *corev1.Pod) corev1.ResourceRequirements {
+	requirements := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+
+	for _, k := range [2]corev1.ResourceName{corev1.ResourceMemory, corev1.ResourceCPU} {
+		// Take max(initContainer resource)
+		maxInitContainerLimit := resource.Quantity{}
+		maxInitContainerRequest := resource.Quantity{}
+		for i := range pod.Spec.InitContainers {
+			c := &pod.Spec.InitContainers[i]
+			if initContainerIsSidecar(c) {
+				// Sidecar containers run alongside main containers, so skip here
+				continue
+			}
+			if limit, ok := c.Resources.Limits[k]; ok {
+				if limit.Cmp(maxInitContainerLimit) == 1 {
+					maxInitContainerLimit = limit
+				}
+			}
+			if request, ok := c.Resources.Requests[k]; ok {
+				if request.Cmp(maxInitContainerRequest) == 1 {
+					maxInitContainerRequest = request
+				}
+			}
+		}
+
+		// Take sum(container resources) + sum(sidecar containers)
+		limitSum := resource.Quantity{}
+		reqSum := resource.Quantity{}
+		for i := range pod.Spec.Containers {
+			c := &pod.Spec.Containers[i]
+			if l, ok := c.Resources.Limits[k]; ok {
+				limitSum.Add(l)
+			}
+			if l, ok := c.Resources.Requests[k]; ok {
+				reqSum.Add(l)
+			}
+		}
+		for i := range pod.Spec.InitContainers {
+			c := &pod.Spec.InitContainers[i]
+			if !initContainerIsSidecar(c) {
+				continue
+			}
+			if l, ok := c.Resources.Limits[k]; ok {
+				limitSum.Add(l)
+			}
+			if l, ok := c.Resources.Requests[k]; ok {
+				reqSum.Add(l)
+			}
+		}
+
+		// Take max(max(initContainer resources), sum(container resources) + sum(sidecar containers))
+		if limitSum.Cmp(maxInitContainerLimit) == 1 {
+			maxInitContainerLimit = limitSum
+		}
+		if reqSum.Cmp(maxInitContainerRequest) == 1 {
+			maxInitContainerRequest = reqSum
+		}
+
+		// Ensure that the limit is greater or equal to the request
+		if maxInitContainerRequest.Cmp(maxInitContainerLimit) == 1 {
+			maxInitContainerLimit = maxInitContainerRequest
+		}
+
+		if maxInitContainerLimit.CmpInt64(0) == 1 {
+			requirements.Limits[k] = maxInitContainerLimit
+		}
+		if maxInitContainerRequest.CmpInt64(0) == 1 {
+			requirements.Requests[k] = maxInitContainerRequest
+		}
+	}
+
+	return requirements
+}
+
+// initContainerIsSidecar returns true if the init container is a sidecar container.
+func initContainerIsSidecar(container *corev1.Container) bool {
+	return container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways
+}
+
+// Verify that InitContainerProvider implements LibraryInjectionProvider.
+var _ LibraryInjectionProvider = (*InitContainerProvider)(nil)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/pod_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/pod_mutator.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package libraryinjection
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+)
+
+// PodMutator provides helper functions for mutating pods.
+// It encapsulates common operations like adding volumes, volume mounts, and init containers.
+type PodMutator struct {
+	pod *corev1.Pod
+	cfg ProviderConfig
+}
+
+// NewPodMutator creates a new PodMutator for the given pod.
+func NewPodMutator(pod *corev1.Pod, cfg ProviderConfig) *PodMutator {
+	return &PodMutator{
+		pod: pod,
+		cfg: cfg,
+	}
+}
+
+// AddVolume adds a volume to the pod. If a volume with the same name exists, it replaces it.
+// It also marks the volume as safe to evict for the cluster autoscaler.
+func (m *PodMutator) AddVolume(vol corev1.Volume) {
+	for i, existing := range m.pod.Spec.Volumes {
+		if existing.Name == vol.Name {
+			m.pod.Spec.Volumes[i] = vol
+			mutatecommon.MarkVolumeAsSafeToEvictForAutoscaler(m.pod, vol.Name)
+			return
+		}
+	}
+	m.pod.Spec.Volumes = append(m.pod.Spec.Volumes, vol)
+	mutatecommon.MarkVolumeAsSafeToEvictForAutoscaler(m.pod, vol.Name)
+}
+
+// AddVolumeMount adds a volume mount to all application containers (filtered by ContainerFilter).
+// If a mount with the same name and path exists, it replaces it.
+func (m *PodMutator) AddVolumeMount(mount corev1.VolumeMount) {
+	for i := range m.pod.Spec.Containers {
+		ctr := &m.pod.Spec.Containers[i]
+		if m.cfg.ContainerFilter != nil && !m.cfg.ContainerFilter(ctr) {
+			continue
+		}
+		m.addVolumeMountToContainer(ctr, mount)
+	}
+}
+
+// AddVolumeMountToContainer adds a volume mount to a specific container.
+func (m *PodMutator) addVolumeMountToContainer(ctr *corev1.Container, mount corev1.VolumeMount) {
+	for j, existing := range ctr.VolumeMounts {
+		if existing.Name == mount.Name && existing.MountPath == mount.MountPath {
+			ctr.VolumeMounts[j] = mount
+			return
+		}
+	}
+	// Prepend volume mounts
+	ctr.VolumeMounts = append([]corev1.VolumeMount{mount}, ctr.VolumeMounts...)
+}
+
+// AddInitContainer adds an init container to the pod.
+// If an init container with the same name exists, it replaces it.
+// The init container is prepended to run before other init containers.
+func (m *PodMutator) AddInitContainer(initCtr corev1.Container) {
+	for i, existing := range m.pod.Spec.InitContainers {
+		if existing.Name == initCtr.Name {
+			m.pod.Spec.InitContainers[i] = initCtr
+			return
+		}
+	}
+	// Prepend init containers
+	m.pod.Spec.InitContainers = append([]corev1.Container{initCtr}, m.pod.Spec.InitContainers...)
+}
+
+// AddEnvVar adds an environment variable to all application containers (filtered by ContainerFilter).
+// If the env var already exists, it is not overwritten.
+func (m *PodMutator) AddEnvVar(env corev1.EnvVar) {
+	for i := range m.pod.Spec.Containers {
+		ctr := &m.pod.Spec.Containers[i]
+		if m.cfg.ContainerFilter != nil && !m.cfg.ContainerFilter(ctr) {
+			continue
+		}
+		m.addEnvVarToContainer(ctr, env)
+	}
+}
+
+// addEnvVarToContainer adds an env var to a specific container if it doesn't already exist.
+func (m *PodMutator) addEnvVarToContainer(ctr *corev1.Container, env corev1.EnvVar) {
+	for _, existing := range ctr.Env {
+		if existing.Name == env.Name {
+			return // Already exists, don't overwrite
+		}
+	}
+	// Prepend env var
+	ctr.Env = append([]corev1.EnvVar{env}, ctr.Env...)
+}
+
+// Pod returns the underlying pod being mutated.
+func (m *PodMutator) Pod() *corev1.Pod {
+	return m.pod
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/provider.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/provider.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package libraryinjection provides different strategies for injecting APM libraries into pods.
+// It defines a common interface (LibraryInjectionProvider) that can be implemented by different
+// injection mechanisms such as init containers and CSI volumes.
+package libraryinjection
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// InjectionMode represents the method used to inject APM libraries into pods.
+type InjectionMode string
+
+const (
+	// InjectionModeInitContainer uses init containers to copy library files into an EmptyDir volume.
+	// This is the traditional/default injection method.
+	InjectionModeInitContainer InjectionMode = "init_container"
+
+	// InjectionModeCSI uses a CSI driver to mount library files directly into the pod.
+	InjectionModeCSI InjectionMode = "csi"
+)
+
+// MutationStatus represents the outcome of a mutation operation.
+type MutationStatus string
+
+const (
+	// MutationStatusInjected indicates the injection was successful.
+	MutationStatusInjected MutationStatus = "injected"
+	// MutationStatusSkipped indicates the injection was skipped (e.g., insufficient resources).
+	MutationStatusSkipped MutationStatus = "skipped"
+	// MutationStatusError indicates an error occurred during injection.
+	MutationStatusError MutationStatus = "error"
+)
+
+// MutationResult contains the result of a mutation operation.
+type MutationResult struct {
+	// Status indicates the outcome of the mutation.
+	Status MutationStatus
+	// Message contains additional information (skip reason or error details).
+	Message string
+}
+
+// InjectorConfig contains the configuration needed to inject the APM injector component.
+type InjectorConfig struct {
+	// Image is the full image reference for the APM injector.
+	Image string
+	// Registry is the container registry to use.
+	Registry string
+	// InitSecurityContext is the security context to apply to init containers for this specific injection.
+	// This may differ from ProviderConfig.InitSecurityContext if the namespace requires a specific context.
+	InitSecurityContext *corev1.SecurityContext
+}
+
+// InjectorEnvConfig contains the configuration for injector environment variables.
+// This is separate from InjectorConfig because env vars are added by the mutator core,
+// not by the individual providers.
+type InjectorEnvConfig struct {
+	// Debug enables debug mode for the injector.
+	Debug bool
+	// InjectTime is the time when the injection was initiated.
+	InjectTime time.Time
+}
+
+// LibraryConfig contains the configuration needed to inject a language-specific tracing library.
+type LibraryConfig struct {
+	// Language is the programming language (e.g., "java", "python", "js").
+	Language string
+	// Image is the full image reference for the library init container.
+	Image string
+	// Registry is the container registry.
+	Registry string
+	// Repository is the image repository name (e.g., "dd-lib-java-init").
+	Repository string
+	// Tag is the image tag/version.
+	Tag string
+	// ContainerName is the target container name (empty means all containers).
+	ContainerName string
+	// InitSecurityContext is the security context to apply to init containers for this specific injection.
+	// This may differ from ProviderConfig.InitSecurityContext if the namespace requires a specific context.
+	InitSecurityContext *corev1.SecurityContext
+}
+
+// ProviderConfig contains the configuration passed to providers.
+// This allows providers to access settings they need for injection.
+type ProviderConfig struct {
+	// DefaultResourceRequirements are the default resource requirements for init containers.
+	// If empty, the provider will compute requirements based on the pod's existing resources.
+	DefaultResourceRequirements map[corev1.ResourceName]resource.Quantity
+
+	// InitSecurityContext is the security context to apply to init containers.
+	// If nil, the provider may compute one based on namespace labels.
+	InitSecurityContext *corev1.SecurityContext
+
+	// ContainerFilter is an optional filter to select which containers to mutate.
+	// If nil, all containers are mutated.
+	ContainerFilter func(*corev1.Container) bool
+}
+
+// LibraryInjectionProvider defines the strategy for injecting APM libraries into pods.
+// Providers mutate the pod directly and return a status indicating the result.
+//
+// Different implementations can use different mechanisms:
+// - InitContainerProvider: Uses init containers with EmptyDir volumes
+// - CSIProvider: Uses a CSI driver to mount library files
+type LibraryInjectionProvider interface {
+	// InjectInjector mutates the pod to add the APM injector component.
+	// The injector is responsible for the LD_PRELOAD mechanism that enables auto-instrumentation.
+	// It adds volumes, volume mounts, and optionally init containers to the pod.
+	InjectInjector(pod *corev1.Pod, cfg InjectorConfig) MutationResult
+
+	// InjectLibrary mutates the pod to add a language-specific tracing library.
+	// It adds volumes, volume mounts, and optionally init containers for the library.
+	// Returns MutationStatusError if the language is not supported.
+	InjectLibrary(pod *corev1.Pod, cfg LibraryConfig) MutationResult
+}
+
+// NewProvider creates a LibraryInjectionProvider based on the specified injection mode.
+// The providerCfg is used to configure the provider with necessary settings.
+func NewProvider(mode InjectionMode, providerCfg ProviderConfig) LibraryInjectionProvider {
+	switch mode {
+	case InjectionModeCSI:
+		return NewCSIProvider(providerCfg)
+	case InjectionModeInitContainer:
+		fallthrough
+	default:
+		return NewInitContainerProvider(providerCfg)
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/registry.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/registry.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package libraryinjection
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// InjectionModeAnnotation is the annotation key to override the injection mode per-pod.
+	// Valid values: "init_container" and "csi"
+	InjectionModeAnnotation = "admission.datadoghq.com/apm-inject.injection-mode"
+)
+
+// Registry holds all available injection providers and handles provider selection.
+type Registry struct {
+	// defaultMode is the default injection mode to use when no annotation is present.
+	defaultMode InjectionMode
+	// providers maps injection modes to their corresponding providers.
+	providers map[InjectionMode]LibraryInjectionProvider
+}
+
+// NewRegistry creates a new Registry with all available providers.
+func NewRegistry(defaultMode InjectionMode, cfg ProviderConfig) *Registry {
+	// Treat empty string as init_container for backwards compatibility
+	if defaultMode == "" {
+		defaultMode = InjectionModeInitContainer
+	}
+
+	initContainerProvider := NewInitContainerProvider(cfg)
+
+	return &Registry{
+		defaultMode: defaultMode,
+		providers: map[InjectionMode]LibraryInjectionProvider{
+			InjectionModeInitContainer: initContainerProvider,
+			InjectionModeCSI:           NewCSIProvider(cfg),
+			// Empty string is treated as init_container for backwards compatibility
+			"": initContainerProvider,
+		},
+	}
+}
+
+// DefaultProvider returns the default injection provider based on the configured mode.
+func (r *Registry) DefaultProvider() LibraryInjectionProvider {
+	return r.providers[r.defaultMode]
+}
+
+// DefaultMode returns the default injection mode.
+func (r *Registry) DefaultMode() InjectionMode {
+	return r.defaultMode
+}
+
+// GetProvider returns the provider for the specified injection mode.
+// If the mode is not found, it returns the default provider.
+func (r *Registry) GetProvider(mode InjectionMode) LibraryInjectionProvider {
+	if provider, exists := r.providers[mode]; exists {
+		return provider
+	}
+	return r.DefaultProvider()
+}
+
+// GetProviderForPod returns the appropriate injection provider for a pod.
+// It checks for the injection mode annotation on the pod and returns the corresponding provider.
+// If no annotation is present or the value is invalid, it returns the default provider.
+func (r *Registry) GetProviderForPod(pod *corev1.Pod) LibraryInjectionProvider {
+	if pod.Annotations == nil {
+		return r.DefaultProvider()
+	}
+
+	modeStr, ok := pod.Annotations[InjectionModeAnnotation]
+	if !ok || modeStr == "" {
+		return r.DefaultProvider()
+	}
+
+	mode := InjectionMode(modeStr)
+	if provider, exists := r.providers[mode]; exists {
+		log.Debugf("Using injection mode %q from pod annotation for pod %s/%s", modeStr, pod.Namespace, pod.Name)
+		return provider
+	}
+
+	log.Warnf("Unknown injection mode %q in pod annotation for pod %s/%s, using default", modeStr, pod.Namespace, pod.Name)
+	return r.DefaultProvider()
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/volumes.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/volumes.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package libraryinjection
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Volume and mount path constants shared across injection providers.
+const (
+	// VolumeName is the name of the main volume used for library injection.
+	VolumeName = "datadog-auto-instrumentation"
+
+	// MountPath is the mount path for the library files in application containers.
+	MountPath = "/datadog-lib"
+
+	// InjectPackageDir is the path where the APM injector files are stored.
+	InjectPackageDir = "opt/datadog-packages/datadog-apm-inject"
+
+	// LibraryPackagesDir is the path where language-specific library files are stored.
+	LibraryPackagesDir = "opt/datadog/apm/library"
+
+	// EtcVolumeName is the name of the volume for /etc/ld.so.preload.
+	EtcVolumeName = "datadog-auto-instrumentation-etc"
+
+	// InjectorInitContainerName is the name of the APM injector init container.
+	InjectorInitContainerName = "datadog-init-apm-inject"
+)
+
+// AsAbsPath converts a relative path to an absolute path.
+func AsAbsPath(path string) string {
+	return "/" + path
+}
+
+// InjectorFilePath returns the full path to an injector file.
+func InjectorFilePath(name string) string {
+	return InjectPackageDir + "/stable/inject/" + name
+}
+
+// LibraryInitContainerName returns the init container name for a language.
+func LibraryInitContainerName(lang string) string {
+	return "datadog-lib-" + lang + "-init"
+}
+
+// SupportedLanguages is the list of languages supported for injection.
+var SupportedLanguages = []string{
+	"java",
+	"js",
+	"python",
+	"dotnet",
+	"ruby",
+	"php",
+}
+
+// IsLanguageSupported checks if a language is supported for injection.
+func IsLanguageSupported(lang string) bool {
+	for _, l := range SupportedLanguages {
+		if l == lang {
+			return true
+		}
+	}
+	return false
+}
+
+// NewEmptyDirVolume creates an EmptyDir volume with the given name.
+func NewEmptyDirVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -108,6 +108,11 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	// We pin to a major version by default.
 	config.BindEnvAndSetDefault("apm_config.instrumentation.injector_image_tag", "0", "DD_APM_INSTRUMENTATION_INJECTOR_IMAGE_TAG")
 
+	// [Internal/Experimental] Injection mode for APM auto-instrumentation.
+	// Possible values: "init_container" (default), "csi", "image_volume"
+	// Empty string is treated as "init_container" for backwards compatibility.
+	config.BindEnvAndSetDefault("apm_config.instrumentation.injection_mode", "", "DD_APM_INSTRUMENTATION_INJECTION_MODE")
+
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")                                           //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")                                                   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnv("apm_config.max_payload_size", "DD_APM_MAX_PAYLOAD_SIZE")                                                   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new CSI-based injection method for APM auto-instrumentation, as an alternative to the existing init container approach. 

Dependencies: It relies on this Datadog CSI driver PR: https://github.com/DataDog/datadog-csi-driver/pull/48

Key Changes
- New `library_injection` package (`pkg/clusteragent/admission/mutate/autoinstrumentation/library_injection/`):
  - `provider.go` - Defines the `LibraryInjectionProvider` interface and common types
  - `registry.go` - Manages provider selection based on configuration or pod annotations
  - `init_container.go` - Extracted init container injection logic (existing behavior)
  - `csi.go` - New CSI-based injection using the Datadog CSI driver
  - `pod_mutator.go` - Helper for common pod mutation operations
  - `volumes.go` - Shared volume constants and utilities
- Updated `namespace_mutator.go` to use the new provider abstraction, making it agnostic to the injection method.
- New configuration option: `apm_config.instrumentation.injection_mode` (init_container | csi)
- Per-pod override: Annotation `admission.datadoghq.com/apm-inject.injection-mode` to override the default mode.

### Motivation

The init container approach has limitations:
- Slow startup: Copying SDK files can take 30+ seconds when multiple languages are enabled
- Resource constraints: May fail in environments with limited CPU/memory
- Pod churn: Each pod restart triggers a full file copy

The CSI driver mounts SDK files directly from the node's cache, providing:
- Instant injection: No file copying, no startup delay
- Lower resource usage: No init container overhead
- Better reliability: No resource-related failures

### Describe how you validated your changes

### Additional Notes

- CSI driver required: The CSI injection mode requires the Datadog CSI driver to be deployed in the cluster.
- Backwards compatible: Default behavior unchanged (init_container mode).
- Future work: The provider architecture is designed to support additional injection methods. A potential future addition is Kubernetes Image Volumes (K8s 1.31+), which would allow mounting OCI images directly without a CSI driver.