### PR TITLE
[do not merge] Extend DNS tracing to support a user defined list of ports

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2254,6 +2254,13 @@ api_key:
 #   # Set to true to enable the Network Module of the System Probe
 #
 #   enabled: false
+
+#   # @param dns_monitoring_ports - list of integers - optional - default: [53]
+#   # @env DD_SYSTEM_PROBE_CONFIG_DNS_MONITORING_PORTS - space separated list of integers - optional - default: [53]
+#   # A list of ports that should be monitored for DNS traffic.
+#
+#   dns_monitoring_ports:
+#     - 53
 {{ end -}}
 {{ if .UniversalServiceMonitoringModule }}
 #############################################################

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -199,6 +199,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("system_probe_config.collect_dns_domains", true, "DD_COLLECT_DNS_DOMAINS")
 	cfg.BindEnvAndSetDefault("system_probe_config.max_dns_stats", 20000)
 	cfg.BindEnvAndSetDefault("system_probe_config.dns_timeout_in_s", 15)
+	cfg.BindEnvAndSetDefault("network_config.dns_monitoring_ports", []int{53})
 
 	cfg.BindEnvAndSetDefault("system_probe_config.enable_conntrack", true)
 	cfg.BindEnvAndSetDefault("system_probe_config.conntrack_max_state_size", 65536*2)

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -7,9 +7,11 @@
 package config
 
 import (
+	"slices"
 	"time"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -58,6 +60,9 @@ type Config struct {
 	// CollectDNSDomains specifies whether collected DNS stats would be scoped by domain
 	// It is relevant *only* when DNSInspection and CollectDNSStats is enabled.
 	CollectDNSDomains bool
+
+	// DNSMonitoringPortList specifies the list of ports to monitor for DNS traffic
+	DNSMonitoringPortList []int
 
 	// DNSTimeout determines the length of time to wait before considering a DNS Query to have timed out
 	DNSTimeout time.Duration
@@ -320,9 +325,26 @@ func New() *Config {
 		log.Info("network tracer DNS inspection disabled by configuration")
 	}
 
+	if err := structure.UnmarshalKey(cfg, sysconfig.FullKeyPath(netNS, "dns_monitoring_ports"), &c.DNSMonitoringPortList); err != nil {
+		log.Warnf("failed to parse dns_monitoring_ports: %v", err)
+	}
+
+	if len(c.DNSMonitoringPortList) == 0 {
+		c.DNSMonitoringPortList = []int{53}
+	}
+
+	c.DNSMonitoringPortList = slices.DeleteFunc(c.DNSMonitoringPortList, func(port int) bool {
+		isHTTP := port == 80 || port == 443
+		if isHTTP {
+			log.Warnf("CNM detected and removed HTTP port %d from %s, which is unsupported due to the large volume of traffic it would capture", port, sysconfig.FullKeyPath(netNS, "dns_monitoring_ports"))
+		}
+		return isHTTP
+	})
+
 	if !c.EnableProcessEventMonitoring {
 		log.Info("network process event monitoring disabled")
 	}
+
 	return c
 }
 

--- a/pkg/network/dns.go
+++ b/pkg/network/dns.go
@@ -12,8 +12,19 @@ import (
 )
 
 // DNSKey generates a key suitable for looking up DNS stats based on a ConnectionStats object
-func DNSKey(c *ConnectionStats) (dns.Key, bool) {
-	if c == nil || c.DPort != 53 {
+func DNSKey(c *ConnectionStats, allowedPorts []int) (dns.Key, bool) {
+	if c == nil {
+		return dns.Key{}, false
+	}
+
+	isDNS := false
+	for _, p := range allowedPorts {
+		if c.DPort == uint16(p) {
+			isDNS = true
+			break
+		}
+	}
+	if !isDNS {
 		return dns.Key{}, false
 	}
 

--- a/pkg/network/dns/bpf.go
+++ b/pkg/network/dns/bpf.go
@@ -8,65 +8,201 @@
 package dns
 
 import (
-	"math"
-
 	"golang.org/x/net/bpf"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
-const port = 53
+const captureSize = 262144
 
 func generateBPFFilter(c *config.Config) ([]bpf.RawInstruction, error) {
-	allowedDestPort := uint32(math.MaxUint32)
+	srcPorts := c.DNSMonitoringPortList
+	var dstPorts []int
 	if c.CollectDNSStats {
-		allowedDestPort = port
+		dstPorts = c.DNSMonitoringPortList
 	}
 
-	return bpf.Assemble([]bpf.Instruction{
-		//(000) ldh      [12] -- load Ethertype
-		bpf.LoadAbsolute{Size: 2, Off: 12},
-		//(001) jeq      #0x86dd          jt 2	jf 9 -- if IPv6, goto 2, else 9
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x86dd, SkipTrue: 0, SkipFalse: 7},
-		//(002) ldb      [20] -- load IPv6 Next Header
-		bpf.LoadAbsolute{Size: 1, Off: 20},
-		//(003) jeq      #0x6             jt 5	jf 4 -- IPv6 Next Header: if TCP, goto 5
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x6, SkipTrue: 1, SkipFalse: 0},
-		//(004) jeq      #0x11            jt 5	jf 21 -- IPv6 Next Header: if UDP, goto 5, else drop
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x11, SkipTrue: 0, SkipFalse: 16},
-		//(005) ldh      [54] -- load source port
-		bpf.LoadAbsolute{Size: 2, Off: 54},
-		//(006) jeq      #0x35            jt 20	jf 7 -- if 53, capture
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: port, SkipTrue: 13, SkipFalse: 0},
-		//(007) ldh      [56] -- load dest port
-		bpf.LoadAbsolute{Size: 2, Off: 56},
-		//(008) jeq      #0x35            jt 20	jf 21 -- if allowedDestPort, capture, else drop
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: allowedDestPort, SkipTrue: 11, SkipFalse: 12},
-		//(009) jeq      #0x800           jt 10	jf 21 -- if IPv4, go next, else drop
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x800, SkipTrue: 0, SkipFalse: 11},
-		//(010) ldb      [23] -- load IPv4 Protocol
-		bpf.LoadAbsolute{Size: 1, Off: 23},
-		//(011) jeq      #0x6             jt 13	jf 12 -- if TCP, goto 13
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x6, SkipTrue: 1, SkipFalse: 0},
-		//(012) jeq      #0x11            jt 13	jf 21 -- if UDP, goto 13, else drop
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x11, SkipTrue: 0, SkipFalse: 8},
-		//(013) ldh      [20] -- load Fragment Offset
-		bpf.LoadAbsolute{Size: 2, Off: 20},
-		//(014) jset     #0x1fff          jt 21	jf 15 -- use 0x1fff as mask for fragment offset, if != 0, drop
-		bpf.JumpIf{Cond: bpf.JumpBitsSet, Val: 0x1fff, SkipTrue: 6, SkipFalse: 0},
-		//(015) ldxb     4*([14]&0xf) -- x = IP header length
-		bpf.LoadMemShift{Off: 14},
-		//(016) ldh      [x + 14] -- load source port
-		bpf.LoadIndirect{Size: 2, Off: 14},
-		//(017) jeq      #0x35            jt 20	jf 18 -- if port 53 capture
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: port, SkipTrue: 2, SkipFalse: 0},
-		//(018) ldh      [x + 16] -- load dest port
-		bpf.LoadIndirect{Size: 2, Off: 16},
-		//(019) jeq      #0x35            jt 20	jf 21 -- if port allowedDestPort capture, else drop
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: allowedDestPort, SkipTrue: 0, SkipFalse: 1},
-		//(020) ret      #262144 -- capture
-		bpf.RetConstant{Val: 262144},
-		//(021) ret      #0 -- drop
-		bpf.RetConstant{Val: 0},
+	ins := buildBPFProgram(srcPorts, dstPorts)
+	return bpf.Assemble(ins)
+}
+
+func buildBPFProgram(srcPorts, dstPorts []int) []bpf.Instruction {
+	// Build a BPF filter program that captures DNS traffic on configured ports.
+	// Structure:
+	// 0: load ethertype
+	// 1: if IPv6, goto IPv6 block; else goto IPv4 check
+	// 2 to 2+ipv6BlockSize-1: IPv6 block
+	// 2+ipv6BlockSize: if IPv4, goto IPv4 block; else drop
+	// ... : IPv4 block
+	// captureIdx: capture
+	// dropIdx: drop
+
+	var ins []bpf.Instruction
+
+	nSrc := len(srcPorts)
+	nDst := len(dstPorts)
+	hasDst := nDst > 0
+
+	// Port check size: load src + checks + [load dst + checks]
+	portChecksSize := 1 + nSrc
+	if hasDst {
+		portChecksSize += 1 + nDst
+	}
+
+	// IPv6 block: header check (1) + TCP check (1) + UDP check (1) + port checks
+	ipv6BlockSize := 3 + portChecksSize
+
+	// IPv4 block: header check (1) + TCP check (1) + UDP check (1) + frag load (1) + frag check (1) + memshift (1) + port checks
+	ipv4BlockSize := 6 + portChecksSize
+
+	captureIdx := 2 + ipv6BlockSize + 1 + ipv4BlockSize
+	dropIdx := captureIdx + 1
+
+	// (0) ldh [12] -- load Ethertype
+	ins = append(ins, bpf.LoadAbsolute{Size: 2, Off: 12})
+
+	// (1) jeq #0x86dd jt IPv6Block jf ipv4Check
+	ipv4CheckIdx := 2 + ipv6BlockSize
+	ins = append(ins, bpf.JumpIf{
+		Cond:      bpf.JumpEqual,
+		Val:       0x86dd,
+		SkipTrue:  0,
+		SkipFalse: uint8(ipv4CheckIdx - len(ins)),
 	})
+
+	// IPv6 block
+	// ldb [20] -- load IPv6 Next Header
+	ins = append(ins, bpf.LoadAbsolute{Size: 1, Off: 20})
+
+	// jeq #0x6 jt +1 jf 0 -- if TCP, skip UDP check
+	ins = append(ins, bpf.JumpIf{
+		Cond:      bpf.JumpEqual,
+		Val:       0x6,
+		SkipTrue:  1,
+		SkipFalse: 0,
+	})
+
+	// jeq #0x11 jt portChecks jf drop
+	ins = append(ins, bpf.JumpIf{
+		Cond:      bpf.JumpEqual,
+		Val:       0x11,
+		SkipTrue:  0,
+		SkipFalse: uint8(dropIdx - len(ins) - 1),
+	})
+
+	// IPv6 port checks
+	ins = append(ins, buildPortChecks(
+		bpf.LoadAbsolute{Size: 2, Off: 54},
+		bpf.LoadAbsolute{Size: 2, Off: 56},
+		srcPorts, dstPorts,
+		captureIdx, dropIdx, len(ins),
+	)...)
+
+	// IPv4 check
+	ins = append(ins, bpf.JumpIf{
+		Cond:      bpf.JumpEqual,
+		Val:       0x800,
+		SkipTrue:  0,
+		SkipFalse: uint8(dropIdx - len(ins) - 1),
+	})
+
+	// IPv4 block
+	// ldb [23] -- load IPv4 Protocol
+	ins = append(ins, bpf.LoadAbsolute{Size: 1, Off: 23})
+
+	// jeq #0x6 jt +1 jf 0 -- if TCP, skip UDP check
+	ins = append(ins, bpf.JumpIf{
+		Cond:      bpf.JumpEqual,
+		Val:       0x6,
+		SkipTrue:  1,
+		SkipFalse: 0,
+	})
+
+	// jeq #0x11 jt +0 jf drop
+	ins = append(ins, bpf.JumpIf{
+		Cond:      bpf.JumpEqual,
+		Val:       0x11,
+		SkipTrue:  0,
+		SkipFalse: uint8(dropIdx - len(ins) - 1),
+	})
+
+	// ldh [20] -- Fragment Offset
+	ins = append(ins, bpf.LoadAbsolute{Size: 2, Off: 20})
+
+	// jset #0x1fff jt drop jf 0
+	ins = append(ins, bpf.JumpIf{
+		Cond:      bpf.JumpBitsSet,
+		Val:       0x1fff,
+		SkipTrue:  uint8(dropIdx - len(ins) - 1),
+		SkipFalse: 0,
+	})
+
+	// ldxb 4*([14]&0xf) -- x = IP header length
+	ins = append(ins, bpf.LoadMemShift{Off: 14})
+
+	// IPv4 port checks
+	ins = append(ins, buildPortChecks(
+		bpf.LoadIndirect{Size: 2, Off: 14},
+		bpf.LoadIndirect{Size: 2, Off: 16},
+		srcPorts, dstPorts,
+		captureIdx, dropIdx, len(ins),
+	)...)
+
+	// Capture
+	ins = append(ins, bpf.RetConstant{Val: captureSize})
+
+	// Drop
+	ins = append(ins, bpf.RetConstant{Val: 0})
+
+	return ins
+}
+
+func buildPortChecks(srcLoad, dstLoad bpf.Instruction, srcPorts, dstPorts []int, captureIdx, dropIdx, startIdx int) []bpf.Instruction {
+	var out []bpf.Instruction
+
+	nDst := len(dstPorts)
+	hasDst := nDst > 0
+
+	out = append(out, srcLoad)
+	currentIdx := startIdx + 1
+
+	for _, p := range srcPorts {
+		skipToCapture := captureIdx - currentIdx - 1
+		out = append(out, bpf.JumpIf{
+			Cond:      bpf.JumpEqual,
+			Val:       uint32(p),
+			SkipTrue:  uint8(skipToCapture),
+			SkipFalse: 0,
+		})
+		currentIdx++
+	}
+
+	if hasDst {
+		out = append(out, dstLoad)
+		currentIdx++
+
+		for i, p := range dstPorts {
+			skipToCapture := captureIdx - currentIdx - 1
+			var skipFalse uint8
+			if i == nDst-1 {
+				skipFalse = uint8(dropIdx - currentIdx - 1)
+			}
+			out = append(out, bpf.JumpIf{
+				Cond:      bpf.JumpEqual,
+				Val:       uint32(p),
+				SkipTrue:  uint8(skipToCapture),
+				SkipFalse: skipFalse,
+			})
+			currentIdx++
+		}
+	} else {
+		if len(out) > 1 {
+			lastIdx := len(out) - 1
+			lastJump := out[lastIdx].(bpf.JumpIf)
+			lastJump.SkipFalse = uint8(dropIdx - (startIdx + lastIdx) - 1)
+			out[lastIdx] = lastJump
+		}
+	}
+
+	return out
 }

