### PR TITLE
fix(installer): Set proper permissions for files written for config

### DIFF
--- a/pkg/fleet/installer/config/config_nix.go
+++ b/pkg/fleet/installer/config/config_nix.go
@@ -13,8 +13,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/symlink"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -58,7 +60,7 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 
 	operations.FileOperations = append(buildOperationsFromLegacyInstaller(d.StablePath), operations.FileOperations...)
 
-	err = operations.Apply(d.ExperimentPath)
+	err = operations.Apply(ctx, d.ExperimentPath)
 	if err != nil {
 		return err
 	}
@@ -138,5 +140,25 @@ func replaceConfigDirectory(oldDir, newDir string) (err error) {
 	if err != nil {
 		return fmt.Errorf("could not rename new directory: %w", err)
 	}
+	return nil
+}
+
+// setFileOwnershipAndPermissions sets the ownership and permissions for a file based on its configFileSpec.
+// If the user doesn't exist (e.g., in tests) or if we don't have permission
+// to change ownership, the function logs a warning and continues without failing.
+func setFileOwnershipAndPermissions(ctx context.Context, filePath string, spec *configFileSpec) error {
+	// Set file permissions
+	if spec.mode != 0 {
+		if err := os.Chmod(filePath, spec.mode); err != nil {
+			return fmt.Errorf("error setting file permissions for %s: %w", filePath, err)
+		}
+	}
+
+	// Set file ownership
+	err := file.Chown(ctx, filePath, spec.owner, spec.group)
+	if err != nil {
+		log.Warnf("error setting file ownership for %s: %v", filePath, err)
+	}
+
 	return nil
 }

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -48,10 +49,12 @@ func TestOperationApply_Patch(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "baz", updatedMap["foo"])
 
