### PR TITLE
do not override configured site with env default

### DIFF
--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -79,9 +79,9 @@ Running the %s installation script (https://github.com/DataDog/datadog-agent/tre
 		Span:      span,
 		Config: config.Config{
 			DatadogYAML: config.DatadogConfig{
-				APIKey:   env.APIKey,
+				APIKey:   os.Getenv("DD_API_KEY"),
 				Hostname: os.Getenv("DD_HOSTNAME"),
-				Site:     env.Site,
+				Site:     os.Getenv("DD_SITE"),
 				Proxy: config.DatadogConfigProxy{
 					HTTP:    os.Getenv("DD_PROXY_HTTP"),
 					HTTPS:   os.Getenv("DD_PROXY_HTTPS"),

--- a/releasenotes/notes/windows-fix-default-site-override-b62a7221c959253e.yaml
+++ b/releasenotes/notes/windows-fix-default-site-override-b62a7221c959253e.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix an issue introduced in 7.73.0 that can cause the MSI to overwrite the ``site`` option in ``datadog.yaml`` with the default value of ``datadoghq.com``.
+
+    This issue impacts users who do not provide the ``SITE`` option to the MSI when upgrading AND who have an error in their ``datadog.yaml`` file that prevents the MSI from reading the existing ``site`` option (MSI log contains ``ReadConfig. User config could not be read``).
+
+    This issue also impacts users of ``datadog-installer.exe`` and ``Install-Datadog.ps1``, introduced in 7.72.0, who do not provide the ``DD_SITE`` environment variable when upgrading.


### PR DESCRIPTION
### What does this PR do?
do not override configured site with env default

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2118
upgrading to 7.73 or later without providing the DD_SITE option may incorrectly change the site option to `datadoghq.com` . Which can cause loss of Agent connectivity in orgs using other sites.
- impacts upgrades using datadog-installer-x86_64.exe / Install-Datadog.ps1 (fleet preview installers)
- impacts upgrades using the MSI ONLY IF the datadog.yaml is invalid
- does not impact remote upgrades

### Additional notes
Workaround
- MSI: run the MSI with the `SITE` option
- install script: run with the `DD_SITE` environment variable