### PR TITLE
[EBPF-993] gpu: use GetRunningProcessDetailList for MIG data

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -35,6 +35,8 @@ const (
 	Low MetricPriority = 0
 	// High priority level (10)
 	High MetricPriority = 10
+	// Higher priority level (20)
+	Higher MetricPriority = 20
 )
 
 // CollectorName is the name of the nvml sub-collectors

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -33,10 +33,10 @@ type MetricPriority int
 const (
 	// Low priority is the default priority level (0)
 	Low MetricPriority = 0
-	// High priority level (10)
-	High MetricPriority = 10
-	// Higher priority level (20)
-	Higher MetricPriority = 20
+	// Medium priority level (10)
+	Medium MetricPriority = 10
+	// High priority level (20)
+	High MetricPriority = 20
 )
 
 // CollectorName is the name of the nvml sub-collectors

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -317,8 +317,8 @@ func TestRemoveDuplicateMetrics(t *testing.T) {
 		// Test the exact scenario from function comment plus additional edge cases including zero priority
 		allMetrics := map[CollectorName][]Metric{
 			sampling: {
-				{Name: "memory.usage", Priority: High, Tags: []string{"pid:1001"}},
-				{Name: "memory.usage", Priority: High, Tags: []string{"pid:1002"}},
+				{Name: "memory.usage", Priority: Medium, Tags: []string{"pid:1001"}},
+				{Name: "memory.usage", Priority: Medium, Tags: []string{"pid:1002"}},
 				{Name: "core.temp", Priority: Low}, // Zero priority (default)
 			},
 			stateless: {
@@ -328,7 +328,7 @@ func TestRemoveDuplicateMetrics(t *testing.T) {
 				{Name: "disk.usage", Priority: Low}, // Zero priority, unique metric
 			},
 			ebpf: {
-				{Name: "core.temp", Priority: High}, // Conflicts with CollectorA, higher priority beats zero
+				{Name: "core.temp", Priority: Medium}, // Conflicts with CollectorA, higher priority beats zero
 				{Name: "voltage", Priority: Low},
 				{Name: "fan.speed", Priority: Low}, // Zero priority tie with CollectorB
 			},
@@ -344,10 +344,10 @@ func TestRemoveDuplicateMetrics(t *testing.T) {
 		for _, metric := range result {
 			switch metric.Name {
 			case "memory.usage":
-				require.Equal(t, High, metric.Priority)
+				require.Equal(t, Medium, metric.Priority)
 				memoryUsageCount++
 			case "core.temp":
-				require.Equal(t, High, metric.Priority)
+				require.Equal(t, Medium, metric.Priority)
 				coreTempCount++
 			case "power.draw":
 				require.Equal(t, Low, metric.Priority)
@@ -376,9 +376,9 @@ func TestRemoveDuplicateMetrics(t *testing.T) {
 		// Ensure intra-collector preservation - no deduplication within same collector
 		allMetrics := map[CollectorName][]Metric{
 			sampling: {
-				{Name: "memory.usage", Priority: High, Tags: []string{"pid:1001"}},
-				{Name: "memory.usage", Priority: High, Tags: []string{"pid:1002"}},
-				{Name: "memory.usage", Priority: High, Tags: []string{"pid:1003"}},
+				{Name: "memory.usage", Priority: Medium, Tags: []string{"pid:1001"}},
+				{Name: "memory.usage", Priority: Medium, Tags: []string{"pid:1002"}},
+				{Name: "memory.usage", Priority: Medium, Tags: []string{"pid:1003"}},
 				{Name: "cpu.usage", Priority: Low},
 			},
 		}
@@ -386,9 +386,9 @@ func TestRemoveDuplicateMetrics(t *testing.T) {
 		result := RemoveDuplicateMetrics(allMetrics)
 
 		expected := []Metric{
-			{Name: "memory.usage", Priority: High, Tags: []string{"pid:1001"}},
-			{Name: "memory.usage", Priority: High, Tags: []string{"pid:1002"}},
-			{Name: "memory.usage", Priority: High, Tags: []string{"pid:1003"}},
+			{Name: "memory.usage", Priority: Medium, Tags: []string{"pid:1001"}},
+			{Name: "memory.usage", Priority: Medium, Tags: []string{"pid:1002"}},
+			{Name: "memory.usage", Priority: Medium, Tags: []string{"pid:1003"}},
 			{Name: "cpu.usage", Priority: Low},
 		}
 

--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -104,7 +104,7 @@ func (c *deviceEventsCollector) Collect() ([]Metric, error) {
 			c.metricsByXidCode[evt.EventData] = &Metric{
 				Name:     "errors.xid.total",
 				Type:     metrics.CountType,
-				Priority: High,
+				Priority: Medium,
 				Tags: []string{
 					"type:" + strconv.Itoa(int(evt.EventData)),
 					"origin:" + xidOrigin,

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -206,7 +206,7 @@ func TestDeviceEventsCollector(t *testing.T) {
 		Name:     xidErrorsMetricName,
 		Value:    1,
 		Type:     metrics.CountType,
-		Priority: High,
+		Priority: Medium,
 		Tags:     []string{"type:31", "origin:hardware"},
 	}, mm[0])
 
@@ -231,14 +231,14 @@ func TestDeviceEventsCollector(t *testing.T) {
 			Name:     xidErrorsMetricName,
 			Value:    1,
 			Type:     metrics.CountType,
-			Priority: High,
+			Priority: Medium,
 			Tags:     []string{"type:12", "origin:driver"},
 		},
 		{
 			Name:     xidErrorsMetricName,
 			Value:    2,
 			Type:     metrics.CountType,
-			Priority: High,
+			Priority: Medium,
 			Tags:     []string{"type:31", "origin:hardware"},
 		},
 	}, mm2)

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf.go
@@ -212,7 +212,7 @@ func (c *ebpfCollector) Collect() ([]Metric, error) {
 			Name:                "core.limit",
 			Value:               float64(devInfo.CoreCount),
 			Type:                ddmetrics.GaugeType,
-			Priority:            High,
+			Priority:            Medium,
 			AssociatedWorkloads: allWorkloadIDs,
 		},
 		Metric{

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -230,7 +230,7 @@ func (c *gpmCollector) Collect() ([]Metric, error) {
 			Name:     metricData.name,
 			Value:    metric.Value,
 			Type:     metricData.metricType,
-			Priority: High, // All GPM metrics have priority over other collectors
+			Priority: Medium, // All GPM metrics have priority over other collectors
 		})
 	}
 

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -132,7 +132,7 @@ func processMemorySample(device ddnvml.Device) ([]Metric, uint64, error) {
 		}
 	}
 
-	return processMemoryUsage(device, usage, High), 0, err
+	return processMemoryUsage(device, usage, Medium), 0, err
 }
 
 func processDetailListSample(device ddnvml.Device) ([]Metric, uint64, error) {
@@ -150,7 +150,7 @@ func processDetailListSample(device ddnvml.Device) ([]Metric, uint64, error) {
 		}
 	}
 
-	return processMemoryUsage(device, usage, Higher), 0, err
+	return processMemoryUsage(device, usage, High), 0, err
 }
 
 // createStatelessAPIs creates API call definitions for all stateless metrics on demand
@@ -179,7 +179,7 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 					return nil, 0, err
 				}
 				return []Metric{
-					{Name: "memory.free", Value: float64(memInfo.Free), Priority: High, Type: metrics.GaugeType},
+					{Name: "memory.free", Value: float64(memInfo.Free), Priority: Medium, Type: metrics.GaugeType},
 					{Name: "memory.reserved", Value: float64(memInfo.Reserved), Type: metrics.GaugeType},
 				}, 0, nil
 			},

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -183,11 +183,11 @@ func TestProcessMemoryMetricTags(t *testing.T) {
 			processMemoryMetrics++
 			require.Len(t, metric.AssociatedWorkloads, 1, "process.memory.usage should have exactly one workload")
 			require.Equal(t, "process", string(metric.AssociatedWorkloads[0].Kind), "process.memory.usage workload should be of kind process")
-			require.Equal(t, High, metric.Priority, "process.memory.usage should have High priority")
+			require.Equal(t, Medium, metric.Priority, "process.memory.usage should have High priority")
 		}
 		if metric.Name == "memory.limit" {
 			require.Len(t, metric.AssociatedWorkloads, 2, "memory.limit should have workloads for all processes")
-			require.Equal(t, High, metric.Priority, "memory.limit should have High priority")
+			require.Equal(t, Medium, metric.Priority, "memory.limit should have High priority")
 		}
 	}
 	require.Equal(t, 2, processMemoryMetrics, "Should have process.memory.usage for each process")

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -28,6 +28,8 @@ type SafeDevice interface {
 	GetClockInfo(clockType nvml.ClockType) (uint32, error)
 	// GetComputeRunningProcesses returns the list of compute processes running on the device
 	GetComputeRunningProcesses() ([]nvml.ProcessInfo, error)
+	// GetRunningProcessDetailList returns the list of running processes on the device
+	GetRunningProcessDetailList() (nvml.ProcessDetailList, error)
 	// GetCudaComputeCapability returns the CUDA compute capability of the device
 	GetCudaComputeCapability() (int, int, error)
 	// GetCurrentClocksThrottleReasons returns the current clock throttle reasons bitmask

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -356,3 +356,11 @@ func (d *safeDeviceImpl) GetMemoryErrorCounter(errorType nvml.MemoryErrorType, e
 	count, ret := d.nvmlDevice.GetMemoryErrorCounter(errorType, eccCounterType, memoryLocation)
 	return count, NewNvmlAPIErrorOrNil("GetMemoryErrorCounter", ret)
 }
+
+func (d *safeDeviceImpl) GetRunningProcessDetailList() (nvml.ProcessDetailList, error) {
+	if err := d.lib.lookup(toNativeName("GetRunningProcessDetailList")); err != nil {
+		return nvml.ProcessDetailList{}, err
+	}
+	processes, ret := d.nvmlDevice.GetRunningProcessDetailList()
+	return processes, NewNvmlAPIErrorOrNil("GetRunningProcessDetailList", ret)
+}

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -87,6 +87,7 @@ func getNonCriticalAPIs() []string {
 		toNativeName("GetSupportedEventTypes"),
 		toNativeName("RegisterEvents"),
 		toNativeName("GetMemoryErrorCounter"),
+		toNativeName("GetRunningProcessDetailList"),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Changes the collector code to ensure that MIG devices use the `GetRunningProcessDetailList` for retrieving per-process memory usage.

However, this API is not always available so we need to keep support for `GetComputeRunningProcesses` for other devices.

### Motivation

Support MIG devices

### Describe how you validated your changes

Tested in a MIG instance that we get the proper data.

### Additional Notes