### PR TITLE
Go fix slicescontains slicessort mapsloop

### DIFF
--- a/cmd/agent/common/misconfig/mounts.go
+++ b/cmd/agent/common/misconfig/mounts.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -56,16 +57,9 @@ func procMount() error {
 	}
 
 	egid := os.Getegid()
-	var haveEgid bool
 	// From `man getgroups`:
 	// It is unspecified whether the effective group ID of the calling process is included in the returned list.
-	for _, gid := range groups {
-		if gid == egid {
-			haveEgid = true
-			break
-		}
-	}
-	if !haveEgid {
+	if !slices.Contains(groups, egid) {
 		groups = append(groups, egid)
 	}
 	path := pkgconfigsetup.Datadog().GetString("container_proc_root")

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
@@ -7,6 +7,7 @@ package autodiscoveryimpl
 
 import (
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/configresolver"
@@ -303,9 +304,7 @@ func (cm *reconcilingConfigManager) getActiveConfigs() map[string]integration.Co
 	defer cm.m.Unlock()
 
 	res := make(map[string]integration.Config, len(cm.activeConfigs))
-	for k, v := range cm.activeConfigs {
-		res[k] = v
-	}
+	maps.Copy(res, cm.activeConfigs)
 	return res
 }
 

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -156,9 +157,7 @@ func (c *actionsController) update(updates map[string]state.RawConfig, applyStat
 		}
 
 		// Copy auth fields first
-		for k, v := range auth {
-			actionsMap[k] = v
-		}
+		maps.Copy(actionsMap, auth)
 		actionsMap["run_once"] = true
 		actionsMap["remote_config_id"] = parsed.remoteConfigID
 

--- a/comp/core/autodiscovery/providers/process_log.go
+++ b/comp/core/autodiscovery/providers/process_log.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -288,13 +289,7 @@ var agentProcessNames = []string{
 func isAgentProcess(process *workloadmeta.Process) bool {
 	// Check if the process name matches any of the known agent process names;
 	// we may not be able to make assumptions about the executable paths.
-	for _, agentName := range agentProcessNames {
-		if process.Name == agentName {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(agentProcessNames, process.Name)
 }
 
 func (p *processLogConfigProvider) processEventsInner(evBundle workloadmeta.EventBundle, verifyReadable bool) integration.ConfigChanges {

--- a/comp/core/diagnose/def/component.go
+++ b/comp/core/diagnose/def/component.go
@@ -8,6 +8,7 @@ package diagnose
 
 import (
 	"encoding/json"
+	"slices"
 	"sync"
 
 	"github.com/fatih/color"
@@ -65,13 +66,7 @@ type Catalog struct {
 
 // Register registers a diagnose function
 func (c *Catalog) Register(name string, diagnoseFunc func(Config) []Diagnosis) {
-	registeredSuite := false
-	for _, suite := range AllSuites {
-		if suite == name {
-			registeredSuite = true
-			break
-		}
-	}
+	registeredSuite := slices.Contains(AllSuites, name)
 	if !registeredSuite {
 		panic("suite not registered. plase update the AllSuites list")
 	}

--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/containerd/containerd"
@@ -514,13 +515,9 @@ func getImageLabels(img containerd.Image, ocispecImage ocispec.Image) map[string
 	// labels.
 	labels := map[string]string{}
 
-	for labelName, labelValue := range img.Labels() {
-		labels[labelName] = labelValue
-	}
+	maps.Copy(labels, img.Labels())
 
-	for labelName, labelValue := range ocispecImage.Config.Labels {
-		labels[labelName] = labelValue
-	}
+	maps.Copy(labels, ocispecImage.Config.Labels)
 
 	return labels
 }

--- a/pkg/collector/corechecks/containers/containerd/events.go
+++ b/pkg/collector/corechecks/containers/containerd/events.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -511,9 +512,7 @@ func (s *subscriber) GetImageSizes() map[string]map[string]int64 {
 	snapshot := make(map[string]map[string]int64)
 	for namespace, images := range s.imageSizeCache {
 		snapshot[namespace] = make(map[string]int64)
-		for imageName, size := range images {
-			snapshot[namespace][imageName] = size
-		}
+		maps.Copy(snapshot[namespace], images)
 	}
 
 	return snapshot

--- a/pkg/collector/corechecks/net/network/network.go
+++ b/pkg/collector/corechecks/net/network/network.go
@@ -11,8 +11,10 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -149,9 +151,7 @@ func (c *NetworkCheck) Run() error {
 			if err != nil {
 				log.Debug(err)
 			} else {
-				for counter, value := range counters {
-					protocolStats.Stats[counter] = value
-				}
+				maps.Copy(protocolStats.Stats, counters)
 			}
 		}
 		submitProtocolMetrics(sender, protocolStats)
@@ -188,10 +188,8 @@ func (c *NetworkCheck) Run() error {
 }
 
 func (c *NetworkCheck) isDeviceExcluded(deviceName string) bool {
-	for _, excludedDevice := range c.config.instance.ExcludedInterfaces {
-		if deviceName == excludedDevice {
-			return true
-		}
+	if slices.Contains(c.config.instance.ExcludedInterfaces, deviceName) {
+		return true
 	}
 	if c.config.instance.ExcludedInterfacePattern != nil {
 		return c.config.instance.ExcludedInterfacePattern.MatchString(deviceName)

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/buildprofile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/buildprofile_test.go
@@ -6,6 +6,8 @@
 package checkconfig
 
 import (
+	"maps"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/profile"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/stretchr/testify/assert"
@@ -93,9 +95,7 @@ func TestBuildProfile(t *testing.T) {
 	mergedMetadata["ip_addresses"] = LegacyMetadataConfig["ip_addresses"]
 
 	vpnTunnelsMergedMetadata := make(profiledefinition.MetadataConfig)
-	for k, v := range mergedMetadata {
-		vpnTunnelsMergedMetadata[k] = v
-	}
+	maps.Copy(vpnTunnelsMergedMetadata, mergedMetadata)
 	mergeMetadata(vpnTunnelsMergedMetadata, VPNTunnelMetadataConfig)
 	mergeMetadata(vpnTunnelsMergedMetadata, RouteMetadataConfig)
 	mergeMetadata(vpnTunnelsMergedMetadata, TunnelMetadataConfig)

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -514,10 +515,8 @@ func getServiceCheckStatus(state string, mapping map[string]string) servicecheck
 
 // isMonitored verifies if a unit should be monitored.
 func (c *SystemdCheck) isMonitored(unitName string) bool {
-	for _, name := range c.config.instance.UnitNames {
-		if name == unitName {
-			return true
-		}
+	if slices.Contains(c.config.instance.UnitNames, unitName) {
+		return true
 	}
 	for _, pattern := range c.unitPatterns {
 		if pattern.MatchString(unitName) {
@@ -528,12 +527,7 @@ func (c *SystemdCheck) isMonitored(unitName string) bool {
 }
 
 func isValidServiceCheckStatus(serviceCheckStatus string) bool {
-	for _, validStatus := range validServiceCheckStatus {
-		if serviceCheckStatus == validStatus {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(validServiceCheckStatus, serviceCheckStatus)
 }
 
 // Configure configures the systemd checks

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -9,6 +9,7 @@ package systemd
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"slices"
 	"testing"
@@ -91,9 +92,7 @@ func getCreatePropertieWithDefaults(props map[string]interface{}) map[string]int
 		"MemoryAccounting": true,
 		"TasksAccounting":  true,
 	}
-	for k, v := range props {
-		defaultProps[k] = v
-	}
+	maps.Copy(defaultProps, props)
 	return defaultProps
 }
 

--- a/pkg/config/helper/get_combine.go
+++ b/pkg/config/helper/get_combine.go
@@ -7,6 +7,7 @@
 package helper
 
 import (
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -32,9 +33,7 @@ func GetViperCombine(cfg model.Reader, key string) interface{} {
 	// If the setting is a map, copy to the tree (return value)
 	tree := make(map[string]interface{})
 	if mapval, ok := rawval.(map[string]interface{}); ok {
-		for k, v := range mapval {
-			tree[k] = v
-		}
+		maps.Copy(tree, mapval)
 	}
 
 	// Iterate the subfields of this setting (will find env vars this way)

--- a/pkg/dyninst/module/diagnostics_test.go
+++ b/pkg/dyninst/module/diagnostics_test.go
@@ -96,8 +96,8 @@ func TestDiagnosticsStates_Summarizes(t *testing.T) {
 	require.True(t, ok, "missing runtime id")
 	got, ok := rt["p1"]
 	require.True(t, ok, "missing probe id")
-	require.True(t, contains(got, "received"))
-	require.True(t, contains(got, "errors"))
+	require.Contains(t, got, "received")
+	require.Contains(t, got, "errors")
 }
 
 type testProbe struct {
@@ -284,12 +284,3 @@ func (p testProbeDefinition) GetTemplate() ir.TemplateDefinition {
 }
 
 var _ ir.ProbeDefinition = testProbeDefinition{}
-
-func contains(ss []string, s string) bool {
-	for _, x := range ss {
-		if x == s {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/ebpf/verifier/calculator/main.go
+++ b/pkg/ebpf/verifier/calculator/main.go
@@ -99,14 +99,7 @@ func main() {
 		}
 
 		if len(filterFiles) > 0 || hasAbsPaths {
-			found := false
-			for _, f := range filterFiles {
-				if d.Name() == f {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !slices.Contains(filterFiles, d.Name()) {
 				return nil
 			}
 		}

--- a/pkg/network/netlink/conntracker_integration_test.go
+++ b/pkg/network/netlink/conntracker_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"net"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -144,10 +145,8 @@ func testMessageDump(t *testing.T, f *os.File, serverIP, clientIP net.IP) {
 }
 
 func skipUnless(t *testing.T, requiredArg string) {
-	for _, arg := range os.Args[1:] {
-		if arg == requiredArg {
-			return
-		}
+	if slices.Contains(os.Args[1:], requiredArg) {
+		return
 	}
 
 	t.Skipf(

--- a/pkg/network/protocols/redis/client.go
+++ b/pkg/network/protocols/redis/client.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
+	"slices"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -48,10 +49,8 @@ func NewClient(serverAddress string, dialer *net.Dialer, enableTLS bool, protoco
 }
 
 func verifyProtocolVersion(protocolVersion int) error {
-	for _, supportedProtocolVersion := range supportedProtocolVersions {
-		if protocolVersion == supportedProtocolVersion {
-			return nil
-		}
+	if slices.Contains(supportedProtocolVersions, protocolVersion) {
+		return nil
 	}
 	return errProtocolVersionNotSupported
 }

--- a/pkg/network/usm/utils/debugger_testutils.go
+++ b/pkg/network/usm/utils/debugger_testutils.go
@@ -97,11 +97,6 @@ func WaitForPathToBeBlocked(t *testing.T, moduleName, programType string, path s
 	require.NoError(t, err)
 	require.Eventuallyf(t, func() bool {
 		blocked := debugger.GetBlockedPathIDs(moduleName, programType)
-		for _, id := range blocked {
-			if id == pathID {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(blocked, pathID)
 	}, time.Second*5, time.Millisecond*100, "path %v is not blocked in %v", path, programType)
 }

--- a/pkg/opentelemetry-mapping-go/otlp/logs/transform.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/transform.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -120,9 +121,7 @@ func transform(lr plog.LogRecord, host, service string, res pcommon.Resource, sc
 			l.Ddtags = datadog.PtrString(tagStr)
 		default:
 			m := flattenAttribute(k, v, 1)
-			for k, v := range m {
-				l.AdditionalProperties[k] = v
-			}
+			maps.Copy(l.AdditionalProperties, m)
 		}
 		return true
 	})
@@ -201,9 +200,7 @@ func flattenAttribute(key string, val pcommon.Value, depth int) map[string]any {
 	val.Map().Range(func(k string, v pcommon.Value) bool {
 		newKey := key + "." + k
 		nestedResult := flattenAttribute(newKey, v, depth+1)
-		for nk, nv := range nestedResult {
-			result[nk] = nv
-		}
+		maps.Copy(result, nestedResult)
 		return true
 	})
 

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/runtime_metric_mappings.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/runtime_metric_mappings.go
@@ -15,6 +15,8 @@
 // Package metrics provides runtime metric mappings.
 package metrics
 
+import "maps"
+
 // runtimeMetricPrefixLanguageMap defines the runtime metric prefixes and which languages they map to
 var runtimeMetricPrefixLanguageMap = map[string]string{
 	"process.runtime.go":     "go",
@@ -375,18 +377,10 @@ var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 
 func getRuntimeMetricsMappings() runtimeMetricMappingList {
 	res := runtimeMetricMappingList{}
-	for k, v := range goRuntimeMetricsMappings {
-		res[k] = v
-	}
-	for k, v := range dotnetRuntimeMetricsMappings {
-		res[k] = v
-	}
-	for k, v := range javaRuntimeMetricsMappings {
-		res[k] = v
-	}
-	for k, v := range stableJavaRuntimeMetricsMappings {
-		res[k] = v
-	}
+	maps.Copy(res, goRuntimeMetricsMappings)
+	maps.Copy(res, dotnetRuntimeMetricsMappings)
+	maps.Copy(res, javaRuntimeMetricsMappings)
+	maps.Copy(res, stableJavaRuntimeMetricsMappings)
 	return res
 }
 

--- a/pkg/privateactionrunner/util/jwt.go
+++ b/pkg/privateactionrunner/util/jwt.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -64,9 +65,7 @@ func GeneratePARJWT(orgId int64, runnerId string, privateKey *ecdsa.PrivateKey, 
 		"exp":      time.Now().Add(time.Minute * 1).Unix(),
 	}
 
-	for k, v := range extraClaims {
-		claims[k] = v
-	}
+	maps.Copy(claims, extraClaims)
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
 	token.Header["alg"] = "ES256"

--- a/pkg/privateactionrunner/util/response_parser.go
+++ b/pkg/privateactionrunner/util/response_parser.go
@@ -17,6 +17,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"unicode/utf16"
 )
@@ -165,12 +166,7 @@ func parseFormData(params map[string]string, data []byte) ([]FormDataField, erro
 }
 
 func isEncoding(encoding string) bool {
-	for _, e := range Encoding {
-		if encoding == e {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(Encoding, encoding)
 }
 
 func getEncodingFromMIME(params map[string]string) string {

--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"runtime"
 
@@ -226,9 +227,7 @@ func variablesFromTestData(testData TestData) (map[string]eval.SECLVariable, err
 	variables := make(map[string]eval.SECLVariable)
 
 	// copy the embedded variables
-	for k, v := range model.SECLVariables {
-		variables[k] = v
-	}
+	maps.Copy(variables, model.SECLVariables)
 
 	varOpts := eval.VariableOpts{
 		TTL: 10000000,

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2022,20 +2022,14 @@ func (p *EBPFProbe) updateProbes(ruleSetEventTypes []eval.EventType, needRawSysc
 	} else {
 		// ActivityDumps
 		if p.config.RuntimeSecurity.ActivityDumpEnabled {
-			for _, e := range p.config.RuntimeSecurity.ActivityDumpTracedEventTypes {
-				if e == model.SyscallsEventType {
-					activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors()...)
-					break
-				}
+			if slices.Contains(p.config.RuntimeSecurity.ActivityDumpTracedEventTypes, model.SyscallsEventType) {
+				activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors()...)
 			}
 		}
 		// SecurityProfiles
 		if p.config.RuntimeSecurity.AnomalyDetectionEnabled {
-			for _, e := range p.config.RuntimeSecurity.AnomalyDetectionEventTypes {
-				if e == model.SyscallsEventType {
-					activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors()...)
-					break
-				}
+			if slices.Contains(p.config.RuntimeSecurity.AnomalyDetectionEventTypes, model.SyscallsEventType) {
+				activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors()...)
 			}
 		}
 	}
@@ -2848,21 +2842,15 @@ func (p *EBPFProbe) initManagerOptionsExcludedFunctions() error {
 // initManagerOptionsActivatedProbes initializes the eBPF manager activated probes options
 func (p *EBPFProbe) initManagerOptionsActivatedProbes() {
 	if p.config.RuntimeSecurity.ActivityDumpEnabled {
-		for _, e := range p.config.RuntimeSecurity.ActivityDumpTracedEventTypes {
-			if e == model.SyscallsEventType {
-				// Add syscall monitor probes
-				p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SyscallMonitorSelectors()...)
-				break
-			}
+		if slices.Contains(p.config.RuntimeSecurity.ActivityDumpTracedEventTypes, model.SyscallsEventType) {
+			// Add syscall monitor probes
+			p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SyscallMonitorSelectors()...)
 		}
 	}
 	if p.config.RuntimeSecurity.AnomalyDetectionEnabled {
-		for _, e := range p.config.RuntimeSecurity.AnomalyDetectionEventTypes {
-			if e == model.SyscallsEventType {
-				// Add syscall monitor probes
-				p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SyscallMonitorSelectors()...)
-				break
-			}
+		if slices.Contains(p.config.RuntimeSecurity.AnomalyDetectionEventTypes, model.SyscallsEventType) {
+			// Add syscall monitor probes
+			p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SyscallMonitorSelectors()...)
 		}
 	}
 	p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SnapshotSelectors(p.useFentry)...)

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -334,15 +334,11 @@ func (cr *Resolver) Iterate(cb func(*cgroupModel.CacheEntry) bool) {
 }
 
 func (cr *Resolver) iterate(cb func(*cgroupModel.CacheEntry) bool) {
-	for _, cgroup := range cr.hostWorkloads.Values() {
-		if cb(cgroup) {
-			return
-		}
+	if slices.ContainsFunc(cr.hostWorkloads.Values(), cb) {
+		return
 	}
-	for _, cgroup := range cr.containerWorkloads.Values() {
-		if cb(cgroup) {
-			return
-		}
+	if slices.ContainsFunc(cr.containerWorkloads.Values(), cb) {
+		return
 	}
 }
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dentry"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -202,14 +203,7 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 	// Find all the mounts that I'm the parent of
 	for mnt := range mr.mounts.ValuesIter() {
 		if mnt.ParentPathKey.MountID == mount.MountID {
-			inserted := false
-			for _, e := range mount.Children {
-				if e == mnt.MountID {
-					inserted = true
-					break
-				}
-			}
-			if inserted {
+			if slices.Contains(mount.Children, mnt.MountID) {
 				continue
 			}
 
@@ -388,14 +382,7 @@ func (mr *Resolver) insert(m *model.Mount, moved bool) {
 	// Update the list of children of the parent
 	parent, ok := mr.mounts.Get(m.ParentPathKey.MountID)
 	if ok {
-		exists := false
-		for _, mntid := range parent.Children {
-			if mntid == m.MountID {
-				exists = true
-				break
-			}
-		}
-		if !exists {
+		if !slices.Contains(parent.Children, m.MountID) {
 			parent.Children = append(parent.Children, m.MountID)
 		}
 	}

--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/textproto"
 	"os"
 	"path/filepath"
@@ -119,12 +120,8 @@ func (s *dpkgScanner) listInstalledFiles(root *os.Root) (map[string][]string, er
 
 	// merge both maps, info dir has priority
 	res := make(map[string][]string, len(installedFilesInfo)+len(installedFilesStatus))
-	for k, v := range installedFilesStatus {
-		res[k] = v
-	}
-	for k, v := range installedFilesInfo {
-		res[k] = v
-	}
+	maps.Copy(res, installedFilesStatus)
+	maps.Copy(res, installedFilesInfo)
 	return res, nil
 }
 

--- a/pkg/security/resolvers/sbom/file_querier.go
+++ b/pkg/security/resolvers/sbom/file_querier.go
@@ -139,11 +139,5 @@ func (q *fixedSizeQueue[T]) contains(value T) bool {
 		return false
 	}
 
-	for _, v := range q.queue {
-		if v == value {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(q.queue, value)
 }

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -8,6 +8,7 @@ package model
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"math/bits"
 	"sort"
@@ -1292,9 +1293,7 @@ func initKernelCapabilityConstants() {
 }
 
 func initPtraceConstants() {
-	for k, v := range ptraceArchConstants {
-		ptraceConstants[k] = v
-	}
+	maps.Copy(ptraceConstants, ptraceArchConstants)
 
 	for k, v := range ptraceConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
@@ -1316,9 +1315,7 @@ func initProtConstansts() {
 }
 
 func initMMapFlagsConstants() {
-	for k, v := range mmapFlagArchConstants {
-		mmapFlagConstants[k] = v
-	}
+	maps.Copy(mmapFlagConstants, mmapFlagArchConstants)
 
 	for k, v := range mmapFlagConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -228,9 +227,7 @@ func (at *ActivityTree) ComputeSyscallsList() []uint32 {
 	for key := range at.SyscallsMask {
 		output = append(output, uint32(key))
 	}
-	sort.Slice(output, func(i, j int) bool {
-		return output[i] < output[j]
-	})
+	slices.Sort(output)
 	return output
 }
 

--- a/pkg/util/cloudproviders/cloudfoundry/cccache.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"strconv"
 	"strings"
@@ -725,9 +726,7 @@ func updateMapInPlace[K comparable, V any](cache map[K]V, newData map[K]V) map[K
 	}
 
 	// Add or update entries
-	for key, value := range newData {
-		cache[key] = value
-	}
+	maps.Copy(cache, newData)
 
 	return cache
 }

--- a/pkg/util/quantile/store.go
+++ b/pkg/util/quantile/store.go
@@ -6,6 +6,7 @@
 package quantile
 
 import (
+	"slices"
 	"sort"
 	"unsafe"
 )
@@ -199,11 +200,9 @@ func (s *sparseStore) insertCounts(c *Config, kcs []KeyCount) {
 func (s *sparseStore) insert(c *Config, keys []Key) {
 	s.count += len(keys)
 
-	// TODO|PERF: A custom uint16 sort should easily beat sort.Sort.
+	// TODO|PERF: A custom uint16 sort should easily beat slices.Sort.
 	// TODO|PERF: Would it be cheaper to sort float64s and then convert to keys?
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i] < keys[j]
-	})
+	slices.Sort(keys)
 
 	// TODO|PERF: Add a non-allocating fast path. When every key is already contained
 	// in the sketch (and no overflow happens) we can just directly update.

--- a/test/e2e-framework/components/datadog/agent/docker.go
+++ b/test/e2e-framework/components/datadog/agent/docker.go
@@ -7,6 +7,7 @@ package agent
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -124,9 +125,7 @@ func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput
 				},
 			},
 		}
-		for key, value := range envVarsResolved {
-			agentManifest.Services["agent"].Environment[key] = value
-		}
+		maps.Copy(agentManifest.Services["agent"].Environment, envVarsResolved)
 		data, err := yaml.Marshal(agentManifest)
 		return string(data), err
 	}).(pulumi.StringOutput)

--- a/test/e2e-framework/scenarios/aws/microVMs/microvms/network.go
+++ b/test/e2e-framework/scenarios/aws/microVMs/microvms/network.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -77,13 +78,7 @@ func getMicroVMGroupSubnetPattern(subnet string) string {
 }
 
 func subnetIsTaken(taken []string, subnet string) bool {
-	for _, t := range taken {
-		if t == subnet {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(taken, subnet)
 }
 
 func getMicroVMGroupSubnet(taken []string) (string, error) {

--- a/test/e2e-framework/testing/provisioners/provisioners.go
+++ b/test/e2e-framework/testing/provisioners/provisioners.go
@@ -9,6 +9,7 @@ package provisioners
 import (
 	"context"
 	"io"
+	"maps"
 )
 
 // Diagnosable defines the interface for a diagnosable provisioner.
@@ -27,9 +28,7 @@ type RawResources map[string][]byte
 
 // Merge merges two RawResources maps
 func (rr RawResources) Merge(in RawResources) {
-	for k, v := range in {
-		rr[k] = v
-	}
+	maps.Copy(rr, in)
 }
 
 // UntypedProvisioner defines the interface for a provisioner without env binding
@@ -50,8 +49,6 @@ type ProvisionerMap map[string]Provisioner
 // CopyProvisioners copies a map of provisioners
 func CopyProvisioners(in ProvisionerMap) ProvisionerMap {
 	out := make(ProvisionerMap, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/test/e2e-framework/testing/runner/configmap.go
+++ b/test/e2e-framework/testing/runner/configmap.go
@@ -8,6 +8,7 @@ package runner
 import (
 	"encoding/json"
 	"errors"
+	"maps"
 
 	commonconfig "github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	infraaws "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
@@ -83,9 +84,7 @@ func (cm ConfigMap) Set(key, val string, secret bool) {
 
 // Merge in ConfigMap into current config map
 func (cm ConfigMap) Merge(in ConfigMap) {
-	for key, val := range in {
-		cm[key] = val
-	}
+	maps.Copy(cm, in)
 }
 
 // ToPulumi casts current config map to a Pulumi auto.ConfigMap

--- a/test/new-e2e/tests/cspm/cspm_test.go
+++ b/test/new-e2e/tests/cspm/cspm_test.go
@@ -11,6 +11,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"testing"
 	"time"
@@ -269,9 +270,7 @@ func isSubset(a, b map[string]string) bool {
 }
 
 func mergeFindings(a, b findings) findings {
-	for k, v := range b {
-		a[k] = v
-	}
+	maps.Copy(a, b)
 	return a
 }
 

--- a/test/new-e2e/tests/installer/windows/install_script.go
+++ b/test/new-e2e/tests/installer/windows/install_script.go
@@ -7,6 +7,7 @@ package installer
 
 import (
 	"fmt"
+	"maps"
 	"path/filepath"
 	"strings"
 
@@ -75,9 +76,7 @@ func (b *baseInstaller) getInstallerURL(params Params) (string, error) {
 func (b *baseInstaller) getBaseEnvVars() map[string]string {
 	envVars := installer.InstallScriptEnv(e2eos.AMD64Arch)
 	envVars["DD_API_KEY"] = installer.GetAPIKey()
-	for k, v := range b.params.extraEnvVars {
-		envVars[k] = v
-	}
+	maps.Copy(envVars, b.params.extraEnvVars)
 	envVars["DD_REMOTE_UPDATES"] = "true"
 	return envVars
 }
@@ -139,9 +138,7 @@ func (b *baseInstaller) prepareInstaller(params Params) (string, error) {
 // This is the base implementation that can be extended by specific installer types.
 func (b *baseInstaller) prepareEnvVars(params Params) map[string]string {
 	envVars := b.getBaseEnvVars()
-	for k, v := range params.extraEnvVars {
-		envVars[k] = v
-	}
+	maps.Copy(envVars, params.extraEnvVars)
 	return envVars
 }
 
@@ -171,9 +168,7 @@ func (d *DatadogInstallScript) Run(opts ...Option) (string, error) {
 	// Start with a copy of the base params
 	params := d.params
 	params.extraEnvVars = make(map[string]string)
-	for k, v := range d.params.extraEnvVars {
-		params.extraEnvVars[k] = v
-	}
+	maps.Copy(params.extraEnvVars, d.params.extraEnvVars)
 
 	// Apply method-specific options
 	err := optional.ApplyOptions(&params, opts)
@@ -240,9 +235,7 @@ func (d *DatadogInstallExe) Run(opts ...Option) (string, error) {
 	// Start with a copy of the base params
 	params := d.params
 	params.extraEnvVars = make(map[string]string)
-	for k, v := range d.params.extraEnvVars {
-		params.extraEnvVars[k] = v
-	}
+	maps.Copy(params.extraEnvVars, d.params.extraEnvVars)
 
 	// Apply method-specific options
 	err := optional.ApplyOptions(&params, opts)


### PR DESCRIPTION
### What does this PR do?
Apply `go fix` simplifications related to slices and maps.

### Motivation
Code simplification, maybe even some performance.

### Describe how you validated your changes
The changes should be exactly equivalent, so CI is enough.

### Additional Notes
Go 1.26's `go fix` command has many simplification passes, this PR applies `go fix -slicescontains -slicessort -mapsloop` (with extra arguments for build tags and list of packages to fix).