### PR TITLE
[CWS] fix `TestCGroupVariablesReleased` test assertion

### DIFF
--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -474,7 +474,7 @@ func TestCGroupVariablesReleased(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond) // wait just a bit of time for the cgroup to be released
 
-	variables := test.ruleEngine.GetRuleSet().GetScopedVariables(rules.ScopeCGroup, "foo")
+	variables := test.ruleEngine.GetRuleSet().GetScopedVariables(rules.ScopeCGroup, "bar")
 	assert.NotNil(t, variables)
 	assert.Len(t, variables, 0)
 }


### PR DESCRIPTION
### What does this PR do?

The `TestCGroupVariablesReleased` test was using the wrong variable name in its last assertion, which would cause the assertion to always be true.

### Motivation

### Describe how you validated your changes

### Additional Notes
