### PR TITLE
Kubernetes actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -474,6 +474,7 @@
 /pkg/cloudfoundry                       @DataDog/agent-integrations
 /pkg/clusteragent/                      @DataDog/container-platform
 /pkg/clusteragent/autoscaling/          @DataDog/container-autoscaling
+/pkg/clusteragent/kubeactions/          @DataDog/container-integrations
 /pkg/clusteragent/evictor/              @DataDog/container-platform @DataDog/container-integrations
 /pkg/clusteragent/metricsstore/         @DataDog/container-autoscaling
 /pkg/clusteragent/admission/mutate/autoscaling          @DataDog/container-integrations

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -130,6 +130,7 @@ core,github.com/DataDog/agent-payload/v5/cws/dumpsv1,BSD-3-Clause,"Copyright (c)
 core,github.com/DataDog/agent-payload/v5/cyclonedx_v1_4,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"
 core,github.com/DataDog/agent-payload/v5/gogen,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"
 core,github.com/DataDog/agent-payload/v5/healthplatform,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"
+core,github.com/DataDog/agent-payload/v5/kubeactions,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"
 core,github.com/DataDog/agent-payload/v5/pb,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"
 core,github.com/DataDog/agent-payload/v5/process,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"
 core,github.com/DataDog/agent-payload/v5/sbom,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -92,6 +92,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/provider"
 	pkgclusterchecks "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/kubeactions"
 	clusteragentMetricsStatus "github.com/DataDog/datadog-agent/pkg/clusteragent/metricsstatus"
 	orchestratorStatus "github.com/DataDog/datadog-agent/pkg/clusteragent/orchestrator"
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
@@ -168,7 +169,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				filterlistfx.Module(),
 				demultiplexerimpl.Module(demultiplexerimpl.NewDefaultParams()),
 				orchestratorForwarderImpl.Module(orchestratorForwarderImpl.NewDefaultParams()),
-				eventplatformimpl.Module(eventplatformimpl.NewDisabledParams()),
+				eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
 				eventplatformreceiverimpl.Module(),
 				// setup workloadmeta
 				wmcatalog.GetCatalog(),
