### PR TITLE
Fix a deadlock if we attempt to stop the config poller before it started

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/config_poller.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/config_poller.go
@@ -49,7 +49,7 @@ func newConfigPoller(provider types.ConfigProvider, canPoll bool, interval time.
 
 // stop stops the provider descriptor if it's polling
 func (cp *configPoller) stop() {
-	if !cp.canPoll || cp.isRunning {
+	if !cp.canPoll || !cp.isRunning {
 		return
 	}
 	cp.stopChan <- struct{}{}


### PR DESCRIPTION
### What does this PR do?

The logic inside `func (cp *configPoller) stop()` is currently inverted:
* if the `configPoller` is running, then `stop` exits without doing anything.
* if the `configPoller` isn’t running, then it tries to enqueue an element in a chan that nobody listens on. And the process dead locks in the following situation:
```
goroutine 494 gp=0xc001551880 m=nil [chan send, 2 minutes]:
runtime.gopark(0x4a9f1d?, 0xc001065b18?, 0x59?, 0x2a?, 0xc001065b20?)
        runtime/proc.go:435 +0xce fp=0xc000c11ae0 sp=0xc000c11ac0 pc=0x48532e
runtime.chansend(0xc0001116c0, 0xc000c11ba0, 0x1, 0xc001065b58?)
        runtime/chan.go:283 +0x3a5 fp=0xc000c11b50 sp=0xc000c11ae0 pc=0x41ba05
runtime.chansend1(0x7640bb39b5c0?, 0x20?)
        runtime/chan.go:161 +0x17 fp=0xc000c11b80 sp=0xc000c11b50 pc=0x41b657
github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.(*configPoller).stop(...)
        github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:55
github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.(*AutoConfig).stop(0xc000e5c900)
        github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:342 +0x66 fp=0xc000c11bf0 sp=0xc000c11b80 pc=0x2028fc6
github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.newAutoConfig.func3({0x352cf40?, 0x44a85e0?})
        github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:186 +0x17 fp=0xc000c11c08 sp=0xc000c11bf0 pc=0x2027837
go.uber.org/fx/internal/lifecycle.(*Lifecycle).runStopHook(0xc000970380, {0x44eb8c8, 0xc001567810}, {0xc0010e3830, 0xc0010e3840, {0x0, 0x0}, {0x0, 0x0}, {{0xc001692540, ...}, ...}})
        go.uber.org/fx@v1.24.0/internal/lifecycle/lifecycle.go:341 +0x1f2 fp=0xc000c11d10 sp=0xc000c11c08 pc=0x8b5f52
go.uber.org/fx/internal/lifecycle.(*Lifecycle).Stop(0xc000970380, {0x44eb8c8, 0xc001567810})
        go.uber.org/fx@v1.24.0/internal/lifecycle/lifecycle.go:303 +0x52e fp=0xc000c11ed0 sp=0xc000c11d10 pc=0x8b584e
go.uber.org/fx.(*App).withRollback(0xc000511ce0, {0x44eb8c8, 0xc001567810}, 0x0?)
        go.uber.org/fx@v1.24.0/app.go:687 +0xd3 fp=0xc000c11f40 sp=0xc000c11ed0 pc=0x8bfe93
go.uber.org/fx.(*App).start(...)
        go.uber.org/fx@v1.24.0/app.go:701
go.uber.org/fx.(*App).start-fm({0x44eb8c8?, 0xc001567810?})
        <autogenerated>:1 +0x49 fp=0xc000c11f80 sp=0xc000c11f40 pc=0x8cae49
go.uber.org/fx.withTimeout.func1()
        go.uber.org/fx@v1.24.0/app.go:801 +0x6b fp=0xc000c11fe0 sp=0xc000c11f80 pc=0x8c080b
runtime.goexit({})
        runtime/asm_amd64.s:1700 +0x1 fp=0xc000c11fe8 sp=0xc000c11fe0 pc=0x48da01
created by go.uber.org/fx.withTimeout in goroutine 1
        go.uber.org/fx@v1.24.0/app.go:789 +0xc5
```

### Motivation

In incident-47120, we have agents that are blocked in the above mentioned state.

### Describe how you validated your changes

In the scope of incident-47120, this change has been deployed on a staging cluster and the agent is now logging the fatal error that makes it exit instead of dead-locking forever.

### Additional Notes
