### PR TITLE
[CWS] force re-adjustment of the config during functional tests

### DIFF
--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -868,6 +868,12 @@ func genTestConfigs(t testing.TB, cfgDir string, opts testOpts) (*emconfig.Confi
 		return nil, nil, fmt.Errorf("unable to set up datadog.yaml configuration: %s", err)
 	}
 
+	// reset the system-probe config to not be adjusted yet
+	// necessary because the config object is a global, and we want the adjustment
+	// to happen again
+	cfg := pkgconfigsetup.GlobalSystemProbeConfigBuilder()
+	cfg.Set("system_probe_config.adjusted", false, pkgconfigmodel.SourceAgentRuntime)
+
 	_, err = spconfig.New(sysprobeConfigName, "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load config: %w", err)

--- a/pkg/system-probe/config/adjust_security.go
+++ b/pkg/system-probe/config/adjust_security.go
@@ -31,12 +31,12 @@ func adjustSecurity(cfg model.Config) {
 	if cfg.GetBool(secNS("enabled")) {
 		// if runtime is enabled then we enable fim as well (except if force disabled)
 		if runtime.GOOS != "windows" || !cfg.IsConfigured(secNS("fim_enabled")) {
-			cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
+			cfg.Set(secNS("fim_enabled"), true, model.SourceDefault)
 		}
 	} else {
 		// if runtime is disabled then we force disable activity dumps and security profiles
-		cfg.Set(secNS("activity_dump.enabled"), false, model.SourceAgentRuntime)
-		cfg.Set(secNS("security_profile.enabled"), false, model.SourceAgentRuntime)
+		cfg.Set(secNS("activity_dump.enabled"), false, model.SourceDefault)
+		cfg.Set(secNS("security_profile.enabled"), false, model.SourceDefault)
 	}
 
 	// further adjustments done in RuntimeSecurityConfig.sanitize


### PR DESCRIPTION
### What does this PR do?

When we reload the config in tests, we actually want to re-adjust the config, for example to ensure `fim_enabled` is set to true when `enabled` is true as well.

This is an issue today if you first run a test that runs with CWS disabled (for example `TestEventMonitor`), all followup tests won't have access to fim event types (because the config has been adjusted with CWS disabled).

To do that, we set `system_probe_config.adjusted` to false before re-loading the config.

### Motivation

### Describe how you validated your changes

### Additional Notes
