### PR TITLE
chore: Remove cgroup prefix config option

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3487,7 +3487,6 @@ api_key:
 #     DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_SECURITY_CONTEXT='{"privileged": false}'
 {{ end -}}
 {{ if .DockerTagging }}
-
 ###########################
 ## Docker tag extraction ##
 ###########################

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3487,17 +3487,6 @@ api_key:
 #     DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_SECURITY_CONTEXT='{"privileged": false}'
 {{ end -}}
 {{ if .DockerTagging }}
-#########################
-## Container detection ##
-#########################
-
-## @param container_cgroup_prefix - string - optional - default: /docker/
-## @env DD_CONTAINER_CGROUP_PREFIX - string - optional - default: /docker/
-## On hosts with mixed workloads, non-containernized processes can
-## mistakenly be detected as containerized. Use this parameter to
-## tune the detection logic to your system and avoid false-positives.
-#
-# container_cgroup_prefix: "/docker/"
 
 ###########################
 ## Docker tag extraction ##


### PR DESCRIPTION
### What does this PR do?

Removes unused configuration option `container_cgroup_prefix` from Datadog config.

### Motivation

Usage removed in 2022 https://github.com/DataDog/datadog-agent/pull/12971/files#diff-876c3bc9d731aecaf41b22178875956cbe440a4645c89a140a6f800ffed217cf

Originally introduced in 2018 https://github.com/DataDog/datadog-agent/pull/2827/files#diff-deb7a8edadb57b2794f620674d404a0e721b877897dc1c91b464cb7b75724205 

