### PR TITLE
ci(e2e): Use correct needs for new-e2e-orchestrator job

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -647,8 +647,7 @@ new-e2e-process:
     ON_NIGHTLY_FIPS: "true"
 
 new-e2e-orchestrator-ecs:
-  extends:
-    - .new_e2e_template_needs_container_deploy
+  extends: .new_e2e_template_needs_container_deploy
   rules:
     - !reference [.on_orchestrator_or_e2e_changes]
     - !reference [.manual]
@@ -660,7 +659,7 @@ new-e2e-orchestrator-ecs:
   timeout: 55m
 
 new-e2e-orchestrator:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_container_deploy
   rules:
     - !reference [.on_orchestrator_or_e2e_changes]
     - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job


### PR DESCRIPTION
### What does this PR do?
Since we merged #43815 we have changed the rules of [this job](https://github.com/DataDog/datadog-agent/commit/5f674d28e7d0a1717933d866d67d9587bb06e3b9#diff-08bac3144036ba1baff79ea26d0091357c83d0abfe2fd21d5aed2edcaf043c73R660), and we see an increase in the number of flake [failures with ImagePullBackOff errors](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1301359592). This is because the job starts before images are available, and the job passes on retries. An update of the dependencies should reduce the flakiness of this job

### Motivation
[Raise of flakiness](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22new-e2e-orchestrator%22&agg_m=%40ci.job.name&agg_m_source=base&agg_t=cardinality&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cipipeline_explorer_sort=time%2Cdesc&colorByAttr=meta%5B%27ci.stage.name%27%5D&cols=%40git.branch%2C%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40ci.stage.name%2C%40ci.job.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name&currentTab=trace&fromUser=false&graphType=flamegraph&index=cipipeline&mode=sliding&saved-view-id=2643993&sort=time&spanViewType=metadata&step=86400000&tab=overview&viz=stream&start=1760776619027&end=1765960619027&paused=false)

### Describe how you validated your changes
CI should pass

### Additional Notes
