### PR TITLE
Disk Go check: Resolve device-mapper devices to match Python psutil behavior

### DIFF
--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -131,6 +131,7 @@ type Check struct {
 	diskIOCounters            func(...string) (map[string]gopsutil_disk.IOCountersStat, error)
 	fs                        afero.Fs
 	statFn                    statFunc
+	goos                      string // OS name, defaults to runtime.GOOS, injectable for testing
 
 	initConfig          diskInitConfig
 	instanceConfig      diskInstanceConfig
@@ -445,7 +446,7 @@ func (c *Check) collectPartitionMetrics(sender sender.Sender) error {
 		return nil
 	}
 	rootDevices := make(map[string]string)
-	if runtime.GOOS == "linux" && !c.instanceConfig.ResolveRootDevice {
+	if c.goos == "linux" && !c.instanceConfig.ResolveRootDevice {
 		rootDevices, err = c.loadRootDevices()
 		if err != nil {
 			log.Warnf("Error reading raw devices: %s", err)
@@ -719,6 +720,7 @@ func newCheck() check.Check {
 		diskIOCounters:            gopsutil_disk.IOCounters,
 		fs:                        afero.NewOsFs(),
 		statFn:                    defaultStatFn,
+		goos:                      runtime.GOOS,
 		initConfig: diskInitConfig{
 			DeviceGlobalExclude:       []string{},
 			DeviceGlobalBlacklist:     []string{},

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix.go
@@ -419,7 +419,7 @@ func (c *Check) loadRootDevices() (map[string]string, error) {
 				log.Debugf("error finding root device: %v", err)
 			}
 		} else {
-			log.Debugf("error stat’ing /: %v", err)
+			log.Debugf("error stat'ing /: %v", err)
 		}
 		hostSys := getSysfsPath()
 		for _, line := range lines {
@@ -437,6 +437,7 @@ func (c *Check) loadRootDevices() (map[string]string, error) {
 			blockDeviceID := fieldsFirstPart[2]
 			fieldsSecondPart := strings.Fields(parts[1])
 			device := fieldsSecondPart[1]
+
 			// /dev/root is not the real device name
 			// so we get the real device name from its major/minor number
 			if device == "/dev/root" || device == "rootfs" {
@@ -453,7 +454,34 @@ func (c *Check) loadRootDevices() (map[string]string, error) {
 					rootDevices[deviceResolved] = device
 				}
 			}
+
+			// Handle device-mapper devices: gopsutil resolves /dev/mapper/name symlinks
+			// to /dev/dm-X, but we want to use the friendly mapper name for tagging
+			// (matching Python psutil behavior which reads from /etc/mtab)
+			if strings.HasPrefix(device, "/dev/mapper/") {
+				// Resolve the symlink to get the dm-X device that gopsutil will return
+				// Use ReadlinkFs to support testing with mock filesystems
+				resolvedPath, err := ReadlinkFs(c.fs, device)
+				if err != nil {
+					log.Debugf("error resolving device-mapper symlink %s: %v", device, err)
+					continue
+				}
+				// The symlink target could be relative (e.g., "../dm-0") or absolute
+				var resolvedDevice string
+				if filepath.IsAbs(resolvedPath) {
+					resolvedDevice = resolvedPath
+				} else {
+					resolvedDevice = filepath.Join(filepath.Dir(device), resolvedPath)
+					resolvedDevice = filepath.Clean(resolvedDevice)
+				}
+				base := filepath.Base(resolvedDevice)
+				if strings.HasPrefix(base, "dm-") {
+					log.Debugf("device-mapper mapping from mountinfo: %s -> %s", resolvedDevice, device)
+					rootDevices[resolvedDevice] = device
+				}
+			}
 		}
 	}
+
 	return rootDevices, nil
 }

--- a/pkg/collector/corechecks/system/disk/diskv2/with_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/with_test.go
@@ -52,3 +52,10 @@ func WithStat(c check.Check, f func(string) (StatT, error)) check.Check {
 	c.(*Check).statFn = f
 	return c
 }
+
+// WithGOOS sets a custom GOOS value on the Check and returns the updated Check.
+// This allows testing Linux-specific code paths on non-Linux platforms.
+func WithGOOS(c check.Check, goos string) check.Check {
+	c.(*Check).goos = goos
+	return c
+}

--- a/releasenotes/notes/diskv2-device-mapper-resolution-aa94b815954f8ac0.yaml
+++ b/releasenotes/notes/diskv2-device-mapper-resolution-aa94b815954f8ac0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed device-mapper (LVM) device tagging in the diskv2 check to match Python psutil behavior.
+    Previously, devices were reported as ``dm-X`` (e.g., ``device:dm-0``) instead of their friendly
+    ``/dev/mapper/*`` names (e.g., ``device:ocivolume-root``). This ensures backward compatibility
+    with the Python disk check and preserves existing dashboards and monitors.


### PR DESCRIPTION
### What does this PR do?
This PR fixes a device naming discrepancy between the Python and Go disk checks for device-mapper (LVM) devices.
### Motivation
After migrating from the Python disk check to the Go diskv2 check, customers reported that device tags changed unexpectedly:
Python (`psutil`): `device:ocivolume-root` (friendly /dev/mapper/* name)
Go (`gopsutil`): `device:dm-0 `(raw device name)
This happens because `gopsutil` resolves `/dev/mapper/*` symlinks to their underlying `/dev/dm-X` devices internally, while Python's `psutil` reads device names directly from `/etc/mtab` which contains the friendly mapper names.
### Describe how you validated your changes
Added 4 new unit tests covering:
Basic device-mapper resolution
Fallback behavior when symlink resolution fails
Integration with lowercase_device_tag configuration
Mixed device types (regular + device-mapper)
Added `WithGOOS()` test helper to enable testing Linux-specific code paths on all platforms
### Additional Notes
Extended the `loadRootDevices()` function in `disk_nix.go` to:
Parse `/proc/self/mountinfo` for `/dev/mapper/*` devices
Resolve symlinks to find the underlying dm-X device that `gopsutil` returns
Create a reverse mapping (dm-X → /dev/mapper/*)
Use this mapping to restore the friendly device name in metric tags
This ensures backward compatibility with the Python check and preserves customer dashboards/monitors that depend on the friendly device names.