### PR TITLE
[ACIX-856] Add `dd-octo-sts` policy for triggering `buildimages-update` workfow from Gitlab

### DIFF
--- a/.github/chainguard/self.buildimages-ci.push-to-datadog-agent.sts.yaml
+++ b/.github/chainguard/self.buildimages-ci.push-to-datadog-agent.sts.yaml
@@ -1,0 +1,16 @@
+---
+# Policy used by the `push_to_datadog_agent` job in `datadog-agent-buildimages` CI.
+# Needs to be able to trigger the `buildimages-update` workflow.
+issuer: https://gitlab.ddbuild.io
+
+subject: repo:DataDog/datadog-agent:ref:refs/heads/main
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/buildimages-update\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write


### PR DESCRIPTION
### What does this PR do?

Adds a new `dd-octo-sts` policy file, `.github/chainguard/self.buildimages-ci.push-to-datadog-agent.sts.yaml` that allows `dd-octo-sts` to create tokens giving permission to trigger the `buildimages-update` workflow.

It is mostly copied from the already-existing `.github/chainguard/self.buildimages-update.create-pr.sts.yaml`, but with Gitlab  as the issuer.

### Motivation

Getting https://github.com/DataDog/datadog-agent-buildimages/pull/1048 to work.

### Describe how you validated your changes

Cannot test it until it is on `main` 😬 

### Additional Notes
