### PR TITLE
Extend `bazel` test scope

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -25,9 +25,6 @@ bazel:test:macos-arm64:
 
 bazel:test:windows-amd64:
   extends: [ .bazel:test, .bazel:runner:windows-amd64 ]
-  rules:
-    - !reference [ .except_skip_windows ]
-    - when: on_success
   variables:
     POWERSHELL_SCRIPT: |-
-      bazel test //bazel/tests/... //rtloader/...
+      bazel test //...


### PR DESCRIPTION
### What does this PR do?
- extend `bazel test` scope in CI from `//bazel/tests/...` to `//...`,
- fix remaining failure after doing so.

### Motivation
1. the `deps/acl/acl.MODULE.bazel` file was out of sync with its generated version (using `url` instead of `urls`), but this inconsistency was not caught: `bazel test //bazel/tests/...` was missing consistency tests in `//deps/**` (addressed by #44750 since),
2. after #44881, was merged, `//pkg/discovery/module/rust:dd_discovery_test`  panicked on `assertion failed: result.is_some()` (addressed by #45140 since),
3. more to come...

### Describe how you validated your changes
CI.

### Additional Notes
We should make sure `bazel test //...` always works, whatever the OS our colleagues are on.