### PR TITLE
Fix deadlock in secret resolver

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/secrets.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/secrets.go
@@ -23,7 +23,7 @@ func decryptConfig(conf integration.Config, secretResolver secrets.Component) (i
 	var err error
 
 	// init_config
-	conf.InitConfig, err = secretResolver.Resolve(conf.InitConfig, conf.Name, conf.ImageName, conf.PodNamespace)
+	conf.InitConfig, err = secretResolver.Resolve(conf.InitConfig, conf.Name, conf.ImageName, conf.PodNamespace, false)
 	if err != nil {
 		return conf, fmt.Errorf("error while decrypting secrets in 'init_config': %s", err)
 	}
@@ -32,7 +32,7 @@ func decryptConfig(conf integration.Config, secretResolver secrets.Component) (i
 	// we cannot update in place as, being a slice, it would modify the input config as well
 	instances := make([]integration.Data, 0, len(conf.Instances))
 	for _, inputInstance := range conf.Instances {
-		decryptedInstance, err := secretResolver.Resolve(inputInstance, conf.Name, conf.ImageName, conf.PodNamespace)
+		decryptedInstance, err := secretResolver.Resolve(inputInstance, conf.Name, conf.ImageName, conf.PodNamespace, false)
 		if err != nil {
 			return conf, fmt.Errorf("error while decrypting secrets in an instance: %s", err)
 		}
@@ -41,13 +41,13 @@ func decryptConfig(conf integration.Config, secretResolver secrets.Component) (i
 	conf.Instances = instances
 
 	// metrics
-	conf.MetricConfig, err = secretResolver.Resolve(conf.MetricConfig, conf.Name, conf.ImageName, conf.PodNamespace)
+	conf.MetricConfig, err = secretResolver.Resolve(conf.MetricConfig, conf.Name, conf.ImageName, conf.PodNamespace, false)
 	if err != nil {
 		return conf, fmt.Errorf("error while decrypting secrets in 'metrics': %s", err)
 	}
 
 	// logs
-	conf.LogsConfig, err = secretResolver.Resolve(conf.LogsConfig, conf.Name, conf.ImageName, conf.PodNamespace)
+	conf.LogsConfig, err = secretResolver.Resolve(conf.LogsConfig, conf.Name, conf.ImageName, conf.PodNamespace, false)
 	if err != nil {
 		return conf, fmt.Errorf("error while decrypting secrets 'logs': %s", err)
 	}

--- a/comp/core/autodiscovery/autodiscoveryimpl/secrets_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/secrets_test.go
@@ -35,7 +35,7 @@ var _ secrets.Component = (*MockSecretResolver)(nil)
 
 func (m *MockSecretResolver) Configure(_ secrets.ConfigParams) {}
 
-func (m *MockSecretResolver) Resolve(data []byte, origin string, _ string, _ string) ([]byte, error) {
+func (m *MockSecretResolver) Resolve(data []byte, origin string, _ string, _ string, _ bool) ([]byte, error) {
 	if m.scenarios == nil {
 		return data, nil
 	}
@@ -48,6 +48,8 @@ func (m *MockSecretResolver) Resolve(data []byte, origin string, _ string, _ str
 	m.t.Errorf("Resolve called with unexpected arguments: data=%s, origin=%s", string(data), origin)
 	return nil, fmt.Errorf("Resolve called with unexpected arguments: data=%s, origin=%s", string(data), origin)
 }
+
+func (m *MockSecretResolver) RemoveOrigin(_ string) {}
 
 func (m *MockSecretResolver) SubscribeToChanges(_ secrets.SecretChangeCallback) {}
 

--- a/comp/core/secrets/def/component.go
+++ b/comp/core/secrets/def/component.go
@@ -32,12 +32,18 @@ type ConfigParams struct {
 type Component interface {
 	// Configure the executable command that is used for decoding secrets
 	Configure(config ConfigParams)
-	// Resolve resolves the secrets in the given yaml data by replacing secrets handles by their corresponding secret value
-	Resolve(data []byte, origin string, imageName string, kubeNamespace string) ([]byte, error)
+	// Resolve resolves the secrets in the given yaml data by replacing secrets handles by their corresponding secret value.
+	//
+	// Setting 'notify' to true will send notifications for any resolve secrets. This is meant for callers that when
+	// to replace handle themselves in memory. only the configuration requires this at the moment.
+	Resolve(data []byte, origin string, imageName string, kubeNamespace string, notify bool) ([]byte, error)
 	// SubscribeToChanges registers a callback to be invoked whenever secrets are resolved or refreshed
 	SubscribeToChanges(callback SecretChangeCallback)
 	// Refresh will resolve secret handles again, notifying any subscribers of changed values.
 	// If updateNow is true, the function performs the refresh immediately and blocks, returning an informative message suitable for user display.
 	// If updateNow is false, the function will asynchronously perform a refresh, and may fail to refresh due to throttling. No message is returned, just an empty string.
 	Refresh(updateNow bool) (string, error)
+	// RemoveOrigin removes a origin from the internal cache of the secret component. This does not remove secrets
+	// from the cache but the reference where those secrets are used.
+	RemoveOrigin(origin string)
 }

--- a/comp/core/secrets/impl/info_nix_test.go
+++ b/comp/core/secrets/impl/info_nix_test.go
@@ -80,9 +80,9 @@ func TestDebugInfo(t *testing.T) {
 		return res, nil
 	}
 
-	_, err := resolver.Resolve(testConf, "test", "", "")
+	_, err := resolver.Resolve(testConf, "test", "", "", true)
 	require.NoError(t, err)
-	_, err = resolver.Resolve(testConfInfo, "test2", "", "")
+	_, err = resolver.Resolve(testConfInfo, "test2", "", "", true)
 	require.NoError(t, err)
 
 	debugInfo := make(map[string]interface{})
@@ -139,9 +139,9 @@ func TestDebugInfoError(t *testing.T) {
 		return res, nil
 	}
 
-	_, err := resolver.Resolve(testConf, "test", "", "")
+	_, err := resolver.Resolve(testConf, "test", "", "", true)
 	require.NoError(t, err)
-	_, err = resolver.Resolve(testConfInfo, "test2", "", "")
+	_, err = resolver.Resolve(testConfInfo, "test2", "", "", true)
 	require.NoError(t, err)
 
 	debugInfo := make(map[string]interface{})

--- a/comp/core/secrets/mock/mock.go
+++ b/comp/core/secrets/mock/mock.go
@@ -41,7 +41,7 @@ func (m *Mock) Configure(_ secrets.ConfigParams) {}
 
 // Resolve resolves the secrets in the given yaml data by replacing secrets handles by their corresponding secret value
 // from the data receive by `SetSecrets` method
-func (m *Mock) Resolve(data []byte, origin string, _ string, _ string) ([]byte, error) {
+func (m *Mock) Resolve(data []byte, origin string, _ string, _ string, notify bool) ([]byte, error) {
 	var config interface{}
 	err := yaml.Unmarshal(data, &config)
 	if err != nil {
@@ -54,8 +54,10 @@ func (m *Mock) Resolve(data []byte, origin string, _ string, _ string) ([]byte, 
 			if ok, handle := utils.IsEnc(value); ok {
 				if secretValue, ok := m.secretsCache[handle]; ok {
 					// notify subscriptions
-					for _, sub := range m.callbacks {
-						sub(handle, origin, path, secretValue, secretValue)
+					if notify {
+						for _, sub := range m.callbacks {
+							sub(handle, origin, path, secretValue, secretValue)
+						}
 					}
 					return secretValue, nil
 				}
@@ -98,3 +100,6 @@ func (m *Mock) Refresh(updateNow bool) (string, error) {
 	}
 	return "", nil
 }
+
+// RemoveOrigin
+func (m *Mock) RemoveOrigin(_ string) {}

--- a/comp/core/secrets/noop-impl/secret_noop.go
+++ b/comp/core/secrets/noop-impl/secret_noop.go
@@ -96,7 +96,7 @@ func (r *secretNoop) Configure(_ secrets.ConfigParams) {}
 func (r *secretNoop) SubscribeToChanges(_ secrets.SecretChangeCallback) {}
 
 // Resolve does nothing
-func (r *secretNoop) Resolve(data []byte, _ string, _ string, _ string) ([]byte, error) {
+func (r *secretNoop) Resolve(data []byte, _ string, _ string, _ string, _ bool) ([]byte, error) {
 	return data, nil
 }
 
@@ -104,3 +104,6 @@ func (r *secretNoop) Resolve(data []byte, _ string, _ string, _ string) ([]byte,
 func (r *secretNoop) Refresh(_ bool) (string, error) {
 	return "", nil
 }
+
+// RemoveOrigin
+func (r *secretNoop) RemoveOrigin(_ string) {}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2618,7 +2618,7 @@ func resolveSecrets(config pkgconfigmodel.Config, secretResolver secrets.Compone
 				log.Errorf("Could not assign new value of secret %s (%+q) to config: %s", handle, settingPath, err)
 			}
 		})
-		if _, err = secretResolver.Resolve(yamlConf, origin, "", ""); err != nil {
+		if _, err = secretResolver.Resolve(yamlConf, origin, "", "", true); err != nil {
 			return fmt.Errorf("unable to decrypt secret from datadog.yaml: %v", err)
 		}
 	}

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1265,7 +1265,7 @@ use_proxy_for_cloud_metadata: true
 	assert.YAMLEq(t, expectedYaml, string(yamlConf))
 
 	// use resolver to modify a 2nd config with a different origin
-	diffYaml, err := resolver.Resolve(testMinimalDiffConf, "diff_test", "", "")
+	diffYaml, err := resolver.Resolve(testMinimalDiffConf, "diff_test", "", "", true)
 	assert.NoError(t, err)
 	assert.YAMLEq(t, expectedDiffYaml, string(diffYaml))
 
@@ -1275,7 +1275,7 @@ use_proxy_for_cloud_metadata: true
 	assert.YAMLEq(t, expectedYaml, string(yamlConf))
 
 	// use resolver again, but with the original origin now
-	diffYaml, err = resolver.Resolve(testMinimalDiffConf, "unit_test", "", "")
+	diffYaml, err = resolver.Resolve(testMinimalDiffConf, "unit_test", "", "", true)
 	assert.NoError(t, err)
 	assert.YAMLEq(t, expectedDiffYaml, string(diffYaml))
 


### PR DESCRIPTION
### What does this PR do?

Secret would notify all subscribers when resolving a new config. This behavior can create a deadlock depending on the subscriber's behavior. We introduce a new parameter to silence notification based on the caller's need.

We also introduce a way to remove origin so unscheduled checks can be removed from the secret cache.

### Describe how you validated your changes

Running the CI is enough