@@ -264,6 +265,7 @@ func start(log log.Component,
 	taggerComp tagger.Component,
 	telemetry telemetry.Component,
 	demultiplexer demultiplexer.Component,
+	epForwarder eventplatform.Component,
 	filterStore workloadfilter.Component,
 	wmeta workloadmeta.Component,
 	ac autodiscovery.Component,
@@ -449,7 +451,8 @@ func start(log log.Component,
 	// Initialize and start remote configuration client
 	var rcClient *rcclient.Client
 	rcserv, isSet := rcService.Get()
-	if configUtils.IsRemoteConfigEnabled(config) && isSet {
+	rcEnabled := configUtils.IsRemoteConfigEnabled(config)
+	if rcEnabled && isSet {
 		var products []string
 		if config.GetBool("admission_controller.auto_instrumentation.patcher.enabled") {
 			products = append(products, state.ProductAPMTracing)
@@ -460,10 +463,12 @@ func start(log log.Component,
 		if config.GetBool("autoscaling.cluster.enabled") {
 			products = append(products, state.ProductClusterAutoscalingValues)
 		}
+		if config.GetBool("kubeactions.enabled") {
+			products = append(products, state.ProductK8SActions)
+		}
 		if config.GetBool("admission_controller.auto_instrumentation.enabled") || config.GetBool("apm_config.instrumentation.enabled") {
 			products = append(products, state.ProductGradualRollout)
 		}
-		// Add private action runner product if enabled
 		if config.GetBool("private_action_runner.enabled") {
 			products = append(products, state.ProductActionPlatformRunnerKeys)
 		}
@@ -555,6 +560,18 @@ func start(log log.Component,
 		if err := cluster.StartClusterAutoscaling(mainCtx, clusterID, clusterName, le.IsLeader, apiCl, rcClient, demultiplexer); err != nil {
 			return fmt.Errorf("Error while starting cluster autoscaling: %w", err)
 		}
+	}
+
+	// Kubernetes Actions
+	if config.GetBool("kubeactions.enabled") {
+		if rcClient == nil {
+			return errors.New("remote config is disabled or failed to initialize, remote config is a required dependency for kubeactions")
+		}
+
+		if _, err := kubeactions.Setup(mainCtx, apiCl.Cl, clusterName, clusterID, le.IsLeader, rcClient, epForwarder); err != nil {
+			return fmt.Errorf("Error while starting kubernetes actions: %v", err)
+		}
+		log.Info("Kubernetes actions subsystem started successfully")
 	}
 
 	// Compliance
@@ -762,13 +779,12 @@ func initializeRemoteConfigClient(rcService rccomp.Component, config config.Comp
 		pkglog.Warn("Error retrieving cluster ID: cluster-id won't be set for remote-config client")
 	}
 
-	pkglog.Debugf("Initializing remote-config client with cluster-name: '%s', cluster-id: '%s', products: %v", clusterName, clusterID, products)
 	rcClient, err := rcclient.NewClient(rcService,
 		rcclient.WithAgent("cluster-agent", version.AgentVersion),
 		rcclient.WithCluster(clusterName, clusterID),
+		rcclient.WithDirectorRootOverride(config.GetString("site"), config.GetString("remote_configuration.director_root")),
 		rcclient.WithProducts(products...),
 		rcclient.WithPollInterval(5*time.Second),
-		rcclient.WithDirectorRootOverride(config.GetString("site"), config.GetString("remote_configuration.director_root")),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create local remote-config client: %w", err)

--- a/comp/forwarder/eventplatform/component.go
+++ b/comp/forwarder/eventplatform/component.go
@@ -41,6 +41,9 @@ const (
 	EventTypeSoftwareInventory = "software-inventory"
 	// EventTypeEventManagement represents an event for the Event Management API
 	EventTypeEventManagement = "event-management"
+	// TODO: Uncomment once kubeactions EVP intake is provisioned
+	// // EventTypeKubeActions represents a kubernetes action result event
+	// EventTypeKubeActions = "kube-actions"
 )
 
 // Component is the interface of the event platform forwarder component.

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -295,6 +295,19 @@ func getPassthroughPipelines() []passthroughPipelineDesc {
 			defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
 			defaultInputChanSize:          500,
 		},
+		// TODO: Add kubeactions EVP pipeline once the intake endpoint is provisioned
+		// {
+		// 	eventType:                     eventplatform.EventTypeKubeActions,
+		// 	category:                      "Kubernetes",
+		// 	contentType:                   logshttp.JSONContentType,
+		// 	endpointsConfigPrefix:         "kubeactions.forwarder.",
+		// 	hostnameEndpointPrefix:        "kubeactions-intake.",
+		// 	intakeTrackType:               "kubeactions",
+		// 	defaultBatchMaxConcurrentSend: 10,
+		// 	defaultBatchMaxContentSize:    pkgconfigsetup.DefaultBatchMaxContentSize,
+		// 	defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
+		// 	defaultInputChanSize:          pkgconfigsetup.DefaultInputChanSize,
+		// },
 	}
 
 	if pkgconfigsetup.Datadog().GetBool("software_inventory.enabled") {

--- a/comp/remote-config/rcservice/impl/rcservice.go
+++ b/comp/remote-config/rcservice/impl/rcservice.go
@@ -78,6 +78,7 @@ func newRemoteConfigService(deps Dependencies) (rcservice.Component, error) {
 		apiKey = deps.Cfg.GetString("remote_configuration.api_key")
 	}
 	apiKey = configUtils.SanitizeAPIKey(apiKey)
+
 	baseRawURL := configUtils.GetMainEndpoint(deps.Cfg, "https://config.", "remote_configuration.rc_dd_url")
 	traceAgentEnv := configUtils.GetTraceAgentDefaultEnv(deps.Cfg)
 

--- a/go.sum
+++ b/go.sum
@@ -1864,8 +1864,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
-github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
+github.com/modelcontextprotocol/go-sdk v1.3.1 h1:TfqtNKOIWN4Z1oqmPAiWDC2Jq7K9OdJaooe0teoXASI=
+github.com/modelcontextprotocol/go-sdk v1.3.1/go.mod h1:DgVX498dMD8UJlseK1S5i1T4tFz2fkBk4xogC3D15nw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -2310,8 +2310,8 @@ github.com/secure-systems-lab/go-securesystemslib v0.9.0 h1:rf1HIbL64nUpEIZnjLZ3
 github.com/secure-systems-lab/go-securesystemslib v0.9.0/go.mod h1:DVHKMcZ+V4/woA/peqr+L0joiRXbPpQ042GgJckkFgw=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
-github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
-github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
+github.com/segmentio/encoding v0.5.3 h1:OjMgICtcSFuNvQCdwqMCv9Tg7lEOXGwm1J5RPQccx6w=
+github.com/segmentio/encoding v0.5.3/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/go.sum
+++ b/go.sum
@@ -1864,8 +1864,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.3.1 h1:TfqtNKOIWN4Z1oqmPAiWDC2Jq7K9OdJaooe0teoXASI=
-github.com/modelcontextprotocol/go-sdk v1.3.1/go.mod h1:DgVX498dMD8UJlseK1S5i1T4tFz2fkBk4xogC3D15nw=
+github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
+github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -2310,8 +2310,8 @@ github.com/secure-systems-lab/go-securesystemslib v0.9.0 h1:rf1HIbL64nUpEIZnjLZ3
 github.com/secure-systems-lab/go-securesystemslib v0.9.0/go.mod h1:DVHKMcZ+V4/woA/peqr+L0joiRXbPpQ042GgJckkFgw=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
-github.com/segmentio/encoding v0.5.3 h1:OjMgICtcSFuNvQCdwqMCv9Tg7lEOXGwm1J5RPQccx6w=
-github.com/segmentio/encoding v0.5.3/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/pkg/clusteragent/kubeactions/action_store.go
+++ b/pkg/clusteragent/kubeactions/action_store.go
@@ -1,0 +1,201 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeactions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// ActionTTL is how long actions are valid for execution
+	ActionTTL = 1 * time.Minute
+	// RecordRetentionTTL is how long action records are kept in memory (24 hours)
+	// This allows for inspection and debugging of executed actions
+	RecordRetentionTTL = 24 * time.Hour
+	// CleanupInterval is how often we clean up expired action records from memory
+	CleanupInterval = 30 * time.Second
+)
+
+// ActionKey uniquely identifies an action by its metadata ID and version
+type ActionKey struct {
+	ID      string
+	Version uint64
+}
+
+// String returns a string representation of the ActionKey
+func (ak ActionKey) String() string {
+	return fmt.Sprintf("%s:v%d", ak.ID, ak.Version)
+}
+
+// ActionRecord stores information about a processed action
+type ActionRecord struct {
+	Key             ActionKey
+	Status          string
+	Message         string
+	ExecutedAt      int64 // Unix timestamp when action was executed
+	ReceivedAt      int64 // Unix timestamp when action was received by agent
+	ActionCreatedAt int64 // Unix timestamp from action.timestamp field
+}
+
+// ActionStore tracks processed actions in-memory to prevent duplicate execution
+// Actions older than ActionTTL are automatically expired
+type ActionStore struct {
+	executed map[string]ActionRecord
+	mu       sync.RWMutex
+	stopCh   chan struct{}
+}
+
+// NewActionStore creates a new ActionStore and starts the cleanup goroutine
+func NewActionStore(ctx context.Context) *ActionStore {
+	store := &ActionStore{
+		executed: make(map[string]ActionRecord),
+		stopCh:   make(chan struct{}),
+	}
+
+	// Start background cleanup goroutine
+	go store.cleanupLoop(ctx)
+
+	log.Infof("Created in-memory action store with action TTL=%v, record retention=%v, cleanup interval=%v",
+		ActionTTL, RecordRetentionTTL, CleanupInterval)
+	return store
+}
+
+// isExpired checks if an action timestamp is older than ActionTTL
+func isExpired(actionCreatedAt time.Time) bool {
+	age := time.Since(actionCreatedAt)
+	return age > ActionTTL
+}
+
+// ValidateTimestamp validates an action timestamp and returns an error if invalid
+func ValidateTimestamp(actionCreatedAt time.Time) error {
+	now := time.Now()
+
+	// Check if timestamp is zero/missing
+	if actionCreatedAt.IsZero() {
+		return errors.New("action timestamp is missing or zero")
+	}
+
+	// Check if timestamp is in the future (with 10 second buffer for clock skew)
+	if actionCreatedAt.After(now.Add(10 * time.Second)) {
+		return fmt.Errorf("action timestamp is in the future: %v (now: %v)", actionCreatedAt, now)
+	}
+
+	// Check if timestamp is expired
+	if isExpired(actionCreatedAt) {
+		return fmt.Errorf("action timestamp is expired: %v (age: %v, TTL: %v)",
+			actionCreatedAt, time.Since(actionCreatedAt), ActionTTL)
+	}
+
+	return nil
+}
+
+// WasExecuted checks if an action was already executed
+func (s *ActionStore) WasExecuted(key ActionKey) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, exists := s.executed[key.String()]
+	return exists
+}
+
+// MarkExecuted marks an action as executed with the given status and message
+func (s *ActionStore) MarkExecuted(key ActionKey, status, message string, executedAt int64, receivedAt int64, actionCreatedAt int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.executed[key.String()] = ActionRecord{
+		Key:             key,
+		Status:          status,
+		Message:         message,
+		ExecutedAt:      executedAt,
+		ReceivedAt:      receivedAt,
+		ActionCreatedAt: actionCreatedAt,
+	}
+}
+
+// GetRecord retrieves the execution record for an action
+func (s *ActionStore) GetRecord(key ActionKey) (ActionRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	record, exists := s.executed[key.String()]
+	return record, exists
+}
+
+// GetAll returns all execution records
+func (s *ActionStore) GetAll() []ActionRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return slices.Collect(maps.Values(s.executed))
+}
+
+// Count returns the number of executed actions
+func (s *ActionStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.executed)
+}
+
+// cleanupLoop periodically removes expired action records from memory
+func (s *ActionStore) cleanupLoop(ctx context.Context) {
+	ticker := time.NewTicker(CleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Infof("Action store cleanup loop stopped")
+			return
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			s.cleanup()
+		}
+	}
+}
+
+// cleanup removes action records that are older than RecordRetentionTTL
+// This keeps executed actions in memory for inspection and debugging
+func (s *ActionStore) cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cutoff := time.Now().Add(-RecordRetentionTTL).Unix()
+	removed := 0
+
+	for key, record := range s.executed {
+		// Use ActionCreatedAt if available, fall back to ExecutedAt for malformed actions
+		ts := record.ActionCreatedAt
+		if ts == 0 {
+			ts = record.ExecutedAt
+		}
+		if ts > 0 && ts < cutoff {
+			delete(s.executed, key)
+			removed++
+		}
+	}
+
+	if removed > 0 {
+		log.Debugf("Cleaned up %d expired action records from memory (remaining: %d)", removed, len(s.executed))
+	}
+}
+
+// Stop stops the cleanup goroutine
+func (s *ActionStore) Stop() {
+	close(s.stopCh)
+}

--- a/pkg/clusteragent/kubeactions/config_retriever.go
+++ b/pkg/clusteragent/kubeactions/config_retriever.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeactions
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// RcClient is a subinterface of rcclient.Component to allow mocking
+type RcClient interface {
+	SubscribeIgnoreExpiration(product string, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
+}
+
+// ConfigRetriever is responsible for retrieving remote config updates for Kubernetes actions
+type ConfigRetriever struct {
+	processor *ActionProcessor
+	isLeader  func() bool
+}
+
+// NewConfigRetriever creates a new ConfigRetriever and subscribes to K8S_ACTIONS
+func NewConfigRetriever(processor *ActionProcessor, isLeader func() bool, rcClient RcClient) *ConfigRetriever {
+	cr := &ConfigRetriever{
+		processor: processor,
+		isLeader:  isLeader,
+	}
+
+	rcClient.SubscribeIgnoreExpiration(state.ProductK8SActions, cr.actionsCallback)
+	log.Infof("[KubeActions] Subscribed to %s remote config product", state.ProductK8SActions)
+
+	return cr
+}
+
+// actionsCallback is called when remote config updates are received
+func (cr *ConfigRetriever) actionsCallback(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	isLeader := cr.isLeader()
+
+	log.Infof("[KubeActions] RC callback invoked: received %d config(s), leader=%v", len(update), isLeader)
+
+	if len(update) == 0 {
+		return
+	}
+
+	for configKey, rawConfig := range update {
+		log.Infof("[KubeActions] Processing config: key=%s, id=%s, version=%d, size=%d bytes",
+			configKey, rawConfig.Metadata.ID, rawConfig.Metadata.Version, len(rawConfig.Config))
+
+		if !isLeader {
+			log.Infof("[KubeActions] Skipping config %s - not the leader", configKey)
+			applyStateCallback(configKey, state.ApplyStatus{
+				State: state.ApplyStateUnacknowledged,
+				Error: "not the leader",
+			})
+			continue
+		}
+
+		err := cr.processor.Process(configKey, rawConfig)
+		if err != nil {
+			log.Errorf("[KubeActions] Error processing actions for %s: %v", configKey, err)
+			applyStateCallback(configKey, state.ApplyStatus{
+				State: state.ApplyStateError,
+				Error: err.Error(),
+			})
+		} else {
+			log.Infof("[KubeActions] Successfully processed actions for config %s", configKey)
+			applyStateCallback(configKey, state.ApplyStatus{
+				State: state.ApplyStateAcknowledged,
+			})
+		}
+	}
+}

--- a/pkg/clusteragent/kubeactions/doc.go
+++ b/pkg/clusteragent/kubeactions/doc.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package kubeactions provides functionality for executing Kubernetes actions
+// received via remote configuration. Actions are one-time operations like
+// deleting pods, restarting deployments, draining nodes, etc.
+//
+// The package tracks executed actions by metadata ID and version to prevent
+// duplicate execution, and provides a framework for validating and executing
+// various types of Kubernetes actions.
+package kubeactions

--- a/pkg/clusteragent/kubeactions/executor.go
+++ b/pkg/clusteragent/kubeactions/executor.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeactions
+
+import (
+	"context"
+	"fmt"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ExecutorRegistry manages action executors
+type ExecutorRegistry struct {
+	executors map[string]ActionExecutor
+	clientset kubernetes.Interface
+}
+
+// NewExecutorRegistry creates a new ExecutorRegistry
+func NewExecutorRegistry(clientset kubernetes.Interface) *ExecutorRegistry {
+	return &ExecutorRegistry{
+		executors: make(map[string]ActionExecutor),
+		clientset: clientset,
+	}
+}
+
+// Register registers an executor for a specific action type
+func (r *ExecutorRegistry) Register(actionType string, executor ActionExecutor) {
+	r.executors[actionType] = executor
+}
+
+// GetExecutor returns the executor for a given action type
+func (r *ExecutorRegistry) GetExecutor(actionType string) (ActionExecutor, error) {
+	executor, exists := r.executors[actionType]
+	if !exists {
+		return nil, fmt.Errorf("no executor registered for action type: %s", actionType)
+	}
+	return executor, nil
+}
+
+// Execute executes an action using the appropriate executor
+func (r *ExecutorRegistry) Execute(ctx context.Context, action *kubeactions.KubeAction) ExecutionResult {
+	actionType := GetActionType(action)
+	executor, err := r.GetExecutor(actionType)
+	if err != nil {
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: err.Error(),
+		}
+	}
+
+	return executor.Execute(ctx, action)
+}
+
+// GetClientset returns the Kubernetes clientset
+func (r *ExecutorRegistry) GetClientset() kubernetes.Interface {
+	return r.clientset
+}

--- a/pkg/clusteragent/kubeactions/executors/adapter.go
+++ b/pkg/clusteragent/kubeactions/executors/adapter.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package executors provides implementations for Kubernetes action executors.
+package executors
+
+import (
+	"context"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+)
+
+// Executor is the interface that all executors in this package implement
+type Executor interface {
+	Execute(ctx context.Context, action *kubeactions.KubeAction) ExecutionResult
+}

--- a/pkg/clusteragent/kubeactions/executors/delete_pod.go
+++ b/pkg/clusteragent/kubeactions/executors/delete_pod.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package executors
+
+import (
+	"context"
+	"fmt"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Execution status constants
+const (
+	StatusSuccess = "success"
+	StatusFailed  = "failed"
+)
+
+// ExecutionResult represents the result of executing an action
+type ExecutionResult struct {
+	Status  string
+	Message string
+}
+
+// DeletePodExecutor executes delete pod actions
+type DeletePodExecutor struct {
+	clientset kubernetes.Interface
+}
+
+// NewDeletePodExecutor creates a new DeletePodExecutor
+func NewDeletePodExecutor(clientset kubernetes.Interface) *DeletePodExecutor {
+	return &DeletePodExecutor{
+		clientset: clientset,
+	}
+}
+
+// Execute deletes a pod
+func (e *DeletePodExecutor) Execute(ctx context.Context, action *kubeactions.KubeAction) ExecutionResult {
+	resource := action.Resource
+	namespace := resource.Namespace
+	name := resource.Name
+	resourceID := resource.ResourceId
+
+	// Get the pod first to verify UID matches resource_id
+	pod, err := e.clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get pod %s/%s: %v", namespace, name, err)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("failed to get pod: %v", err),
+		}
+	}
+
+	if string(pod.UID) != resourceID {
+		log.Errorf("Pod %s/%s UID mismatch: expected %s, got %s - pod may have been replaced", namespace, name, resourceID, pod.UID)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("pod UID mismatch: expected %s, got %s - pod may have been replaced since action was created", resourceID, pod.UID),
+		}
+	}
+
+	// Get delete_pod specific parameters
+	params := action.GetDeletePod()
+
+	// Build delete options
+	deleteOptions := metav1.DeleteOptions{}
+	if params != nil && params.GracePeriodSeconds != nil {
+		gracePeriod := *params.GracePeriodSeconds
+		deleteOptions.GracePeriodSeconds = &gracePeriod
+		log.Infof("Deleting pod %s/%s (uid=%s) with grace period %d seconds", namespace, name, resourceID, gracePeriod)
+	} else {
+		log.Infof("Deleting pod %s/%s (uid=%s) with default grace period", namespace, name, resourceID)
+	}
+
+	// Delete the pod
+	err = e.clientset.CoreV1().Pods(namespace).Delete(ctx, name, deleteOptions)
+	if err != nil {
+		log.Errorf("Failed to delete pod %s/%s: %v", namespace, name, err)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("failed to delete pod: %v", err),
+		}
+	}
+
+	log.Infof("Successfully deleted pod %s/%s", namespace, name)
+	return ExecutionResult{
+		Status:  StatusSuccess,
+		Message: fmt.Sprintf("pod %s/%s deleted", namespace, name),
+	}
+}

