### PR TITLE
[ACTP-1050] par enrollment support

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -69,6 +69,8 @@ func NewComponent(reqs Requires) (Provides, error) {
 			return Provides{}, fmt.Errorf("self-enrollment failed: %w", err)
 		}
 		cfg = updatedCfg
+	} else if cfg.IdentityIsIncomplete() {
+		return Provides{}, fmt.Errorf("identity not found and self-enrollment disabled. Please provide a valid URN and private key")
 	}
 
 	keysManager := remoteconfig.New(reqs.RcClient)

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -122,12 +122,12 @@ func performSelfEnrollment(log log.Component, ddConfig config.Component, cfg *pa
 	cfg.Urn = enrollmentResult.URN
 	cfg.PrivateKey = enrollmentResult.PrivateKey
 
-	_, orgID, runnerID, err := util.ParseRunnerURN(enrollmentResult.URN)
+	urnParts, err := util.ParseRunnerURN(enrollmentResult.URN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse enrollment URN: %w", err)
 	}
-	cfg.OrgId = orgID
-	cfg.RunnerId = runnerID
+	cfg.OrgId = urnParts.OrgID
+	cfg.RunnerId = urnParts.RunnerID
 
 	return cfg, nil
 }

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -8,6 +8,7 @@ package privateactionrunnerimpl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -70,7 +71,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		}
 		cfg = updatedCfg
 	} else if cfg.IdentityIsIncomplete() {
-		return Provides{}, fmt.Errorf("identity not found and self-enrollment disabled. Please provide a valid URN and private key")
+		return Provides{}, errors.New("identity not found and self-enrollment disabled. Please provide a valid URN and private key")
 	}
 
 	keysManager := remoteconfig.New(reqs.RcClient)

