### PR TITLE
prevent empty service extraction tags

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -637,13 +637,7 @@ func convertAndEnrichWithServiceCtx(tags []string, tagOffsets []uint32, serviceC
 	for _, t := range tagOffsets {
 		tagsStr = append(tagsStr, tags[t])
 	}
-
-	for _, serviceCtx := range serviceCtxs {
-		if serviceCtx != "" {
-			tagsStr = append(tagsStr, serviceCtx)
-		}
-	}
-
+	tagsStr = append(tagsStr, serviceCtxs...)
 	return tagsStr
 }
 

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -633,6 +633,9 @@ func groupSize(total, maxBatchSize int) int32 {
 // converts the tags based on the tagOffsets for encoding. It also enriches it with service context if any
 func convertAndEnrichWithServiceCtx(tags []string, tagOffsets []uint32, serviceCtxs ...string) []string {
 	tagCount := len(tagOffsets) + len(serviceCtxs)
+	if tagCount == 0 {
+		return nil
+	}
 	tagsStr := make([]string, 0, tagCount)
 	for _, t := range tagOffsets {
 		tagsStr = append(tagsStr, tags[t])

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -675,37 +675,37 @@ func TestConvertAndEnrichWithServiceTags(t *testing.T) {
 	tests := []struct {
 		name       string
 		tagOffsets []uint32
-		serviceTag string
+		serviceTag []string
 		expected   []string
 	}{
 		{
 			name:       "no tags",
 			tagOffsets: nil,
-			serviceTag: "",
-			expected:   []string{},
+			serviceTag: nil,
+			expected:   nil,
 		},
 		{
 			name:       "convert tags only",
 			tagOffsets: []uint32{0, 2},
-			serviceTag: "",
+			serviceTag: nil,
 			expected:   []string{"tag0", "tag2"},
 		},
 		{
 			name:       "convert service tag only",
 			tagOffsets: nil,
-			serviceTag: "process_context:dogfood",
+			serviceTag: []string{"process_context:dogfood"},
 			expected:   []string{"process_context:dogfood"},
 		},
 		{
 			name:       "convert tags with service tag",
 			tagOffsets: []uint32{0, 2},
-			serviceTag: "process_context:doge",
+			serviceTag: []string{"process_context:doge"},
 			expected:   []string{"tag0", "tag2", "process_context:doge"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, convertAndEnrichWithServiceCtx(tags, tt.tagOffsets, tt.serviceTag))
+			assert.Equal(t, tt.expected, convertAndEnrichWithServiceCtx(tags, tt.tagOffsets, tt.serviceTag...))
 		})
 	}
 }

--- a/pkg/process/metadata/parser/service.go
+++ b/pkg/process/metadata/parser/service.go
@@ -108,10 +108,12 @@ func (d *ServiceExtractor) Extract(processes map[int32]*procutil.Process) {
 			}
 		}
 		meta := d.extractServiceMetadata(proc)
-		if meta != nil && log.ShouldLog(log.TraceLvl) {
-			log.Tracef("detected service metadata: %v", meta)
+		if meta != nil {
+			if log.ShouldLog(log.TraceLvl) {
+				log.Tracef("detected service metadata: %v", meta)
+			}
+			serviceByPID[proc.Pid] = meta
 		}
-		serviceByPID[proc.Pid] = meta
 	}
 
 	d.serviceByPID = serviceByPID
@@ -147,9 +149,7 @@ func (d *ServiceExtractor) GetServiceContext(pid int32) []string {
 func (d *ServiceExtractor) extractServiceMetadata(process *procutil.Process) *serviceMetadata {
 	cmd := process.Cmdline
 	if len(cmd) == 0 || len(cmd[0]) == 0 {
-		return &serviceMetadata{
-			cmdline: cmd,
-		}
+		return nil
 	}
 
 	// check if all args are packed into the first argument
@@ -169,9 +169,7 @@ func (d *ServiceExtractor) extractServiceMetadata(process *procutil.Process) *se
 	}
 
 	if len(cmd) == 0 || len(cmd[0]) == 0 {
-		return &serviceMetadata{
-			cmdline: cmdOrig,
-		}
+		return nil
 	}
 	exe := cmd[0]
 
@@ -186,9 +184,11 @@ func (d *ServiceExtractor) extractServiceMetadata(process *procutil.Process) *se
 
 	if contextFn, ok := binsWithContext[exe]; ok {
 		tag := contextFn(d, process, cmd[1:])
-		return &serviceMetadata{
-			cmdline:        cmdOrig,
-			serviceContext: "process_context:" + tag,
+		if tag != "" {
+			return &serviceMetadata{
+				cmdline:        cmdOrig,
+				serviceContext: "process_context:" + tag,
+			}
 		}
 	}
 
@@ -197,10 +197,13 @@ func (d *ServiceExtractor) extractServiceMetadata(process *procutil.Process) *se
 		exe = exe[:i]
 	}
 
-	return &serviceMetadata{
-		cmdline:        cmdOrig,
-		serviceContext: "process_context:" + exe,
+	if exe != "" {
+		return &serviceMetadata{
+			cmdline:        cmdOrig,
+			serviceContext: "process_context:" + exe,
+		}
 	}
+	return nil
 }
 
 // GetWindowsServiceTags returns the process_context associated with a process by scraping the SCM.
@@ -216,7 +219,9 @@ func (d *ServiceExtractor) getWindowsServiceTags(pid int32) ([]string, error) {
 
 	serviceTags := make([]string, 0, len(entry.ServiceName))
 	for _, serviceName := range entry.ServiceName {
-		serviceTags = append(serviceTags, "process_context:"+serviceName)
+		if serviceName != "" {
+			serviceTags = append(serviceTags, "process_context:"+serviceName)
+		}
 	}
 	return serviceTags, nil
 }
@@ -258,13 +263,15 @@ func extractEnvsFromCommand(cmd []string) ([]string, []string) {
 func chooseServiceNameFromEnvs(envs []string) (string, bool) {
 	for _, env := range envs {
 		if strings.HasPrefix(env, "DD_SERVICE=") {
-			return strings.TrimPrefix(env, "DD_SERVICE="), true
+			svc := strings.TrimPrefix(env, "DD_SERVICE=")
+			return svc, len(svc) > 0
 		}
 		if strings.HasPrefix(env, "DD_TAGS=") && strings.Contains(env, "service:") {
 			parts := strings.Split(strings.TrimPrefix(env, "DD_TAGS="), ",")
 			for _, p := range parts {
 				if strings.HasPrefix(p, "service:") {
-					return strings.TrimPrefix(p, "service:"), true
+					svc := strings.TrimPrefix(p, "service:")
+					return svc, len(svc) > 0
 				}
 			}
 		}

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -366,7 +366,11 @@ func TestExtractServiceMetadata(t *testing.T) {
 			useImprovedAlgorithm := tt.useImprovedAlgorithm
 			se := NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 			se.Extract(procsByPid)
-			assert.Equal(t, []string{tt.expectedServiceTag}, se.GetServiceContext(proc.Pid))
+			if tt.expectedServiceTag != "" {
+				assert.Equal(t, []string{tt.expectedServiceTag}, se.GetServiceContext(proc.Pid))
+			} else {
+				assert.Nil(t, se.GetServiceContext(proc.Pid))
+			}
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Ensures the service extractor doesn't return empty string tags

### Motivation

Clean up data during the service extraction, rather than having to handle it in all users.

### Describe how you validated your changes

Existing tests updated.

### Additional Notes
