### PR TITLE
Gouri/agntlog 387 logsource tag

### DIFF
--- a/pkg/logs/internal/parsers/dockerfile/docker_file.go
+++ b/pkg/logs/internal/parsers/dockerfile/docker_file.go
@@ -90,6 +90,10 @@ func (p *dockerFileFormat) Parse(msg *message.Message) (*message.Message, error)
 	msg.Status = status
 	msg.ParsingExtra.IsPartial = partial
 	msg.ParsingExtra.Timestamp = log.Time
+	// Tag the stream (stdout/stderr) for container logs parsed from docker JSON files
+	if log.Stream == "stdout" || log.Stream == "stderr" {
+		msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.LogSourceTag(log.Stream))
+	}
 	return msg, nil
 }
 

--- a/pkg/logs/internal/parsers/dockerstream/docker_stream.go
+++ b/pkg/logs/internal/parsers/dockerstream/docker_stream.go
@@ -56,6 +56,7 @@ func (p *dockerStreamFormat) SupportsPartialLine() bool {
 
 func parseDockerStream(msg *message.Message, containerID string) (*message.Message, error) {
 	content := msg.GetContent()
+	stream := "" // stdout or stderr
 	// The format of the message should be :
 	// [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
 	// If we don't have at the very least 8 bytes we can consider this message can't be parsed.
@@ -86,6 +87,14 @@ func parseDockerStream(msg *message.Message, containerID string) (*message.Messa
 			msg.Status = status
 			return msg, fmt.Errorf("cannot parse docker message for container %v: message too short after processing", containerID)
 		}
+		// Before removing the header, capture the stream from the first byte:
+		// 1 -> stdout, 2 -> stderr
+		switch content[0] {
+		case 1:
+			stream = "stdout"
+		case 2:
+			stream = "stderr"
+		}
 		// remove the header as we don't need it anymore
 		content = content[dockerHeaderLength:]
 
@@ -102,6 +111,10 @@ func parseDockerStream(msg *message.Message, containerID string) (*message.Messa
 	msg.SetContent(content[idx+1:])
 	msg.Status = status
 	msg.ParsingExtra.IsPartial = false
+	// Add a tag for the stream when deducible from the header byte
+	if stream != "" {
+		msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.LogSourceTag(stream))
+	}
 	return msg, nil
 }
 

--- a/pkg/logs/internal/parsers/dockerstream/docker_stream.go
+++ b/pkg/logs/internal/parsers/dockerstream/docker_stream.go
@@ -116,7 +116,7 @@ func parseDockerStream(msg *message.Message, containerID string) (*message.Messa
 		msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.LogSourceTag(stream))
 	}
 	return msg, nil
-}
+} 
 
 // getDockerSeverity returns the status of the message based on the value of the
 // STREAM_TYPE byte in the header. STREAM_TYPE can be 1 for stdout and 2 for

--- a/pkg/logs/internal/parsers/kubernetes/kubernetes.go
+++ b/pkg/logs/internal/parsers/kubernetes/kubernetes.go
@@ -64,6 +64,11 @@ func parseKubernetes(msg *message.Message) (*message.Message, error) {
 	msg.ParsingExtra = message.ParsingExtra{
 		IsPartial: isPartial(flag),
 	}
+	// Tag the stream (stdout/stderr) so downstream can filter by origin stream.
+	stream := string(components[1]) // stdout or stderr
+	if stream == "stdout" || stream == "stderr" { // tag the stream so downstream can filter by origin stream.
+		msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.LogSourceTag(stream)) // add it to rest of tags
+	}
 
 	// Validate timestamp format. K8s API uses either RFC3339 or RFC3339Nano
 	// but RFC3339Nano is a superset that can parse both formats.

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -398,6 +398,12 @@ func MultiLineSourceTag(source string) string {
 	return "multiline:" + source
 }
 
+// LogSourceTag returns a tag indicating the stream a container log line came from.
+// Example values: "logsource:stdout", "logsource:stderr".
+func LogSourceTag(stream string) string {
+	return "logsource:" + stream
+}
+
 // IsMRF returns true if the payload should be sent to MRF endpoints.
 func (m *Payload) IsMRF() bool {
 	if len(m.MessageMetas) == 0 {


### PR DESCRIPTION
### What does this PR do?
Adds a per-line tag showing the container output stream: logsource:stdout or logsource:stderr

Implemented in:
- pkg/logs/message/message.go (new helper LogSourceTag)
- pkg/logs/internal/parsers/kubernetes/kubernetes.go (tag from stream token)
- pkg/logs/internal/parsers/dockerfile/docker_file.go (tag from JSON stream)
- pkg/logs/internal/parsers/dockerstream/docker_stream.go (derive from header byte 1/2)

Also added releasenotes/notes/logsource-tag-stderr.yaml

### Motivation
- Users want to route/filter/alert on stderr vs stdout without parsing rules.
- We already parse the stream; surfacing it as a tag is low-risk and improves UX.
- Related: https://github.com/DataDog/datadog-agent/issues/33375 (internal: [AGNTLOG-387](https://datadoghq.atlassian.net/browse/AGNTLOG-387))

### Describe how you validated your changes
Andrew Q got my image from ci and made a file `docker-compose.yml` with the following content
```
services:
  agent:
    image: datadog/agent-dev:gyerra-feat-logsource-tag-stderr-stdout-py3-jmx
    environment:
      DD_API_KEY: "your api key"
      DD_LOGS_ENABLED: "true"
      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "true"
      DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE: "false" # important on macOS Docker Desktop
      DD_LOG_LEVEL: "debug"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro

  logsource-test:
    image: busybox:1.36
    # docker compose interpolates `$VAR` from host env; escape `$` as `$$` so the container shell sees it.
    command:
      - sh
      - -c
      - |
        i=0
        while true; do
          echo "hello stdout $$i"
          echo "hello stderr $$i" 1>&2
          i=$$((i+1))
          sleep 1
        done
```
and after running `docker compose up -d` he was able to start both the containers up and run them and then he did `docker exec -it {container-id} bin/bash`  to get into the shell of the agent container and i was able to run `agent stream-logs` to see the logs with the tags
log:
<img width="2262" height="534" alt="image" src="https://github.com/user-attachments/assets/4f0eec6a-5bff-49b0-9616-6972ae70954d" />

### Additional Notes


[AGNTLOG-387]: https://datadoghq.atlassian.net/browse/AGNTLOG-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