### PR TITLE
Restore Telemetry collection through RAR for system-probe

### DIFF
--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -78,8 +78,13 @@ type remoteagentImpl struct {
 }
 
 func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetryRequest) (*pbcore.GetTelemetryResponse, error) {
-	// Disable telemetry collection temporarily, as it triggers a memory usage quality gate.
-	prometheusText := ""
+	prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
+	// Add here the metric names that should be included in the telemetry response.
+	// This is useful to avoid sending too many metrics to the Core Agent.
+	))
+	if err != nil {
+		return nil, err
+	}
 
 	return &pbcore.GetTelemetryResponse{
 		Payload: &pbcore.GetTelemetryResponse_PromText{


### PR DESCRIPTION
### What does this PR do?
This PR restores the actual telemetry collection through the Remote Agent Registry for the `system-probe` agent.

### Motivation
Restore functionality which was temporarily disabled to mitigate increased memory consumption in an idle scenario.

### Describe how you validated your changes
Manual validation and CI.

### Additional Notes
