### PR TITLE
reduce repetitive debug/error log resulting in flooding cluster agent's logs

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -882,7 +882,6 @@ func (k *KSMCheck) hostnameAndTags(labels map[string]string, labelJoiner *labelJ
 	if tagErr != nil {
 		log.Errorf("failed to get namespace tags for %q from tagger: %v", resourceNamespace, tagErr)
 	} else if len(namespaceTags) > 0 {
-		log.Debugf("obtained tags for namespace %q from tagger: %v", resourceNamespace, namespaceTags)
 		tagList = append(tagList, namespaceTags...)
 	}
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -237,25 +237,25 @@ type KSMConfig struct {
 // KSMCheck wraps the config and the metric stores needed to run the check
 type KSMCheck struct {
 	core.CheckBase
-	agentConfig               model.Config
-	instance                  *KSMConfig
-	allStores                 [][]cache.Store
-	telemetry                 *telemetryCache
-	tagger                    tagger.Component
-	cancel                    context.CancelFunc
-	isCLCRunner               bool
-	isRunningOnNodeAgent      bool
-	clusterIDTagValue         string
-	clusterNameTagValue       string
-	clusterNameRFC1123        string
-	metricNamesMapper         map[string]string
-	metricAggregators         map[string]metricAggregator
-	metricTransformers        map[string]metricTransformerFunc
-	metadataMetricsRegex      *regexp.Regexp
-	initRetry                 retry.Retrier
-	workloadmetaStore         workloadmeta.Component
-	rolloutTracker            *customresources.RolloutTracker
-	customResourceDiscoverer  *ksmDiscovery.CRDiscoverer
+	agentConfig                model.Config
+	instance                   *KSMConfig
+	allStores                  [][]cache.Store
+	telemetry                  *telemetryCache
+	tagger                     tagger.Component
+	cancel                     context.CancelFunc
+	isCLCRunner                bool
+	isRunningOnNodeAgent       bool
+	clusterIDTagValue          string
+	clusterNameTagValue        string
+	clusterNameRFC1123         string
+	metricNamesMapper          map[string]string
+	metricAggregators          map[string]metricAggregator
+	metricTransformers         map[string]metricTransformerFunc
+	metadataMetricsRegex       *regexp.Regexp
+	initRetry                  retry.Retrier
+	workloadmetaStore          workloadmeta.Component
+	rolloutTracker             *customresources.RolloutTracker
+	customResourceDiscoverer   *ksmDiscovery.CRDiscoverer
 	namespaceTagsErrorLogLimit *log.Limit
 }
 


### PR DESCRIPTION
### What does this PR do?

Drops a debug log that floods the cluster agent's logs for every namespace.

Throttles error logs to avoid flodding the dca logs with error logs in case something goes wrong.

### Motivation

### Describe how you validated your changes

E2E and unit tests.

### Additional Notes