-	// Check file permissions
-	stat, err := os.Stat(filePath)
-	assert.NoError(t, err)
-	assert.Equal(t, os.FileMode(0640), stat.Mode().Perm())
+	// Check file permissions (skip on Windows as POSIX permissions don't apply)
+	if runtime.GOOS != "windows" {
+		stat, err := os.Stat(filePath)
+		assert.NoError(t, err)
+		assert.Equal(t, os.FileMode(0640), stat.Mode().Perm())
+	}
 }
 
 func TestOperationApply_MergePatch(t *testing.T) {
@@ -717,7 +720,10 @@ func TestOperationApply_ApplicationMonitoringPermissions(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check file permissions - should be world-readable (0644)
-	stat, err := os.Stat(filePath)
-	assert.NoError(t, err)
-	assert.Equal(t, os.FileMode(0644), stat.Mode().Perm(), "application_monitoring.yaml should be world-readable (0644)")
+	// Skip on Windows as POSIX permissions don't apply
+	if runtime.GOOS != "windows" {
+		stat, err := os.Stat(filePath)
+		assert.NoError(t, err)
+		assert.Equal(t, os.FileMode(0644), stat.Mode().Perm(), "application_monitoring.yaml should be world-readable (0644)")
+	}
 }

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -37,7 +37,7 @@ func TestOperationApply_Patch(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check file content
@@ -47,6 +47,11 @@ func TestOperationApply_Patch(t *testing.T) {
 	err = yaml.Unmarshal(updated, &updatedMap)
 	assert.NoError(t, err)
 	assert.Equal(t, "baz", updatedMap["foo"])
+
+	// Check file permissions
+	stat, err := os.Stat(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0640), stat.Mode().Perm())
 }
 
 func TestOperationApply_MergePatch(t *testing.T) {
@@ -70,7 +75,7 @@ func TestOperationApply_MergePatch(t *testing.T) {
 		Patch:             []byte(mergePatch),
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	updated, err := os.ReadFile(filePath)
@@ -98,7 +103,7 @@ func TestOperationApply_Delete(t *testing.T) {
 		FilePath:          "/datadog.yaml",
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 	_, err = os.Stat(filePath)
 	assert.Error(t, err)
@@ -122,7 +127,7 @@ func TestOperationApply_EmptyYAMLFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that the file now contains the patched value
@@ -149,7 +154,7 @@ func TestOperationApply_NoFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	filePath := filepath.Join(tmpDir, "datadog.yaml")
@@ -178,7 +183,7 @@ func TestOperationApply_DisallowedFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not allowed")
 }
@@ -206,7 +211,7 @@ func TestOperationApply_NestedConfigFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	updated, err := os.ReadFile(filePath)
@@ -397,7 +402,7 @@ func TestOperationApply_Copy(t *testing.T) {
 		DestinationPath:   "/security-agent.yaml",
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that source file still exists
@@ -430,7 +435,7 @@ func TestOperationApply_Move(t *testing.T) {
 		DestinationPath:   "/otel-config.yaml",
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that source file no longer exists
@@ -465,7 +470,7 @@ func TestOperationApply_CopyWithNestedDestination(t *testing.T) {
 		DestinationPath:   "/conf.d/mycheck.d/config.yaml",
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that nested directories were created
@@ -499,7 +504,7 @@ func TestOperationApply_MoveWithNestedDestination(t *testing.T) {
 		DestinationPath:   "/conf.d/mycheck.d/config.yaml",
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check that nested directories were created
@@ -530,7 +535,7 @@ func TestOperationApply_CopyMissingSource(t *testing.T) {
 		DestinationPath:   "/security-agent.yaml",
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.Error(t, err)
 }
 
@@ -547,7 +552,7 @@ func TestOperationApply_MoveMissingSource(t *testing.T) {
 		DestinationPath:   "/otel-config.yaml",
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.Error(t, err)
 }
 
@@ -671,7 +676,7 @@ api_key: "KEY_2"
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(root, tmpDir)
+	err = op.apply(context.Background(), root, tmpDir)
 	assert.NoError(t, err)
 
 	// Check file content, should now have api_key: NEW_KEY
@@ -685,4 +690,34 @@ api_key: "KEY_2"
 	// The map should take only the last value (or now, our patched one)
 	assert.Equal(t, "NEW_KEY", updatedMap["api_key"])
 	assert.Equal(t, "value", updatedMap["some_other"])
+}
+
+func TestOperationApply_ApplicationMonitoringPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "application_monitoring.yaml")
+	orig := map[string]any{"enabled": true}
+	origBytes, err := yaml.Marshal(orig)
+	assert.NoError(t, err)
+	err = os.WriteFile(filePath, origBytes, 0600)
+	assert.NoError(t, err)
+
+	root, err := os.OpenRoot(tmpDir)
+	assert.NoError(t, err)
+	defer root.Close()
+
+	// Patch the file
+	patchJSON := `[{"op": "replace", "path": "/enabled", "value": false}]`
+	op := &FileOperation{
+		FileOperationType: FileOperationPatch,
+		FilePath:          "/application_monitoring.yaml",
+		Patch:             []byte(patchJSON),
+	}
+
+	err = op.apply(context.Background(), root, tmpDir)
+	assert.NoError(t, err)
+
+	// Check file permissions - should be world-readable (0644)
+	stat, err := os.Stat(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0644), stat.Mode().Perm(), "application_monitoring.yaml should be world-readable (0644)")
 }

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -67,7 +67,7 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 		return fmt.Errorf("error writing deployment ID file: %w", err)
 	}
 	operations.FileOperations = append(buildOperationsFromLegacyInstaller(d.StablePath), operations.FileOperations...)
-	err = operations.Apply(d.StablePath)
+	err = operations.Apply(ctx, d.StablePath)
 	if err != nil {
 		return fmt.Errorf("error applying operations: %w", err)
 	}
@@ -181,4 +181,10 @@ func secureCreateTargetDirectoryWithSourcePermissions(sourcePath, targetPath str
 	}
 	sddl := sd.String()
 	return paths.SecureCreateDirectory(targetPath, sddl)
+}
+
+// setFileOwnershipAndPermissions is a no-op on Windows as file ownership and permissions
+// are handled differently through ACLs, not POSIX ownership and modes.
+func setFileOwnershipAndPermissions(_ context.Context, _ string, _ *configFileSpec) error {
+	return nil
 }

--- a/pkg/fleet/installer/packages/file/file.go
+++ b/pkg/fleet/installer/packages/file/file.go
@@ -155,7 +155,7 @@ func (p Permission) Ensure(ctx context.Context, rootPath string) (err error) {
 	}
 	for _, file := range files {
 		if p.Owner != "" && p.Group != "" {
-			if err := chown(ctx, file, p.Owner, p.Group); err != nil && !errors.Is(err, os.ErrNotExist) {
+			if err := Chown(ctx, file, p.Owner, p.Group); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("error changing file ownership: %w", err)
 			}
 		}
@@ -240,7 +240,8 @@ func getUserAndGroup(ctx context.Context, username, group string) (uid, gid int,
 	return uid, gid, nil
 }
 
-func chown(ctx context.Context, path string, username string, group string) (err error) {
+// Chown changes the ownership of a file to the specified owner and group.
+func Chown(ctx context.Context, path string, username string, group string) (err error) {
 	uid, gid, err := getUserAndGroup(ctx, username, group)
 	if err != nil {
 		return fmt.Errorf("error getting user and group IDs: %w", err)

--- a/test/new-e2e/tests/fleet/config_test.go
+++ b/test/new-e2e/tests/fleet/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/agent"
@@ -153,4 +154,90 @@ func (s *configSuite) TestConfigFailureHealth() {
 	config, err = s.Agent.Configuration()
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), "info", config["log_level"])
+}
+
+func (s *configSuite) TestConfigFilePermissions() {
+	// Skip on Windows as POSIX permissions don't apply
+	if s.Env().RemoteHost.OSFamily == e2eos.WindowsFamily {
+		s.T().Skip("Skipping file permission test on Windows (POSIX permissions not applicable)")
+	}
+
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+
+	// Configure multiple files with different permission requirements
+	nginxConfig := `{
+		"init_config": {},
+		"instances": [
+			{
+				"nginx_status_url": "http://localhost:8080/status"
+			}
+		]
+	}`
+
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID: "file-permissions",
+		FileOperations: []backend.FileOperation{
+			{
+				FileOperationType: backend.FileOperationMergePatch,
+				FilePath:          "/datadog.yaml",
+				Patch:             []byte(`{"log_level": "debug"}`),
+			},
+			{
+				FileOperationType: backend.FileOperationMergePatch,
+				FilePath:          "/application_monitoring.yaml",
+				Patch:             []byte(`{"enabled": true}`),
+			},
+			{
+				FileOperationType: backend.FileOperationMergePatch,
+				FilePath:          "/conf.d/nginx.yaml",
+				Patch:             []byte(nginxConfig),
+			},
+		},
+	})
+	require.NoError(s.T(), err)
+
+	// Check datadog.yaml permissions (should be restricted: 640)
+	datadogPerms, err := s.Host.GetFilePermissions("/etc/datadog-agent-exp/datadog.yaml")
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "640", datadogPerms.Mode, "datadog.yaml should be restricted (640)")
+	assert.Equal(s.T(), "dd-agent", datadogPerms.Owner, "datadog.yaml should be owned by dd-agent")
+	assert.Equal(s.T(), "dd-agent", datadogPerms.Group, "datadog.yaml should have group dd-agent")
+
+	// Check application_monitoring.yaml permissions (should be world-readable: 644)
+	appMonPerms, err := s.Host.GetFilePermissions("/etc/datadog-agent-exp/application_monitoring.yaml")
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "644", appMonPerms.Mode, "application_monitoring.yaml should be world-readable (644)")
+	assert.Equal(s.T(), "root", appMonPerms.Owner, "application_monitoring.yaml should be owned by root")
+	assert.Equal(s.T(), "root", appMonPerms.Group, "application_monitoring.yaml should have group root")
+
+	// Check conf.d/nginx.yaml permissions (should be restricted: 640)
+	nginxPerms, err := s.Host.GetFilePermissions("/etc/datadog-agent-exp/conf.d/nginx.yaml")
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "640", nginxPerms.Mode, "integration configs should be restricted (640)")
+	assert.Equal(s.T(), "dd-agent", nginxPerms.Owner, "integration configs should be owned by dd-agent")
+	assert.Equal(s.T(), "dd-agent", nginxPerms.Group, "integration configs should have group dd-agent")
+
+	// Promote and verify permissions persist
+	err = s.Backend.PromoteConfigExperiment()
+	require.NoError(s.T(), err)
+
+	// Verify permissions after promotion
+	datadogPerms, err = s.Host.GetFilePermissions("/etc/datadog-agent/datadog.yaml")
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "640", datadogPerms.Mode)
+	assert.Equal(s.T(), "dd-agent", datadogPerms.Owner)
+	assert.Equal(s.T(), "dd-agent", datadogPerms.Group)
+
+	appMonPerms, err = s.Host.GetFilePermissions("/etc/datadog-agent/application_monitoring.yaml")
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "644", appMonPerms.Mode)
+	assert.Equal(s.T(), "root", appMonPerms.Owner)
+	assert.Equal(s.T(), "root", appMonPerms.Group)
+
+	nginxPerms, err = s.Host.GetFilePermissions("/etc/datadog-agent/conf.d/nginx.yaml")
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "640", nginxPerms.Mode)
+	assert.Equal(s.T(), "dd-agent", nginxPerms.Owner)
+	assert.Equal(s.T(), "dd-agent", nginxPerms.Group)
 }

