### PR TITLE
Make Azure Container App tags independent of cloudservice Init

### DIFF
--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -65,6 +65,17 @@ func (c *ContainerApp) GetTags() map[string]string {
 	revision := os.Getenv(ContainerAppRevision)
 	replica := os.Getenv(ContainerAppReplicaName)
 
+	// Check ContainerApp struct first, then fall back to environment variables
+	subscriptionID := c.SubscriptionId
+	if subscriptionID == "" {
+		subscriptionID = os.Getenv(AzureSubscriptionIdEnvVar)
+	}
+
+	resourceGroup := c.ResourceGroup
+	if resourceGroup == "" {
+		resourceGroup = os.Getenv(AzureResourceGroupEnvVar)
+	}
+
 	// There are some duplicate tags here because we are updating billing and adding
 	// an abbreviated namespace per Azure environment. We must maintain backwards
 	// compatibility. An example is "replica_name" and "aca.replica.name"
@@ -83,18 +94,18 @@ func (c *ContainerApp) GetTags() map[string]string {
 		"_dd.origin": ContainerAppOrigin,
 	}
 
-	if c.SubscriptionId != "" {
-		tags["subscription_id"] = c.SubscriptionId
-		tags[acaSubscriptionID] = c.SubscriptionId
+	if subscriptionID != "" {
+		tags["subscription_id"] = subscriptionID
+		tags[acaSubscriptionID] = subscriptionID
 	}
 
-	if c.ResourceGroup != "" {
-		tags["resource_group"] = c.ResourceGroup
-		tags[acaResourceGroup] = c.ResourceGroup
+	if resourceGroup != "" {
+		tags["resource_group"] = resourceGroup
+		tags[acaResourceGroup] = resourceGroup
 	}
 
-	if c.SubscriptionId != "" && c.ResourceGroup != "" {
-		resourceID := fmt.Sprintf("/subscriptions/%v/resourcegroups/%v/providers/microsoft.app/containerapps/%v", c.SubscriptionId, c.ResourceGroup, strings.ToLower(appName))
+	if subscriptionID != "" && resourceGroup != "" {
+		resourceID := fmt.Sprintf("/subscriptions/%v/resourcegroups/%v/providers/microsoft.app/containerapps/%v", subscriptionID, resourceGroup, strings.ToLower(appName))
 		tags["resource_id"] = resourceID
 		tags[acaResourceID] = resourceID
 


### PR DESCRIPTION
### What does this PR do?
* Handles regression of ACA tags in 1.9.0
* containerapp tags now generated without a dependency on Init, consistent with other cloud provider GetTags

### Motivation
* Bugfix

### Describe how you validated your changes
- [x] New unit test
- [x] test in containerapp self-monitoring

#### Before:

<img width="720" height="455" alt="Screenshot 2025-12-18 at 12 39 02 PM" src="https://github.com/user-attachments/assets/6c7347c8-3c82-477f-8bf8-77e4bb16af40" />

#### After:

<img width="1050" height="509" alt="Screenshot 2025-12-18 at 12 39 19 PM" src="https://github.com/user-attachments/assets/754d0f93-f4cc-4da8-b6a2-2a292c592c84" />

