### PR TITLE
Replace `gh` with `curl` to retry label fetching

### DIFF
--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -65,7 +65,11 @@ jobs:
           EVENT_NUMBER: ${{ github.event.number }}
         id: pr-labels
         run: |
-          labels="$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | (join(" "))')"
+          labels="$(curl --retry 4 -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$GH_REPO/pulls/$PR_NUMBER" \
+            | jq -r '[.labels[].name] | join(" ")')"
           echo "Fetched labels for PR $EVENT_NUMBER: $labels"
           echo "LABELS=$labels" >> "$GITHUB_OUTPUT"
   team-label-check:


### PR DESCRIPTION
### Motivation
The `gh` CLI does not support retry flags for network failures (see cli/cli#7533), causing occasional "dial tcp: i/o timeout" [errors in the label-analysis workflow](https://github.com/DataDog/datadog-agent/actions/runs/20335221784/job/58420064943):
```
Run labels="$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | (join(" "))')"
[...]
Post "https://api.github.com/graphql": dial tcp 140.82.116.6:443: i/o timeout
Error: Process completed with exit code 1.
```

### What does this PR do?
Replace with curl which has native `--retry` support with exponential backoff.
This provides [automatic retry on transient network failures](https://github.com/DataDog/datadog-agent/actions/runs/20336669775/job/58424962808) without adding more dependencies:
```
Run labels="$(curl --retry 4 -fsSL \
[...]
curl: (28) Failed to connect to api.github.com port 443 after 132736 ms: Couldn't connect to server
Fetched labels for PR 44399: changelog/no-changelog short review team/agent-devx
```