### PR TITLE
[CONTP-1155] fix(Dockerfile): Grant dd-agent write permissions to /opt/datadog-agent/run

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile
+++ b/Dockerfiles/agent-ddot/Dockerfile
@@ -13,6 +13,6 @@ COPY s6-services/otel /etc/services.d/otel
 COPY entrypoint.d /opt/entrypoints
 RUN chmod 755 -R /opt/entrypoints \
   && chown dd-agent:root /etc/datadog-agent/otel-config.yaml \
-  && rm -rf /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog \
-  && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ \
-  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/
+  && rm -rf /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \
+  && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
+  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -194,9 +194,9 @@ COPY --from=extract /output/ /
 RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agent \
   && addgroup --system secret-manager \
   && usermod -a -G secret-manager dd-agent \
-  && rm /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog \
-  && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ \
-  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ \
+  && rm /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \
+  && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
+  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod 755 /probe.sh /initlog.sh \
   && chown root:secret-manager /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
   && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -87,11 +87,11 @@ RUN addgroup --system secret-manager \
 RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agent \
     && addgroup --system secret-manager \
     && usermod -a -G secret-manager dd-agent \
-    && mkdir -p /var/log/datadog/ /conf.d \
+    && mkdir -p /var/log/datadog/ /conf.d /opt/datadog-agent/run \
     && touch /var/log/datadog/.placeholder \
     && touch /tmp/.placeholder \
-    && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ /conf.d /tmp/ \
-    && chmod g+r,g+w,g+X -R /var/log/datadog/ /conf.d /tmp/ \
+    && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ /conf.d /tmp/ /opt/datadog-agent/run \
+    && chmod g+r,g+w,g+X -R /var/log/datadog/ /conf.d /tmp/ /opt/datadog-agent/run \
     && chmod g+r,g-w,g+X,o-w -R /etc/datadog-agent/
 
 # Ensure the glibc doesn't try to call syscalls that may not be supported

--- a/releasenotes/notes/grant-dd-agent-write-permissions-run-directory-1588ad932b3b85b8.yaml
+++ b/releasenotes/notes/grant-dd-agent-write-permissions-run-directory-1588ad932b3b85b8.yaml
@@ -1,5 +1,6 @@
 fixes:
     - |
-      In the Agent and Cluster Agent Docker images, the `/opt/datadog-agent/run` directory is now owned by the
-      `dd-agent` user and writable by the `root` group. This allows the Agent to function correctly (e.g.,
-      using Remote Configuration) when running as the non-root `dd-agent` user (UID 100).
+      Fixed ownership and permissions for the `/opt/datadog-agent/run` directory 
+      in Agent and Cluster Agent Docker images. This resolves permission errors 
+      encountered by Remote Configuration when running as a non-root user 
+      (UID 100), such as in AWS ECS Fargate environments.

--- a/releasenotes/notes/grant-dd-agent-write-permissions-run-directory-1588ad932b3b85b8.yaml
+++ b/releasenotes/notes/grant-dd-agent-write-permissions-run-directory-1588ad932b3b85b8.yaml
@@ -1,0 +1,5 @@
+fixes:
+    - |
+      In the Agent and Cluster Agent Docker images, the `/opt/datadog-agent/run` directory is now owned by the
+      `dd-agent` user and writable by the `root` group. This allows the Agent to function correctly (e.g.,
+      using Remote Configuration) when running as the non-root `dd-agent` user (UID 100).


### PR DESCRIPTION
### What does this PR do?

Updates the Agent Dockerfiles (`agent`, `agent-ddot` and `cluster-agent`) to explicitly create the `/opt/datadog-agent/run` directory and grant ownership/write permissions to the dd-agent user (UID 100).

### Motivation

Customers running the Datadog Agent as a non-root user (specifically dd-agent, UID 100) on platforms like ECS Fargate were encountering connection errors with Remote Configuration because RC is failing to write a database to `/opt/datadog-agent/run/reomte-config.db` citing permission errors.

While building the Agent image, select directories are granted write permission to the `dd-agent` user; however `/opt/datadog-agent/run` is missing from this list.

Adding this permission ensures `/opt/datadog-agent/run` write ops work out-of-the box while running the agent with `dd-agent` user.

### Describe how you validated your changes

- Build CI is green

### Additional Notes

- Addressing customer support issue [CONS-7919](https://datadoghq.atlassian.net/browse/CONS-7919)


[CONS-7919]: https://datadoghq.atlassian.net/browse/CONS-7919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