### PR TITLE
[OTAGENT-733] Update otelcol converter README

### DIFF
--- a/comp/otelcol/converter/README.md
+++ b/comp/otelcol/converter/README.md
@@ -17,7 +17,8 @@ The converter supports selective enabling and disabling of features through the 
 - **`pprof`**: Adds the pprof extension for profiling capabilities
 - **`zpages`**: Adds the zpages extension for debugging information
 - **`health_check`**: Adds the health check extension for health monitoring
-- **`ddflare`**: Adds the Datadog flare extension for diagnostic information
+- **`ddflare`**: Adds the Datadog flare extension for diagnostic information, it should not be used together with `datadog`
+- **`datadog`**: Adds the OSS Datadog extension to send Fleet Automation data, it should not be used together with `ddflare`
 
 ### Configuration Examples
 
@@ -49,7 +50,7 @@ export DD_OTELCOLLECTOR_CONVERTER_FEATURES="infraattributes,prometheus,pprof"
 
 ### Extensions
 
-The converter looks for the `pprof`, `health_check`, `zpages` and `datadog` extensions. If these are already defined in the service pipeline, it makes no changes. If any of these extensions are not defined, it will add the extensions config (name: `<extension_name>/dd-autoconfigured`) and add the component in the services extension pipeline.
+The converter looks for the `pprof`, `health_check`, `zpages`, `ddflare` and `datadog` extensions. If these are already defined in the service pipeline, it makes no changes. If any of these extensions are not defined, it will add the extensions config (name: `<extension_name>/dd-autoconfigured`) and add the component in the services extension pipeline.
 
 ### Infra Attributes Processor
 
@@ -77,7 +78,8 @@ Please refer to the following example in order to manually set the `pprof`, `hea
 - [pprof](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/pprofextension/README.md): Enables collecting collector profiles at a defined endpoint.
 - [health_check](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension/README.md): Enables an HTTP url that can be probed to check the status of the OpenTelemetry Collector.
 - [zpages](https://github.com/open-telemetry/opentelemetry-collector/blob/main/extension/zpagesextension/README.md): Enables an extension that serves zPages, an HTTP endpoint that provides live data for debugging different components
-- [datadog](../extension/README.md): Enables otel-agent information to be collected in the datadog-agent flare.
+- [ddflare](../extension/README.md): Enables otel-agent information to be collected in the datadog-agent flare.
+- [datadog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/datadogextension): Enables collector configuration and build info to be viewed in both Datadog Infrastructure Monitoring and Fleet Automation.
 
 ### Prometheus Receiver
 


### PR DESCRIPTION
### What does this PR do?
Update otelcol converter README to include the datadog extension

### Motivation
The functionality to configure datadog extension was added some time ago but readme was not updated.

### Describe how you validated your changes
N/A

### Additional Notes