--- a/test/new-e2e/tests/fleet/host/host.go
+++ b/test/new-e2e/tests/fleet/host/host.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package host contains host-level test helpers for fleet tests.
+package host
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+)
+
+// Host wraps an environments.Host with helper methods for fleet tests.
+type Host struct {
+	*environments.Host
+}
+
+// New creates a new Host wrapper.
+func New(host *environments.Host) *Host {
+	return &Host{Host: host}
+}
+
+// FilePermissions represents the permissions of a file on Unix systems.
+type FilePermissions struct {
+	Mode  string
+	Owner string
+	Group string
+}
+
+// GetFilePermissions returns the permissions of a file on Unix systems.
+// Returns an error on Windows as POSIX permissions don't apply.
+func (h *Host) GetFilePermissions(filePath string) (*FilePermissions, error) {
+	switch h.RemoteHost.OSFamily {
+	case e2eos.LinuxFamily:
+		// Use stat to get file permissions, owner, and group
+		output, err := h.RemoteHost.Execute("stat -c '%a %U %G' " + filePath)
+		if err != nil {
+			return nil, err
+		}
+		parts := strings.Fields(strings.TrimSpace(output))
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("unexpected stat output: %s", output)
+		}
+		return &FilePermissions{
+			Mode:  parts[0],
+			Owner: parts[1],
+			Group: parts[2],
+		}, nil
+	case e2eos.WindowsFamily:
+		// Windows doesn't use POSIX permissions
+		return nil, errors.New("file permissions check not supported on Windows")
+	default:
+		return nil, fmt.Errorf("unsupported OS family: %v", h.RemoteHost.OSFamily)
+	}
+}

--- a/test/new-e2e/tests/fleet/suite/suite.go
+++ b/test/new-e2e/tests/fleet/suite/suite.go
@@ -18,6 +18,7 @@ import (
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/agent"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/backend"
+	fleethost "github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/host"
 )
 
 var (
@@ -47,6 +48,7 @@ type FleetSuite struct {
 
 	Agent   *agent.Agent
 	Backend *backend.Backend
+	Host    *fleethost.Host
 }
 
 // SetupSuite sets up the fleet suite.
@@ -57,6 +59,7 @@ func (s *FleetSuite) SetupSuite() {
 
 	s.Agent = agent.New(s.T, s.Env())
 	s.Backend = backend.New(s.T, s.Env())
+	s.Host = fleethost.New(s.Env())
 }
 
 // Run runs the fleet suite for the given platforms.


### PR DESCRIPTION
### What does this PR do?
Sets proper permissions for files written for config:
- 0644 for application_monitoring.yaml
- root:root & 0640 for system-probe.yaml & security-agent.yaml
- dd-agent:dd-agent with 0640 for the other files

### Motivation

### Describe how you validated your changes
E2E test

### Additional Notes
