### PR TITLE
[CSPM] Allow re-enabling compliance module

### DIFF
--- a/cmd/system-probe/modules/compliance_test.go
+++ b/cmd/system-probe/modules/compliance_test.go
@@ -46,7 +46,13 @@ func TestComplianceCheckModuleWithProcess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pid := launchFakeProcess(ctx, t, tmp, "postgres")
+	fakePgConfPath := filepath.Join(tmp, "postgresql.conf")
+	if err := os.WriteFile(fakePgConfPath, []byte(`wal_level = 'logical'`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pid, stop := launchFakeProcess(ctx, t, tmp, "postgres", "--config-file="+fakePgConfPath)
+	defer stop()
 	url := fmt.Sprintf("/dbconfig?pid=%d", pid)
 	statusCode, headers, respBody := doDBConfigRequest(t, url)
 	require.Equal(t, http.StatusOK, statusCode)
@@ -59,31 +65,75 @@ func TestComplianceCheckModuleWithProcess(t *testing.T) {
 	require.Equal(t, types.ResourceTypeDbPostgresql, resource.Type)
 	require.Equal(t, "postgres", resource.Config.ProcessName)
 	require.NotEmpty(t, resource.Config.ProcessUser)
-	require.Equal(t, filepath.Join(tmp, "postgresql.conf"), resource.Config.ConfigFilePath)
+	require.Equal(t, fakePgConfPath, resource.Config.ConfigFilePath)
 	require.NotEmpty(t, resource.Config.ConfigFileUser)
 	require.NotEmpty(t, resource.Config.ConfigFileGroup)
-	require.Equal(t, uint32(0600), resource.Config.ConfigFileMode)
-	require.Equal(t, map[string]interface{}{"foo": "bar"}, resource.Config.ConfigData)
+	require.Equal(t, uint32(0644), resource.Config.ConfigFileMode)
+	require.Equal(t, map[string]interface{}{"wal_level": "logical"}, resource.Config.ConfigData)
 }
 
-func launchFakeProcess(ctx context.Context, t *testing.T, tmp, procname string) int {
-	fakePgBinPath := filepath.Join(tmp, "postgres")
-	fakePgConfPath := filepath.Join(tmp, "postgresql.conf")
-
-	if err := os.WriteFile(fakePgBinPath, []byte("#!/bin/bash\nsleep 10"), 0700); err != nil {
+func launchFakeProcess(ctx context.Context, t *testing.T, tmp, procname string, args ...string) (int, func()) {
+	exe, err := os.Executable()
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(fakePgConfPath, []byte(`foo = 'bar'`), 0600); err != nil {
-		t.Fatal(err)
+	copyBin := func(w io.WriteCloser, r io.ReadCloser) {
+		defer w.Close()
+		defer r.Close()
+		_, err = io.Copy(w, r)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	cmd := exec.CommandContext(ctx, fakePgBinPath, "--config-file="+fakePgConfPath)
+	binPath := filepath.Join(tmp, procname)
+	r, err := os.Open(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w, err := os.OpenFile(binPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	copyBin(w, r)
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pipeR.Close()
+	defer pipeW.Close()
+
+	args = append([]string{"-test.run=TestComplianceCheckModuleLaunchFakeProcess", "--"}, args...)
+	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = pipeW
+	cmd.Env = append([]string{}, os.Environ()...)
+	cmd.Env = append(cmd.Env, "GO_TEST_COMPLIANCE_CHECK_MODULE_FAKE_PROCESS=1")
+
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("could not start fake process %q: %v", procname, err)
+		t.Fatal(err)
 	}
+	var b [16]byte
+	if _, err := pipeR.Read(b[:]); err != nil {
+		t.Fatal(err)
+	}
+	go io.Copy(io.Discard, pipeR)
 
-	return cmd.Process.Pid
+	pid := cmd.Process.Pid
+
+	return pid, func() {
+		cmd.Process.Kill()
+		cmd.Process.Wait()
+	}
+}
+
+func TestComplianceCheckModuleLaunchFakeProcess(t *testing.T) {
+	if os.Getenv("GO_TEST_COMPLIANCE_CHECK_MODULE_FAKE_PROCESS") != "1" {
+		t.Skip()
+	}
+	fmt.Printf("READY") // sending output to signal to caller that the process is properly execed and ready.
+	time.Sleep(1 * time.Minute)
 }
 
 func doDBConfigRequest(t *testing.T, url string) (int, http.Header, []byte) {

--- a/cmd/system-probe/modules/compliance_test.go
+++ b/cmd/system-probe/modules/compliance_test.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package modules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
+	"github.com/DataDog/datadog-agent/pkg/compliance/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComplianceModuleNoProcess(t *testing.T) {
+	{
+		url := "/dbconfig"
+		statusCode, _, respBody := doDBConfigRequest(t, url)
+		require.Contains(t, string(respBody), "pid query parameter is not an integer")
+		require.Equal(t, http.StatusBadRequest, statusCode)
+	}
+
+	{
+		url := "/dbconfig?pid=0"
+		statusCode, _, respBody := doDBConfigRequest(t, url)
+		require.Contains(t, "resource not found for pid=0", string(respBody))
+		require.Equal(t, http.StatusNotFound, statusCode)
+	}
+}
+
+func TestComplianceCheckModuleWithProcess(t *testing.T) {
+	tmp := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pid := launchFakeProcess(ctx, t, tmp, "postgres")
+	url := fmt.Sprintf("/dbconfig?pid=%d", pid)
+	statusCode, headers, respBody := doDBConfigRequest(t, url)
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "application/json", headers.Get("Content-Type"))
+
+	var resource *dbconfig.DBResource
+	if err := json.Unmarshal(respBody, &resource); err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, types.ResourceTypeDbPostgresql, resource.Type)
+	require.Equal(t, "postgres", resource.Config.ProcessName)
+	require.NotEmpty(t, resource.Config.ProcessUser)
+	require.Equal(t, filepath.Join(tmp, "postgresql.conf"), resource.Config.ConfigFilePath)
+	require.NotEmpty(t, resource.Config.ConfigFileUser)
+	require.NotEmpty(t, resource.Config.ConfigFileGroup)
+	require.Equal(t, uint32(0600), resource.Config.ConfigFileMode)
+	require.Equal(t, map[string]interface{}{"foo": "bar"}, resource.Config.ConfigData)
+}
+
+func launchFakeProcess(ctx context.Context, t *testing.T, tmp, procname string) int {
+	fakePgBinPath := filepath.Join(tmp, "postgres")
+	fakePgConfPath := filepath.Join(tmp, "postgresql.conf")
+
+	if err := os.WriteFile(fakePgBinPath, []byte("#!/bin/bash\nsleep 10"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(fakePgConfPath, []byte(`foo = 'bar'`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.CommandContext(ctx, fakePgBinPath, "--config-file="+fakePgConfPath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("could not start fake process %q: %v", procname, err)
+	}
+
+	return cmd.Process.Pid
+}
+
+func doDBConfigRequest(t *testing.T, url string) (int, http.Header, []byte) {
+	rec := httptest.NewRecorder()
+
+	m := &complianceModule{}
+	m.handleScanDBConfig(rec, httptest.NewRequest(http.MethodGet, url, nil))
+
+	response := rec.Result()
+
+	defer response.Body.Close()
+	resBytes, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	return response.StatusCode, response.Header, resBytes
+}

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -69,6 +69,9 @@ func StartCompliance(log log.Component,
 	enabledConfigurationsExporters := []ConfigurationExporter{
 		KubernetesExporter,
 	}
+	if config.GetBool("compliance_config.database_benchmarks.enabled") {
+		enabledConfigurationsExporters = append(enabledConfigurationsExporters, DBExporter)
+	}
 
 	reporter := NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression)
 	telemetrySender := telemetry.NewSimpleTelemetrySenderFromStatsd(statsdClient)

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -142,6 +142,11 @@ func load() (*types.Config, error) {
 		diEnabled {
 		c.EnabledModules[EventMonitorModule] = struct{}{}
 	}
+	complianceEnabled := cfg.GetBool(compNS("enabled")) ||
+		(cfg.GetBool(secNS("enabled")) && cfg.GetBool(secNS("compliance_module.enabled")))
+	if complianceEnabled {
+		c.EnabledModules[ComplianceModule] = struct{}{}
+	}
 	if cfg.GetBool(spNS("process_config.enabled")) {
 		c.EnabledModules[ProcessModule] = struct{}{}
 	}

--- a/pkg/system-probe/config/ns.go
+++ b/pkg/system-probe/config/ns.go
@@ -47,6 +47,11 @@ func evNS(k ...string) string {
 	return NSkey("event_monitoring_config", k...)
 }
 
+// compNS adds `compliance_config` namespace to configuration key
+func compNS(k ...string) string {
+	return NSkey("compliance_config", k...)
+}
+
 // NSkey returns a full key path in the config file by joining the given namespace and the rest of the path fragments
 func NSkey(ns string, pieces ...string) string {
 	return strings.Join(append([]string{ns}, pieces...), ".")


### PR DESCRIPTION
### What does this PR do?

This PR allows re-enabling the compliance module in system-probe (reverting #43889).
The module is still experimental and disabled by default.

### Motivation

In retrospect, disabling the module was not really necessary as both these benchmarks and module were already disabled by default via our configuration.

### Describe how you validated your changes

Tested in staging.

### Additional Notes
