### PR TITLE
ci: fix unbound variable in retry.sh

### DIFF
--- a/tools/ci/retry.sh
+++ b/tools/ci/retry.sh
@@ -18,7 +18,7 @@ fi
 for i in $(seq 1 $((NB_ATTEMPTS - 1))); do
     "$@" && exit 0
     exitCode=$?
-    if [ ! -z "$NO_RETRY_EXIT_CODE" ] && [ "$exitCode" = "$NO_RETRY_EXIT_CODE" ]; then
+    if [ -n "${NO_RETRY_EXIT_CODE-}" ] && [ "$exitCode" = "$NO_RETRY_EXIT_CODE" ]; then
         >&2 echo "Attempt #$i/$NB_ATTEMPTS failed with error code $exitCode, but not retrying since NO_RETRY_EXIT_CODE is set to $NO_RETRY_EXIT_CODE"
         exit $exitCode
     fi


### PR DESCRIPTION
### What does this PR do?

Fixes an unbound bash variable in the retry.sh script.

### Motivation

Fix the script

### Describe how you validated your changes

Ran the script locally wihtout the env var defined to ensure it works.

### Additional Notes
