### PR TITLE
fix(installer): Fix uninstall after remote upgrade

### DIFF
--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -8,18 +8,20 @@
 ##########################################################################
 
 INSTALLER_DEB=/opt/datadog-agent/embedded/bin/installer
-INSTALLER_OCI=/opt/datadog-package/datadog-agent/stable/embedded/bin/installer
+INSTALLER_OCI=/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer
+
+# Remove the agent if it was upgraded using the installer
+# Check if INSTALLER_OCI exists and doesn't resolve to the same path as INSTALLER_DEB
+# (accounting for symlinks at any level in the path)
+if [ -f ${INSTALLER_OCI} ] && [ "$(readlink -f ${INSTALLER_OCI})" != "$(readlink -f ${INSTALLER_DEB})" ] && [ "$1" = "remove" ]; then
+    ${INSTALLER_OCI} remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
+fi
 
 # Run the postinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
 if [ -f ${INSTALLER_DEB} ] && [ "$1" = "remove" ]; then
     ${INSTALLER_DEB} prerm datadog-agent deb || true
 elif [ -f ${INSTALLER_DEB} ] && [ "$1" = "upgrade" ]; then
     ${INSTALLER_DEB} prerm --upgrade datadog-agent deb || true
-fi
-
-# Remove the agent if it was upgraded using the installer
-if [ -f ${INSTALLER_OCI} ] && [ "$1" = "remove" ]; then
-    ${INSTALLER_OCI} remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
 fi
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -11,7 +11,7 @@ INSTALLER_DEB=/opt/datadog-agent/embedded/bin/installer
 INSTALLER_OCI=/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer
 
 # Remove the agent if it was upgraded using the installer
-if [ -f ${INSTALLER_OCI} ] && [ "$(readlink -f ${INSTALLER_OCI})" != "$(readlink -f ${INSTALLER_DEB})" ] && [ "$1" = "remove" ]; then
+if [ -f ${INSTALLER_OCI} ] && [ "$(readlink -f ${INSTALLER_OCI})" != "$(readlink -f ${INSTALLER_DEB})" ] && [ "$*" = "0" ]; then
     ${INSTALLER_OCI} remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
 fi
 

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -8,17 +8,17 @@
 ##########################################################################
 
 INSTALLER_DEB=/opt/datadog-agent/embedded/bin/installer
-INSTALLER_OCI=/opt/datadog-package/datadog-agent/stable/embedded/bin/installer
+INSTALLER_OCI=/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer
+
+# Remove the agent if it was upgraded using the installer
+if [ -f ${INSTALLER_OCI} ] && [ "$(readlink -f ${INSTALLER_OCI})" != "$(readlink -f ${INSTALLER_DEB})" ] && [ "$1" = "remove" ]; then
+    ${INSTALLER_OCI} remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
+fi
 
 # Run the uninstall prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
 # Note: the upgrade prerm is handled in the preinst script of the new package on rpm.
 if [ -f ${INSTALLER_DEB} ] && [ "$*" = "0" ]; then
     ${INSTALLER_DEB} prerm datadog-agent rpm || true
