### PR TITLE
[CWS] skip some flaky signature tests

### DIFF
--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -959,6 +959,10 @@ func TestActionKillContainerWithSignature(t *testing.T) {
 		t.Skip("Skip test where docker is unavailable")
 	}
 
+	checkKernelCompatibility(t, "broken containerd support on Suse 12", func(kv *kernel.Version) bool {
+		return kv.IsSuse12Kernel()
+	})
+
 	checkKernelCompatibility(t, "agent is running in container mode", func(_ *kernel.Version) bool {
 		return env.IsContainerized()
 	})
@@ -1156,6 +1160,10 @@ func TestActionKillContainerWithSignatureBroadRule(t *testing.T) {
 	if _, err := whichNonFatal("docker"); err != nil {
 		t.Skip("Skip test where docker is unavailable")
 	}
+
+	checkKernelCompatibility(t, "broken containerd support on Suse 12", func(kv *kernel.Version) bool {
+		return kv.IsSuse12Kernel()
+	})
 
 	checkKernelCompatibility(t, "agent is running in container mode", func(_ *kernel.Version) bool {
 		return env.IsContainerized()

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -459,6 +459,8 @@ func TestRawPacketActionWithSignature(t *testing.T) {
 }
 
 func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
+	t.Skip("This test is flaky, let's skip it for now")
+
 	SkipIfNotAvailable(t)
 
 	checkKernelCompatibility(t, "network feature", isRawPacketNotSupported)


### PR DESCRIPTION
### What does this PR do?

This PR:
- similar to https://github.com/DataDog/datadog-agent/pull/44273 for new signature tests, skip test on suse 12 that require docker
- skip fully TestRawPacketActionProcessScopeWithSignature that is just flaky for now

### Motivation

### Describe how you validated your changes

### Additional Notes
