### PR TITLE
[CWS] zero related events when getting from pool instead of before put

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1046,6 +1046,7 @@ func (p *EBPFProbe) zeroEvent() *model.Event {
 
 func (p *EBPFProbe) getPoolEvent() *model.Event {
 	event := p.eventPool.Get()
+	relatedEventZeroer(event)
 	event.FieldHandlers = p.fieldHandlers
 	return event
 }
@@ -1053,7 +1054,6 @@ func (p *EBPFProbe) getPoolEvent() *model.Event {
 var relatedEventZeroer = model.NewEventZeroer()
 
 func (p *EBPFProbe) putBackPoolEvent(event *model.Event) {
-	relatedEventZeroer(event)
 	p.eventPool.Put(event)
 }
 


### PR DESCRIPTION
### What does this PR do?

`TestPutBackPoolEvent` has been quite flaky lately, this PR moves the zeroing of the event to the Get side of the related events pool operations, ensuring the event is in know state when we use it.

### Motivation

### Describe how you validated your changes

### Additional Notes
