### PR TITLE
Adjust Slack channel for `opentelemetry-agent` reviews

### DIFF
--- a/tasks/libs/pipeline/github_slack_review_map.yaml
+++ b/tasks/libs/pipeline/github_slack_review_map.yaml
@@ -48,7 +48,7 @@
 '@datadog/network-device-monitoring': '#network-device-monitoring'
 '@datadog/network-path': '#network-path-dev'
 '@datadog/opentelemetry': '#opentelemetry-ops'
-'@datadog/opentelemetry-agent': '#opentelemetry-agent-ops'
+'@datadog/opentelemetry-agent': '#opentelemetry-agent'
 '@datadog/profiling-full-host': '#profiling-full-host-project'
 '@datadog/remote-config': '#remote-config-platform'
 '@datadog/sdlc-security': '#sdlc-security'


### PR DESCRIPTION
### Motivation
`#opentelemetry-agent-ops` is for monitoring purposes, and PR requests are better considered when landing on `#opentelemetry-agent`.