### PR TITLE
[AGENTRUN-409] Make default port values integer rather than string

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -583,7 +583,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 		`^kubectl\.kubernetes\.io\/last-applied-configuration$`,
 		`^ad\.datadoghq\.com\/([[:alnum:]]+\.)?(checks|check_names|init_configs|instances)$`,
 	})
-	config.BindEnvAndSetDefault("metrics_port", "5000")
+	config.BindEnvAndSetDefault("metrics_port", 5000)
 	config.BindEnvAndSetDefault("cluster_agent.language_detection.patcher.enabled", true)
 	config.BindEnvAndSetDefault("cluster_agent.language_detection.patcher.base_backoff", "5m")
 	config.BindEnvAndSetDefault("cluster_agent.language_detection.patcher.max_backoff", "1h")
@@ -749,7 +749,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("jmx_statsd_client_socket_timeout", 0)
 
 	// Go_expvar server port
-	config.BindEnvAndSetDefault("expvar_port", "5000")
+	config.BindEnvAndSetDefault("expvar_port", 5000)
 
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
@@ -1176,7 +1176,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// Appsec Proxy Config Injection (Experimental)
 	config.BindEnvAndSetDefault("appsec.proxy.enabled", false)
-	config.BindEnvAndSetDefault("appsec.proxy.processor.port", "443")
+	config.BindEnvAndSetDefault("appsec.proxy.processor.port", 443)
 	config.BindEnvAndSetDefault("appsec.proxy.processor.address", "")
 	config.BindEnvAndSetDefault("appsec.proxy.auto_detect", true)
 	config.BindEnvAndSetDefault("appsec.proxy.proxies", []string{})

--- a/test/new-e2e/tests/agent-subcommands/config/config_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/config/config_common_test.go
@@ -62,7 +62,7 @@ func (v *baseConfigSuite) TestDefaultConfig() {
 
 	assertConfigValueContains(v.T(), config, "api_key", "*******")
 	assertConfigValueEqual(v.T(), config, "fips.enabled", false)
-	assertConfigValueEqual(v.T(), config, "expvar_port", "5000")
+	assertConfigValueEqual(v.T(), config, "expvar_port", 5000)
 	assertConfigValueEqual(v.T(), config, "network_devices.snmp_traps.forwarder.logs_no_ssl", false)
 	assertConfigValueContains(v.T(), config, "cloud_provider_metadata", "aws")
 }
@@ -84,7 +84,7 @@ func (v *baseConfigSuite) TestNonDefaultConfig() {
 	assertConfigValueEqual(v.T(), config, "inventories_enabled", false)
 	assertConfigValueEqual(v.T(), config, "inventories_min_interval", 1234)
 	assertConfigValueEqual(v.T(), config, "inventories_max_interval", 3456)
-	assertConfigValueEqual(v.T(), config, "expvar_port", "5678")
+	assertConfigValueEqual(v.T(), config, "expvar_port", 5678)
 	assertConfigValueContains(v.T(), config, "tags", "e2e")
 	assertConfigValueContains(v.T(), config, "tags", "test")
 }

--- a/test/new-e2e/tests/agent-subcommands/config/fixtures/datadog-agent.yaml
+++ b/test/new-e2e/tests/agent-subcommands/config/fixtures/datadog-agent.yaml
@@ -5,4 +5,4 @@ tags:
 inventories_enabled: false
 inventories_min_interval: 1234
 inventories_max_interval: 3456
-expvar_port: "5678"
+expvar_port: 5678


### PR DESCRIPTION
For consistency with config template and with user expectation.

### What does this PR do?

Makes the default port values integers rather than strings for three configs where they were incorrectly specified as strings.

### Motivation

Ports should not be specified as strings.

### Describe how you validated your changes

I ran the agent with the default configuration and with the port values manually specified and ensured that they were reported correctly and that `agent configcheck` didn't report any errors.