--- a/go.mod
+++ b/go.mod
@@ -502,7 +502,7 @@ require (
 	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect
-	github.com/DataDog/jsonapi v0.12.0 // indirect
+	github.com/DataDog/jsonapi v0.12.0
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f // indirect
 	github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7 // indirect

--- a/pkg/privateactionrunner/adapters/config/config_adapter.go
+++ b/pkg/privateactionrunner/adapters/config/config_adapter.go
@@ -102,3 +102,7 @@ func (c *Config) IsURLInAllowlist(urlStr string) bool {
 
 	return false
 }
+
+func (c *Config) IdentityIsIncomplete() bool {
+	return c.Urn == "" || c.PrivateKey == nil
+}

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -53,9 +53,16 @@ func FromDDConfig(config config.Component) (*Config, error) {
 		privateKey = jwk.Key.(*ecdsa.PrivateKey)
 	}
 
-	urnParts, err := util.ParseRunnerURN(urn)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URN: %w", err)
+	var orgID int64
+	var runnerID string
+	// allow empty urn for self-enrollment
+	if urn != "" {
+		urnParts, err := util.ParseRunnerURN(urn)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse URN: %w", err)
+		}
+		orgID = urnParts.OrgID
+		runnerID = urnParts.RunnerID
 	}
 
 	return &Config{
@@ -82,9 +89,9 @@ func FromDDConfig(config config.Component) (*Config, error) {
 		AllowIMDSEndpoint:         config.GetBool("privateactionrunner.allow_imds_endpoint"),
 		DDHost:                    strings.Join([]string{"api", ddSite}, "."),
 		Modes:                     []modes.Mode{modes.ModePull},
-		OrgId:                     urnParts.OrgID,
+		OrgId:                     orgID,
 		PrivateKey:                privateKey,
-		RunnerId:                  urnParts.RunnerID,
+		RunnerId:                  runnerID,
 		Urn:                       urn,
 		DatadogSite:               ddSite,
 	}, nil

--- a/pkg/privateactionrunner/adapters/regions/regions.go
+++ b/pkg/privateactionrunner/adapters/regions/regions.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package regions
+
+import "strings"
+
+func GetRegionFromDDSite(ddSite string) string {
+	if ddSite == "datadoghq.eu" {
+		return "eu1"
+	}
+	if strings.HasSuffix(ddSite, ".datadoghq.com") {
+		region := strings.TrimSuffix(ddSite, ".datadoghq.com")
+		return region
+	}
+	return "us1"
+}

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package enrollment
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+)
+
+// Result contains the result of a successful enrollment
+type Result struct {
+	PrivateKey *ecdsa.PrivateKey
+	URN        string
+}
+
+// SelfEnroll performs self-registration of a private action runner using API credentials
+func SelfEnroll(ddSite, runnerName, apiKey, appKey string) (*Result, error) {
+	privateJwk, publicJwk, err := util.GenerateKeys()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+
+	ddBaseURL := "https://api." + ddSite
+	publicClient := opms.NewPublicClient(ddBaseURL)
+
+	ctx := context.Background()
+	runnerModes := []modes.Mode{modes.ModePull}
+	runnerHost := ""
+
+	createRunnerResponse, err := publicClient.EnrollWithApiKey(
+		ctx,
+		apiKey,
+		appKey,
+		runnerName,
+		runnerModes,
+		runnerHost,
+		publicJwk,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("enrollment API call failed: %w", err)
+	}
+
+	region := "us1" // TODO
+	urn := util.MakeRunnerURN(region, createRunnerResponse.OrgID, createRunnerResponse.RunnerID)
+
+	return &Result{
+		PrivateKey: privateJwk.Key.(*ecdsa.PrivateKey),
+		URN:        urn,
+	}, nil
+}

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/regions"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 )
@@ -33,7 +34,6 @@ func SelfEnroll(ddSite, runnerName, apiKey, appKey string) (*Result, error) {
 
 	ctx := context.Background()
 	runnerModes := []modes.Mode{modes.ModePull}
-	runnerHost := ""
 
 	createRunnerResponse, err := publicClient.EnrollWithApiKey(
 		ctx,
@@ -41,14 +41,13 @@ func SelfEnroll(ddSite, runnerName, apiKey, appKey string) (*Result, error) {
 		appKey,
 		runnerName,
 		runnerModes,
-		runnerHost,
 		publicJwk,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)
 	}
 
-	region := "us1" // TODO
+	region := regions.GetRegionFromDDSite(ddSite)
 	urn := util.MakeRunnerURN(region, createRunnerResponse.OrgID, createRunnerResponse.RunnerID)
 
 	return &Result{

--- a/pkg/privateactionrunner/libs/par/opms_api.go
+++ b/pkg/privateactionrunner/libs/par/opms_api.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
 package par
 
 import (

--- a/pkg/privateactionrunner/libs/par/opms_api.go
+++ b/pkg/privateactionrunner/libs/par/opms_api.go
@@ -18,10 +18,6 @@ type CreateRunnerRequest struct {
 	PublicKeyPEM string       `json:"public_key_pem" jsonapi:"attribute" validate:"required"`
 }
 
-func (req *CreateRunnerRequest) UnmarshalID(id string) error {
-	return nil
-}
-
 // CreateRunnerResponse represents the response for runner creation
 type CreateRunnerResponse struct {
 	ID          string   `jsonapi:"primary,createRunnerResponse"`

--- a/pkg/privateactionrunner/libs/par/opms_api.go
+++ b/pkg/privateactionrunner/libs/par/opms_api.go
@@ -1,0 +1,26 @@
+package par
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
+)
+
+// CreateRunnerRequest represents the request to create a runner with API key auth
+type CreateRunnerRequest struct {
+	ID           string       `jsonapi:"primary,createRunnerRequest"`
+	RunnerName   string       `json:"runner_name" jsonapi:"attribute" validate:"required"`
+	RunnerModes  []modes.Mode `json:"runner_modes" jsonapi:"attribute" validate:"gt=0,max=2,dive"`
+	RunnerHost   string       `json:"runner_host" jsonapi:"attribute" validate:"omitempty,hostname"`
+	PublicKeyPEM string       `json:"public_key_pem" jsonapi:"attribute" validate:"required"`
+}
+
+func (req *CreateRunnerRequest) UnmarshalID(id string) error {
+	return nil
+}
+
+// CreateRunnerResponse represents the response for runner creation
+type CreateRunnerResponse struct {
+	ID          string   `jsonapi:"primary,createRunnerResponse"`
+	RunnerID    string   `json:"runner_id" jsonapi:"attribute"`
+	OrgID       int64    `json:"org_id" jsonapi:"attribute"`
+	RunnerModes []string `json:"runner_modes" jsonapi:"attribute"`
+}

--- a/pkg/privateactionrunner/opms/public_opms.go
+++ b/pkg/privateactionrunner/opms/public_opms.go
@@ -94,17 +94,17 @@ func (p *publicClient) EnrollWithApiKey(ctx context.Context, apiKey string, appK
 	if err != nil {
 		return nil, fmt.Errorf("failed to send runner creation request: %w", err)
 	}
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			log.Error("error closing runner creation response body", log.ErrorField(err))
+		}
+	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and failed to read HTTP response with error %w", resp.StatusCode, err)
 	}
-	defer func() {
-		err = req.Body.Close()
-		if err != nil {
-			log.Error("error closing runner creation response body", log.ErrorField(err))
-		}
-	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and response %s", resp.StatusCode, string(respBody))

--- a/pkg/privateactionrunner/opms/public_opms.go
+++ b/pkg/privateactionrunner/opms/public_opms.go
@@ -99,6 +99,12 @@ func (p *publicClient) EnrollWithApiKey(ctx context.Context, apiKey string, appK
 	if err != nil {
 		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and failed to read HTTP response with error %w", resp.StatusCode, err)
 	}
+	defer func() {
+		err = req.Body.Close()
+		if err != nil {
+			log.Error("error closing runner creation response body", log.ErrorField(err))
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and response %s", resp.StatusCode, string(respBody))

--- a/pkg/privateactionrunner/opms/public_opms.go
+++ b/pkg/privateactionrunner/opms/public_opms.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package opms
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
+	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/parversion"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/par"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+	"github.com/DataDog/jsonapi"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/google/uuid"
+)
+
+const (
+	createPARPath = "/api/unstable/on_prem_runners"
+)
+
+// PublicClient exposes endpoint that don't require JWT authentication
+type PublicClient interface {
+	EnrollWithApiKey(ctx context.Context, apiKey string, appKey string, runnerName string, runnerModes []modes.Mode, runnerHost string, publicJwk *jose.JSONWebKey) (*par.CreateRunnerResponse, error)
+}
+
+type publicClient struct {
+	ddBaseURL  string
+	httpClient *http.Client
+}
+
+func NewPublicClient(ddBaseURL string) PublicClient {
+	return &publicClient{
+		ddBaseURL: ddBaseURL,
+		httpClient: &http.Client{
+			Timeout: time.Millisecond * time.Duration(30_000),
+		},
+	}
+}
+
+func (p *publicClient) EnrollWithApiKey(ctx context.Context, apiKey string, appKey string, runnerName string, runnerModes []modes.Mode, runnerHost string, publicJwk *jose.JSONWebKey) (*par.CreateRunnerResponse, error) {
+	publicKeyPEM, err := util.JWKToPEM(publicJwk)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert public key to PEM: %w", err)
+	}
+
+	createRunnerUrl := url.URL{
+		Host:   strings.Replace(p.ddBaseURL, "https://", "", 1),
+		Scheme: "https",
+		Path:   createPARPath,
+	}
+
+	request := par.CreateRunnerRequest{
+		ID:           uuid.New().String(),
+		RunnerName:   runnerName,
+		RunnerModes:  runnerModes,
+		RunnerHost:   runnerHost,
+		PublicKeyPEM: publicKeyPEM,
+	}
+
+	requestBodyJSON, err := jsonapi.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", createRunnerUrl.String(), strings.NewReader(string(requestBodyJSON)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build runner creation request: %w", err)
+	}
+	defer func() {
+		err = req.Body.Close()
+		if err != nil {
+			log.Error("error closing runner creation response body", log.ErrorField(err))
+		}
+	}()
+
+	req.Header.Set("Content-Type", "application/vnd.api+json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("DD-API-KEY", apiKey)
+	req.Header.Set("DD-APPLICATION-KEY", appKey)
+	req.Header.Set(app.VersionHeaderName, parversion.RunnerVersion)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send runner creation request: %w", err)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and failed to read HTTP response with error %w", resp.StatusCode, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and response %s", resp.StatusCode, string(respBody))
+	}
+
+	createRunnerResponse := new(par.CreateRunnerResponse)
+	err = jsonapi.Unmarshal(respBody, createRunnerResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal runner creation response: %w", err)
+	}
+	return createRunnerResponse, nil
+}

--- a/pkg/privateactionrunner/util/jwt.go
+++ b/pkg/privateactionrunner/util/jwt.go
@@ -8,8 +8,12 @@ package util
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"maps"
@@ -18,6 +22,26 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 )
+
+func GenerateKeys() (*jose.JSONWebKey, *jose.JSONWebKey, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	publicKey := &privateKey.PublicKey
+
+	privateJwk, err := EcdsaToJWK(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to encode private key: %w", err)
+	}
+
+	publicJwk, err := EcdsaToJWK(publicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to encode public key: %w", err)
+	}
+
+	return privateJwk, publicJwk, nil
+}
 
 func Base64ToJWK(privateKey string) (jwk jose.JSONWebKey, err error) {
 	decodedKeyBytes, err := base64.RawURLEncoding.DecodeString(privateKey)
@@ -77,4 +101,26 @@ func GeneratePARJWT(orgId int64, runnerId string, privateKey *ecdsa.PrivateKey, 
 	}
 
 	return signed, nil
+}
+func JWKToPEM(pubJWK *jose.JSONWebKey) (string, error) {
+	if !pubJWK.IsPublic() {
+		return "", errors.New("error converting JWK to PEM: the key is not public")
+	}
+
+	pk, ok := pubJWK.Key.(*ecdsa.PublicKey)
+	if !ok {
+		return "", errors.New("error converting JWK to PEM: wrong underlying key type")
+	}
+
+	x509EncodedPub, err := x509.MarshalPKIXPublicKey(pk)
+	if err != nil {
+		return "", errors.New("error converting JWK to PEM: failed to marshal public key")
+	}
+
+	pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509EncodedPub})
+	if pemEncodedPub == nil {
+		return "", errors.New("error converting JWK to PEM: failed to encode public key to PEM format")
+	}
+
+	return string(pemEncodedPub), nil
 }

