### PR TITLE
[VULN-13389] Use ParseUint to convert int with correct size

### DIFF
--- a/comp/api/api/apiimpl/listener.go
+++ b/comp/api/api/apiimpl/listener.go
@@ -32,7 +32,7 @@ func getListener(address string) (net.Listener, error) {
 			return nil, err
 		}
 
-		port, err := strconv.Atoi(sPort)
+		port, err := strconv.ParseUint(sPort, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid port for vsock listener: %v", err)
 		}

--- a/comp/api/api/apiimpl/listener.go
+++ b/comp/api/api/apiimpl/listener.go
@@ -32,7 +32,7 @@ func getListener(address string) (net.Listener, error) {
 			return nil, err
 		}
 
-		port, err := strconv.ParseUint(sPort, 10, 32)
+		port, err := strconv.ParseUint(sPort, 10, 16)
 		if err != nil {
 			return nil, fmt.Errorf("invalid port for vsock listener: %v", err)
 		}


### PR DESCRIPTION
### What does this PR do?
Use `strconv.ParseUint` instead of `strconv.Atoi` to convert a string to `uint32`.

### Motivation
Avoid vulnerability related to int overflow when converting between different sizes.

### Describe how you validated your changes
CI

### Additional Notes
