### PR TITLE
[EBPF-993] gpu: emit metrics for MIG devices

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -169,12 +169,12 @@ func (c *Check) ensureInitCollectors() error {
 	// the list of devices can change over time, so grab the latest and:
 	// - remove collectors for the devices that are not present anymore
 	// - collect devices for which a new collector must be added
-	physicalDevices, err := c.deviceCache.AllPhysicalDevices()
+	devices, err := c.deviceCache.All()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve physical devices: %w", err)
 	}
 	curDevices := map[string]ddnvml.Device{}
-	for _, d := range physicalDevices {
+	for _, d := range devices {
 		curDevices[d.GetDeviceInfo().UUID] = d
 	}
 

--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -284,6 +284,10 @@ func (c *DeviceEventsGatherer) GetEvents(deviceUUID string) ([]ddnvml.DeviceEven
 func (c *DeviceEventsGatherer) SupportsDevice(device ddnvml.Device) (bool, error) {
 	evtTypes, err := device.GetSupportedEventTypes()
 	if err != nil {
+		if ddnvml.IsAPIUnsupportedOnDevice(err, device) {
+			return false, nil
+		}
+
 		return false, fmt.Errorf("failed to query supported device event types for %s: %w", device.GetDeviceInfo().UUID, err)
 	}
 	return (evtTypes & eventSetMask) != 0, nil

--- a/pkg/collector/corechecks/gpu/nvidia/fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/fields.go
@@ -48,7 +48,7 @@ func (c *fieldsCollector) removeUnsupportedMetrics() {
 	fieldValues, err := c.getFieldValues()
 	if err != nil {
 		// If the entire field values API is unsupported, remove all metrics
-		if ddnvml.IsUnsupported(err) {
+		if ddnvml.IsAPIUnsupportedOnDevice(err, c.device) {
 			c.fieldMetrics = nil
 		}
 		// Otherwise, do nothing and keep all metrics

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -324,16 +324,8 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 		},
 		{
 			Name: "device_count",
-			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				isMig, err := device.IsMigDeviceHandle()
-				if err != nil {
-					return nil, 0, err
-				}
-				var count float64
-				if !isMig {
-					count = 1
-				}
-				return []Metric{{Name: "device.total", Value: count, Type: metrics.GaugeType}}, 0, nil
+			Handler: func(_ ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+				return []Metric{{Name: "device.total", Value: 1, Type: metrics.GaugeType}}, 0, nil
 			},
 		},
 		{

--- a/pkg/gpu/safenvml/errors.go
+++ b/pkg/gpu/safenvml/errors.go
@@ -67,3 +67,15 @@ func IsDriverNotLoaded(err error) bool {
 	var nvmlErr *NvmlAPIError
 	return err != nil && errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_DRIVER_NOT_LOADED)
 }
+
+func IsInvalidArgument(err error) bool {
+	var nvmlErr *NvmlAPIError
+	return err != nil && errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_INVALID_ARGUMENT)
+}
+
+// IsAPIUnsupportedOnDevice checks if an error indicates that the API is not supported on the device.
+// Requires the device because some error codes indicate unsupported APIs when the device is MIG.
+func IsAPIUnsupportedOnDevice(err error, device Device) bool {
+	_, isMig := device.(*MIGDevice)
+	return IsUnsupported(err) || (isMig && IsInvalidArgument(err))
+}


### PR DESCRIPTION
### What does this PR do?

Changes the collector logic to also emit metrics for MIG devices, which were previously disabled. 

### Motivation

Support MIG devices for GPUm.

### Describe how you validated your changes

Tested in a MIG instance that the collectors are created and metrics are emitted.

### Additional Notes