### PR TITLE
[CWS] fix cleanup of in upper layer kfilter

### DIFF
--- a/pkg/security/probe/kfilters/approvers.go
+++ b/pkg/security/probe/kfilters/approvers.go
@@ -55,6 +55,7 @@ func newInUpperLayerKFilter(tableName string, eventType model.EventType) (kFilte
 		tableName:    tableName,
 		tableKey:     uint32(0),
 		eventMask:    uint64(1 << (eventType - 1)),
+		isArrayMap:   true,
 	}, nil
 }
 

--- a/pkg/security/probe/kfilters/approvers.go
+++ b/pkg/security/probe/kfilters/approvers.go
@@ -53,7 +53,7 @@ func newInUpperLayerKFilter(tableName string, eventType model.EventType) (kFilte
 	return &eventMaskKFilter{
 		approverType: InUpperLayerApproverType,
 		tableName:    tableName,
-		tableKey:     uint32(0),
+		tableKey:     ebpf.Uint32MapItem(0),
 		eventMask:    uint64(1 << (eventType - 1)),
 		isArrayMap:   true,
 	}, nil

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1885,7 +1885,7 @@ func (p *EBPFProbe) setApprovers(eventType eval.EventType, approvers rules.Appro
 	for _, newKFilter := range newKFilters {
 		seclog.Tracef("Applying kfilter %+v for event type %s", newKFilter, eventType)
 		if err := newKFilter.Apply(p.Manager); err != nil {
-			return err
+			return fmt.Errorf("failed applying new kfilter: %w", err)
 		}
 
 		approverType := newKFilter.GetApproverType()


### PR DESCRIPTION
### What does this PR do?

This PR allows the kfilter cleanup feature to work correctly for `in_upper_layer` kfilter which is backed by an array eBPF map, which doesn't support the delete operation. 

### Motivation

When running
```
$ inv -e security-agent.functional-tests --skip-linters -t "-test.v -test.run TestFilterInUpperLayerApprover\|TestFilterDiscarderRetention -no-trace-pipe"
...
=== RUN   TestFilterDiscarderRetention
[2025-12-19 15:23:04.212] [ERROR] github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).ApplyRuleSet:2437 Error while adding approvers fallback in-kernel policy to `accept` for `open`: delete: invalid argument
...
```
this PR fixes that.

### Describe how you validated your changes

### Additional Notes
