### PR TITLE
fix(ask_review): Get data from the PR context

### DIFF
--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -138,4 +138,5 @@ jobs:
       - name: Ask for code reviews
         env:
           SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          PR_REQUESTED_TEAMS: ${{ toJSON(github.event.pull_request.requested_teams) }}
         run: dda inv -- -e issue.ask-reviews -p ${{ github.event.pull_request.number }}

--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -1,3 +1,4 @@
+import json
 import os
 import random
 import re
@@ -21,7 +22,7 @@ def ask_reviews(_, pr_id):
         return
     if any(label.name == 'ask-review' for label in pr.get_labels()):
         actor = ask_review_actor(pr)
-        reviewers = [f"@datadog/{team.slug}" for team in pr.requested_teams]
+        reviewers = [f"@datadog/{team['slug']}" for team in json.loads(os.environ['PR_REQUESTED_TEAMS'])]
         print(f"Reviewers: {reviewers}")
 
         from slack_sdk import WebClient


### PR DESCRIPTION
### What does this PR do?
Get the `requested_teams` directly from the current github PR context instead of reading it from the REST API result

### Motivation
The `ask_review` workflow was not working recently because the content of the `requested_teams` was empty, as we can see [here](https://github.com/DataDog/datadog-agent/actions/runs/20338152152/job/58429905793?pr=44403)
This is most probably because the `requested_teams` is related to organisation permission and is not directly available when calling the API with the `GITHUB_TOKEN`.

As we can get this information from the PR context directly we can have a workaround.

### Describe how you validated your changes
Workflow triggered successfully from my PR

<img width="677" height="126" alt="image" src="https://github.com/user-attachments/assets/802e5fee-bb75-43fb-8ee3-b288664c4010" />

### Additional Notes
