### PR TITLE
chore(autodiscovery): log missing config paths at debug level

### DIFF
--- a/comp/core/autodiscovery/providers/config_reader.go
+++ b/comp/core/autodiscovery/providers/config_reader.go
@@ -216,7 +216,11 @@ func (r *configFilesReader) read(keep FilterFunc) ([]integration.Config, []Confi
 
 		entries, err := os.ReadDir(path)
 		if err != nil {
-			log.Warnf("Skipping, %s", err)
+			if errors.Is(err, os.ErrNotExist) {
+				log.Debugf("Skipping, %s", err)
+			} else {
+				log.Warnf("Skipping, %s", err)
+			}
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?

Changes the log level from warning to debug when autodiscovery config directories don't exist.

### Motivation

Missing config directories are expected during config path scanning and shouldn't generate warnings. Other errors (permissions, I/O) still log as warnings.

### Describe how you validated your changes

Before
```
[cluster-agent] 2025-12-17 16:12:27 UTC | CLUSTER | INFO | (comp/core/autodiscovery/providers/config_reader.go:215 in read) | Searching for configuration files at: /etc/datadog-agent/conf.d
[cluster-agent] 2025-12-17 16:12:27 UTC | CLUSTER | INFO | (comp/core/autodiscovery/providers/config_reader.go:215 in read) | Searching for configuration files at: /opt/datadog-agent/bin/dist/conf.d
[cluster-agent] 2025-12-17 16:12:27 UTC | CLUSTER | WARN | (comp/core/autodiscovery/providers/config_reader.go:219 in read) | Skipping, open /opt/datadog-agent/bin/dist/conf.d: no such file or directory
[cluster-agent] 2025-12-17 16:12:27 UTC | CLUSTER | INFO | (comp/core/autodiscovery/providers/config_reader.go:215 in read) | Searching for configuration files at: 
[cluster-agent] 2025-12-17 16:12:27 UTC | CLUSTER | WARN | (comp/core/autodiscovery/providers/config_reader.go:219 in read) | Skipping, open : no such file or directory
```

After
```
2025-12-17 16:25:32 UTC | CORE | INFO | (comp/core/autodiscovery/providers/config_reader.go:215 in read) | Searching for configuration files at: /opt/datadog-agent/bin/agent/dist/conf.d
2025-12-17 16:25:32 UTC | CORE | DEBUG | (comp/core/autodiscovery/providers/config_reader.go:220 in read) | Skipping, open /opt/datadog-agent/bin/agent/dist/conf.d: no such file or directory
2025-12-17 16:25:32 UTC | CORE | INFO | (comp/core/autodiscovery/providers/config_reader.go:215 in read) | Searching for configuration files at:
2025-12-17 16:25:32 UTC | CORE | DEBUG | (comp/core/autodiscovery/providers/config_reader.go:220 in read) | Skipping, open : no such file or directory
```

### Additional Notes

N/A