### PR TITLE
[ACIX-856] fix(dd-octo-sts): Fix chainguard policy syntax after additional testing

### DIFF
--- a/.github/chainguard/self.buildimages-ci.push-to-datadog-agent.sts.yaml
+++ b/.github/chainguard/self.buildimages-ci.push-to-datadog-agent.sts.yaml
@@ -3,12 +3,10 @@
 # Needs to be able to trigger the `buildimages-update` workflow.
 issuer: https://gitlab.ddbuild.io
 
-subject: repo:DataDog/datadog-agent:ref:refs/heads/main
+subject_pattern: "project_path:DataDog/datadog-agent-buildimages:.*"
 
 claim_pattern:
   event_name: workflow_dispatch
-  ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/buildimages-update\.yml@refs/heads/main
 
 permissions:


### PR DESCRIPTION
### What does this PR do?

Fixes #44286

### Motivation

### Describe how you validated your changes

Testing on a personal repo: https://github.com/DataDog/ishirui-test/blob/main/.github/chainguard/self.buildimages-ci.push-to-datadog-agent.sts.yaml

+ Using `dd-octo-sts check`

### Additional Notes
