### PR TITLE
Use similar internal error messages in slog logger

### DIFF
--- a/pkg/util/log/slog/filewriter/file_writer.go
+++ b/pkg/util/log/slog/filewriter/file_writer.go
@@ -196,7 +196,7 @@ func (rw *rollingFileWriter) deleteOldRolls(history []string) error {
 	for i := 0; i < rollsToDelete; i++ {
 		// Try best to delete files without breaking the loop.
 		if err = tryRemoveFile(filepath.Join(rw.currentDirPath, history[i])); err != nil {
-			reportInternalError(err)
+			fmt.Fprintf(os.Stderr, "log: filewriter internal error: %v\n", err)
 		}
 	}
 
@@ -455,8 +455,4 @@ func tryRemoveFile(filePath string) (err error) {
 		return
 	}
 	return
-}
-
-func reportInternalError(err error) {
-	fmt.Fprintf(os.Stderr, "log: filewriter internal error: %v\n", err)
 }

--- a/pkg/util/log/slog/filewriter/file_writer.go
+++ b/pkg/util/log/slog/filewriter/file_writer.go
@@ -458,5 +458,5 @@ func tryRemoveFile(filePath string) (err error) {
 }
 
 func reportInternalError(err error) {
-	fmt.Fprintf(os.Stderr, "log internal error: %s\n", err)
+	fmt.Fprintf(os.Stderr, "log: filewriter internal error: %v\n", err)
 }

--- a/pkg/util/log/slog/handlers/async.go
+++ b/pkg/util/log/slog/handlers/async.go
@@ -61,7 +61,7 @@ func (h *Async) writeList(queue list.List) {
 		msg := e.Value.(msg)
 		err := h.innerHandler.Handle(msg.ctx, msg.record)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "slog handler error: %v", err)
+			fmt.Fprintf(os.Stderr, "log: async internal error: %v\n", err)
 		}
 	}
 }

--- a/pkg/util/log/slog/wrapper.go
+++ b/pkg/util/log/slog/wrapper.go
@@ -89,7 +89,7 @@ func (w *Wrapper) handle(level types.LogLevel, message string) {
 
 	err := w.handler.Handle(context.Background(), r)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "slog handler error: %v", err)
+		fmt.Fprintf(os.Stderr, "log: wrapper internal error: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Update the internal error messages in the slog logger to be more similar (but still allow differentiating them).
In particular two of them were missing a newline, which made the errors less readable.

### Motivation
Clean up internal error messages, have them show a similar message, with a newline, but still allow knowing which one logged.

### Describe how you validated your changes
CI

### Additional Notes
