### PR TITLE
fix(assign): Add correct file path to check slack channels

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -199,7 +199,7 @@ jobs:
               echo "team=unknown" >> $GITHUB_OUTPUT
             fi
             SLACK=$(grep SLACK claude.txt | cut -d ':' -f2)
-            if grep -q "$SLACK" github_slack_map.yaml; then
+            if grep -q "$SLACK" tasks/libs/pipeline/github_slack_map.yaml || grep -q "$SLACK" tasks/libs/pipeline/github_slack_review_map.yaml; then
               # We validate the slack channel against the github_slack_map.yaml file
               echo "slack=$SLACK" >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
### What does this PR do?
Use the correct file path of the `github_slack` maps. And test against the 2 maps for safety

### Motivation
Prevent workflow [issue](https://github.com/DataDog/datadog-agent/actions/runs/20372770033/job/58543286686) in sending message
<img width="713" height="162" alt="image" src="https://github.com/user-attachments/assets/d709b3bc-b45e-4484-88be-37d2b75fdaa6" />

### Describe how you validated your changes
n/a

### Additional Notes
