### PR TITLE
[CWS] Do not rate limit rules with 'fim' event type

### DIFF
--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -109,13 +109,13 @@ func (rl *RateLimiter) Apply(ruleSet *rules.RuleSet, customRuleIDs []eval.RuleID
 		}
 
 		if len(rule.Def.RateLimiterToken) > 0 {
-			newLimiters[rule.Def.ID], err = NewTokenLimiter(maxUniqueToken, burst, every, rule.Def.RateLimiterToken)
+			newLimiters[rule.ID], err = NewTokenLimiter(maxUniqueToken, burst, every, rule.Def.RateLimiterToken)
 			if err != nil {
 				seclog.Errorf("unable to use the token based rate limiter, fallback to the standard one: %s", err)
-				newLimiters[rule.Def.ID] = NewStdLimiter(rate.Every(time.Duration(every)), burst)
+				newLimiters[rule.ID] = NewStdLimiter(rate.Every(time.Duration(every)), burst)
 			}
 		} else {
-			newLimiters[rule.Def.ID] = NewStdLimiter(rate.Every(time.Duration(every)), burst)
+			newLimiters[rule.ID] = NewStdLimiter(rate.Every(time.Duration(every)), burst)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Do not rate limit rules with 'fim' event type

### Motivation

The 'fim' event type makes uses of internal expanded rules for the different event types.
These rules have an internal ID that is not registered with the rate limiter, causing these rules
to be rate limited.

### Describe how you validated your changes

Create an agent rule with the "fim" event type, triggered the rule and checked that it was properly sent to the BE.

### Additional Notes

This is a regression introduced by https://github.com/DataDog/datadog-agent/pull/43553