### PR TITLE
[CWS] Use secinfo track in security-agent

### DIFF
--- a/pkg/security/agent/start.go
+++ b/pkg/security/agent/start.go
@@ -48,12 +48,23 @@ func StartRuntimeSecurity(log log.Component, config config.Component, hostname s
 	}
 	stopper.Add(ctx)
 
-	reporter, err := reporter.NewCWSReporter(hostname, stopper, endpoints, ctx, compression)
+	runtimeReporter, err := reporter.NewCWSReporter(hostname, stopper, endpoints, ctx, compression)
 	if err != nil {
 		return nil, err
 	}
 
-	agent.Start(reporter, endpoints)
+	secInfoEndpoints, secInfoCtx, err := common.NewLogContextSecInfo()
+	if err != nil {
+		_ = log.Error(err)
+	}
+	stopper.Add(secInfoCtx)
+
+	secInfoReporter, err := reporter.NewCWSReporter(hostname, stopper, secInfoEndpoints, secInfoCtx, compression)
+	if err != nil {
+		return nil, err
+	}
+
+	agent.Start(runtimeReporter, endpoints, secInfoReporter, secInfoEndpoints)
 
 	log.Info("Datadog runtime security agent is now running")
 

--- a/pkg/security/common/logs_context.go
+++ b/pkg/security/common/logs_context.go
@@ -15,8 +15,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// TrackType represents the type of track for event routing
+type TrackType = logsconfig.IntakeTrackType
+
 const (
 	cwsIntakeOrigin logsconfig.IntakeOrigin = "cloud-workload-security"
+
+	// SecRuntime is the track type for secruntime events
+	SecRuntime TrackType = "secruntime"
+	// Logs is the track type for logs events
+	Logs TrackType = "logs"
+	// SecInfo is the track type for secinfo events
+	SecInfo TrackType = "secinfo"
 )
 
 // NewLogContextCompliance returns the context fields to send compliance events to the intake
@@ -28,14 +38,12 @@ func NewLogContextCompliance() (*logsconfig.Endpoints, *client.DestinationsConte
 // NewLogContextRuntime returns the context fields to send runtime (CWS) events to the intake
 // This function will only be used on Linux. The only platforms where the runtime agent runs
 func NewLogContextRuntime(useSecRuntimeTrack bool) (*logsconfig.Endpoints, *client.DestinationsContext, error) {
-	var (
-		trackType logsconfig.IntakeTrackType
-	)
+	var trackType TrackType
 
 	if useSecRuntimeTrack {
-		trackType = "secruntime"
+		trackType = SecRuntime
 	} else {
-		trackType = "logs"
+		trackType = Logs
 	}
 
 	logsRuntimeConfigKeys := logsconfig.NewLogsConfigKeys("runtime_security_config.endpoints.", pkgconfigsetup.Datadog())
@@ -45,7 +53,7 @@ func NewLogContextRuntime(useSecRuntimeTrack bool) (*logsconfig.Endpoints, *clie
 // NewLogContextSecInfo returns the context fields to send remediation events to the intake
 func NewLogContextSecInfo() (*logsconfig.Endpoints, *client.DestinationsContext, error) {
 	logsRuntimeConfigKeys := logsconfig.NewLogsConfigKeys("runtime_security_config.endpoints.", pkgconfigsetup.Datadog())
-	return NewLogContext(logsRuntimeConfigKeys, "runtime-security-http-intake.logs.", "secinfo", cwsIntakeOrigin, logsconfig.DefaultIntakeProtocol)
+	return NewLogContext(logsRuntimeConfigKeys, "runtime-security-http-intake.logs.", SecInfo, cwsIntakeOrigin, logsconfig.DefaultIntakeProtocol)
 }
 
 // NewLogContext returns the context fields to send events to the intake

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -47,17 +47,6 @@ type ChanMsgSender[T any] struct {
 	msgs chan *T
 }
 
-type TrackType string
-
-const (
-	// Runtime is the track type for runtime events
-	Runtime TrackType = "runtime"
-	// Logs is the track type for logs events
-	Logs TrackType = "logs"
-	// SecInfo is the track type for secinfo events
-	SecInfo TrackType = "secinfo"
-)
-
 // Send the message
 func (cs *ChanMsgSender[T]) Send(msg *T, expireFnc func(*T)) {
 	select {
@@ -108,7 +97,7 @@ var _ EndpointsStatusFetcher = &DirectEventMsgSender{}
 
 // Send the message
 func (ds *DirectEventMsgSender) Send(msg *api.SecurityEventMessage, _ func(*api.SecurityEventMessage)) {
-	if msg.Track == string(SecInfo) {
+	if msg.Track == string(common.SecInfo) {
 		ds.secInfoReporter.ReportRaw(msg.Data, msg.Service, msg.Timestamp.AsTime(), msg.Tags...)
 	} else {
 		ds.reporter.ReportRaw(msg.Data, msg.Service, msg.Timestamp.AsTime(), msg.Tags...)

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -284,7 +284,7 @@ func (a *APIServer) updateMsgService(msg *api.SecurityEventMessage) {
 
 func (a *APIServer) updateMsgTrack(msg *api.SecurityEventMessage) {
 	if slices.Contains(events.AllSecInfoRuleIDs(), msg.RuleID) {
-		msg.Track = string(SecInfo)
+		msg.Track = string(common.SecInfo)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR is a follow up to [this PR](https://github.com/DataDog/datadog-agent/pull/44107).
In the same way, it adds the use of secinfo for remediation status in the security-agent sender
### Motivation

### Describe how you validated your changes

### Additional Notes