--- a/pkg/clusteragent/kubeactions/executors/patch_deployment.go
+++ b/pkg/clusteragent/kubeactions/executors/patch_deployment.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package executors
+
+import (
+	"context"
+	"fmt"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// PatchDeploymentExecutor executes patch deployment actions
+type PatchDeploymentExecutor struct {
+	clientset kubernetes.Interface
+}
+
+// NewPatchDeploymentExecutor creates a new PatchDeploymentExecutor
+func NewPatchDeploymentExecutor(clientset kubernetes.Interface) *PatchDeploymentExecutor {
+	return &PatchDeploymentExecutor{
+		clientset: clientset,
+	}
+}
+
+// resolvePatchType maps a patch strategy string to the corresponding Kubernetes patch type.
+// Defaults to strategic merge if unspecified or unrecognized.
+func resolvePatchType(strategy string) types.PatchType {
+	switch strategy {
+	case "merge":
+		return types.MergePatchType
+	case "json":
+		return types.JSONPatchType
+	default:
+		return types.StrategicMergePatchType
+	}
+}
+
+// Execute applies a patch to a deployment using the specified strategy
+func (e *PatchDeploymentExecutor) Execute(ctx context.Context, action *kubeactions.KubeAction) ExecutionResult {
+	resource := action.Resource
+	namespace := resource.Namespace
+	name := resource.Name
+	resourceID := resource.ResourceId
+
+	// Get patch params
+	patchParams := action.GetPatchDeployment()
+	if patchParams == nil || patchParams.GetPatch() == nil {
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: "patch is required for patch_deployment action",
+		}
+	}
+
+	// Marshal the protobuf Value back to JSON bytes for the Kubernetes API
+	patchBytes, err := patchParams.GetPatch().MarshalJSON()
+	if err != nil {
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("failed to serialize patch to JSON: %v", err),
+		}
+	}
+
+	log.Infof("Patching deployment %s/%s (uid=%s) with patch: %s", namespace, name, resourceID, string(patchBytes))
+
+	// Get the deployment first to verify UID matches resource_id
+	deployment, err := e.clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get deployment %s/%s: %v", namespace, name, err)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("failed to get deployment: %v", err),
+		}
+	}
+
+	if string(deployment.UID) != resourceID {
+		log.Errorf("Deployment %s/%s UID mismatch: expected %s, got %s - deployment may have been replaced", namespace, name, resourceID, deployment.UID)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("deployment UID mismatch: expected %s, got %s - deployment may have been replaced since action was created", resourceID, deployment.UID),
+		}
+	}
+
+	// Determine patch strategy
+	patchType := resolvePatchType(patchParams.GetPatchStrategy())
+	log.Infof("Using patch strategy %q for deployment %s/%s", patchParams.GetPatchStrategy(), namespace, name)
+
+	// Apply the patch
+	_, err = e.clientset.AppsV1().Deployments(namespace).Patch(ctx, name, patchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		log.Errorf("Failed to patch deployment %s/%s: %v", namespace, name, err)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("failed to patch deployment: %v", err),
+		}
+	}
+
+	log.Infof("Successfully patched deployment %s/%s", namespace, name)
+	return ExecutionResult{
+		Status:  StatusSuccess,
+		Message: fmt.Sprintf("deployment %s/%s patched", namespace, name),
+	}
+}

