### PR TITLE
Bump secret-generic-connector to 1.4.2.

### DIFF
--- a/deps/secret_connector/secret_connector.MODULE.bazel
+++ b/deps/secret_connector/secret_connector.MODULE.bazel
@@ -2,7 +2,7 @@
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "1.4.1"
+VERSION = "1.4.2"
 
 # Define URLs for each platform
 secret_generic_urls = {
@@ -24,16 +24,16 @@ secret_generic_urls = {
 # Note: These should be updated for each version
 secret_generic_sha256 = {
     "linux": {
-        "x86_64": "88677d8a70c0d5018fd0719ffaa3b82c7b43ab2a38b1d743aed8b7a1d7bbae27",
-        "arm64": "3d1ec9987d46ce92c6d0e9fd0a84d859cf6450db76e344bdfb6ebc1494c07820",
+        "x86_64": "91962d9c683b591769c60c09f34e5211124a703545e40a2fa5286f79fd3f2ddc",
+        "arm64": "c7aabfdf0b14ee263304104058b0b98e2bf68d22fcc88e8df53d2b83fdb80f0e",
     },
     "windows": {
-        "x86_64": "55cf4c672564f68687bd8272db95c282cdf2caafe7fc91a6b868b8b5d932231b",
-        "arm64": "7d681b44c68bc963049ddaf0774642db5db2c50714b2495cba6feb5f7f96c8d8",
+        "x86_64": "06483a4a3f6a2d18ae20bfa1cce791e30d43997941cbff9c64ca2ce09bb249d0",
+        "arm64": "0c45c233ef2b0a5c7433684dae1306c9b290327a3d9e2f257348a45549caf20d",
     },
     "macos": {
-        "x86_64": "b4a1ee58b2371ca4bf90518bd8169354e799d7a49ce5c8c9aa3eb247c632b96d",
-        "arm64": "bbe2774bbc00c7f5380b59891e7ceb61bf5efb87ccaba29a8a7846ef98cd8109",
+        "x86_64": "9b198a301e82ff796d82ea08315777ee58dd4e684684158c29030196864b52d5",
+        "arm64": "a2d5e0cd931f9e5b8cc572af6a2b3271714c179d21c30266bbf5ce67909df265",
     },
 }
 


### PR DESCRIPTION
### What does this PR do?
Bumps the secret-generic-connector to 1.4.2. which added needed `go` & `go/crypto` **CVE** fixes in the datadog-secret-backend

### Motivation
https://datadoghq.atlassian.net/browse/VULN-15308
https://datadoghq.atlassian.net/browse/VULN-13484

### Describe how you validated your changes

### Additional Notes
