### PR TITLE
[CWS] Fix TestMoveMountRecursivePropagation

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -213,7 +213,7 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 
 	allChildren, err := mr.getAllChildren(mount)
 	if err != nil {
-		seclog.Warnf("Error getting the list of children for mount id %d", mount.MountID)
+		seclog.Warnf("Error getting the list of children for mount id %d. err = %v", mount.MountID, err)
 	}
 
 	for _, child := range allChildren {
@@ -226,16 +226,13 @@ func (mr *Resolver) getAllChildren(mount *model.Mount) (map[uint32]*model.Mount,
 	children := map[uint32]*model.Mount{}
 
 	err := mr.getAllChildrenRecursive(mount, children)
-	if err != nil {
-		return nil, err
-	}
 
-	return children, nil
+	return children, err
 }
 
 func (mr *Resolver) getAllChildrenRecursive(mount *model.Mount, mountList map[uint32]*model.Mount) error {
 	if _, existed := mountList[mount.MountID]; existed {
-		return fmt.Errorf("mount ID %d already visited – potential cycle detected", mount.MountID)
+		return nil
 	}
 	mountList[mount.MountID] = mount
 

--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -274,7 +274,6 @@ func TestMoveMountRecursiveNoPropagation(t *testing.T) {
 }
 
 func TestMoveMountRecursivePropagation(t *testing.T) {
-	t.Helper()
 	SkipIfNotAvailable(t)
 
 	// Docker messes up with the propagation


### PR DESCRIPTION
### What does this PR do?

When inserting a new element to the mount resolver, sometimes it would detect a loop and stop looking for new children to be updated, which resulted in not all children being updated sometimes. Now it continues to look for other children when it fails.

Also, some fixes to the test. 


### Motivation

### Describe how you validated your changes

### Additional Notes
