### PR TITLE
Revert "Upgrade to datadog-traceroute (#44281)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.73.0-rc.11
 	github.com/DataDog/datadog-go/v5 v5.8.2
 	github.com/DataDog/datadog-operator/api v0.0.0-20251127112405-4be7033d5f47
-	github.com/DataDog/datadog-traceroute v1.0.3
+	github.com/DataDog/datadog-traceroute v0.1.33
 	github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251120091008-29f645374bec
 	github.com/DataDog/ebpf-manager v0.7.15
 	github.com/DataDog/go-sqllexer v0.1.10

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/DataDog/datadog-go/v5 v5.8.2 h1:9IEfH1Mw9AjWwhAMqCAkhbxjuJeMxm2ARX2Vd
 github.com/DataDog/datadog-go/v5 v5.8.2/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20251127112405-4be7033d5f47 h1:uh2sJ7hctv0J3tRfQDQfauCy6x45Ex/A4RdG4/aEOnk=
 github.com/DataDog/datadog-operator/api v0.0.0-20251127112405-4be7033d5f47/go.mod h1:Mx5FrO5t4VF62KTT77HQDheyfGsbufrrBidd+jScicE=
-github.com/DataDog/datadog-traceroute v1.0.3 h1:84fcvLfsOmdm7T6+7Y07KmQfXJR8gjMdmD4j+vuf8Qo=
-github.com/DataDog/datadog-traceroute v1.0.3/go.mod h1:aA+OKmKRPghOH/DPIrepgLXos++CHZQ5L/uCCeaaNII=
+github.com/DataDog/datadog-traceroute v0.1.33 h1:Wd4NbyIuubSnMMGZ1F0f1ECConVv1VjOa28WViY+rDU=
+github.com/DataDog/datadog-traceroute v0.1.33/go.mod h1:sJBXljUoO4m8mcbOH4DCgwEsdq10a81WBCVw/oc1Nes=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251120091008-29f645374bec h1:Cm7Ksl+mKn9ev56CMpYtUs/rQriT4pmLlgaxzkZ8tXU=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251120091008-29f645374bec/go.mod h1:zMOs5XpXrqK5KMLnQDkwwWKF2yVzN2TQGSrBHgPP+eY=
 github.com/DataDog/ebpf-manager v0.7.15 h1:14PbnvXFQccV3zexENfNuADAxCuwHNori7sK55CP0SU=


### PR DESCRIPTION
### Motivation
[#incident-47421](https://dd.enterprise.slack.com/archives/C0A4JRDJMFD):
```
Installing Go tools...
cd internal/tools && go install github.com/frapposelli/wwhrd
github.com/DataDog/datadog-traceroute@v1.0.3: reading github.com/DataDog/datadog-traceroute/go.mod at revision v1.0.3: unknown revision refs/tags/v1.0.3
[1 / 3] Failed running command `go install github.com/frapposelli/wwhrd`, retrying in 10 seconds
cd internal/tools && go install github.com/frapposelli/wwhrd
github.com/DataDog/datadog-traceroute@v1.0.3: reading github.com/DataDog/datadog-traceroute/go.mod at revision v1.0.3: unknown revision refs/tags/v1.0.3
[2 / 3] Failed running command `go install github.com/frapposelli/wwhrd`, retrying in 100 seconds
cd internal/tools && go install github.com/frapposelli/wwhrd
github.com/DataDog/datadog-traceroute@v1.0.3: reading github.com/DataDog/datadog-traceroute/go.mod at revision v1.0.3: unknown revision refs/tags/v1.0.3
[3 / 3] Failed running command `go install github.com/frapposelli/wwhrd`, retrying in 1000 seconds
Failed to run command
```

### What does this PR do?
This reverts commit d950249f1db661d09876bae85661b1c2bb856c3d.