### PR TITLE
[AGENTRUN-970] Enable new slog-based logger by default

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1287,7 +1287,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("log_to_console", true)
 	config.BindEnvAndSetDefault("log_format_rfc3339", false)
 	config.BindEnvAndSetDefault("log_all_goroutines_when_unhealthy", false)
-	config.BindEnvAndSetDefault("log_use_slog", false)
+	config.BindEnvAndSetDefault("log_use_slog", true)
 	config.BindEnvAndSetDefault("logging_frequency", int64(500))
 	config.BindEnvAndSetDefault("disable_file_logging", false)
 	config.BindEnvAndSetDefault("syslog_uri", "")

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -108,7 +108,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("log_file_max_rolls", 1)
 	cfg.BindEnvAndSetDefault("disable_file_logging", false)
 	cfg.BindEnvAndSetDefault("log_format_rfc3339", false)
-	cfg.BindEnvAndSetDefault("log_use_slog", false)
+	cfg.BindEnvAndSetDefault("log_use_slog", true)
 
 	// secrets backend
 	cfg.BindEnvAndSetDefault("secret_backend_command", "")

--- a/releasenotes/notes/log-slog-impl-default-b131efb9733b5ef1.yaml
+++ b/releasenotes/notes/log-slog-impl-default-b131efb9733b5ef1.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The agent's logger has been rewritten with a more modern library to improve
+    security and performance. No visible change is expected for users.
+    In case of issue, the previous logger can still be used by setting
+    `log_use_slog` to `false` in the agent configuration. This configuration will
+    be removed in a future release.

--- a/releasenotes/notes/log-slog-impl-default-b131efb9733b5ef1.yaml
+++ b/releasenotes/notes/log-slog-impl-default-b131efb9733b5ef1.yaml
@@ -8,8 +8,8 @@
 ---
 enhancements:
   - |
-    The agent's logger has been rewritten with a more modern library to improve
+    The Agent's logger has been rewritten with a more modern library to improve
     security and performance. No visible change is expected for users.
-    In case of issue, the previous logger can still be used by setting
-    `log_use_slog` to `false` in the agent configuration. This configuration will
+    In case of issues, the previous logger can still be used by setting
+    `log_use_slog` to `false` in the Agent configuration. This configuration will
     be removed in a future release.


### PR DESCRIPTION
### What does this PR do?
Enable the new slog-based logger implementation by default.

### Motivation
Eventually remove the old logger entirely, which will provide many benefits (security, performance, ease of introducing new features).

### Describe how you validated your changes
CI.

### Additional Notes
