### PR TITLE
[CWS-5609] Fix container-scoped SECL variables not being released

### DIFF
--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -35,6 +35,14 @@ func NewCacheEntry(containerContext model.ContainerContext, cgroupContext model.
 		PIDs:             make(map[uint32]bool, 10),
 	}
 
+	// should not happen but added as a safe-guard to avoid overriding
+	// a Releasable pointer which would cause Releasable callbacks to not be called
+	if newCGroup.ContainerContext.Releasable == nil {
+		// we need this here because the newCGroup entry will be propagated back to both the cgroup resolver
+		// and the process cache entry upon context context resolution
+		newCGroup.ContainerContext.Releasable = &model.Releasable{}
+	}
+
 	for _, pid := range pids {
 		newCGroup.PIDs[pid] = true
 	}

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -102,8 +102,7 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupFS FSInterface) (*Re
 	}
 
 	cleanup := func(value *cgroupModel.CacheEntry) {
-
-		if value.ContainerContext.Resolved && value.ContainerContext.ContainerID != "" {
+		if value.ContainerContext.Releasable != nil {
 			value.ContainerContext.CallReleaseCallback()
 		}
 		if value.CGroupContext.Releasable != nil {

--- a/pkg/security/resolvers/cgroup/resolver_test.go
+++ b/pkg/security/resolvers/cgroup/resolver_test.go
@@ -54,6 +54,7 @@ func createTestProcess(pid, ppid uint32, containerID containerutils.ContainerID)
 				},
 				PPid: ppid,
 				ContainerContext: model.ContainerContext{
+					Releasable:  &model.Releasable{},
 					ContainerID: containerID,
 				},
 				CGroup: model.CGroupContext{

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -309,13 +309,9 @@ func deepCopyContainerContext(fieldToCopy ContainerContext) ContainerContext {
 	copied := ContainerContext{}
 	copied.ContainerID = fieldToCopy.ContainerID
 	copied.CreatedAt = fieldToCopy.CreatedAt
-	copied.Releasable = deepCopyReleasable(fieldToCopy.Releasable)
+	copied.Releasable = deepCopyReleasablePtr(fieldToCopy.Releasable)
 	copied.Resolved = fieldToCopy.Resolved
 	copied.Tags = deepCopystringArr(fieldToCopy.Tags)
-	return copied
-}
-func deepCopyReleasable(fieldToCopy Releasable) Releasable {
-	copied := Releasable{}
 	return copied
 }
 func deepCopyCredentials(fieldToCopy Credentials) Credentials {

--- a/pkg/security/secl/model/event_deep_copy_windows.go
+++ b/pkg/security/secl/model/event_deep_copy_windows.go
@@ -121,13 +121,16 @@ func deepCopyContainerContext(fieldToCopy ContainerContext) ContainerContext {
 	copied := ContainerContext{}
 	copied.ContainerID = fieldToCopy.ContainerID
 	copied.CreatedAt = fieldToCopy.CreatedAt
-	copied.Releasable = deepCopyReleasable(fieldToCopy.Releasable)
+	copied.Releasable = deepCopyReleasablePtr(fieldToCopy.Releasable)
 	copied.Resolved = fieldToCopy.Resolved
 	copied.Tags = deepCopystringArr(fieldToCopy.Tags)
 	return copied
 }
-func deepCopyReleasable(fieldToCopy Releasable) Releasable {
-	copied := Releasable{}
+func deepCopyReleasablePtr(fieldToCopy *Releasable) *Releasable {
+	if fieldToCopy == nil {
+		return nil
+	}
+	copied := &Releasable{}
 	return copied
 }
 func deepCopyEnvsEntryPtr(fieldToCopy *EnvsEntry) *EnvsEntry {

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -93,7 +93,7 @@ func (r *Releasable) AppendReleaseCallback(callback func()) {
 
 // ContainerContext holds the container context of an event
 type ContainerContext struct {
-	Releasable
+	*Releasable
 	ContainerID containerutils.ContainerID `field:"id,handler:ResolveContainerID,opts:gen_getters"`                // SECLDoc[id] Definition:`ID of the container`
 	CreatedAt   uint64                     `field:"created_at,handler:ResolveContainerCreatedAt,opts:gen_getters"` // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
 	Tags        []string                   `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"`    // SECLDoc[tags] Definition:`Tags of the container`

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -419,6 +419,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 	event.ProcessContext = &model.ProcessContext{
 		Process: model.Process{
 			ContainerContext: model.ContainerContext{
+				Releasable:  &model.Releasable{},
 				ContainerID: "0123456789abcdef",
 			},
 		},
@@ -2384,6 +2385,7 @@ func TestActionSetVariableLength(t *testing.T) {
 	event.ProcessContext = &model.ProcessContext{
 		Process: model.Process{
 			ContainerContext: model.ContainerContext{
+				Releasable:  &model.Releasable{},
 				ContainerID: "0123456789abcdef",
 			},
 		},

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -93,7 +93,7 @@ func (r *Releasable) AppendReleaseCallback(callback func()) {
 
 // ContainerContext holds the container context of an event
 type ContainerContext struct {
-	Releasable
+	*Releasable
 	ContainerID containerutils.ContainerID `field:"id,handler:ResolveContainerID,opts:gen_getters"`                // SECLDoc[id] Definition:`ID of the container`
 	CreatedAt   uint64                     `field:"created_at,handler:ResolveContainerCreatedAt,opts:gen_getters"` // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
 	Tags        []string                   `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"`    // SECLDoc[tags] Definition:`Tags of the container`

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -181,3 +181,74 @@ func TestContainerVariables(t *testing.T) {
 		})
 	})
 }
+
+func TestContainerVariablesReleased(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+
+	checkKernelCompatibility(t, "broken containerd support on Suse 12", func(kv *kernel.Version) bool {
+		return kv.IsSuse12Kernel()
+	})
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_container_set_variable",
+			Expression: `process.container.id != "" && open.file.path == "/tmp/test-open"`,
+			Actions: []*rules.ActionDefinition{
+				{
+					Set: &rules.SetDefinition{
+						Scope: "container",
+						Value: 999,
+						Name:  "bar",
+					},
+				},
+			},
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	dockerWrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "ubuntu", "")
+	if err != nil {
+		t.Fatalf("failed to create docker wrapper: %v", err)
+	}
+	_, err = dockerWrapper.start()
+	if err != nil {
+		t.Fatalf("failed to start docker wrapper: %v", err)
+	}
+
+	test.WaitSignal(t, func() error {
+		return dockerWrapper.Command("touch", []string{"/tmp/test-open"}, nil).Run()
+	}, func(event *model.Event, rule *rules.Rule) {
+		assertTriggeredRule(t, rule, "test_container_set_variable")
+		assertFieldEqual(t, event, "open.file.path", "/tmp/test-open")
+		assertFieldNotEmpty(t, event, "process.container.id", "container id shouldn't be empty")
+
+		variables := test.ruleEngine.GetRuleSet().GetScopedVariables(rules.ScopeContainer, "bar")
+		assert.NotNil(t, variables)
+		assert.Contains(t, variables, event.ProcessContext.Process.ContainerContext.Hash())
+		variable, ok := variables[event.ProcessContext.Process.ContainerContext.Hash()]
+		assert.True(t, ok)
+		value, ok := variable.GetValue()
+		assert.True(t, ok)
+		assert.Equal(t, 999, value.(int))
+	})
+
+	_, err = dockerWrapper.stop()
+	if err != nil {
+		t.Fatalf("failed to stop docker wrapper: %v", err)
+	}
+
+	time.Sleep(500 * time.Millisecond) // wait just a bit of time for the container to be released
+
+	variables := test.ruleEngine.GetRuleSet().GetScopedVariables(rules.ScopeContainer, "bar")
+	assert.NotNil(t, variables)
+	assert.Len(t, variables, 0)
+}


### PR DESCRIPTION
### What does this PR do?

Make it so the Releasable object of a container context is shared between multiple copies of the same container context.
Also, make it so we release container variables no matter whether the container context is resolved and no matter whether it has a container ID. 

### Motivation

Fix container-scoped SECL variables not being released.

### Describe how you validated your changes

Added a new `TestContainerVariablesReleased` test.

### Additional Notes
