### PR TITLE
[ABLD-257] Add module to bring in windows procmon drivers.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -184,6 +184,9 @@ include("//deps/secret_connector:secret_connector.MODULE.bazel")
 # buildifier: leave-alone
 include("//deps/snmp_traps:snmp_traps.MODULE.bazel")
 
+# buildifier: leave-alone
+include("//deps/windows:drivers.MODULE.bazel")
+
 # This enables cross-compilation for macOS x86_64 on Apple Silicon.
 # Simply add --platforms=@apple_support//platforms:macos_x86_64
 # to the build command to enable it.

--- a/deps/windows/BUILD.bazel
+++ b/deps/windows/BUILD.bazel
@@ -1,0 +1,22 @@
+# Windows drivers.
+
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//packages:__subpackages__"])
+
+pkg_files(
+    name = "all_files",
+    srcs = [
+        "@windows_npm_driver//:DDNPM.msm",
+        "@windows_procmon_driver//:DDPROCMON.msm",
+    ],
+    prefix = "bin/agent",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
+    ],
+)

--- a/deps/windows/drivers.MODULE.bazel
+++ b/deps/windows/drivers.MODULE.bazel
@@ -1,0 +1,17 @@
+"""Fetch the windows drives based on the current values in //relase.json."""
+
+get_file_using_release_constants = use_repo_rule("//deps/windows:module_utils.bzl", "get_file_using_release_constants")
+
+get_file_using_release_constants(
+    name = "windows_npm_driver",
+    sha256 = "WINDOWS_DDNPM_SHASUM",
+    target_filename = "DDNPM.msm",
+    url = "https://s3.amazonaws.com/dd-windowsfilter/builds/{WINDOWS_DDNPM_DRIVER}/ddnpminstall-{WINDOWS_DDNPM_VERSION}.msm",
+)
+
+get_file_using_release_constants(
+    name = "windows_procmon_driver",
+    sha256 = "WINDOWS_DDPROCMON_SHASUM",
+    target_filename = "DDPROCMON.msm",
+    url = "https://s3.amazonaws.com/dd-windowsfilter/builds/{WINDOWS_DDPROCMON_DRIVER}/ddprocmoninstall-{WINDOWS_DDPROCMON_VERSION}.msm",
+)