--- a/pkg/clusteragent/kubeactions/executors/patch_deployment_test.go
+++ b/pkg/clusteragent/kubeactions/executors/patch_deployment_test.go
@@ -1,0 +1,221 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package executors
+
+import (
+	"context"
+	"testing"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// mustNewValue creates a structpb.Value from a Go value, panicking on error.
+func mustNewValue(v interface{}) *structpb.Value {
+	val, err := structpb.NewValue(v)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func TestPatchDeploymentExecutor_ScaleReplicas(t *testing.T) {
+	replicas := int32(2)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-deployment",
+			Namespace: "default",
+			UID:       k8stypes.UID("test-uid-123"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment)
+	executor := NewPatchDeploymentExecutor(clientset)
+
+	action := &kubeactions.KubeAction{
+		Resource: &kubeactions.KubeResource{
+			Kind:       "Deployment",
+			Namespace:  "default",
+			Name:       "my-deployment",
+			ResourceId: "test-uid-123",
+		},
+		Action: &kubeactions.KubeAction_PatchDeployment{
+			PatchDeployment: &kubeactions.PatchDeploymentParams{
+				Patch: mustNewValue(map[string]interface{}{
+					"spec": map[string]interface{}{
+						"replicas": 5,
+					},
+				}),
+			},
+		},
+	}
+
+	result := executor.Execute(context.Background(), action)
+	assert.Equal(t, "success", result.Status)
+	assert.Contains(t, result.Message, "patched")
+}
+
+func TestPatchDeploymentExecutor_UIDMismatch(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-deployment",
+			Namespace: "default",
+			UID:       k8stypes.UID("real-uid"),
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment)
+	executor := NewPatchDeploymentExecutor(clientset)
+
+	action := &kubeactions.KubeAction{
+		Resource: &kubeactions.KubeResource{
+			Kind:       "Deployment",
+			Namespace:  "default",
+			Name:       "my-deployment",
+			ResourceId: "wrong-uid",
+		},
+		Action: &kubeactions.KubeAction_PatchDeployment{
+			PatchDeployment: &kubeactions.PatchDeploymentParams{
+				Patch: mustNewValue(map[string]interface{}{
+					"spec": map[string]interface{}{"replicas": 5},
+				}),
+			},
+		},
+	}
+
+	result := executor.Execute(context.Background(), action)
+	assert.Equal(t, "failed", result.Status)
+	assert.Contains(t, result.Message, "UID mismatch")
+}
+
+func TestPatchDeploymentExecutor_MissingNamespace(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	executor := NewPatchDeploymentExecutor(clientset)
+
+	action := &kubeactions.KubeAction{
+		Resource: &kubeactions.KubeResource{
+			Kind:       "Deployment",
+			Namespace:  "",
+			Name:       "my-deployment",
+			ResourceId: "test-uid",
+		},
+		Action: &kubeactions.KubeAction_PatchDeployment{
+			PatchDeployment: &kubeactions.PatchDeploymentParams{
+				Patch: mustNewValue(map[string]interface{}{
+					"spec": map[string]interface{}{"replicas": 5},
+				}),
+			},
+		},
+	}
+
+	result := executor.Execute(context.Background(), action)
+	assert.Equal(t, "failed", result.Status)
+	assert.Contains(t, result.Message, "namespace is required")
+}
+
+func TestPatchDeploymentExecutor_MissingPatch(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	executor := NewPatchDeploymentExecutor(clientset)
+
+	action := &kubeactions.KubeAction{
+		Resource: &kubeactions.KubeResource{
+			Kind:       "Deployment",
+			Namespace:  "default",
+			Name:       "my-deployment",
+			ResourceId: "test-uid",
+		},
+		Action: &kubeactions.KubeAction_PatchDeployment{
+			PatchDeployment: &kubeactions.PatchDeploymentParams{
+				Patch: nil,
+			},
+		},
+	}
+
+	result := executor.Execute(context.Background(), action)
+	assert.Equal(t, "failed", result.Status)
+	assert.Contains(t, result.Message, "patch is required")
+}
+
+func TestPatchDeploymentExecutor_WithMergeStrategy(t *testing.T) {
+	replicas := int32(2)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-deployment",
+			Namespace: "default",
+			UID:       k8stypes.UID("test-uid-merge"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(deployment)
+	executor := NewPatchDeploymentExecutor(clientset)
+
+	action := &kubeactions.KubeAction{
+		Resource: &kubeactions.KubeResource{
+			Kind:       "Deployment",
+			Namespace:  "default",
+			Name:       "my-deployment",
+			ResourceId: "test-uid-merge",
+		},
+		Action: &kubeactions.KubeAction_PatchDeployment{
+			PatchDeployment: &kubeactions.PatchDeploymentParams{
+				Patch: mustNewValue(map[string]interface{}{
+					"spec": map[string]interface{}{"replicas": 10},
+				}),
+				PatchStrategy: "merge",
+			},
+		},
+	}
+
+	result := executor.Execute(context.Background(), action)
+	assert.Equal(t, "success", result.Status)
+	assert.Contains(t, result.Message, "patched")
+}
+
+func TestResolvePatchType(t *testing.T) {
+	assert.Equal(t, k8stypes.StrategicMergePatchType, resolvePatchType(""))
+	assert.Equal(t, k8stypes.StrategicMergePatchType, resolvePatchType("strategic-merge"))
+	assert.Equal(t, k8stypes.MergePatchType, resolvePatchType("merge"))
+	assert.Equal(t, k8stypes.JSONPatchType, resolvePatchType("json"))
+	assert.Equal(t, k8stypes.StrategicMergePatchType, resolvePatchType("unknown"))
+}
+
+func TestPatchDeploymentExecutor_DeploymentNotFound(t *testing.T) {
+	clientset := fake.NewSimpleClientset() // empty — no deployments
+	executor := NewPatchDeploymentExecutor(clientset)
+
+	action := &kubeactions.KubeAction{
+		Resource: &kubeactions.KubeResource{
+			Kind:       "Deployment",
+			Namespace:  "default",
+			Name:       "nonexistent",
+			ResourceId: "test-uid",
+		},
+		Action: &kubeactions.KubeAction_PatchDeployment{
+			PatchDeployment: &kubeactions.PatchDeploymentParams{
+				Patch: mustNewValue(map[string]interface{}{
+					"spec": map[string]interface{}{"replicas": 5},
+				}),
+			},
+		},
+	}
+
+	result := executor.Execute(context.Background(), action)
+	assert.Equal(t, "failed", result.Status)
+	assert.Contains(t, result.Message, "failed to get deployment")
+}

--- a/pkg/clusteragent/kubeactions/executors/patch_deployment_test.go
+++ b/pkg/clusteragent/kubeactions/executors/patch_deployment_test.go
@@ -123,7 +123,9 @@ func TestPatchDeploymentExecutor_MissingNamespace(t *testing.T) {
 
 	result := executor.Execute(context.Background(), action)
 	assert.Equal(t, "failed", result.Status)
-	assert.Contains(t, result.Message, "namespace is required")
+	// Namespace validation happens in the validator layer before the executor is called.
+	// With an empty namespace, the k8s API returns a not-found error.
+	assert.Contains(t, result.Message, "not found")
 }
 
 func TestPatchDeploymentExecutor_MissingPatch(t *testing.T) {

--- a/pkg/clusteragent/kubeactions/executors/restart_deployment.go
+++ b/pkg/clusteragent/kubeactions/executors/restart_deployment.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package executors
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// RestartDeploymentExecutor executes restart deployment actions
+type RestartDeploymentExecutor struct {
+	clientset kubernetes.Interface
+}
+
+// NewRestartDeploymentExecutor creates a new RestartDeploymentExecutor
+func NewRestartDeploymentExecutor(clientset kubernetes.Interface) *RestartDeploymentExecutor {
+	return &RestartDeploymentExecutor{
+		clientset: clientset,
+	}
+}
+
+// Execute restarts a deployment by updating its restart annotation
+func (e *RestartDeploymentExecutor) Execute(ctx context.Context, action *kubeactions.KubeAction) ExecutionResult {
+	resource := action.Resource
+	namespace := resource.Namespace
+	name := resource.Name
+	resourceID := resource.ResourceId
+
+	log.Infof("Restarting deployment %s/%s (uid=%s)", namespace, name, resourceID)
+
+	// Get the deployment and verify UID matches resource_id
+	deployment, err := e.clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get deployment %s/%s: %v", namespace, name, err)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("failed to get deployment: %v", err),
+		}
+	}
+
+	if string(deployment.UID) != resourceID {
+		log.Errorf("Deployment %s/%s UID mismatch: expected %s, got %s - deployment may have been replaced", namespace, name, resourceID, deployment.UID)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("deployment UID mismatch: expected %s, got %s - deployment may have been replaced since action was created", resourceID, deployment.UID),
+		}
+	}
+
+	// Add or update the restart annotation
+	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+		deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+	// Update the deployment
+	_, err = e.clientset.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	if err != nil {
+		log.Errorf("Failed to restart deployment %s/%s: %v", namespace, name, err)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: fmt.Sprintf("failed to restart deployment: %v", err),
+		}
+	}
+
+	log.Infof("Successfully restarted deployment %s/%s", namespace, name)
+	return ExecutionResult{
+		Status:  StatusSuccess,
+		Message: fmt.Sprintf("deployment %s/%s restarted", namespace, name),
+	}
+}

