### PR TITLE
[AGENTRUN-961] Fix format when using slog-based syslog logger

### DIFF
--- a/pkg/util/log/setup/internal/seelog/seelog_config.go
+++ b/pkg/util/log/setup/internal/seelog/seelog_config.go
@@ -183,7 +183,7 @@ func (c *Config) commonSyslogFormatter(_ context.Context, r stdslog.Record) stri
 	syslogHeader := syslogHeaderFormatter(r.Message, seelog.LogLevel(types.FromSlogLevel(r.Level)), nil)
 
 	frame := formatters.Frame(r)
-	level := formatters.CapitalizedLevel(r.Level)
+	level := formatters.UppercaseLevel(r.Level)
 	shortFilePath := formatters.ShortFilePath(frame)
 	funcShort := formatters.ShortFunction(frame)
 	extraContext := formatters.ExtraTextContext(r)
@@ -201,7 +201,7 @@ func (c *Config) jsonSyslogFormatter(_ context.Context, r stdslog.Record) string
 
 	frame := formatters.Frame(r)
 	level := formatters.UppercaseLevel(r.Level)
-	relfile := formatters.RelFile(frame)
+	relfile := formatters.ShortFilePath(frame)
 	extraContext := formatters.ExtraJSONContext(r)
 
 	return fmt.Sprintf(`%s {"agent":"%s","level":"%s","relfile":"%s","line":"%d","msg":"%s"%s}`+"\n", syslogHeader, strings.ToLower(c.loggerName), level, relfile, frame.Line, r.Message, extraContext)

--- a/pkg/util/log/setup/internal/seelog/seelog_config_test.go
+++ b/pkg/util/log/setup/internal/seelog/seelog_config_test.go
@@ -163,8 +163,12 @@ func testSeelogConfig(t *testing.T, config *Config, testName string) {
 
 func TestCommonSyslogFormatter(t *testing.T) {
 	pid := os.Getpid()
-	expected := fmt.Sprintf(`<166>seelog.test[%d]: CORE | INFO | (pkg/util/log/setup/internal/seelog/seelog_config_test.go:28 in callerPC) | check:cpu | Done running check
-`, pid)
+	procName := "seelog.test"
+	if runtime.GOOS == "windows" {
+		procName = "seelog.test.exe"
+	}
+	expected := fmt.Sprintf(`<166>%s[%d]: CORE | INFO | (pkg/util/log/setup/internal/seelog/seelog_config_test.go:28 in callerPC) | check:cpu | Done running check
+`, procName, pid)
 
 	cfg := Config{loggerName: "CORE"}
 	logTime := time.Now()
@@ -182,8 +186,12 @@ func TestCommonSyslogFormatter(t *testing.T) {
 
 func TestJsonSyslogFormatter(t *testing.T) {
 	pid := os.Getpid()
-	expected := fmt.Sprintf(`<166>1 seelog.test %d - - {"agent":"core","level":"INFO","relfile":"pkg/util/log/setup/internal/seelog/seelog_config_test.go","line":"28","msg":"Done running check","check":"cpu"}
-`, pid)
+	procName := "seelog.test"
+	if runtime.GOOS == "windows" {
+		procName = "seelog.test.exe"
+	}
+	expected := fmt.Sprintf(`<166>1 %s %d - - {"agent":"core","level":"INFO","relfile":"pkg/util/log/setup/internal/seelog/seelog_config_test.go","line":"28","msg":"Done running check","check":"cpu"}
+`, procName, pid)
 
 	cfg := Config{loggerName: "CORE", syslogRFC: true}
 	logTime := time.Now()


### PR DESCRIPTION
### What does this PR do?
Two format fixes when using the syslog exporter with the slog-based implementation of the logger:
- Use uppercase level in common format
- Use short file path in json format

### Motivation
Have the exact same format output as previously. 

### Describe how you validated your changes
Manual testing to find differences between the two implementations, added unit tests to avoid regressions.

### Additional Notes
Even without this fix nothing should break, but we aim at having the exact same output as we previously had.