--- a/deps/windows/module_utils.bzl
+++ b/deps/windows/module_utils.bzl
@@ -1,0 +1,99 @@
+"""MODULE wrapper for http_file that uses variables from release.json.
+
+This loads 'dependencies' from release.json and uses that to substitute into url paths.
+
+Usage:
+  get_file_using_release_constants = use_repo_rule(":module_utils.bzl", "get_file_using_release_constants")
+
+  get_file_using_release_constants(
+      name = "windows_npm_driver",
+      # Note that this is the name of the element holding the SHA, not the SHA itself.
+      sha256 = "WINDOWS_DDNPM_SHASUM",
+      target_filename = "DDPROCMON.msm",
+      url = "https://s3.amazonaws.com/dd-windowsfilter/builds/{WINDOWS_DDNPM_PATH}/ddprocmoninstall-{WINDOWS_DDNPM_VERSION}.msm",
+  )
+"""
+
+load(
+    "@@//third_party/bazel/tools/build_defs/repo:cache.bzl",
+    "DEFAULT_CANONICAL_ID_ENV",
+    "get_default_canonical_id",
+)
+load(
+    "@@//third_party/bazel/tools/build_defs/repo:utils.bzl",
+    "get_auth",
+)
+
+get_file_using_release_constants_attrs = {
+    "executable": attr.bool(
+        doc = "If the downloaded file should be made executable.",
+    ),
+    "target_filename": attr.string(
+        default = "downloaded",
+        doc = "Name assigned to the downloaded file.",
+    ),
+    "sha256": attr.string(doc = "Name of variable in release_info.dependencies for SHA"),
+    "url": attr.string(),
+    "urls": attr.string_list(),
+    "auth_patterns": attr.string_dict(),
+    "canonical_id": attr.string(),
+    "_release_info": attr.label(default = "//:release.json", allow_single_file = True),
+}
+
+def _get_source_urls(ctx, substitutions):
+    """Returns source urls provided via the url, urls attributes.
+
+    Also checks that at least one url is provided."""
+    if not ctx.attr.url and not ctx.attr.urls:
+        fail("At least one of url and urls must be provided")
+
+    source_urls = []
+    if ctx.attr.urls:
+        source_urls = ctx.attr.urls
+    if ctx.attr.url:
+        source_urls = [ctx.attr.url] + source_urls
+    return [url.format(**substitutions) for url in source_urls]
+
+_GET_FILE_BUILD = """\
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))
+
+filegroup(
+    name = "file",
+    srcs = ["{target_filename}"],
+)
+"""
+
+def _get_file_using_release_constants_impl(rctx):
+    """Implementation of the get_file_using_release_constants rule."""
+    release_info = json.decode(rctx.read(rctx.path(rctx.attr._release_info)))
+    vars = release_info["dependencies"]
+    repo_root = rctx.path(".")
+    forbidden_files = [
+        repo_root,
+        rctx.path("MODULE.bazel"),
+        rctx.path("BUILD"),
+    ]
+    target_filename = rctx.attr.target_filename
+    download_path = rctx.path("file/" + target_filename)
+    if download_path in forbidden_files or not str(download_path).startswith(str(repo_root)):
+        fail("'%s' cannot be used as target_filename in get_file_using_release_constants" % rctx.attr.target_filename)
+    source_urls = _get_source_urls(rctx, vars)
+    rctx.download(
+        source_urls,
+        target_filename,
+        vars[rctx.attr.sha256],
+        rctx.attr.executable,
+        canonical_id = rctx.attr.canonical_id or get_default_canonical_id(rctx, source_urls),
+        auth = get_auth(rctx, source_urls),
+    )
+    rctx.file("MODULE.bazel", "module(name = \"{name}\")\n".format(name = rctx.name))
+    rctx.file("BUILD", _GET_FILE_BUILD.format(target_filename = target_filename))
+    return rctx.repo_metadata(reproducible = True)
+
+get_file_using_release_constants = repository_rule(
+    implementation = _get_file_using_release_constants_impl,
+    attrs = get_file_using_release_constants_attrs,
+    environ = [DEFAULT_CANONICAL_ID_ENV],
+)


### PR DESCRIPTION
- Create a very magical repo rule that can do substitutions from variables in release.json.
- Use that to bring in the two files as distinct modules
- Add a rough pkg_install.

This does not hook them up yet. We'll do that after the code freeze.

This is roughly based on the http_file implementation, but drastically simplified for our needs.

## Try it
```
$ bazel run -- //deps/windows:install --destdir=/tmp/opt/datadog
$ file /tmp/opt/datadog/bin/agent/*
/tmp/opt/datadog/bin/agent/DDNPM.msm:     Composite Document File V2 Document, Little Endian, Os: Windows, Version 6.2, MSI Installer, Code page: 1252, Title: Installation Database, Subject: ddnpminstall, Author: DataDog, Keywords: Installer, Comments: This installer database contains the logic and data required to install ddnpminstall., Template: x64;1033, Revision Number: {2076C31D-3254-4207-B273-B762F9FCDC25}, Create Time/Date: Fri Dec  5 16:37:12 2025, Last Saved Time/Date: Fri Dec  5 16:37:12 2025, Number of Pages: 400, Number of Words: 2, Name of Creating Application: Windows Installer XML Toolset (3.11.2.4516), Security: 2
/tmp/opt/datadog/bin/agent/DDPROCMON.msm: Composite Document File V2 Document, Little Endian, Os: Windows, Version 6.2, MSI Installer, Code page: 1252, Title: Installation Database, Subject: ddprocmoninstall, Author: DataDog, Keywords: Installer, Comments: This installer database contains the logic and data required to install ddprocmoninstall., Template: x64;1033, Revision Number: {350C901A-53FE-476A-B6AF-D234C53FA6C0}, Create Time/Date: Thu Oct 30 03:25:48 2025, Last Saved Time/Date: Thu Oct 30 03:25:48 2025, Number of Pages: 400, Number of Words: 2, Name of Creating Application: Windows Installer XML Toolset (3.11.2.4516), Security: 2
```

## Alternatives considered

Have rules to sync release.json -> release.bzl -> generate http_file() stanza like we could do for anything else.
- That will mean every time someone update release.json, the diff test on release.bzll or the generated module file will fail.
- That will upset users.
 
