### PR TITLE
Allow BSP-aware IDEs to sync with `bazel`

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,1 @@
-.bazelbsp/
 .cache/


### PR DESCRIPTION
### Motivation
IntelliJ IDEA, GoLand and other BSP-aware IDEs can sync with `bazel` (i.e. fetch its project structure) provided the Build Server Protocol folder (IDE-injected [aspects](https://bazel.build/extending/aspects)) is tracked by `bazel` itself, otherwise one gets sth like:
```
Label '//.bazelbsp/aspects:core.bzl' is invalid because '.bazelbsp/aspects' is not a package; perhaps you meant to put the colon here: '//:.bazelbsp/aspects/core.bzl'?
INFO: Found 66 targets...
ERROR: command succeeded, but not all targets were analyzed
ERROR: Build did NOT complete successfully
FAILED:
INFO: Build Event Protocol files produced successfully.
Command completed in 4.6s (exit code 1)
```
<img width="689" height="253" alt="image" src="https://github.com/user-attachments/assets/3da1a695-1223-47e6-b3ef-e7c555294d8a" />

### What does this PR do?
The fix is trivial: remove the offending line from `.bazelignore`, similar to bazelbuild/intellij#7334 (we're also using `bazel` 7.4.x as we speak).

<img width="689" height="253" alt="image" src="https://github.com/user-attachments/assets/71551337-c94b-4762-8ba7-aa38ff62eec6" />