### PR TITLE
Go fix forvar

### DIFF
--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -41,7 +41,6 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait ti
 	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.
 	syncTimeout := timeoutConfig + extraWait
 	for name := range informers {
-		name := name // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), syncTimeout)
 			defer cancel()
@@ -77,7 +76,6 @@ func SyncInformersReturnErrors(informers map[InformerName]cache.SharedInformer, 
 	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.
 	syncTimeout := timeoutConfig + extraWait
 	for name := range informers {
-		name := name // https://golang.org/doc/faq#closures_and_goroutines
 		go (func() {
 			ctx, cancel := context.WithTimeout(context.Background(), syncTimeout)
 			defer cancel()


### PR DESCRIPTION
### What does this PR do?
Remove unneeded workaround for for loop variables.

### Motivation
It's been fixed since Go 1.22, removing that just simplifies the code.

### Describe how you validated your changes

### Additional Notes
This was generated using `go fix -forvar` (with some extra arguments), where go is version 1.26rc1.