### PR TITLE
[CWS] Check for protobuf-based generated go files

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -716,6 +716,7 @@ class FailingTask:
 def go_generate_check(ctx):
     tasks = [
         [cws_go_generate],
+        [generate_cws_proto],
         [gen_mocks],
     ]
     failing_tasks = []


### PR DESCRIPTION
### What does this PR do?

Check for dirty protobuf-based generated go files when running `dda inv -- -e security-agent.go-generate-check`. 

### Motivation

Force gRPC or other protobuf-based files to be updated when protobuf is.

### Describe how you validated your changes

### Additional Notes