--- a/pkg/clusteragent/kubeactions/processor.go
+++ b/pkg/clusteragent/kubeactions/processor.go
@@ -1,0 +1,194 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeactions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/hashicorp/go-multierror"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// ActionStoreInterface defines the interface for action stores
+type ActionStoreInterface interface {
+	WasExecuted(key ActionKey) bool
+	MarkExecuted(key ActionKey, status, message string, executedAt int64, receivedAt int64, actionCreatedAt int64)
+	GetRecord(key ActionKey) (ActionRecord, bool)
+}
+
+// ActionProcessor processes Kubernetes actions from remote-config
+type ActionProcessor struct {
+	validator *ActionValidator
+	registry  *ExecutorRegistry
+	store     ActionStoreInterface
+	reporter  *ResultReporter
+	ctx       context.Context
+}
+
+// NewActionProcessor creates a new ActionProcessor with the given store and event platform forwarder
+func NewActionProcessor(ctx context.Context, registry *ExecutorRegistry, store ActionStoreInterface, epForwarder eventplatform.Forwarder, clusterName, clusterID string) *ActionProcessor {
+	return &ActionProcessor{
+		validator: NewActionValidator(),
+		registry:  registry,
+		store:     store,
+		reporter:  NewResultReporter(epForwarder, clusterName, clusterID),
+		ctx:       ctx,
+	}
+}
+
+// Process processes a remote config update containing Kubernetes actions
+func (p *ActionProcessor) Process(configKey string, rawConfig state.RawConfig) error {
+	log.Infof("[KubeActions] Processor.Process called for config key: %s", configKey)
+
+	// Validate metadata
+	if rawConfig.Metadata.ID == "" {
+		log.Errorf("[KubeActions] Skipping action with missing metadata.id")
+		return errors.New("action metadata.id is missing")
+	}
+	if rawConfig.Metadata.Version == 0 {
+		log.Errorf("[KubeActions] Skipping action %s with missing or zero metadata.version", rawConfig.Metadata.ID)
+		return errors.New("action metadata.version is missing or zero")
+	}
+
+	log.Infof("[KubeActions] Metadata validated: ID=%s, Version=%d", rawConfig.Metadata.ID, rawConfig.Metadata.Version)
+
+	// Parse the actions list from the config
+	// NOTE: We use protojson instead of encoding/json because the KubeAction message
+	// uses protobuf oneof fields (delete_pod, restart_deployment) which encoding/json
+	// cannot properly unmarshal. protojson handles oneof fields correctly.
+	log.Infof("[KubeActions] Attempting to unmarshal config data...")
+	actionsList := &kubeactions.KubeActionsList{}
+	unmarshaler := protojson.UnmarshalOptions{
+		DiscardUnknown: true, // Ignore unknown fields for forward compatibility
+	}
+	err := unmarshaler.Unmarshal(rawConfig.Config, actionsList)
+	if err != nil {
+		log.Errorf("[KubeActions] Failed to unmarshal config: %v", err)
+		return fmt.Errorf("failed to unmarshal config id:%s, version: %d, config key: %s, err: %v",
+			rawConfig.Metadata.ID, rawConfig.Metadata.Version, configKey, err)
+	}
+
+	log.Infof("[KubeActions] Successfully unmarshaled config. Actions count: %d", len(actionsList.Actions))
+
+	// Enforce exactly one action per config
+	if len(actionsList.Actions) != 1 {
+		return fmt.Errorf("expected exactly 1 action per config, got %d", len(actionsList.Actions))
+	}
+
+	// Create action key for tracking
+	actionKey := ActionKey{
+		ID:      rawConfig.Metadata.ID,
+		Version: rawConfig.Metadata.Version,
+	}
+
+	// Record when we received this action
+	receivedAt := time.Now().Unix()
+
+	// Check if this action was already executed
+	if p.store.WasExecuted(actionKey) {
+		record, _ := p.store.GetRecord(actionKey)
+		log.Infof("[KubeActions] Action %s was already executed with status: %s", actionKey.String(), record.Status)
+		if record.Status == StatusFailed || record.Status == StatusExpired {
+			return fmt.Errorf("action previously %s: %s", record.Status, record.Message)
+		}
+		return nil
+	}
+
+	log.Infof("[KubeActions] Action %s not yet executed, proceeding with processing", actionKey.String())
+
+	// Process all actions in the list
+	var processingErrors error
+	for i, action := range actionsList.Actions {
+		log.Infof("[KubeActions] Processing action %d/%d", i+1, len(actionsList.Actions))
+		if err := p.processAction(action, i, actionKey, receivedAt); err != nil {
+			processingErrors = multierror.Append(processingErrors, err)
+		}
+	}
+
+	if processingErrors != nil {
+		log.Errorf("[KubeActions] Finished processing with errors: %v", processingErrors)
+	} else {
+		log.Infof("[KubeActions] Finished processing all actions successfully")
+	}
+
+	return processingErrors
+}
+
+// processAction processes a single action
+func (p *ActionProcessor) processAction(action *kubeactions.KubeAction, index int, actionKey ActionKey, receivedAt int64) error {
+	actionType := GetActionType(action)
+	log.Infof("[KubeActions] === Processing action %d ===", index)
+	log.Infof("[KubeActions]   ActionType: %s", actionType)
+	if action.Resource != nil {
+		log.Infof("[KubeActions]   Resource: %s/%s in %s", action.Resource.Kind, action.Resource.Name, action.Resource.Namespace)
+	}
+
+	// Extract action timestamp
+	var actionCreatedAt int64
+	if action.Timestamp != nil {
+		actionCreatedAt = action.Timestamp.GetSeconds()
+		log.Infof("[KubeActions]   Timestamp: %d (%s)", actionCreatedAt, action.Timestamp.AsTime().String())
+
+		// Validate the timestamp
+		log.Infof("[KubeActions] Validating timestamp...")
+		if err := ValidateTimestamp(action.Timestamp.AsTime()); err != nil {
+			log.Errorf("[KubeActions] Timestamp validation failed: %v", err)
+			p.store.MarkExecuted(actionKey, StatusExpired, fmt.Sprintf("timestamp validation failed: %v", err), time.Now().Unix(), receivedAt, actionCreatedAt)
+			return err
+		}
+		log.Infof("[KubeActions] Timestamp validation passed")
+	} else {
+		log.Errorf("[KubeActions] Action timestamp is missing")
+		p.store.MarkExecuted(actionKey, StatusFailed, "timestamp is missing", time.Now().Unix(), receivedAt, 0)
+		return errors.New("action timestamp is missing")
+	}
+
+	// Validate the action
+	log.Infof("[KubeActions] Validating action...")
+	if err := p.validator.ValidateAction(action); err != nil {
+		log.Errorf("[KubeActions] Action validation failed: %v", err)
+		p.store.MarkExecuted(actionKey, StatusFailed, fmt.Sprintf("validation failed: %v", err), time.Now().Unix(), receivedAt, actionCreatedAt)
+		return err
+	}
+	log.Infof("[KubeActions] Action validation passed")
+
+	// Execute the action
+	log.Infof("[KubeActions] Executing action via registry...")
+	result := p.registry.Execute(p.ctx, action)
+	log.Infof("[KubeActions] Execution completed: status=%s, message=%s", result.Status, result.Message)
+
+	// Store the result with all timestamps
+	executedAt := time.Now()
+	p.store.MarkExecuted(actionKey, result.Status, result.Message, executedAt.Unix(), receivedAt, actionCreatedAt)
+	log.Infof("[KubeActions] Result stored in action store")
+
+	// TODO: Report the result to backend via Event Platform once the intake is configured
+	// p.reporter.ReportResult(actionKey, action, result, executedAt)
+
+	// Log the result
+	if result.Status == StatusSuccess {
+		log.Infof("[KubeActions] ✓ Action executed successfully: %s", result.Message)
+	} else {
+		log.Errorf("[KubeActions] ✗ Action execution failed: %s", result.Message)
+		return fmt.Errorf("action execution failed: %s", result.Message)
+	}
+
+	return nil
+}
+
+// GetStore returns the action store for inspection
+func (p *ActionProcessor) GetStore() ActionStoreInterface {
+	return p.store
+}

