### PR TITLE
start kmt jobs needing instance with kmt setup job

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -103,6 +103,11 @@
 .tag_kmt_ci_job:
   - dda inv -- -e kmt.tag-ci-job
 
+.kmt_setup_needs:
+  - go_deps
+  - go_tools_deps
+  - go_e2e_deps
+
 # -- Test dependencies
 
 .package_dependencies:
@@ -134,7 +139,7 @@
     - .kmt_ec2_location_us_east_1
   stage: kernel_matrix_testing_prepare
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  needs: ["go_deps", "go_tools_deps", "go_e2e_deps"]
+  needs: !reference [.kmt_setup_needs]
   tags: ["arch:amd64", "specific:true"]
   retry: !reference [.retry_only_infra_failure, retry]
   variables:

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -1,6 +1,8 @@
 # Security agent overrides
 upload_dependencies_secagent_x64:
-  needs: ["go_deps", "go_tools_deps"]
+  needs:
+    - !reference [.kmt_setup_needs]
+    - pull_test_dockers_x64
   extends:
     - .package_dependencies
   rules: !reference [.on_security_agent_changes_or_manual]
@@ -11,7 +13,9 @@ upload_dependencies_secagent_x64:
     TEST_COMPONENT: security-agent
 
 upload_dependencies_secagent_arm64:
-  needs: ["go_deps", "go_tools_deps"]
+  needs:
+    - !reference [.kmt_setup_needs]
+    - pull_test_dockers_arm64
   extends:
     - .package_dependencies
   rules: !reference [.on_security_agent_changes_or_manual]
@@ -84,7 +88,9 @@ kmt_setup_env_secagent_x64:
 upload_secagent_tests_x64:
   extends:
     - .upload_secagent_tests
-  needs: ["go_deps", "prepare_secagent_ebpf_functional_tests_x64"]
+  needs:
+    - !reference [.kmt_setup_needs]
+    - prepare_secagent_ebpf_functional_tests_x64
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   variables:
@@ -94,7 +100,9 @@ upload_secagent_tests_x64:
 upload_secagent_tests_arm64:
   extends:
     - .upload_secagent_tests
-  needs: ["go_deps", "prepare_secagent_ebpf_functional_tests_arm64"]
+  needs:
+    - !reference [.kmt_setup_needs]
+    - prepare_secagent_ebpf_functional_tests_arm64
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
   variables:

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -2,7 +2,9 @@
 upload_dependencies_sysprobe_x64:
   extends:
     - .package_dependencies
-  needs: ["pull_test_dockers_x64", "go_deps", "go_tools_deps"]
+  needs:
+    - !reference [.kmt_setup_needs]
+    - pull_test_dockers_x64
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   variables:
     ARCH: x86_64
@@ -12,7 +14,9 @@ upload_dependencies_sysprobe_x64:
 upload_dependencies_sysprobe_arm64:
   extends:
     - .package_dependencies
-  needs: ["pull_test_dockers_arm64", "go_deps", "go_tools_deps"]
+  needs:
+    - !reference [.kmt_setup_needs]
+    - pull_test_dockers_arm64
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   variables:
     ARCH: arm64
@@ -89,7 +93,9 @@ pull_test_dockers_arm64:
 upload_minimized_btfs_sysprobe_x64:
   extends:
     - .upload_minimized_btfs
-  needs: ["generate_minimized_btfs_x64"]
+  needs:
+    - !reference [.kmt_setup_needs]
+    - generate_minimized_btfs_x64
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   variables:
     ARCHIVE_NAME: btfs-x86_64.tar.gz
@@ -100,7 +106,9 @@ upload_minimized_btfs_sysprobe_x64:
 upload_minimized_btfs_sysprobe_arm64:
   extends:
     - .upload_minimized_btfs
-  needs: ["generate_minimized_btfs_arm64"]
+  needs:
+    - !reference [.kmt_setup_needs]
+    - generate_minimized_btfs_arm64
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   variables:
     ARCHIVE_NAME: btfs-arm64.tar.gz
@@ -171,7 +179,9 @@ upload_sysprobe_tests_x64:
   extends:
     - .upload_sysprobe_tests
   needs:
-    ["go_deps", "prepare_sysprobe_ebpf_functional_tests_x64", "tests_ebpf_x64"]
+    - !reference [.kmt_setup_needs]
+    - prepare_sysprobe_ebpf_functional_tests_x64
+    - tests_ebpf_x64
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   variables:
@@ -182,11 +192,9 @@ upload_sysprobe_tests_arm64:
   extends:
     - .upload_sysprobe_tests
   needs:
-    [
-      "go_deps",
-      "prepare_sysprobe_ebpf_functional_tests_arm64",
-      "tests_ebpf_arm64",
-    ]
+    - !reference [.kmt_setup_needs]
+    - prepare_sysprobe_ebpf_functional_tests_arm64
+    - tests_ebpf_arm64
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
   variables:


### PR DESCRIPTION
### What does this PR do?

Uses a `!reference` to ensure `kmt_setup_env_*` job needs and any KMT jobs needing the metal instance include the same needs.

### Motivation

Similar to #24151 we need to ensure any KMT jobs which need the metal instance do not start before the setup job. Otherwise they can timeout before the metal instance has even had a chance to launch. 

### Describe how you validated your changes

Run CI

### Additional Notes

Added missing `pull_test_dockers_*` needs to `upload_dependencies_secagent_*` jobs.
