### PR TITLE
[Backport 7.73.x] fix(installer): Set proper permissions for files written for config

### DIFF
--- a/pkg/fleet/installer/config/config_nix.go
+++ b/pkg/fleet/installer/config/config_nix.go
@@ -13,8 +13,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/symlink"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -58,7 +60,7 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 
 	operations.FileOperations = append(buildOperationsFromLegacyInstaller(d.StablePath), operations.FileOperations...)
 
-	err = operations.Apply(d.ExperimentPath)
+	err = operations.Apply(ctx, d.ExperimentPath)
 	if err != nil {
 		return err
 	}
@@ -138,5 +140,25 @@ func replaceConfigDirectory(oldDir, newDir string) (err error) {
 	if err != nil {
 		return fmt.Errorf("could not rename new directory: %w", err)
 	}
+	return nil
+}
+
+// setFileOwnershipAndPermissions sets the ownership and permissions for a file based on its configFileSpec.
+// If the user doesn't exist (e.g., in tests) or if we don't have permission
+// to change ownership, the function logs a warning and continues without failing.
+func setFileOwnershipAndPermissions(ctx context.Context, filePath string, spec *configFileSpec) error {
+	// Set file permissions
+	if spec.mode != 0 {
+		if err := os.Chmod(filePath, spec.mode); err != nil {
+			return fmt.Errorf("error setting file permissions for %s: %w", filePath, err)
+		}
+	}
+
+	// Set file ownership
+	err := file.Chown(ctx, filePath, spec.owner, spec.group)
+	if err != nil {
+		log.Warnf("error setting file ownership for %s: %v", filePath, err)
+	}
+
 	return nil
 }

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -67,7 +67,7 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 		return fmt.Errorf("error writing deployment ID file: %w", err)
 	}
 	operations.FileOperations = append(buildOperationsFromLegacyInstaller(d.StablePath), operations.FileOperations...)
-	err = operations.Apply(d.StablePath)
+	err = operations.Apply(ctx, d.StablePath)
 	if err != nil {
 		return fmt.Errorf("error applying operations: %w", err)
 	}
@@ -181,4 +181,10 @@ func secureCreateTargetDirectoryWithSourcePermissions(sourcePath, targetPath str
 	}
 	sddl := sd.String()
 	return paths.SecureCreateDirectory(targetPath, sddl)
+}
+
+// setFileOwnershipAndPermissions is a no-op on Windows as file ownership and permissions
+// are handled differently through ACLs, not POSIX ownership and modes.
+func setFileOwnershipAndPermissions(_ context.Context, _ string, _ *configFileSpec) error {
+	return nil
 }

--- a/test/new-e2e/tests/fleet/host/host.go
+++ b/test/new-e2e/tests/fleet/host/host.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package host contains host-level test helpers for fleet tests.
+package host
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	e2eos "github.com/DataDog/test-infra-definitions/components/os"
+)
+
+// Host wraps an environments.Host with helper methods for fleet tests.
+type Host struct {
+	*environments.Host
+}
+
+// New creates a new Host wrapper.
+func New(host *environments.Host) *Host {
+	return &Host{Host: host}
+}
+
+// FilePermissions represents the permissions of a file on Unix systems.
+type FilePermissions struct {
+	Mode  string
+	Owner string
+	Group string
+}
+
+// GetFilePermissions returns the permissions of a file on Unix systems.
+// Returns an error on Windows as POSIX permissions don't apply.
+func (h *Host) GetFilePermissions(filePath string) (*FilePermissions, error) {
+	switch h.RemoteHost.OSFamily {
+	case e2eos.LinuxFamily:
+		// Use stat to get file permissions, owner, and group
+		output, err := h.RemoteHost.Execute("stat -c '%a %U %G' " + filePath)
+		if err != nil {
+			return nil, err
+		}
+		parts := strings.Fields(strings.TrimSpace(output))
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("unexpected stat output: %s", output)
+		}
+		return &FilePermissions{
+			Mode:  parts[0],
+			Owner: parts[1],
+			Group: parts[2],
+		}, nil
+	case e2eos.WindowsFamily:
+		// Windows doesn't use POSIX permissions
+		return nil, errors.New("file permissions check not supported on Windows")
+	default:
+		return nil, fmt.Errorf("unsupported OS family: %v", h.RemoteHost.OSFamily)
+	}
+}


### PR DESCRIPTION
Backports https://github.com/DataDog/datadog-agent/pull/44320 to `7.73.x`