### PR TITLE
Add `trimpath` arg when running Go tests

### DIFF
--- a/cmd/host-profiler/dist_test.go
+++ b/cmd/host-profiler/dist_test.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package main
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed dist/host-profiler-config.yaml
+var config string
+
+func TestConverterInfraAttributesName(t *testing.T) {
+	require.Equal(t, 6, strings.Count(config, "infraattributes/default"))
+}

--- a/comp/host-profiler/collector/impl/converters/converters_test.go
+++ b/comp/host-profiler/collector/impl/converters/converters_test.go
@@ -9,12 +9,7 @@ package converters
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -106,19 +101,6 @@ service:
 			"extensions": []any{},
 		},
 	})
-}
-
-func TestConverterInfraAttributesName(t *testing.T) {
-	config := getDefaultConfig(t)
-	require.Equal(t, 6, strings.Count(config, infraAttributesName()))
-}
-
-func getDefaultConfig(t *testing.T) string {
-	_, file, _, _ := runtime.Caller(0)
-	configPath := filepath.Join(filepath.Dir(file), "../../../../..", "cmd", "host-profiler", "dist", "host-profiler-config.yaml")
-	configData, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	return string(configData)
 }
 
 func readFromYamlFile(t *testing.T, yamlContent string) map[string]any {

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -309,6 +309,7 @@ def test(
     covermode_opt = "-covermode=" + ("atomic" if race else "count") if coverage else ""
     build_cpus_opt = f"-p {cpus}" if cpus else ""
     test_cpus_opt = f"-parallel {cpus}" if cpus else ""
+    trimpath_opt = "-trimpath" if 'DELVE' not in os.environ else ""
 
     nocache = '-count=1' if not cache else ''
 
@@ -335,9 +336,7 @@ def test(
         '-mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" {build_cpus} {race_opt}'
     )
     govet_flags = '-vet=off'
-    gotest_flags = (
-        '{verbose} {test_cpus} -timeout {timeout}s -short {covermode_opt} {test_run_arg} {nocache} {extra_args}'
-    )
+    gotest_flags = '{verbose} {test_cpus} -timeout {timeout}s -short {covermode_opt} {test_run_arg} {nocache} {extra_args} {trimpath_opt}'
     cmd = f'gotestsum {gotestsum_flags} -- {gobuild_flags} {govet_flags} {gotest_flags}'
     args = {
         "go_mod": go_mod,
@@ -356,6 +355,7 @@ def test(
         "skip_flakes": "--skip-flake" if skip_flakes else "",
         "gotestsum_format": "standard-verbose" if verbose else "pkgname",
         "extra_args": extra_args or "",
+        "trimpath_opt": trimpath_opt,
     }
 
     # Test


### PR DESCRIPTION
### What does this PR do?
Run tests using `-trimpath`.

### Motivation
We use `-trimpath` when building the agent, so this makes test closer to actual agent behavior.
In particular some logger tests rely on file paths, using `-trimpath` makes those more reliable, and avoid failures when the cloned agent directory name is not the expected one.  

### Describe how you validated your changes
CI

### Additional Notes
