### PR TITLE
Use ParseUint instead of Atoi to convert command port

### DIFF
--- a/pkg/util/grpc/agent_client.go
+++ b/pkg/util/grpc/agent_client.go
@@ -49,7 +49,7 @@ func getGRPCClientConn(ctx context.Context, ipcAddress string, cmdPort string, t
 			return nil, err
 		}
 
-		port, err := strconv.Atoi(cmdPort)
+		port, err := strconv.ParseUint(cmdPort, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid cmd_port %s", cmdPort)
 		}

--- a/pkg/util/grpc/agent_client.go
+++ b/pkg/util/grpc/agent_client.go
@@ -49,7 +49,7 @@ func getGRPCClientConn(ctx context.Context, ipcAddress string, cmdPort string, t
 			return nil, err
 		}
 
-		port, err := strconv.ParseUint(cmdPort, 10, 32)
+		port, err := strconv.ParseUint(cmdPort, 10, 16)
 		if err != nil {
 			return nil, fmt.Errorf("invalid cmd_port %s", cmdPort)
 		}


### PR DESCRIPTION
### What does this PR do?

Converting the result of `strconv.Atoi`, `strconv.ParseInt`, and `strconv.ParseUint` to integer types of smaller bit size can produce unexpected values.

### Motivation

Alert Location: https://github.com/DataDog/datadog-agent/blob/6a0ae12a73531dc86d51f1d4ab634f6980736ef1/pkg/util/grpc/agent_client.go#L58-L58

### Describe how you validated your changes

### Additional Notes
