### PR TITLE
Remove last calls to SetKnown from system-probe

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -95,8 +95,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("dogstatsd_port", 8125)
 
 	// logging
-	cfg.SetKnown(join(spNS, "log_file"))  //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.SetKnown(join(spNS, "log_level")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault(join(spNS, "log_file"), "")
+	cfg.BindEnvAndSetDefault(join(spNS, "log_level"), "")
 	cfg.BindEnvAndSetDefault("log_file", defaultSystemProbeLogFilePath)
 	cfg.BindEnvAndSetDefault("log_level", "info", "DD_LOG_LEVEL", "LOG_LEVEL")
 	cfg.BindEnvAndSetDefault("syslog_uri", "")
@@ -243,7 +243,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "language_detection.enabled"), false)
 
-	cfg.SetKnown(join(spNS, "process_service_inference", "use_improved_algorithm")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault(join(spNS, "process_service_inference", "use_improved_algorithm"), false)
 
 	// For backward compatibility
 	cfg.BindEnv(join(smNS, "process_service_inference", "enabled"), "DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_ENABLED") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'


### PR DESCRIPTION
### What does this PR do?

This should be safe to replace:
* `log_file `and `log_level` seems to only be used [here](https://github.com/DataDog/datadog-agent/blob/main/pkg/system-probe/config/adjust.go#L28-L29)
* `use_improved_algorithm` is a boolean

This should be vetted by the system-probe team of course.

### Describe how you validated your changes

Running the CI.