--- a/pkg/network/dns/bpf_test.go
+++ b/pkg/network/dns/bpf_test.go
@@ -1,0 +1,227 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package dns
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/bpf"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+)
+
+func TestGenerateBPFFilter(t *testing.T) {
+	tests := []struct {
+		name             string
+		ports            []int
+		collectDNSStats  bool
+		expectAssembleOK bool
+	}{
+		{
+			name:             "default port 53",
+			ports:            []int{53},
+			collectDNSStats:  true,
+			expectAssembleOK: true,
+		},
+		{
+			name:             "multiple ports",
+			ports:            []int{53, 5353},
+			collectDNSStats:  true,
+			expectAssembleOK: true,
+		},
+		{
+			name:             "custom port only",
+			ports:            []int{8053},
+			collectDNSStats:  true,
+			expectAssembleOK: true,
+		},
+		{
+			name:             "stats disabled",
+			ports:            []int{53},
+			collectDNSStats:  false,
+			expectAssembleOK: true,
+		},
+		{
+			name:             "multiple ports stats disabled",
+			ports:            []int{53, 5353, 8053},
+			collectDNSStats:  false,
+			expectAssembleOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				DNSMonitoringPortList: tt.ports,
+				CollectDNSStats:       tt.collectDNSStats,
+			}
+
+			rawIns, err := generateBPFFilter(cfg)
+			if tt.expectAssembleOK {
+				require.NoError(t, err)
+				require.NotEmpty(t, rawIns)
+			}
+		})
+	}
+}
+
+func TestBPFFilterMatchesPackets(t *testing.T) {
+	tests := []struct {
+		name            string
+		ports           []int
+		collectDNSStats bool
+		packets         []testPacket
+	}{
+		{
+			name:            "default port 53 with stats",
+			ports:           []int{53},
+			collectDNSStats: true,
+			packets: []testPacket{
+				{desc: "IPv4 UDP src port 53", ipv6: false, proto: 0x11, srcPort: 53, dstPort: 12345, shouldMatch: true},
+				{desc: "IPv4 UDP dst port 53", ipv6: false, proto: 0x11, srcPort: 12345, dstPort: 53, shouldMatch: true},
+				{desc: "IPv4 UDP port 80", ipv6: false, proto: 0x11, srcPort: 80, dstPort: 8080, shouldMatch: false},
+				{desc: "IPv4 TCP src port 53", ipv6: false, proto: 0x6, srcPort: 53, dstPort: 12345, shouldMatch: true},
+				{desc: "IPv4 TCP dst port 53", ipv6: false, proto: 0x6, srcPort: 12345, dstPort: 53, shouldMatch: true},
+				{desc: "IPv6 UDP src port 53", ipv6: true, proto: 0x11, srcPort: 53, dstPort: 12345, shouldMatch: true},
+				{desc: "IPv6 UDP dst port 53", ipv6: true, proto: 0x11, srcPort: 12345, dstPort: 53, shouldMatch: true},
+				{desc: "IPv6 UDP port 80", ipv6: true, proto: 0x11, srcPort: 80, dstPort: 8080, shouldMatch: false},
+				{desc: "IPv4 TCP src port 80", ipv6: false, proto: 0x6, srcPort: 80, dstPort: 12345, shouldMatch: false},
+				{desc: "IPv4 TCP dst port 80", ipv6: false, proto: 0x6, srcPort: 12345, dstPort: 80, shouldMatch: false},
+				{desc: "IPv4 TCP src port 443", ipv6: false, proto: 0x6, srcPort: 80, dstPort: 12345, shouldMatch: false},
+				{desc: "IPv4 TCP dst port 443", ipv6: false, proto: 0x6, srcPort: 12345, dstPort: 80, shouldMatch: false},
+			},
+		},
+		{
+			name:            "default port 53 stats disabled",
+			ports:           []int{53},
+			collectDNSStats: false,
+			packets: []testPacket{
+				{desc: "IPv4 UDP src port 53", ipv6: false, proto: 0x11, srcPort: 53, dstPort: 12345, shouldMatch: true},
+				{desc: "IPv4 UDP dst port 53 only", ipv6: false, proto: 0x11, srcPort: 12345, dstPort: 53, shouldMatch: false},
+			},
+		},
+		{
+			name:            "multiple ports",
+			ports:           []int{53, 5353},
+			collectDNSStats: true,
+			packets: []testPacket{
+				{desc: "IPv4 UDP src port 53", ipv6: false, proto: 0x11, srcPort: 53, dstPort: 12345, shouldMatch: true},
+				{desc: "IPv4 UDP src port 5353", ipv6: false, proto: 0x11, srcPort: 5353, dstPort: 12345, shouldMatch: true},
+				{desc: "IPv4 UDP dst port 53", ipv6: false, proto: 0x11, srcPort: 12345, dstPort: 53, shouldMatch: true},
+				{desc: "IPv4 UDP dst port 5353", ipv6: false, proto: 0x11, srcPort: 12345, dstPort: 5353, shouldMatch: true},
+				{desc: "IPv4 UDP no match", ipv6: false, proto: 0x11, srcPort: 80, dstPort: 8080, shouldMatch: false},
+				{desc: "IPv6 UDP src port 5353", ipv6: true, proto: 0x11, srcPort: 5353, dstPort: 12345, shouldMatch: true},
+				{desc: "IPv4 TCP src port 80", ipv6: false, proto: 0x6, srcPort: 80, dstPort: 12345, shouldMatch: false},
+				{desc: "IPv4 TCP dst port 80", ipv6: false, proto: 0x6, srcPort: 12345, dstPort: 80, shouldMatch: false},
+				{desc: "IPv4 TCP src port 443", ipv6: false, proto: 0x6, srcPort: 80, dstPort: 12345, shouldMatch: false},
+				{desc: "IPv4 TCP dst port 443", ipv6: false, proto: 0x6, srcPort: 12345, dstPort: 80, shouldMatch: false},
+			},
+		},
+		{
+			name:            "custom port 8053",
+			ports:           []int{8053},
+			collectDNSStats: true,
+			packets: []testPacket{
+				{desc: "IPv4 UDP src port 8053", ipv6: false, proto: 0x11, srcPort: 8053, dstPort: 12345, shouldMatch: true},
+				{desc: "IPv4 UDP dst port 8053", ipv6: false, proto: 0x11, srcPort: 12345, dstPort: 8053, shouldMatch: true},
+				{desc: "IPv4 UDP port 53 no match", ipv6: false, proto: 0x11, srcPort: 53, dstPort: 12345, shouldMatch: false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				DNSMonitoringPortList: tt.ports,
+				CollectDNSStats:       tt.collectDNSStats,
+			}
+
+			rawIns, err := generateBPFFilter(cfg)
+			require.NoError(t, err)
+
+			// Convert RawInstruction to Instruction for VM
+			ins := make([]bpf.Instruction, len(rawIns))
+			for i, raw := range rawIns {
+				ins[i] = raw.Disassemble()
+			}
+
+			vm, err := bpf.NewVM(ins)
+			require.NoError(t, err)
+
+			for _, pkt := range tt.packets {
+				packet := buildTestPacket(pkt.ipv6, pkt.proto, pkt.srcPort, pkt.dstPort)
+				result, err := vm.Run(packet)
+				require.NoError(t, err, pkt.desc)
+
+				if pkt.shouldMatch {
+					assert.Greater(t, result, 0, "expected match for: %s", pkt.desc)
+				} else {
+					assert.Equal(t, 0, result, "expected no match for: %s", pkt.desc)
+				}
+			}
+		})
+	}
+}
+
+type testPacket struct {
+	desc        string
+	ipv6        bool
+	proto       uint8 // 0x6=TCP, 0x11=UDP
+	srcPort     uint16
+	dstPort     uint16
+	shouldMatch bool
+}
+
+func buildTestPacket(ipv6 bool, proto uint8, srcPort, dstPort uint16) []byte {
+	if ipv6 {
+		return buildIPv6Packet(proto, srcPort, dstPort)
+	}
+	return buildIPv4Packet(proto, srcPort, dstPort)
+}
+
+func buildIPv4Packet(proto uint8, srcPort, dstPort uint16) []byte {
+	packet := make([]byte, 54) // 14 (eth) + 20 (IP) + 20 (TCP/UDP header space)
+
+	// Ethernet header (14 bytes)
+	// Dst MAC (6) + Src MAC (6) + Ethertype (2)
+	packet[12] = 0x08
+	packet[13] = 0x00 // IPv4
+
+	// IPv4 header (20 bytes, starting at offset 14)
+	packet[14] = 0x45  // version=4, IHL=5 (20 bytes)
+	packet[23] = proto // Protocol (TCP=6, UDP=17)
+	packet[20] = 0     // Fragment offset = 0 (no fragmentation)
+	packet[21] = 0     // Fragment offset (low bits)
+
+	// TCP/UDP ports start at offset 14 + 20 = 34
+	binary.BigEndian.PutUint16(packet[34:36], srcPort)
+	binary.BigEndian.PutUint16(packet[36:38], dstPort)
+
+	return packet
+}
+
+func buildIPv6Packet(proto uint8, srcPort, dstPort uint16) []byte {
+	packet := make([]byte, 74) // 14 (eth) + 40 (IPv6) + 20 (TCP/UDP header space)
+
+	// Ethernet header (14 bytes)
+	packet[12] = 0x86
+	packet[13] = 0xdd // IPv6
+
+	// IPv6 header (40 bytes, starting at offset 14)
+	packet[14] = 0x60  // version=6
+	packet[20] = proto // Next Header (TCP=6, UDP=17)
+
+	// TCP/UDP ports start at offset 14 + 40 = 54
+	binary.BigEndian.PutUint16(packet[54:56], srcPort)
+	binary.BigEndian.PutUint16(packet[56:58], dstPort)
+
+	return packet
+}

