### PR TITLE
Re-enable RAR with reservations

### DIFF
--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -81,14 +81,6 @@ func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetry
 	// Disable telemetry collection temporarily, as it triggers a memory usage quality gate.
 	prometheusText := ""
 
-	// prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
-	// // Add here the metric names that should be included in the telemetry response.
-	// // This is useful to avoid sending too many metrics to the Core Agent.
-	// ))
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	return &pbcore.GetTelemetryResponse{
 		Payload: &pbcore.GetTelemetryResponse_PromText{
 			PromText: prometheusText,

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -78,13 +78,16 @@ type remoteagentImpl struct {
 }
 
 func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetryRequest) (*pbcore.GetTelemetryResponse, error) {
-	prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
-	// Add here the metric names that should be included in the telemetry response.
-	// This is useful to avoid sending too many metrics to the Core Agent.
-	))
-	if err != nil {
-		return nil, err
-	}
+	// Disable telemetry collection temporarily, as it triggers a memory usage quality gate.
+	prometheusText := ""
+
+	// prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
+	// // Add here the metric names that should be included in the telemetry response.
+	// // This is useful to avoid sending too many metrics to the Core Agent.
+	// ))
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	return &pbcore.GetTelemetryResponse{
 		Payload: &pbcore.GetTelemetryResponse_PromText{

--- a/comp/core/remoteagent/impl-trace/remoteagent.go
+++ b/comp/core/remoteagent/impl-trace/remoteagent.go
@@ -81,14 +81,6 @@ func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetry
 	// Disable telemetry collection temporarily, as it triggers a memory usage quality gate.
 	prometheusText := ""
 
-	// prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
-	// // Add here the metric names that should be included in the telemetry response.
-	// // This is useful to avoid sending too many metrics to the Core Agent.
-	// ))
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	return &pbcore.GetTelemetryResponse{
 		Payload: &pbcore.GetTelemetryResponse_PromText{
 			PromText: prometheusText,

--- a/comp/core/remoteagent/impl-trace/remoteagent.go
+++ b/comp/core/remoteagent/impl-trace/remoteagent.go
@@ -78,13 +78,16 @@ type remoteagentImpl struct {
 }
 
 func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetryRequest) (*pbcore.GetTelemetryResponse, error) {
-	prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
-	// Add here the metric names that should be included in the telemetry response.
-	// This is useful to avoid sending too many metrics to the Core Agent.
-	))
-	if err != nil {
-		return nil, err
-	}
+	// Disable telemetry collection temporarily, as it triggers a memory usage quality gate.
+	prometheusText := ""
+
+	// prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
+	// // Add here the metric names that should be included in the telemetry response.
+	// // This is useful to avoid sending too many metrics to the Core Agent.
+	// ))
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	return &pbcore.GetTelemetryResponse{
 		Payload: &pbcore.GetTelemetryResponse_PromText{

--- a/comp/core/remoteagentregistry/impl/registry_test.go
+++ b/comp/core/remoteagentregistry/impl/registry_test.go
@@ -112,6 +112,9 @@ func TestDisabled(t *testing.T) {
 func buildComponent(t *testing.T) (Provides, *compdef.TestLifecycle, config.Component, telemetry.Component, ipc.Component) {
 	config := configmock.New(t)
 
+	// enable the remote agent registry
+	config.SetWithoutSource("remote_agent_registry.enabled", true)
+
 	provides, lc, telemetry, ipc := buildComponentWithConfig(t, config)
 	return provides, lc, config, telemetry, ipc
 }

--- a/comp/core/remoteagentregistry/impl/registry_test.go
+++ b/comp/core/remoteagentregistry/impl/registry_test.go
@@ -112,9 +112,6 @@ func TestDisabled(t *testing.T) {
 func buildComponent(t *testing.T) (Provides, *compdef.TestLifecycle, config.Component, telemetry.Component, ipc.Component) {
 	config := configmock.New(t)
 
-	// enable the remote agent registry
-	config.SetWithoutSource("remote_agent_registry.enabled", true)
-
 	provides, lc, telemetry, ipc := buildComponentWithConfig(t, config)
 	return provides, lc, config, telemetry, ipc
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1215,7 +1215,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.rate_limiter.recovery_interval", time.Duration(0))
 
 	// Remote agents
-	config.BindEnvAndSetDefault("remote_agent_registry.enabled", false)
+	config.BindEnvAndSetDefault("remote_agent_registry.enabled", true)
 	config.BindEnvAndSetDefault("remote_agent_registry.idle_timeout", time.Duration(30*time.Second))
 	config.BindEnvAndSetDefault("remote_agent_registry.query_timeout", time.Duration(3*time.Second))
 	config.BindEnvAndSetDefault("remote_agent_registry.recommended_refresh_interval", time.Duration(10*time.Second))


### PR DESCRIPTION

### What does this PR do?
This PR basically reverts https://github.com/DataDog/datadog-agent/pull/43804, and thus re-enables the Remote Agent Registry (RAR) globally, with 2 reservations.
The RAR was disabled due to an increase in memory usage when agents are idle. Two agents are especially impacted: `system-probe` and `trace-agent`. For these 2 processes, RAR is re-enabled with an no-op `GetTelemetry`, which seems to be the cause of higher memory usage.

### Motivation
Restore RAR globally, while buying some time to investigate the issue further.

### Describe how you validated your changes
Tested under `idle` load generated by `lading` and PSS monitoring.

### Additional Notes