### PR TITLE
Disk Go check: Handle PartitionsWithContext errors gracefully instead of failing the check

### DIFF
--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -432,8 +432,11 @@ func (c *Check) collectPartitionMetrics(sender sender.Sender) error {
 	}
 	partitions, err := c.diskPartitionsWithContext(ctx, c.instanceConfig.IncludeAllDevices)
 	if err != nil {
-		log.Warnf("Unable to get disk partitions: %s", err)
-		return err
+		log.Warnf("Error getting some disk partitions (continuing with %d partitions): %v", len(partitions), err)
+	}
+	if len(partitions) == 0 {
+		log.Debug("No disk partitions found")
+		return nil
 	}
 	rootDevices := make(map[string]string)
 	if runtime.GOOS == "linux" && !c.instanceConfig.ResolveRootDevice {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -432,10 +432,16 @@ func (c *Check) collectPartitionMetrics(sender sender.Sender) error {
 	}
 	partitions, err := c.diskPartitionsWithContext(ctx, c.instanceConfig.IncludeAllDevices)
 	if err != nil {
+		if len(partitions) == 0 {
+			// Complete failure - no partitions retrieved
+			log.Warnf("Unable to get disk partitions: %v", err)
+			return err
+		}
+		// Partial success - some partitions retrieved despite error
 		log.Warnf("Error getting some disk partitions (continuing with %d partitions): %v", len(partitions), err)
-	}
-	if len(partitions) == 0 {
-		log.Debug("No disk partitions found")
+	} else if len(partitions) == 0 {
+		// No error but no partitions - unusual, could indicate a problem
+		log.Warn("No disk partitions found - this may indicate a configuration or access issue")
 		return nil
 	}
 	rootDevices := make(map[string]string)

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -183,6 +183,36 @@ func TestGivenADiskCheckWithIncludeAllDevicesFalseConfigured_WhenCheckRuns_ThenO
 	m.AssertNotCalled(t, "Gauge", "system.disk.free", float64(6835937.5), "", []string{"device:shm", "device_name:shm"})
 }
 
+func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallReturnsPartialResultsWithError_ThenMetricsAreReportedForReturnedPartitions(t *testing.T) {
+	setupDefaultMocks()
+	diskCheck := createDiskCheck(t)
+	// Simulate partial success: return some partitions along with an error
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskCheck, func(mountpoint string) (*gopsutil_disk.UsageStat, error) {
+		return usageData[mountpoint], nil
+	}), func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
+		return []gopsutil_disk.PartitionStat{
+			{
+				Device:     "/dev/sda1",
+				Mountpoint: "/",
+				Fstype:     "ext4",
+				Opts:       []string{"rw", "relatime"},
+			},
+		}, errors.New("error reading some partitions")
+	})
+	m := mocksender.NewMockSender(diskCheck.ID())
+	m.SetupAcceptAll()
+
+	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	err := diskCheck.Run()
+
+	// No error returned, and metrics are reported for the partitions that were returned
+	assert.Nil(t, err)
+	// usageData["/"] has Total=100GB, Used=70GB, Free=30GB - metrics are in kB (divided by 1024)
+	m.AssertMetric(t, "Gauge", "system.disk.total", float64(97656250), "", []string{"device:/dev/sda1", "device_name:sda1"})
+	m.AssertMetric(t, "Gauge", "system.disk.used", float64(68359375), "", []string{"device:/dev/sda1", "device_name:sda1"})
+	m.AssertMetric(t, "Gauge", "system.disk.free", float64(29296875), "", []string{"device:/dev/sda1", "device_name:sda1"})
+}
+
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturnsEmptyDevice_ThenNoUsageMetricsAreReportedForThatPartition(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -219,7 +219,7 @@ func TestGivenADiskCheckAndStoppedSender(t *testing.T) {
 	assert.Equal(t, stoppedSenderError, err)
 }
 
-func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallReturnsError_ThenErrorIsReturnedAndNoUsageMetricsAreReported(t *testing.T) {
+func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallReturnsError_ThenNoErrorIsReturnedAndNoUsageMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
 	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
@@ -231,7 +231,8 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallRe
 	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
 	err := diskCheck.Run()
 
-	assert.NotNil(t, err)
+	// PartitionsWithContext errors are now handled gracefully - no error returned but no metrics reported
+	assert.Nil(t, err)
 	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "Gauge", "system.disk.used", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "Gauge", "system.disk.free", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -235,36 +235,6 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallRe
 	assert.NotNil(t, err)
 }
 
-func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallReturnsPartialResultsWithError_ThenMetricsAreReportedForReturnedPartitions(t *testing.T) {
-	setupDefaultMocks()
-	diskCheck := createDiskCheck(t)
-	// Simulate partial success: return some partitions along with an error
-	diskCheck = diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskCheck, func(mountpoint string) (*gopsutil_disk.UsageStat, error) {
-		return usageData[mountpoint], nil
-	}), func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
-		return []gopsutil_disk.PartitionStat{
-			{
-				Device:     "/dev/sda1",
-				Mountpoint: "/",
-				Fstype:     "ext4",
-				Opts:       []string{"rw", "relatime"},
-			},
-		}, errors.New("error reading some partitions")
-	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
-	err := diskCheck.Run()
-
-	// No error returned, and metrics are reported for the partitions that were returned
-	assert.Nil(t, err)
-	// usageData["/"] has Total=100GB, Used=70GB, Free=30GB - metrics are in kB (divided by 1024)
-	m.AssertMetric(t, "Gauge", "system.disk.total", float64(97656250), "", []string{"device:/dev/sda1", "device_name:sda1"})
-	m.AssertMetric(t, "Gauge", "system.disk.used", float64(68359375), "", []string{"device:/dev/sda1", "device_name:sda1"})
-	m.AssertMetric(t, "Gauge", "system.disk.free", float64(29296875), "", []string{"device:/dev/sda1", "device_name:sda1"})
-}
-
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallReturnsNoPartitionsWithoutError_ThenNoErrorIsReturnedAndNoMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)

--- a/releasenotes/notes/fix-diskpartitions-graceful-error-handling-478010b7288e8476.yaml
+++ b/releasenotes/notes/fix-diskpartitions-graceful-error-handling-478010b7288e8476.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The disk check now handles ``PartitionsWithContext`` errors gracefully instead of failing entirely.
+    When some partitions fail to load, the check continues collecting metrics for the partitions that
+    succeeded. This aligns the Go implementation with the Python check behavior.


### PR DESCRIPTION
###  What does this PR do?
Changes the disk check to handle errors from `PartitionsWithContext` gracefully, allowing the check to continue with whatever partitions were successfully retrieved instead of failing entirely.
### Motivation
`gopsutil.PartitionsWithContext` can return partial results along with an error when it fails to read some partitions but succeeds with others. Previously, the disk check would fail entirely on any error, causing a complete loss of disk metrics even when most partitions were accessible.
The Python implementation of the disk check handles this case correctly and continues collecting metrics for accessible partitions. Some customers had to roll back to the Python check as a workaround for this issue. This PR aligns the Go implementation with the Python behavior.
### Describe how you validated your changes
Updated existing test to reflect new behavior
Verified that no metrics are reported when no partitions are available
All existing tests pass
### Additional Notes
**Before:** Any error from `PartitionsWithContext` caused the check to return an error and report no metrics
**After:** Errors are logged as warnings, and the check continues with whatever partitions were retrieved. If no partitions are available, the check returns early without error.
