### PR TITLE
[AGENTRUN-965] Set timeout on RAR call test

### DIFF
--- a/comp/core/remoteagentregistry/impl/client_test.go
+++ b/comp/core/remoteagentregistry/impl/client_test.go
@@ -145,6 +145,7 @@ func TestCallAgentsForService(t *testing.T) {
 			expectedCodes: map[string][]codes.Code{
 				"fast-agent": {codes.OK},
 			},
+			shouldSucceedInLessThan: 200 * time.Millisecond,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?
Sets the same timeout as for other subtests on RAR call test.

### Motivation
Avoid flakiness (default timeout is very low).

### Describe how you validated your changes

### Additional Notes