--- a/pkg/network/dns/monitor_windows.go
+++ b/pkg/network/dns/monitor_windows.go
@@ -14,7 +14,7 @@ import (
 
 // NewReverseDNS starts snooping on DNS traffic to allow IP -> domain reverse resolution
 func NewReverseDNS(cfg *config.Config, telemetrycomp telemetry.Component) (ReverseDNS, error) {
-	packetSrc, err := newWindowsPacketSource(telemetrycomp)
+	packetSrc, err := newWindowsPacketSource(telemetrycomp, cfg.DNSMonitoringPortList)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/dns/packet_source_windows.go
+++ b/pkg/network/dns/packet_source_windows.go
@@ -27,8 +27,8 @@ type windowsPacketSource struct {
 }
 
 // newWindowsPacketSource constructs a new packet source
-func newWindowsPacketSource(telemetrycomp telemetry.Component) (filter.PacketSource, error) {
-	di, err := newDriver(telemetrycomp)
+func newWindowsPacketSource(telemetrycomp telemetry.Component, dnsMonitoringPorts []int) (filter.PacketSource, error) {
+	di, err := newDriver(telemetrycomp, dnsMonitoringPorts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/dns/parser.go
+++ b/pkg/network/dns/parser.go
@@ -58,7 +58,7 @@ type dnsParser struct {
 	layers             []gopacket.LayerType
 	ipv4Payload        *layers.IPv4
 	ipv6Payload        *layers.IPv6
-	udpPayload         *layers.UDP
+	udpPayload         *udpWithDNSSupport
 	tcpPayload         *tcpWithDNSSupport
 	dnsPayload         *layers.DNS
 	collectDNSStats    bool
@@ -69,7 +69,7 @@ type dnsParser struct {
 func newDNSParser(layerType gopacket.LayerType, cfg *config.Config) *dnsParser {
 	ipv4Payload := &layers.IPv4{}
 	ipv6Payload := &layers.IPv6{}
-	udpPayload := &layers.UDP{}
+	udpPayload := &udpWithDNSSupport{}
 	tcpPayload := &tcpWithDNSSupport{}
 	dnsPayload := &layers.DNS{}
 	queryTypes := getRecordedQueryTypes(cfg)

--- a/pkg/network/dns/udp_dns_layer.go
+++ b/pkg/network/dns/udp_dns_layer.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (windows && npm) || linux_bpf
+
+package dns
+
+import (
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+var _ gopacket.DecodingLayer = &udpWithDNSSupport{}
+
+// udpWithDNSSupport wraps layers.UDP to always decode the payload as DNS,
+// regardless of the port number. This is necessary because gopacket's UDP layer
+// has port-based heuristics that may try to decode port 5353 as mDNS or other
+// protocols instead of standard DNS.
+type udpWithDNSSupport struct {
+	layers.UDP
+}
+
+// NextLayerType always returns LayerTypeDNS to ensure the payload is decoded as DNS
+func (m *udpWithDNSSupport) NextLayerType() gopacket.LayerType {
+	return layers.LayerTypeDNS
+}

--- a/pkg/network/dns_test.go
+++ b/pkg/network/dns_test.go
@@ -1,0 +1,95 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/network/dns"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+func TestDNSKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		c            *ConnectionStats
+		allowedPorts []int
+		expectedKey  dns.Key
+		expectedOk   bool
+	}{
+		{
+			name: "DNS port 53",
+			c: &ConnectionStats{
+				ConnectionTuple: ConnectionTuple{
+					DPort:  53,
+					Source: util.AddressFromString("1.2.3.4"),
+					Dest:   util.AddressFromString("5.6.7.8"),
+					SPort:  12345,
+					Type:   UDP,
+				},
+			},
+			allowedPorts: []int{53},
+			expectedOk:   true,
+		},
+		{
+			name: "Non-DNS port 80",
+			c: &ConnectionStats{
+				ConnectionTuple: ConnectionTuple{
+					DPort:  80,
+					Source: util.AddressFromString("1.2.3.4"),
+					Dest:   util.AddressFromString("5.6.7.8"),
+					SPort:  12345,
+					Type:   TCP,
+				},
+			},
+			allowedPorts: []int{53},
+			expectedOk:   false,
+		},
+		{
+			name: "Custom DNS port 5353",
+			c: &ConnectionStats{
+				ConnectionTuple: ConnectionTuple{
+					DPort:  5353,
+					Source: util.AddressFromString("1.2.3.4"),
+					Dest:   util.AddressFromString("5.6.7.8"),
+					SPort:  12345,
+					Type:   UDP,
+				},
+			},
+			allowedPorts: []int{53, 5353},
+			expectedOk:   true,
+		},
+		{
+			name: "Custom DNS port 5353 not in allowed list",
+			c: &ConnectionStats{
+				ConnectionTuple: ConnectionTuple{
+					DPort:  5353,
+					Source: util.AddressFromString("1.2.3.4"),
+					Dest:   util.AddressFromString("5.6.7.8"),
+					SPort:  12345,
+					Type:   UDP,
+				},
+			},
+			allowedPorts: []int{53},
+			expectedOk:   false,
+		},
+		{
+			name:         "Nil connection",
+			c:            nil,
+			allowedPorts: []int{53},
+			expectedOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := DNSKey(tt.c, tt.allowedPorts)
+			assert.Equal(t, tt.expectedOk, ok)
+		})
+	}
+}

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -590,7 +590,7 @@ func TestNoPriorRegistrationActiveConnections(t *testing.T) {
 func TestCleanupClient(t *testing.T) {
 	clientID := "1"
 
-	state := NewState(nil, 100*time.Millisecond, 50000, 75000, 75000, 7500, 7500, 7500, 7500, false, false)
+	state := NewState(nil, 100*time.Millisecond, 50000, 75000, 75000, 7500, 7500, 7500, 7500, false, false, []int{53})
 	clients := state.(*networkState).getClients()
 	assert.Equal(t, 0, len(clients))
 
@@ -2621,7 +2621,7 @@ func latestEpochTime() uint64 {
 
 func newDefaultState() *networkState {
 	// Using values from ebpf.NewConfig()
-	return NewState(nil, 2*time.Minute, 50000, 75000, 75000, 7500, 7500, 7500, 7500, false, false).(*networkState)
+	return NewState(nil, 2*time.Minute, 50000, 75000, 75000, 7500, 7500, 7500, 7500, false, false, []int{53}).(*networkState)
 }
 
 func getIPProtocol(nt ConnectionType) uint8 {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -242,6 +242,7 @@ func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Compone
 		cfg.MaxRedisStatsBuffered,
 		cfg.EnableNPMConnectionRollup,
 		cfg.EnableProcessEventMonitoring,
+		cfg.DNSMonitoringPortList,
 	)
 
 	return tr, nil

--- a/pkg/network/tracer/tracer_shared.go
+++ b/pkg/network/tracer/tracer_shared.go
@@ -26,7 +26,14 @@ func convertToFilterable(conn *network.ConnectionStats) filter.FilterableConnect
 // shouldSkipConnection returns whether or not the tracer should ignore a given connection:
 //   - Local DNS (*:53) requests if configured (default: true)
 func (t *Tracer) shouldSkipConnection(conn *network.ConnectionStats) bool {
-	isDNSConnection := conn.DPort == 53 || conn.SPort == 53
+	isDNSConnection := false
+	for _, p := range t.config.DNSMonitoringPortList {
+		if conn.DPort == uint16(p) || conn.SPort == uint16(p) {
+			isDNSConnection = true
+			break
+		}
+	}
+
 	if !t.config.CollectLocalDNS && isDNSConnection && conn.Dest.IsLoopback() {
 		return true
 	} else if filter.IsExcludedConnection(t.sourceExcludes, t.destExcludes, convertToFilterable(conn)) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -716,7 +716,7 @@ func (s *TracerSuite) TestShouldExcludeEmptyStatsConnection() {
 
 func TestSkipConnectionDNS(t *testing.T) {
 	t.Run("CollectLocalDNS disabled", func(t *testing.T) {
-		tr := &Tracer{config: &config.Config{CollectLocalDNS: false}}
+		tr := &Tracer{config: &config.Config{CollectLocalDNS: false, DNSMonitoringPortList: []int{53}}}
 		assert.True(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
@@ -743,7 +743,7 @@ func TestSkipConnectionDNS(t *testing.T) {
 	})
 
 	t.Run("CollectLocalDNS disabled", func(t *testing.T) {
-		tr := &Tracer{config: &config.Config{CollectLocalDNS: true}}
+		tr := &Tracer{config: &config.Config{CollectLocalDNS: true, DNSMonitoringPortList: []int{53}}}
 
 		assert.False(t, tr.shouldSkipConnection(&network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 			Source: util.AddressFromString("10.0.0.1"),

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -95,6 +95,7 @@ func NewTracer(config *config.Config, telemetry telemetry.Component, _ statsd.Cl
 		config.MaxRedisStatsBuffered,
 		config.EnableNPMConnectionRollup,
 		config.EnableProcessEventMonitoring,
+		config.DNSMonitoringPortList,
 	)
 
 	reverseDNS := dns.NewNullReverseDNS()

--- a/releasenotes/notes/system-probe-custom-dns-ports-5da60334ffeba187.yaml
+++ b/releasenotes/notes/system-probe-custom-dns-ports-5da60334ffeba187.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added ``network_config.dns_monitoring_ports``, which is a list of DNS ports Cloud Network Monitoring will use to monitor DNS traffic on.


### PR DESCRIPTION
This PR should not be merged, #43756 should be merged instead.
### What does this PR do?
Built on top of [Extend DNS tracing to support a user defined list of ports](https://github.com/DataDog/datadog-agent/pull/43756) with some extra changes:
1. Fixes gopacket parsing of DNS traffic that isn't on port 53
2. Clears the port map before populating it to ensure that if a DNS port is removed from the config, system-probe will stop capturing it
3. Forbids HTTP ports from being added to the list, which would just cause trouble