### PR TITLE
deps: xz: simplify BUILD file

### DIFF
--- a/deps/xz.BUILD.bazel
+++ b/deps/xz.BUILD.bazel
@@ -31,7 +31,7 @@ license(
 )
 
 copy_file(
-    name = "copy_config",
+    name = "copy_config_h",
     src = selects.with_or({
         "@//:linux_arm64": "config.lzma-linux-arm64.h",
         "@//:linux_x86_64": "config.lzma-linux-x86_64.h",
@@ -39,7 +39,7 @@ copy_file(
         "@//:macos_x86_64": "config.lzma-osx-x86_64.h",
         "@platforms//os:windows": "config.lzma-windows.h",
     }),
-    out = "src/liblzma/api/config.h",  # minimize the number of exported include paths
+    out = "config.h",
 )
 
 _MAIN_HEADER = ["src/liblzma/api/lzma.h"]
@@ -53,6 +53,9 @@ cc_library(
     srcs = [
         "src/common/tuklib_cpucores.c",
         "src/common/tuklib_physmem.c",
+        "src/common/tuklib_exit.c",
+        "src/common/tuklib_progname.c",
+        ":copy_config_h",
     ] + glob(
         [
             "src/**/*.h",
@@ -74,6 +77,8 @@ cc_library(
     }),
     local_defines = [
         "TUKLIB_SYMBOL_PREFIX=lzma_",
+        "TUKLIB_GETTEXT=0",
+        "HAVE_CONFIG_H",
     ],
     linkopts = select({
         "@platforms//os:android": [],
@@ -85,94 +90,17 @@ cc_library(
     }),
     strip_include_prefix = "src/liblzma/api",  # Allows public header without the path and without COPTS -I or includes = []
     visibility = ["//visibility:public"],
-    deps = [
-        "//:lzma_src_common",
-        "//:lzma_src_liblzma",
-        "//:lzma_src_liblzma_api",
-        "//:lzma_src_liblzma_check",
-        "//:lzma_src_liblzma_common",
-        "//:lzma_src_liblzma_delta",
-        "//:lzma_src_liblzma_lz",
-        "//:lzma_src_liblzma_lzma",
-        "//:lzma_src_liblzma_rangecoder",
-        "//:lzma_src_liblzma_simpler",
-    ],
-)
-
-cc_library(
-    name = "lzma_src_common",
-    srcs = [
-        "src/common/tuklib_exit.c",
-        "src/common/tuklib_progname.c",
-    ],
-    hdrs = glob(["src/common/*.h"]),
-    defines = ["HAVE_CONFIG_H"] + select({
-        "@platforms//os:windows": [
-            "LZMA_API_STATIC",
-            "TUKLIB_GETTEXT=0",  # Disable libintl for windows
-        ],
-        "//conditions:default": [],
-    }),
-    strip_include_prefix = "src/common",
-    deps = [
-        "//:lzma_src_liblzma_api",
-    ],
-)
-
-cc_library(
-    name = "lzma_src_liblzma",
-    strip_include_prefix = "src/liblzma",
-)
-
-cc_library(
-    name = "lzma_src_liblzma_api",
-    hdrs = [
-        "src/liblzma/api/config.h",  # Generated above, so missed by glob. In srcs so it's not public like the other headers
-    ] + _API_HEADERS,
-    strip_include_prefix = "src/liblzma/api",
-)
-
-cc_library(
-    name = "lzma_src_liblzma_check",
-    hdrs = glob(["src/liblzma/check/*.h"]),
-    strip_include_prefix = "src/liblzma/check",
-)
-
-cc_library(
-    name = "lzma_src_liblzma_common",
-    hdrs = glob(["src/liblzma/common/*.h"]),
-    includes = ["src/liblzma"],  # Needed as well as some usages use common/*.h instead of just the header
-    strip_include_prefix = "src/liblzma/common",
-)
-
-cc_library(
-    name = "lzma_src_liblzma_delta",
-    hdrs = glob(["src/liblzma/delta/*.h"]),
-    strip_include_prefix = "src/liblzma/delta",
-)
-
-cc_library(
-    name = "lzma_src_liblzma_lz",
-    hdrs = glob(["src/liblzma/lz/*.h"]),
-    strip_include_prefix = "src/liblzma/lz",
-)
-
-cc_library(
-    name = "lzma_src_liblzma_lzma",
-    hdrs = glob(["src/liblzma/lzma/*.h"]),
-    strip_include_prefix = "src/liblzma/lzma",
-)
-
-cc_library(
-    name = "lzma_src_liblzma_rangecoder",
-    hdrs = glob(["src/liblzma/rangecoder/*.h"]),
-    strip_include_prefix = "src/liblzma/rangecoder",
-)
-
-cc_library(
-    name = "lzma_src_liblzma_simpler",
-    hdrs = glob(["src/liblzma/simple/*.h"]),
-    strip_include_prefix = "src/liblzma/simple",
+    includes = [
+        ".",
+        "src/common",
+        "src/liblzma/common",
+        "src/liblzma/check",
+        "src/liblzma/lzma",
+        "src/liblzma/lz",
+        "src/liblzma/simple",
+        "src/liblzma/delta",
+        "src/liblzma/rangecoder",
+    ]
 )
 
 cc_shared_library(


### PR DESCRIPTION
### What does this PR do?

Simplify liblzma's BUILD file by switching to a single cc_library and stop exposing `config.h` publicly

### Motivation

Exposing config.h through `hdrs`  will make it available for the libraries depending on xz which causes conflicts with their own config.h

### Describe how you validated your changes

Local builds in a WIP openscap branch

### Additional Notes

There might be better ways to achieve this, I'm open to alternatives :) 
What matters is that the config file stays in sources rather that `hdrs`
