### PR TITLE
Add `go.mod` to trigger all tests on dependency changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -567,6 +567,7 @@ workflow:
   - test/e2e-framework/testing/runner/**/*
   - test/e2e-framework/testing/utils/**/*
   - test/new-e2e/go.mod
+  - go.mod
   - tasks/security_agent.py
   - tasks/kmt.py
   - tasks/kernel_matrix_testing/*
@@ -621,6 +622,7 @@ workflow:
   - test/e2e-framework/testing/runner/**/*
   - test/e2e-framework/testing/utils/**/*
   - test/new-e2e/go.mod
+  - go.mod
   - tasks/system_probe.py
   - tasks/kmt.py
   - tasks/kernel_matrix_testing/*
@@ -654,6 +656,7 @@ workflow:
         - .gitlab/e2e/e2e.yml
         - test/e2e-framework/**/*
         - test/new-e2e/go.mod
+        - go.mod
         - flakes.yaml
         - release.json
       compare_to: $COMPARE_TO_BRANCH
@@ -675,6 +678,7 @@ workflow:
         - .gitlab/e2e/e2e.yml
         - test/e2e-framework/testing/**/*
         - test/new-e2e/go.mod
+        - go.mod
         - flakes.yaml
         - release.json
       compare_to: $COMPARE_TO_BRANCH
@@ -740,6 +744,7 @@ workflow:
         - pkg/util/trivy/**/*
         - test/new-e2e/tests/containers/**/*
         - test/new-e2e/go.mod
+        - go.mod
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
@@ -888,6 +893,7 @@ workflow:
         - comp/trace/**/*
         - test/new-e2e/tests/apm/**/*
         - test/new-e2e/go.mod
+        - go.mod
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
@@ -911,6 +917,7 @@ workflow:
         - comp/netflow/**/*
         - test/new-e2e/tests/ndm/netflow/**/*
         - test/new-e2e/go.mod
+        - go.mod
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
@@ -921,6 +928,7 @@ workflow:
         - pkg/collector/corechecks/snmp/**/*
         - test/new-e2e/tests/ndm/snmp/**/*
         - test/new-e2e/go.mod
+        - go.mod
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
   - when: manual
@@ -934,6 +942,7 @@ workflow:
         - pkg/aggregator/**/*
         - test/new-e2e/tests/ha-agent/**/*
         - test/new-e2e/go.mod
+        - go.mod
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
@@ -947,6 +956,7 @@ workflow:
         - comp/networkpath/**/*
         - test/new-e2e/tests/netpath/**/*
         - test/new-e2e/go.mod
+        - go.mod
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 

--- a/tasks/dyntest.py
+++ b/tasks/dyntest.py
@@ -29,6 +29,7 @@ def compute_and_upload_job_index(ctx: Context, bucket_uri: str, coverage_folder:
     run_all_paths = [
         "test/new-e2e/pkg/**/*",  # Modification to the framework should trigger all tests
         "test/new-e2e/go.mod",
+        "go.mod",  # incident-47421
         "flakes.yaml",
         "release.json",
         ".gitlab/e2e/e2e.yml",

--- a/tasks/unit_tests/testdata/ci_config_with_reference.yml
+++ b/tasks/unit_tests/testdata/ci_config_with_reference.yml
@@ -90,6 +90,7 @@ workflow:
       paths:
         - test/e2e-framework/testing/**/*
         - test/new-e2e/go.mod
+        - go.mod
       compare_to: main
 
 .on_container_or_e2e_changes_or_manual:

--- a/tasks/unit_tests/testdata/expected.yml
+++ b/tasks/unit_tests/testdata/expected.yml
@@ -64,6 +64,7 @@
     paths:
     - test/e2e-framework/testing/**/*
     - test/new-e2e/go.mod
+    - go.mod
 .on_packaging_change:
 - !reference [.except_mergequeue]
 - changes:


### PR DESCRIPTION
### What does this PR do?
For the time being, when `go.mod` changes, all tests should run since dependency modifications can have widespread impact across the codebase.

This is of course temporary, since the top level build system doesn't provide with a queryable build graph at the moment (a few more months will be needed to transition it to `bazel`).

This ensures the dynamic test index marks all tests as impacted when `go.mod` is modified, similar to `test/new-e2e/go.mod`.

### Motivation
Triggered by #incident-47421 where `go.mod` changes broke tests that weren't predicted as impacted by the test selection algorithm.