--- a/pkg/privateactionrunner/util/urn.go
+++ b/pkg/privateactionrunner/util/urn.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func ParseRunnerURN(urn string) (string, int64, string, error) {
+	urnParts := strings.Split(urn, ":")
+	if len(urnParts) != 7 {
+		return "", 0, "", fmt.Errorf("invalid URN format: %s", urn)
+	}
+	orgId, err := strconv.ParseInt(urnParts[5], 10, 64)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("invalid orgId in URN: %s", urnParts[5])
+	}
+	return urnParts[6], orgId, urnParts[6], nil
+}
+
+func MakeRunnerURN(region string, orgID int64, runnerID string) string {
+	return fmt.Sprintf("urn:dd:apps:on-prem-runner:%s:%d:%s", region, orgID, runnerID)
+}

--- a/pkg/privateactionrunner/util/urn.go
+++ b/pkg/privateactionrunner/util/urn.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
 package util
 
 import (
@@ -6,16 +11,26 @@ import (
 	"strings"
 )
 
-func ParseRunnerURN(urn string) (string, int64, string, error) {
+type RunnerURNParts struct {
+	Region   string
+	OrgID    int64
+	RunnerID string
+}
+
+func ParseRunnerURN(urn string) (RunnerURNParts, error) {
 	urnParts := strings.Split(urn, ":")
 	if len(urnParts) != 7 {
-		return "", 0, "", fmt.Errorf("invalid URN format: %s", urn)
+		return RunnerURNParts{}, fmt.Errorf("invalid URN format: %s", urn)
 	}
 	orgId, err := strconv.ParseInt(urnParts[5], 10, 64)
 	if err != nil {
-		return "", 0, "", fmt.Errorf("invalid orgId in URN: %s", urnParts[5])
+		return RunnerURNParts{}, fmt.Errorf("invalid orgId in URN: %s", urnParts[5])
 	}
-	return urnParts[6], orgId, urnParts[6], nil
+	return RunnerURNParts{
+		Region:   urnParts[4],
+		OrgID:    orgId,
+		RunnerID: urnParts[6],
+	}, nil
 }
 
 func MakeRunnerURN(region string, orgID int64, runnerID string) string {


### PR DESCRIPTION
### What does this PR do?

uses the self enrollment endpoint for runners if the config has
```
privateactionrunner:
  enabled: true
  self_enroll: true
```

### Motivation

We want to have a way to enroll from config

### Describe how you validated your changes

I ran the command with a proper configuration file 

```
go run ./cmd/privateactionrunner run -c dev/dist/datadog-enroll.yaml
```

### Additional Notes

Right now the identity is not properly persisted so if we kill the process and restart the PAR it will attempt to reenroll. Followup PR to persist the identity once the enrollment is done https://github.com/DataDog/datadog-agent/pull/44646