-fi
-
-# Remove the agent if it was upgraded using the installer
-if [ -f ${INSTALLER_OCI} ] && [ "$*" = "0" ]; then
-    ${INSTALLER_OCI} remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
 fi
 
 exit 0

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -42,7 +42,6 @@ var (
 		// e2eos.FedoraDefault, // Skipped instead of marked as flaky to avoid useless logs
 		e2eos.CentOS7,
 		e2eos.Suse15,
-		e2eos.WindowsServer2022,
 	}
 	arm64Flavors = []e2eos.Descriptor{
 		e2eos.Ubuntu2404,
@@ -50,10 +49,10 @@ var (
 		e2eos.Suse15,
 	}
 	packagesTestsWithSkippedFlavors = []packageTestsWithSkippedFlavors{
-		{t: testAgent, skippedFlavors: []e2eos.Descriptor{e2eos.WindowsServer2022}},
-		{t: testDDOT, skippedFlavors: []e2eos.Descriptor{e2eos.WindowsServer2022}, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
-		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.FedoraDefault, e2eos.AmazonLinux2, e2eos.WindowsServer2022}},
-		{t: testUpgradeScenario, skippedFlavors: []e2eos.Descriptor{e2eos.WindowsServer2022}},
+		{t: testAgent},
+		{t: testDDOT, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
+		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.FedoraDefault, e2eos.AmazonLinux2}},
+		{t: testUpgradeScenario},
 	}
 )
 

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
@@ -333,6 +334,58 @@ func (s *upgradeScenarioSuite) TestRemoteInstallUninstall() {
 	state := s.host.State()
 	state.AssertPathDoesNotExist("/opt/datadog-packages/datadog-apm-inject")
 
+}
+
+func (s *upgradeScenarioSuite) TestUpgradeAndUninstall() {
+	// 1. Install with remote updates enabled
+	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+	s.host.WaitForUnitActive(s.T(),
+		"datadog-agent.service",
+		"datadog-agent-trace.service",
+		"datadog-agent-installer.service",
+	)
+	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
+
+	// 2. Perform remote upgrade (experiment + promote)
+	s.setCatalog(s.testCatalog())
+	s.executeAgentGoldenPath()
+
+	// 3. Uninstall/purge the agent and installer
+	pkgManager := s.host.GetPkgManager()
+	if pkgManager == "apt" {
+		// Use purge for Debian-based systems
+		s.Env().RemoteHost.MustExecute("sudo apt-get purge -y --purge datadog-agent")
+	} else if pkgManager == "yum" {
+		// Use remove for RedHat-based systems
+		s.Env().RemoteHost.MustExecute("sudo yum remove -y datadog-agent")
+	} else if pkgManager == "zypper" {
+		// Use remove for SUSE-based systems
+		s.Env().RemoteHost.MustExecute("sudo zypper remove -y datadog-agent")
+	}
+
+	// 4. Verify no leftover files exist
+	state := s.host.State()
+	state.AssertPathDoesNotExist("/opt/datadog-agent")
+
+	// Check that /opt/datadog-packages is either fully removed or only contains packages.db
+	packagesDbPath := "/opt/datadog-packages/packages.db"
+	datadogPackagesPath := "/opt/datadog-packages"
+
+	// Get the contents of /opt/datadog-packages if it exists
+	output, err := s.Env().RemoteHost.Execute("sudo ls -la " + datadogPackagesPath + " 2>/dev/null || echo 'DIR_DOES_NOT_EXIST'")
+	if err == nil && !strings.Contains(output, "DIR_DOES_NOT_EXIST") {
+		// Directory exists, check its contents
+		files, err := s.Env().RemoteHost.Execute("sudo find " + datadogPackagesPath + " -mindepth 1 -not -path " + packagesDbPath)
+		require.NoError(s.T(), err, "Failed to list files in /opt/datadog-packages")
+
+		// Only packages.db should remain (if anything)
+		filesOutput := strings.TrimSpace(files)
+		if filesOutput != "" {
+			s.T().Errorf("Unexpected leftover files in /opt/datadog-packages:\n%s", filesOutput)
+		}
+	}
+	// If directory doesn't exist at all, that's fine too
 }
 
 func (s *upgradeScenarioSuite) installPackage(pkg packageName, version string) (string, error) {


### PR DESCRIPTION
### What does this PR do?
After a remote upgrade on Linux a few things happen:
- `/opt/datadog-agent` is removed to avoid having two installations on disk
- The new Agent lives under `/opt/datadog-packages` (notice the plural)
- Some files are created but not tracked by the deb / rpm, especially under `/opt/datadog-packages/run`

This means that calling the `prerm` from the installer under `/opt/datadog-agent` doesn't work anymore and files are left on disk. Additionally, the new files are not deleted but are owned by `dd-agent`, user which is deleted on a `purge`. These files become ownerless, and a subsequent reinstallation may create the user again with a different ID, causing ownership issues and breaking remote upgrades.

This PR fixes it by:
- Fixing the `/opt/datadog-packages/datadog-agent/stable` path to call the OCI installer if and only if it's not the same file as the deb installer (e.g. before the first remote upgrade)
  - This makes sure the Agent OCI doesn't remain installed as it is the case today
- Removing the additional files during the Agent's `prerm`
  - This fixes the aforementioned ownership issues on reinstallation

### Motivation
Fixing issues with uninstallation / reinstallation after a remote upgrade

### Describe how you validated your changes
Manual QA, new E2E test.

### Additional Notes
- Calling `remove` on an OCI does call `prerm` under the hood