### PR TITLE
Mark gohai/network tests as flaky

### DIFF
--- a/pkg/gohai/go.mod
+++ b/pkg/gohai/go.mod
@@ -6,6 +6,7 @@ go 1.24.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel
+	github.com/DataDog/datadog-agent/pkg/util/testutil v0.0.0-00010101000000-000000000000
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/shirou/gopsutil/v4 v4.25.11
 	github.com/stretchr/testify v1.11.1

--- a/pkg/gohai/network/network_test.go
+++ b/pkg/gohai/network/network_test.go
@@ -11,11 +11,13 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCollect(t *testing.T) {
+	flake.Mark(t)
 	netInfo, err := CollectInfo()
 	require.NoError(t, err)
 
@@ -41,6 +43,7 @@ func TestCollect(t *testing.T) {
 }
 
 func TestAsJSON(t *testing.T) {
+	flake.Mark(t)
 	netInfo, err := CollectInfo()
 	require.NoError(t, err)
 


### PR DESCRIPTION
### What does this PR do?

Marks failing tests (such as in [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1298291692#L1278)) as flaky.

### Motivation

Mitigation for #incident-47105 to unblock the release.

The failures seem to be coming from interface configurations that are not accounted for by neither the code nor the tests, concerning which interfaces may or may not have a MAC address assigned.

### Describe how you validated your changes

### Additional Notes