--- a/pkg/clusteragent/kubeactions/reporter.go
+++ b/pkg/clusteragent/kubeactions/reporter.go
@@ -1,0 +1,164 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeactions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// --- Event payload types ---
+
+// ActionResultEvent is the EVP event payload sent to the backend when an action is executed.
+// Fields match the backend's UpdateActionRequest / KubeActionEvent schema.
+type ActionResultEvent struct {
+	ActionID    string                 `json:"action_id"`
+	OrgID       int64                  `json:"org_id"`
+	EventType   string                 `json:"event_type"`
+	Status      string                 `json:"status"`
+	ActionType  string                 `json:"action_type"`
+	ClusterID   string                 `json:"cluster_id"`
+	ResourceID  string                 `json:"resource_id"`
+	RequestedBy string                 `json:"requested_by"`
+	Timestamp   string                 `json:"timestamp"`
+	Data        map[string]interface{} `json:"data,omitempty"`
+}
+
+// --- Reporter ---
+
+// ResultReporter handles reporting action execution results back to the backend via Event Platform
+type ResultReporter struct {
+	epForwarder    eventplatform.Forwarder
+	httpClient     *http.Client
+	intakeEndpoint string
+	orgID          int64
+	clusterName    string
+	clusterID      string
+}
+
+// NewResultReporter creates a new ResultReporter with the given Event Platform forwarder
+func NewResultReporter(epForwarder eventplatform.Forwarder, clusterName, clusterID string) *ResultReporter {
+	// TODO(KUBEACTIONS-POC): Using direct HTTP POST to internal staging intake
+	// For production, this should use the epForwarder component
+	return &ResultReporter{
+		epForwarder: epForwarder,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		intakeEndpoint: "http://all-internal-intake-logs.staging.dog",
+		orgID:          2, // Staging org
+		clusterName:    clusterName,
+		clusterID:      clusterID,
+	}
+}
+
+// ReportResult reports an action execution result via Event Platform
+func (r *ResultReporter) ReportResult(actionKey ActionKey, action *kubeactions.KubeAction, result ExecutionResult, executedAt time.Time) {
+	actionType := GetActionType(action)
+	if actionType == ActionTypeUnknown {
+		log.Warnf("[KubeActions] Reporting result for unknown action type, action_key=%s", actionKey.String())
+	}
+
+	// Use action_id from payload, fall back to RC metadata ID
+	actionID := action.GetActionId()
+	if actionID == "" {
+		actionID = actionKey.ID
+	}
+
+	// Build resource_id from the action's resource
+	var resourceID string
+	if res := action.GetResource(); res != nil {
+		resourceID = res.GetResourceId()
+	}
+
+	// Build the data map with action-specific details and execution context
+	data := map[string]interface{}{
+		"message":      result.Message,
+		"cluster_name": r.clusterName,
+	}
+	if res := action.GetResource(); res != nil {
+		data["resource_kind"] = res.GetKind()
+		data["resource_name"] = res.GetName()
+		data["resource_namespace"] = res.GetNamespace()
+		data["resource_api_version"] = res.GetApiVersion()
+	}
+	switch actionType {
+	case ActionTypeDeletePod:
+		if params := action.GetDeletePod(); params != nil && params.GracePeriodSeconds != nil {
+			data["grace_period_seconds"] = *params.GracePeriodSeconds
+		}
+	}
+
+	event := ActionResultEvent{
+		ActionID:    actionID,
+		OrgID:       r.orgID,
+		EventType:   "action_executed",
+		Status:      result.Status,
+		ActionType:  actionType,
+		ClusterID:   r.clusterID,
+		ResourceID:  resourceID,
+		RequestedBy: action.GetRequestedBy(),
+		Timestamp:   executedAt.Format(time.RFC3339),
+		Data:        data,
+	}
+
+	log.Infof("[KubeActions] Reporting result: action_id=%s, type=%s, status=%s", event.ActionID, event.ActionType, event.Status)
+
+	// Serialize to JSON
+	payload, err := json.Marshal(event)
+	if err != nil {
+		log.Errorf("[KubeActions] Failed to marshal action result for %s: %v", actionKey.String(), err)
+		return
+	}
+
+	log.Debugf("[KubeActions] EVP payload: %s", string(payload))
+
+	// TODO(KUBEACTIONS-POC): Direct HTTP POST to staging intake
+	// For production, use: r.epForwarder.SendEventPlatformEvent(...)
+	url := fmt.Sprintf("%s/v2/track/demoalpha/org/%d", r.intakeEndpoint, r.orgID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		log.Errorf("[KubeActions] Failed to create HTTP request: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("DD-EVP-ORIGIN", "kubernetes-actions")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		log.Errorf("[KubeActions] Failed to send result to Event Platform: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Errorf("[KubeActions] Failed to read response body: %v", err)
+		return
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		log.Errorf("[KubeActions] Event Platform returned status %d: %s", resp.StatusCode, string(respBody))
+		return
+	}
+
+	log.Infof("[KubeActions] Reported result for action %s (status=%s)", actionID, result.Status)
+}

--- a/pkg/clusteragent/kubeactions/setup.go
+++ b/pkg/clusteragent/kubeactions/setup.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeactions
+
+import (
+	"context"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/kubeactions/executors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Setup initializes the kubeactions subsystem with all executors registered
+func Setup(ctx context.Context, clientset kubernetes.Interface, clusterName, clusterID string, isLeader func() bool, rcClient RcClient, epForwarderComp eventplatform.Component) (*ConfigRetriever, error) {
+	log.Infof("Setting up Kubernetes actions subsystem")
+
+	// Create the executor registry
+	registry := NewExecutorRegistry(clientset)
+
+	// Register all action executors
+	registerExecutors(registry, clientset)
+
+	// Create in-memory action store with TTL-based expiration
+	store := NewActionStore(ctx)
+
+	// Get the event platform forwarder if available
+	log.Infof("[KubeActions] Attempting to get Event Platform forwarder from component...")
+	var epForwarder eventplatform.Forwarder
+	if forwarder, ok := epForwarderComp.Get(); ok {
+		epForwarder = forwarder
+		log.Infof("[KubeActions] SUCCESS: Event Platform forwarder available for kubeactions result reporting (forwarder=%p)", epForwarder)
+	} else {
+		log.Errorf("[KubeActions] CRITICAL: Event Platform forwarder not available, result reporting will be disabled")
+	}
+
+	// Create the processor with in-memory store and event platform forwarder
+	log.Infof("[KubeActions] Creating ActionProcessor with epForwarder=%p", epForwarder)
+	processor := NewActionProcessor(ctx, registry, store, epForwarder, clusterName, clusterID)
+	log.Infof("[KubeActions] ActionProcessor created successfully")
+
+	// Create and return the config retriever
+	return NewConfigRetriever(processor, isLeader, rcClient), nil
+}
+
+// executorAdapter adapts an executors.Executor to an ActionExecutor
+type executorAdapter struct {
+	exec executors.Executor
+}
+
+func (a *executorAdapter) Execute(ctx context.Context, action *kubeactions.KubeAction) ExecutionResult {
+	result := a.exec.Execute(ctx, action)
+	return ExecutionResult{
+		Status:  result.Status,
+		Message: result.Message,
+	}
+}
+
+// registerExecutors registers all available action executors
+func registerExecutors(registry *ExecutorRegistry, clientset kubernetes.Interface) {
+	// Register delete_pod executor
+	registry.Register("delete_pod", &executorAdapter{exec: executors.NewDeletePodExecutor(clientset)})
+	log.Infof("Registered executor for action type: delete_pod")
+
+	// Register restart_deployment executor
+	registry.Register("restart_deployment", &executorAdapter{exec: executors.NewRestartDeploymentExecutor(clientset)})
+	log.Infof("Registered executor for action type: restart_deployment")
+
+	// Register patch_deployment executor
+	registry.Register("patch_deployment", &executorAdapter{exec: executors.NewPatchDeploymentExecutor(clientset)})
+	log.Infof("Registered executor for action type: patch_deployment")
+
+	// TODO: Add more executors here as they are implemented:
+	// registry.Register("drain_node", &executorAdapter{exec: executors.NewDrainNodeExecutor(clientset)})
+	// registry.Register("cordon_node", &executorAdapter{exec: executors.NewCordonNodeExecutor(clientset)})
+	// registry.Register("uncordon_node", &executorAdapter{exec: executors.NewUncordonNodeExecutor(clientset)})
+}

--- a/pkg/clusteragent/kubeactions/types.go
+++ b/pkg/clusteragent/kubeactions/types.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeactions
+
+import (
+	"context"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+)
+
+// Action type constants
+const (
+	ActionTypeDeletePod         = "delete_pod"
+	ActionTypeRestartDeployment = "restart_deployment"
+	ActionTypePatchDeployment   = "patch_deployment"
+	ActionTypeUnknown           = "unknown"
+)
+
+// Execution status constants
+const (
+	StatusSuccess = "success"
+	StatusFailed  = "failed"
+	StatusSkipped = "skipped"
+	StatusExpired = "expired"
+)
+
+// ExecutionResult represents the result of executing an action
+type ExecutionResult struct {
+	Status  string
+	Message string
+}
+
+// ActionExecutor is the interface that all action executors must implement
+type ActionExecutor interface {
+	// Execute performs the action and returns the result
+	Execute(ctx context.Context, action *kubeactions.KubeAction) ExecutionResult
+}
+
+// GetActionType extracts the action type string from a KubeAction's oneof field.
+// Returns ActionTypeUnknown if no action type is set.
+func GetActionType(action *kubeactions.KubeAction) string {
+	if action == nil {
+		return ActionTypeUnknown
+	}
+
+	switch action.GetAction().(type) {
+	case *kubeactions.KubeAction_DeletePod:
+		return ActionTypeDeletePod
+	case *kubeactions.KubeAction_RestartDeployment:
+		return ActionTypeRestartDeployment
+	case *kubeactions.KubeAction_PatchDeployment:
+		return ActionTypePatchDeployment
+	default:
+		return ActionTypeUnknown
+	}
+}

--- a/pkg/clusteragent/kubeactions/validator.go
+++ b/pkg/clusteragent/kubeactions/validator.go
@@ -1,0 +1,172 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeactions
+
+import (
+	"fmt"
+
+	kubeactions "github.com/DataDog/agent-payload/v5/kubeactions"
+)
+
+// ValidationError represents an error during action validation
+type ValidationError struct {
+	Action  *kubeactions.KubeAction
+	Message string
+}
+
+// Error implements the error interface
+func (e *ValidationError) Error() string {
+	actionType := GetActionType(e.Action)
+	resourceKind := ""
+	resourceName := ""
+	if e.Action != nil && e.Action.Resource != nil {
+		resourceKind = e.Action.Resource.Kind
+		resourceName = e.Action.Resource.Name
+	}
+	return fmt.Sprintf("validation error for action %s on %s/%s: %s",
+		actionType,
+		resourceKind,
+		resourceName,
+		e.Message)
+}
+
+// ActionValidator validates actions before execution
+type ActionValidator struct {
+	// Add configuration fields here as needed
+	// For example: allowedActions, allowedNamespaces, etc.
+}
+
+// NewActionValidator creates a new ActionValidator
+func NewActionValidator() *ActionValidator {
+	return &ActionValidator{}
+}
+
+// ValidateAction validates a single action before execution
+// This is the main hook where we can add safety checks
+func (v *ActionValidator) ValidateAction(action *kubeactions.KubeAction) error {
+	if action == nil {
+		return &ValidationError{
+			Action:  action,
+			Message: "action is nil",
+		}
+	}
+
+	// Validate action type is provided (one of the oneof fields must be set)
+	actionType := GetActionType(action)
+	if actionType == ActionTypeUnknown {
+		return &ValidationError{
+			Action:  action,
+			Message: "action type is required (must specify delete_pod, restart_deployment, etc.)",
+		}
+	}
+
+	// Validate resource is provided
+	if action.Resource == nil {
+		return &ValidationError{
+			Action:  action,
+			Message: "resource is required",
+		}
+	}
+
+	// Validate resource has required fields
+	if action.Resource.Kind == "" {
+		return &ValidationError{
+			Action:  action,
+			Message: "resource.kind is required",
+		}
+	}
+
+	if action.Resource.Name == "" {
+		return &ValidationError{
+			Action:  action,
+			Message: "resource.name is required",
+		}
+	}
+
+	// Common preflight: namespace and resource_id are required for all actions
+	if action.Resource.Namespace == "" {
+		return &ValidationError{
+			Action:  action,
+			Message: "resource.namespace is required",
+		}
+	}
+	if action.Resource.ResourceId == "" {
+		return &ValidationError{
+			Action:  action,
+			Message: "resource.resource_id is required",
+		}
+	}
+
+	// Action-specific validation
+	switch actionType {
+	case ActionTypeDeletePod:
+		if action.Resource.Kind != "Pod" {
+			return &ValidationError{
+				Action:  action,
+				Message: "resource.kind must be 'Pod' for delete_pod action",
+			}
+		}
+	case ActionTypeRestartDeployment:
+		if action.Resource.Kind != "Deployment" {
+			return &ValidationError{
+				Action:  action,
+				Message: "resource.kind must be 'Deployment' for restart_deployment action",
+			}
+		}
+	case ActionTypePatchDeployment:
+		if action.Resource.Kind != "Deployment" {
+			return &ValidationError{
+				Action:  action,
+				Message: "resource.kind must be 'Deployment' for patch_deployment action",
+			}
+		}
+		patchParams := action.GetPatchDeployment()
+		if patchParams == nil || patchParams.GetPatch() == nil {
+			return &ValidationError{
+				Action:  action,
+				Message: "patch is required for patch_deployment action",
+			}
+		}
+	}
+
+	// Block actions on protected system namespaces
+	if isProtectedNamespace(action.Resource.Namespace) {
+		return &ValidationError{
+			Action:  action,
+			Message: fmt.Sprintf("actions are not allowed on protected namespace %q", action.Resource.Namespace),
+		}
+	}
+
+	return nil
+}
+
+// protectedNamespaces are Kubernetes system namespaces where actions must not be executed
+var protectedNamespaces = map[string]struct{}{
+	"kube-system":     {},
+	"kube-public":     {},
+	"kube-node-lease": {},
+}
+
+// isProtectedNamespace returns true if the namespace is a protected system namespace
+func isProtectedNamespace(namespace string) bool {
+	_, ok := protectedNamespaces[namespace]
+	return ok
+}
+
+// ValidateActions validates a list of actions
+func (v *ActionValidator) ValidateActions(actions []*kubeactions.KubeAction) []error {
+	var errors []error
+
+	for _, action := range actions {
+		if err := v.ValidateAction(action); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	return errors
+}

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -38,6 +38,8 @@ const (
 	ProductContainerAutoscalingValues = "CONTAINER_AUTOSCALING_VALUES"
 	// ProductClusterAutoscalingValues receives values for cluster autoscaling
 	ProductClusterAutoscalingValues = "CLUSTER_AUTOSCALING_VALUES"
+	// ProductKubeActions receives Kubernetes actions to execute
+	ProductKubeActions = "K8S_ACTIONS"
 	// ProductDataStreamsLiveMessages is to capture messages from Kafka
 	ProductDataStreamsLiveMessages = "DSM_LIVE_MESSAGES"
 	// ProductDataStreamsKafkaActions is to execute Kafka actions remotely

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1269,6 +1269,9 @@ func autoscaling(config pkgconfigmodel.Setup) {
 
 	// Cluster autoscaling product
 	config.BindEnvAndSetDefault("autoscaling.cluster.enabled", false)
+
+	// Kubernetes actions
+	config.BindEnvAndSetDefault("kubeactions.enabled", false)
 }
 
 func fips(config pkgconfigmodel.Setup) {

--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -45,6 +45,7 @@ var validProducts = map[string]struct{}{
 	ProductBTFDD:                        {},
 	ProductFFEFlags:                     {},
 	ProductDOQueryActions:               {},
+	ProductK8SActions:                   {},
 }
 
 const (
@@ -127,4 +128,6 @@ const (
 	ProductFFEFlags = "FFE_FLAGS"
 	// ProductDOQueryActions is used for executing database queries remotely for Data Observability
 	ProductDOQueryActions = "DO_QUERY_ACTIONS"
+	// ProductK8SActions receives Kubernetes actions to execute on cluster resources
+	ProductK8SActions = "K8S_ACTIONS"
 )

--- a/releasenotes/notes/add-kubernetes-actions-b9e80f1b78915ebf.yaml
+++ b/releasenotes/notes/add-kubernetes-actions-b9e80f1b78915ebf.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adds cluster agent processing of select actions on kubernetes resources


### PR DESCRIPTION
### What does this PR do?

The cluster-agent subscribes to the K8S_ACTIONS Remote Configuration product on startup when kubeactions.enabled is true. When a config arrives, the ConfigRetriever acknowledges receipt via RC's applyStateCallback and passes it to the ActionProcessor. The processor validates the action: checking the timestamp is within the 1-minute TTL, confirming the action type is set, and running action-specific validation (e.g. delete_pod requires namespace and a resource_id for UID verification). An in-memory ActionStore tracks processesd actions to prevent duplicate execution.

  Validated actions are dispatched through an ExecutorRegistry to the appropriate executor, which uses the client-go typed Kubernetes client to call the API server. After execution, the result is acknowledged back to RC and sent to EVP.

### Motivation

### Describe how you validated your changes

### Additional Notes
testing rbac
```
# Additional RBAC for kubeactions - allows pod deletion and deployment restarts
# This creates a separate ClusterRole with the necessary permissions for testing
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: datadog-cluster-agent-kubeactions
  labels:
    app: datadog-cluster-agent
rules:
  # Allow deleting pods
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["delete", "get", "list"]
  # Allow restarting deployments (via patch to trigger rollout)
  - apiGroups: ["apps"]
    resources: ["deployments"]
    verbs: ["get", "list", "patch"]
  # Allow reading deployment status
  - apiGroups: ["apps"]
    resources: ["deployments/status"]
    verbs: ["get"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: datadog-cluster-agent-kubeactions
  labels:
    app: datadog-cluster-agent
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: datadog-cluster-agent-kubeactions
subjects:
  - kind: ServiceAccount
    name: dd-datadog-cluster-agent
    namespace: default
```