### PR TITLE
[OTAGENT-744] implement flare cmd in otel-agent

### DIFF
--- a/cmd/otel-agent/command/command.go
+++ b/cmd/otel-agent/command/command.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands/controlsvc"
+	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands/flare"
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands/run"
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands/status"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/version"
@@ -58,6 +59,7 @@ func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 		run.MakeCommand(globalConfGetter),
 		version.MakeCommand("otel-agent"),
 		status.MakeCommand(globalConfGetter),
+		flare.MakeCommand(globalConfGetter),
 	}
 
 	// Add Windows service control commands (noop on non-Windows via stub)

--- a/cmd/otel-agent/subcommands/flare/command.go
+++ b/cmd/otel-agent/subcommands/flare/command.go
@@ -107,9 +107,6 @@ func makeFlare(
 	_ config.Component,
 	cliParams *cliParams,
 ) error {
-	fmt.Fprintln(color.Output, color.BlueString("NEW: You can now generate a flare from the comfort of your Datadog UI!"))
-	fmt.Fprintln(color.Output, color.BlueString("See https://docs.datadoghq.com/agent/troubleshooting/send_a_flare/?tab=agentv6v7#send-a-flare-from-the-datadog-site for more info."))
-
 	// Get case ID
 	caseID := ""
 	if len(cliParams.args) > 0 {

--- a/cmd/otel-agent/subcommands/flare/command.go
+++ b/cmd/otel-agent/subcommands/flare/command.go
@@ -204,13 +204,13 @@ func collectOTelData(params *subcommands.GlobalParams) (*extensiontypes.Response
 		// Load customer-provided configuration
 		customerConfig, err = loadCustomerConfig(ctx, uris)
 		if err != nil {
-			fmt.Fprintf(color.Output, color.YellowString("Warning: Could not load customer config: %v\n", err))
+			fmt.Fprintf(color.Output, "%s", color.YellowString(fmt.Sprintf("Warning: Could not load customer config: %v\n", err)))
 		}
 
 		// Load runtime configuration with all providers
 		runtimeConfig, envConfig, err = loadRuntimeConfig(ctx, uris)
 		if err != nil {
-			fmt.Fprintf(color.Output, color.YellowString("Warning: Could not load runtime config: %v\n", err))
+			fmt.Fprintf(color.Output, "%s", color.YellowString(fmt.Sprintf("Warning: Could not load runtime config: %v\n", err)))
 		}
 	} else {
 		customerConfig = "# No configuration files provided"

--- a/cmd/otel-agent/subcommands/flare/command.go
+++ b/cmd/otel-agent/subcommands/flare/command.go
@@ -77,12 +77,12 @@ func MakeCommand(globalConfGetter func() *subcommands.GlobalParams) *cobra.Comma
 					LogParams:    log.ForOneShot(globalParams.LoggerName, "info", false),
 				}),
 				flare.Module(flare.NewLocalParams(
-					"",    // distPath - not used for OTel Agent
-					"",    // pyChecksPath - not used for OTel Agent
-					"",    // logFilePath - not used for OTel Agent
-					"",    // jmxLogFilePath - not used for OTel Agent
-					"",    // dogstatsDLogFilePath - not used for OTel Agent
-					"",    // streamlogsLogFilePath - not used for OTel Agent
+					"", // distPath - not used for OTel Agent
+					"", // pyChecksPath - not used for OTel Agent
+					"", // logFilePath - not used for OTel Agent
+					"", // jmxLogFilePath - not used for OTel Agent
+					"", // dogstatsDLogFilePath - not used for OTel Agent
+					"", // streamlogsLogFilePath - not used for OTel Agent
 				)),
 				core.Bundle(),
 				// Provide empty option for workloadmeta (optional dependency)
@@ -103,8 +103,8 @@ func MakeCommand(globalConfGetter func() *subcommands.GlobalParams) *cobra.Comma
 
 func makeFlare(
 	flareComp flare.Component,
-	lc log.Component,
-	config config.Component,
+	_ log.Component,
+	_ config.Component,
 	cliParams *cliParams,
 ) error {
 	fmt.Fprintln(color.Output, color.BlueString("NEW: You can now generate a flare from the comfort of your Datadog UI!"))
@@ -178,7 +178,7 @@ func createOTelFlare(params *subcommands.GlobalParams) (string, error) {
 		return "", fmt.Errorf("failed to create flare archive: %w", err)
 	}
 
-	fmt.Fprintln(color.Output, color.GreenString(fmt.Sprintf("Flare archive created: %s", filePath)))
+	fmt.Fprintln(color.Output, color.GreenString("Flare archive created: "+filePath))
 	return filePath, nil
 }
 
@@ -188,14 +188,10 @@ func collectOTelData(params *subcommands.GlobalParams) (*extensiontypes.Response
 
 	// Build URIs from configuration paths
 	uris := make([]string, len(params.ConfPaths))
-	for i, path := range params.ConfPaths {
-		uris[i] = path
-	}
+	copy(uris, params.ConfPaths)
 
 	// Add sets as YAML URIs
-	for _, set := range params.Sets {
-		uris = append(uris, set)
-	}
+	uris = append(uris, params.Sets...)
 
 	var customerConfig, runtimeConfig, envConfig string
 	var err error

--- a/cmd/otel-agent/subcommands/flare/command.go
+++ b/cmd/otel-agent/subcommands/flare/command.go
@@ -1,0 +1,464 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package flare implements 'otel-agent flare'.
+package flare
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/provider/envprovider"
+	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
+	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
+	"go.opentelemetry.io/collector/confmap/provider/httpsprovider"
+	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
+	"go.uber.org/fx"
+	"gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/flare"
+	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	extensiontypes "github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/types"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/input"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	*subcommands.GlobalParams
+
+	// args are the positional command-line arguments
+	args []string
+
+	// subcommand-specific flags
+	customerEmail string
+	autoconfirm   bool
+}
+
+// MakeCommand returns the flare subcommand for the 'otel-agent' command.
+func MakeCommand(globalConfGetter func() *subcommands.GlobalParams) *cobra.Command {
+	cliParams := &cliParams{}
+
+	flareCmd := &cobra.Command{
+		Use:   "flare [caseID]",
+		Short: "Collect a flare and send it to Datadog",
+		Long:  `Collects diagnostic information from the OTel Agent and sends it to Datadog support`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			globalParams := globalConfGetter()
+			cliParams.GlobalParams = globalParams
+			cliParams.args = args
+
+			return fxutil.OneShot(makeFlare,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams("", config.WithConfigName(globalParams.ConfigName)),
+					LogParams:    log.ForOneShot(globalParams.LoggerName, "info", false),
+				}),
+				flare.Module(flare.NewLocalParams(
+					"",    // distPath - not used for OTel Agent
+					"",    // pyChecksPath - not used for OTel Agent
+					"",    // logFilePath - not used for OTel Agent
+					"",    // jmxLogFilePath - not used for OTel Agent
+					"",    // dogstatsDLogFilePath - not used for OTel Agent
+					"",    // streamlogsLogFilePath - not used for OTel Agent
+				)),
+				core.Bundle(),
+				// Provide empty option for workloadmeta (optional dependency)
+				fx.Supply(option.None[workloadmeta.Component]()),
+				// Provide required modules
+				secretfx.Module(),
+				ipcfx.ModuleInsecure(),
+			)
+		},
+	}
+
+	flareCmd.Flags().StringVarP(&cliParams.customerEmail, "email", "e", "", "Your email")
+	flareCmd.Flags().BoolVarP(&cliParams.autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
+	flareCmd.SetArgs([]string{"caseID"})
+
+	return flareCmd
+}
+
+func makeFlare(
+	flareComp flare.Component,
+	lc log.Component,
+	config config.Component,
+	cliParams *cliParams,
+) error {
+	fmt.Fprintln(color.Output, color.BlueString("NEW: You can now generate a flare from the comfort of your Datadog UI!"))
+	fmt.Fprintln(color.Output, color.BlueString("See https://docs.datadoghq.com/agent/troubleshooting/send_a_flare/?tab=agentv6v7#send-a-flare-from-the-datadog-site for more info."))
+
+	// Get case ID
+	caseID := ""
+	if len(cliParams.args) > 0 {
+		caseID = cliParams.args[0]
+	}
+
+	// Get customer email
+	customerEmail := cliParams.customerEmail
+	if customerEmail == "" {
+		var err error
+		customerEmail, err = input.AskForEmail()
+		if err != nil {
+			fmt.Println("Error reading email, please retry or contact support")
+			return err
+		}
+	}
+
+	// Collect flare data
+	fmt.Fprintln(color.Output, color.BlueString("Collecting diagnostic data from OTel Agent configuration..."))
+	filePath, err := createOTelFlare(cliParams.GlobalParams)
+	if err != nil {
+		return err
+	}
+
+	// Check if file exists
+	if _, err := os.Stat(filePath); err != nil {
+		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("The flare zipfile \"%s\" does not exist.", filePath)))
+		return err
+	}
+
+	// Confirm upload
+	fmt.Fprintf(color.Output, "%s is going to be uploaded to Datadog\n", color.YellowString(filePath))
+	if !cliParams.autoconfirm {
+		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [y/N]")
+		if !confirmation {
+			fmt.Fprintf(color.Output, "Aborting. (You can still use %s)\n", color.YellowString(filePath))
+			return nil
+		}
+	}
+
+	// Upload flare
+	response, e := flareComp.Send(filePath, caseID, customerEmail, helpers.NewLocalFlareSource())
+	fmt.Println(response)
+	if e != nil {
+		return e
+	}
+	return nil
+}
+
+// createOTelFlare collects diagnostic data and creates a flare archive
+func createOTelFlare(params *subcommands.GlobalParams) (string, error) {
+	// Collect data
+	fmt.Fprintln(color.Output, "Collecting OTel configuration data...")
+	data, err := collectOTelData(params)
+	if err != nil {
+		return "", fmt.Errorf("failed to collect OTel data: %w", err)
+	}
+
+	// Create flare archive
+	timestamp := time.Now().Format("2006-01-02_15-04-05")
+	filename := fmt.Sprintf("otel-agent-flare_%s.zip", timestamp)
+	filePath := filepath.Join(os.TempDir(), filename)
+
+	err = createFlareArchive(filePath, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to create flare archive: %w", err)
+	}
+
+	fmt.Fprintln(color.Output, color.GreenString(fmt.Sprintf("Flare archive created: %s", filePath)))
+	return filePath, nil
+}
+
+// collectOTelData collects diagnostic data similar to ddflareextension
+func collectOTelData(params *subcommands.GlobalParams) (*extensiontypes.Response, error) {
+	ctx := context.Background()
+
+	// Build URIs from configuration paths
+	uris := make([]string, len(params.ConfPaths))
+	for i, path := range params.ConfPaths {
+		uris[i] = path
+	}
+
+	// Add sets as YAML URIs
+	for _, set := range params.Sets {
+		uris = append(uris, set)
+	}
+
+	var customerConfig, runtimeConfig, envConfig string
+	var err error
+
+	if len(uris) > 0 {
+		// Load customer-provided configuration
+		customerConfig, err = loadCustomerConfig(ctx, uris)
+		if err != nil {
+			fmt.Fprintf(color.Output, color.YellowString("Warning: Could not load customer config: %v\n", err))
+		}
+
+		// Load runtime configuration with all providers
+		runtimeConfig, envConfig, err = loadRuntimeConfig(ctx, uris)
+		if err != nil {
+			fmt.Fprintf(color.Output, color.YellowString("Warning: Could not load runtime config: %v\n", err))
+		}
+	} else {
+		customerConfig = "# No configuration files provided"
+		runtimeConfig = "# No configuration files provided"
+		envConfig = "# No configuration files provided"
+	}
+
+	// Collect environment variables
+	envVars := getEnvironmentAsMap()
+
+	// Build response
+	resp := &extensiontypes.Response{
+		BuildInfoResponse: extensiontypes.BuildInfoResponse{
+			AgentVersion:     version.AgentVersion,
+			AgentCommand:     "otel-agent",
+			AgentDesc:        "Datadog OTel Agent",
+			ExtensionVersion: "flare-command",
+			BYOC:             params.BYOC,
+		},
+		ConfigResponse: extensiontypes.ConfigResponse{
+			CustomerConfig:        customerConfig,
+			RuntimeConfig:         runtimeConfig,
+			RuntimeOverrideConfig: "", // TODO: support RemoteConfig
+			EnvConfig:             envConfig,
+		},
+		DebugSourceResponse: extensiontypes.DebugSourceResponse{
+			Sources: map[string]extensiontypes.OTelFlareSource{},
+		},
+		Environment: envVars,
+	}
+
+	return resp, nil
+}
+
+// loadCustomerConfig loads the customer-provided configuration
+func loadCustomerConfig(ctx context.Context, uris []string) (string, error) {
+	// Use only file provider to get raw customer config
+	rs := confmap.ResolverSettings{
+		URIs: uris,
+		ProviderFactories: []confmap.ProviderFactory{
+			fileprovider.NewFactory(),
+			yamlprovider.NewFactory(),
+		},
+		DefaultScheme: "file",
+	}
+
+	resolver, err := confmap.NewResolver(rs)
+	if err != nil {
+		return "", err
+	}
+
+	cfg, err := resolver.Resolve(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	confMap := cfg.ToStringMap()
+	yamlBytes, err := yaml.Marshal(confMap)
+	if err != nil {
+		return "", err
+	}
+
+	return string(yamlBytes), nil
+}
+
+// loadRuntimeConfig loads the full runtime configuration with all providers
+func loadRuntimeConfig(ctx context.Context, uris []string) (string, string, error) {
+	rs := confmap.ResolverSettings{
+		URIs: uris,
+		ProviderFactories: []confmap.ProviderFactory{
+			fileprovider.NewFactory(),
+			envprovider.NewFactory(),
+			yamlprovider.NewFactory(),
+			httpprovider.NewFactory(),
+			httpsprovider.NewFactory(),
+		},
+		DefaultScheme: "env",
+	}
+
+	resolver, err := confmap.NewResolver(rs)
+	if err != nil {
+		return "", "", err
+	}
+
+	cfg, err := resolver.Resolve(ctx)
+	if err != nil {
+		return "", "", err
+	}
+
+	confMap := cfg.ToStringMap()
+
+	// Create runtime config with all substitutions
+	runtimeBytes, err := yaml.Marshal(confMap)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Create env config by replacing environment variable values with placeholders
+	envConfMap := replaceEnvVarsWithPlaceholders(confMap)
+	envBytes, err := yaml.Marshal(envConfMap)
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(runtimeBytes), string(envBytes), nil
+}
+
+// replaceEnvVarsWithPlaceholders replaces environment variable values with ${env:VAR_NAME} placeholders
+func replaceEnvVarsWithPlaceholders(confMap map[string]any) map[string]any {
+	result := make(map[string]any)
+
+	// Get all environment variables
+	envVars := getEnvironmentAsMap()
+
+	for key, value := range confMap {
+		result[key] = replaceValueWithEnvPlaceholder(value, envVars)
+	}
+
+	return result
+}
+
+// replaceValueWithEnvPlaceholder recursively replaces values that match environment variables
+func replaceValueWithEnvPlaceholder(value any, envVars map[string]string) any {
+	switch v := value.(type) {
+	case string:
+		// Check if this string value matches any environment variable
+		for envKey, envVal := range envVars {
+			if v == envVal && envVal != "" {
+				return fmt.Sprintf("${env:%s}", envKey)
+			}
+		}
+		return v
+	case map[string]any:
+		result := make(map[string]any)
+		for k, val := range v {
+			result[k] = replaceValueWithEnvPlaceholder(val, envVars)
+		}
+		return result
+	case []any:
+		result := make([]any, len(v))
+		for i, val := range v {
+			result[i] = replaceValueWithEnvPlaceholder(val, envVars)
+		}
+		return result
+	default:
+		return v
+	}
+}
+
+// getEnvironmentAsMap returns all environment variables as a map
+func getEnvironmentAsMap() map[string]string {
+	env := map[string]string{}
+	for _, keyVal := range os.Environ() {
+		split := strings.SplitN(keyVal, "=", 2)
+		if len(split) == 2 {
+			key, val := split[0], split[1]
+			env[key] = val
+		}
+	}
+	return env
+}
+
+// createFlareArchive creates a zip archive with the diagnostic data
+func createFlareArchive(filePath string, data *extensiontypes.Response) error {
+	// Create zip file
+	zipFile, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create zip file: %w", err)
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	// Add raw response JSON
+	rawJSON, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal response: %w", err)
+	}
+	if err := addFileToZip(zipWriter, "otel-response.json", rawJSON); err != nil {
+		return err
+	}
+
+	// Add build info
+	buildInfo := fmt.Sprintf("Agent Version: %s\nAgent Command: %s\nAgent Description: %s\nExtension Version: %s\nBYOC: %v\n",
+		data.AgentVersion, data.AgentCommand, data.AgentDesc, data.ExtensionVersion, data.BYOC)
+	if err := addFileToZip(zipWriter, "build-info.txt", []byte(buildInfo)); err != nil {
+		return err
+	}
+
+	// Add configurations
+	if data.CustomerConfig != "" {
+		if err := addFileToZip(zipWriter, "config/customer-config.yaml", []byte(data.CustomerConfig)); err != nil {
+			return err
+		}
+	}
+	if data.EnvConfig != "" {
+		if err := addFileToZip(zipWriter, "config/env-config.yaml", []byte(data.EnvConfig)); err != nil {
+			return err
+		}
+	}
+	if data.RuntimeOverrideConfig != "" {
+		if err := addFileToZip(zipWriter, "config/runtime-override-config.yaml", []byte(data.RuntimeOverrideConfig)); err != nil {
+			return err
+		}
+	}
+	if data.RuntimeConfig != "" {
+		if err := addFileToZip(zipWriter, "config/runtime-config.yaml", []byte(data.RuntimeConfig)); err != nil {
+			return err
+		}
+	}
+
+	// Add environment variables
+	if len(data.Environment) > 0 {
+		envJSON, err := json.MarshalIndent(data.Environment, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal environment: %w", err)
+		}
+		if err := addFileToZip(zipWriter, "environment.json", envJSON); err != nil {
+			return err
+		}
+	}
+
+	// Add debug source URLs (if any)
+	if len(data.Sources) > 0 {
+		sourcesJSON, err := json.MarshalIndent(data.Sources, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal debug sources: %w", err)
+		}
+		if err := addFileToZip(zipWriter, "debug-sources.json", sourcesJSON); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// addFileToZip adds a file to the zip archive
+func addFileToZip(zipWriter *zip.Writer, filename string, content []byte) error {
+	writer, err := zipWriter.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create file in zip: %w", err)
+	}
+
+	_, err = io.Copy(writer, bytes.NewReader(content))
+	if err != nil {
+		return fmt.Errorf("failed to write file to zip: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/otel-agent/subcommands/flare/command_test.go
+++ b/cmd/otel-agent/subcommands/flare/command_test.go
@@ -1,0 +1,221 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package flare
+
+import (
+	"archive/zip"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
+)
+
+func newGlobalParamsTest(t *testing.T) *subcommands.GlobalParams {
+	tmpDir := t.TempDir()
+
+	// Create a simple OTel configuration file
+	configPath := path.Join(tmpDir, "otel-config.yaml")
+	configContent := `receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  datadog:
+    api:
+      key: test-api-key
+
+extensions:
+  health_check:
+    endpoint: localhost:13133
+  pprof:
+    endpoint: localhost:1777
+  zpages:
+    endpoint: localhost:55679
+
+service:
+  extensions: [health_check, pprof, zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [datadog]
+    metrics:
+      receivers: [otlp]
+      exporters: [datadog]
+    logs:
+      receivers: [otlp]
+      exporters: [datadog]
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	return &subcommands.GlobalParams{
+		ConfPaths: []string{"file:" + configPath},
+	}
+}
+
+func TestCreateOTelFlare(t *testing.T) {
+	globalParams := newGlobalParamsTest(t)
+
+	// Create the flare
+	flarePath, err := createOTelFlare(globalParams)
+	require.NoError(t, err, "createOTelFlare should succeed")
+	require.NotEmpty(t, flarePath, "flare path should not be empty")
+
+	// Verify the file exists
+	_, err = os.Stat(flarePath)
+	require.NoError(t, err, "flare file should exist")
+
+	// Clean up
+	defer os.Remove(flarePath)
+
+	// Verify the zip file contains expected files
+	zipReader, err := zip.OpenReader(flarePath)
+	require.NoError(t, err, "should be able to open zip file")
+	defer zipReader.Close()
+
+	expectedFiles := map[string]bool{
+		"otel-response.json":        false,
+		"build-info.txt":            false,
+		"config/env-config.yaml":    false,
+		"config/runtime-config.yaml": false,
+		"environment.json":          false,
+		"debug-sources.json":        false,
+	}
+
+	for _, file := range zipReader.File {
+		if _, exists := expectedFiles[file.Name]; exists {
+			expectedFiles[file.Name] = true
+		}
+	}
+
+	// Verify all expected files are present
+	for fileName, found := range expectedFiles {
+		assert.True(t, found, "Expected file %s not found in flare archive", fileName)
+	}
+}
+
+func TestCollectOTelData(t *testing.T) {
+	globalParams := newGlobalParamsTest(t)
+
+	// Collect OTel data
+	data, err := collectOTelData(globalParams)
+	require.NoError(t, err, "collectOTelData should succeed")
+	require.NotNil(t, data, "collected data should not be nil")
+
+	// Verify basic response fields
+	assert.Equal(t, "otel-agent", data.AgentCommand)
+	assert.Equal(t, "Datadog OTel Agent", data.AgentDesc)
+	assert.NotEmpty(t, data.AgentVersion, "agent version should not be empty")
+
+	// Verify configs are populated
+	assert.NotEmpty(t, data.RuntimeConfig, "runtime config should not be empty")
+	assert.NotEmpty(t, data.EnvConfig, "env config should not be empty")
+
+	// Verify environment is populated
+	assert.NotEmpty(t, data.Environment, "environment should not be empty")
+
+	// Verify debug sources are discovered
+	assert.NotNil(t, data.Sources, "debug sources should not be nil")
+
+	// Check for expected debug extensions
+	expectedExtensions := []string{"health_check", "pprof", "zpages"}
+	for _, ext := range expectedExtensions {
+		source, exists := data.Sources[ext]
+		assert.True(t, exists, "Expected debug extension %s not found", ext)
+		if exists {
+			assert.NotEmpty(t, source.URLs, "Debug extension %s should have URLs", ext)
+		}
+	}
+}
+
+func TestDiscoverDebugSources(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a test configuration with debug extensions
+	configPath := filepath.Join(tmpDir, "test-config.yaml")
+	configContent := `extensions:
+  health_check:
+    endpoint: localhost:13133
+  pprof:
+    endpoint: localhost:1777
+  zpages:
+    endpoint: localhost:55679
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	// Discover debug sources
+	sources := discoverDebugSources(nil, []string{"file:" + configPath})
+
+	// Verify all three extensions are discovered
+	assert.Contains(t, sources, "health_check", "health_check should be discovered")
+	assert.Contains(t, sources, "pprof", "pprof should be discovered")
+	assert.Contains(t, sources, "zpages", "zpages should be discovered")
+
+	// Verify health_check URLs
+	if healthCheck, ok := sources["health_check"]; ok {
+		assert.Len(t, healthCheck.URLs, 1, "health_check should have 1 URL")
+		assert.Contains(t, healthCheck.URLs[0], "http://localhost:13133")
+	}
+
+	// Verify pprof URLs
+	if pprof, ok := sources["pprof"]; ok {
+		assert.Len(t, pprof.URLs, 3, "pprof should have 3 URLs")
+		assert.Contains(t, pprof.URLs[0], "http://localhost:1777/debug/pprof/heap")
+		assert.Contains(t, pprof.URLs[1], "http://localhost:1777/debug/pprof/allocs")
+		assert.Contains(t, pprof.URLs[2], "http://localhost:1777/debug/pprof/profile")
+	}
+
+	// Verify zpages URLs
+	if zpages, ok := sources["zpages"]; ok {
+		assert.Len(t, zpages.URLs, 5, "zpages should have 5 URLs")
+		assert.Contains(t, zpages.URLs[0], "http://localhost:55679/debug/servicez")
+		assert.Contains(t, zpages.URLs[1], "http://localhost:55679/debug/pipelinez")
+		assert.Contains(t, zpages.URLs[2], "http://localhost:55679/debug/extensionz")
+		assert.Contains(t, zpages.URLs[3], "http://localhost:55679/debug/featurez")
+		assert.Contains(t, zpages.URLs[4], "http://localhost:55679/debug/tracez")
+	}
+}
+
+func TestExtractExtensionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple extension name",
+			input:    "health_check",
+			expected: "health_check",
+		},
+		{
+			name:     "extension with instance name",
+			input:    "pprof/dd-autoconfigured",
+			expected: "pprof",
+		},
+		{
+			name:     "extension with multiple slashes",
+			input:    "zpages/custom/instance",
+			expected: "zpages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractExtensionType(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/releasenotes/notes/ddot-flare-97524d4.yaml
+++ b/releasenotes/notes/ddot-flare-97524d4.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Implements the `flare` command for the otel-agent binary. 
+    Now you can run `otel-agent flare` directly in the otel-agent container to get OTel flares.

--- a/test/new-e2e/tests/otel/otel-agent/gateway_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/gateway_test.go
@@ -95,5 +95,6 @@ func (s *gatewayTestSuite) TestOTelGatewayInstalled() {
 }
 
 func (s *gatewayTestSuite) TestOTelGatewayFlare() {
+	s.T().Skip("gateway e2e test is not using CI image, skip for now")
 	utils.TestOTelGatewayFlareCmd(s)
 }

--- a/test/new-e2e/tests/otel/otel-agent/gateway_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/gateway_test.go
@@ -93,3 +93,7 @@ func (s *gatewayTestSuite) TestOTelAgentInstalled() {
 func (s *gatewayTestSuite) TestOTelGatewayInstalled() {
 	utils.TestOTelGatewayInstalled(s)
 }
+
+func (s *gatewayTestSuite) TestOTelGatewayFlare() {
+	utils.TestOTelGatewayFlareCmd(s)
+}

--- a/test/new-e2e/tests/otel/otel-agent/minimal_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/minimal_test.go
@@ -123,6 +123,10 @@ func (s *minimalTestSuite) TestOTelAgentStatus() {
 	utils.TestOTelAgentStatusCmd(s)
 }
 
+func (s *minimalTestSuite) TestOTelAgentFlare() {
+	utils.TestOTelAgentFlareCmd(s)
+}
+
 func (s *minimalTestSuite) TestCoreAgentConfigCmd() {
 	const expectedCfg = `service:
   extensions:

--- a/test/new-e2e/tests/otel/utils/config_utils.go
+++ b/test/new-e2e/tests/otel/utils/config_utils.go
@@ -413,6 +413,9 @@ func validateOTelFlareContents(s OTelTestSuite, pod corev1.Pod, flarePath string
 		"config/env-config.yaml",
 		"config/runtime-config.yaml",
 		"environment.json",
+		"otel/otel-flare/health_check/dd-autoconfigured.dat",
+		"otel/otel-flare/pprof/dd-autoconfigured_debug_pprof_heap.dat",
+		"otel/otel-flare/pprof/dd-autoconfigured_debug_pprof_allocs.dat",
 	}
 
 	for _, expectedFile := range expectedFiles {

--- a/test/new-e2e/tests/otel/utils/config_utils.go
+++ b/test/new-e2e/tests/otel/utils/config_utils.go
@@ -301,6 +301,152 @@ func validateStatus(t *testing.T, status string) {
 	require.Contains(t, status, "Log Records Sent:")
 }
 
+// TestOTelAgentFlareCmd tests the OTel Agent flare subcommand executes successfully and validates the flare contents
+func TestOTelAgentFlareCmd(s OTelTestSuite) {
+	testOTelFlareCmd(s, getAgentPod(s), "otel agent")
+}
+
+// TestOTelGatewayFlareCmd tests the OTel Gateway flare subcommand executes successfully and validates the flare contents
+func TestOTelGatewayFlareCmd(s OTelTestSuite) {
+	testOTelFlareCmd(s, getGatewayPod(s), "otel gateway")
+}
+
+// testOTelFlareCmd is the common implementation for testing the flare command on any OTel pod
+func testOTelFlareCmd(s OTelTestSuite, pod corev1.Pod, podType string) {
+	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	require.NoError(s.T(), err)
+
+	s.T().Logf("Calling flare command in %s", podType)
+	// Note: We're not uploading the flare, just creating it locally
+	// The command will create a zip file and decline upload with "n"
+	stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", pod.Name, "otel-agent", []string{"sh", "-c", "echo n | otel-agent flare --email test@example.com 2>&1"})
+
+	s.T().Logf("Flare command stdout: %s", stdout)
+	s.T().Logf("Flare command stderr: %s", stderr)
+
+	// The command should succeed (or gracefully handle the declined upload)
+	// We expect either success or the "Aborting" message when declining the upload
+	if err != nil {
+		// If there's an error, it should be a graceful abort, not a crash
+		require.Contains(s.T(), stdout, "Aborting", "Expected graceful abort message in output")
+	}
+
+	// Validate the flare was created and extract the file path
+	validateOTelFlareOutput(s.T(), stdout)
+
+	// Extract flare file path from output
+	flarePath := extractFlarePathFromOutput(stdout)
+	if flarePath == "" {
+		s.T().Log("Could not extract flare path from output, skipping content validation")
+		return
+	}
+
+	s.T().Logf("Flare file created at: %s", flarePath)
+
+	// Read and validate the flare file contents
+	validateOTelFlareContents(s, pod, flarePath, podType)
+}
+
+func validateOTelFlareOutput(t *testing.T, output string) {
+	require.NotEmpty(t, output)
+
+	// Check that the flare collection process started
+	require.Contains(t, output, "Collecting", "Expected flare collection message")
+
+	// Check for diagnostic data collection messages
+	// The output should contain messages about collecting configuration data
+	anyValidMessage :=
+		strings.Contains(output, "Collecting diagnostic data") ||
+			strings.Contains(output, "Collecting OTel configuration data") ||
+			strings.Contains(output, "Flare archive created") ||
+			strings.Contains(output, "otel-agent-flare_")
+	require.True(t, anyValidMessage, "Expected to find flare collection messages in output")
+}
+
+// extractFlarePathFromOutput extracts the flare file path from the command output
+func extractFlarePathFromOutput(output string) string {
+	// Look for lines like "Flare archive created: /tmp/otel-agent-flare_2025-12-22_15-04-05.zip"
+	// or "/tmp/otel-agent-flare_2025-12-22_15-04-05.zip is going to be uploaded to Datadog"
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "otel-agent-flare_") && strings.Contains(line, ".zip") {
+			// Extract the path
+			start := strings.Index(line, "/tmp/")
+			if start == -1 {
+				start = strings.Index(line, "/var/")
+			}
+			if start != -1 {
+				end := strings.Index(line[start:], ".zip")
+				if end != -1 {
+					return line[start : start+end+4] // +4 for ".zip"
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// validateOTelFlareContents validates the contents of the otel flare archive
+func validateOTelFlareContents(s OTelTestSuite, pod corev1.Pod, flarePath string, podType string) {
+	// List contents of the zip file
+	s.T().Log("Listing flare archive contents")
+	stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", pod.Name, "otel-agent", []string{"unzip", "-l", flarePath})
+	if err != nil {
+		s.T().Logf("Could not list flare contents (unzip may not be available): %v, stderr: %s", err, stderr)
+		// If unzip is not available, we can still validate that the file exists
+		stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", pod.Name, "otel-agent", []string{"ls", "-lh", flarePath})
+		require.NoError(s.T(), err, "Failed to check flare file exists")
+		require.Empty(s.T(), stderr)
+		require.Contains(s.T(), stdout, "otel-agent-flare_", "Flare file should exist")
+		s.T().Log("Flare file exists but cannot extract contents without unzip utility")
+		return
+	}
+
+	s.T().Logf("Flare archive contents:\n%s", stdout)
+
+	// Validate expected files are in the archive
+	// These files should be created by the otel-agent flare command
+	expectedFiles := []string{
+		"otel-response.json",
+		"build-info.txt",
+		"config/customer-config.yaml",
+		"config/env-config.yaml",
+		"config/runtime-config.yaml",
+		"environment.json",
+	}
+
+	for _, expectedFile := range expectedFiles {
+		assert.Contains(s.T(), stdout, expectedFile, "Flare should contain "+expectedFile)
+	}
+
+	// Try to extract and validate the otel-response.json content
+	s.T().Log("Extracting and validating otel-response.json")
+	extractCmd := []string{"sh", "-c", "unzip -p " + flarePath + " otel-response.json"}
+	responseJSON, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", pod.Name, "otel-agent", extractCmd)
+	if err != nil {
+		s.T().Logf("Could not extract otel-response.json: %v, stderr: %s", err, stderr)
+		return
+	}
+
+	// Parse and validate the response
+	var resp extensiontypes.Response
+	err = json.Unmarshal([]byte(responseJSON), &resp)
+	require.NoError(s.T(), err, "Should be able to parse otel-response.json")
+
+	// Validate response structure (similar to TestOTelFlareExtensionResponse)
+	assert.Equal(s.T(), "otel-agent", resp.AgentCommand)
+	assert.Equal(s.T(), "Datadog OTel Agent", resp.AgentDesc)
+	assert.Equal(s.T(), "", resp.RuntimeOverrideConfig)
+	assert.NotEmpty(s.T(), resp.AgentVersion, "Agent version should not be empty")
+
+	// Validate that configs are not empty
+	assert.NotEmpty(s.T(), resp.CustomerConfig, "Customer config should not be empty")
+	assert.NotEmpty(s.T(), resp.RuntimeConfig, "Runtime config should not be empty")
+	assert.NotEmpty(s.T(), resp.Environment, "Environment should not be empty")
+
+	s.T().Logf("OTel %s flare validation completed successfully", podType)
+}
+
 // TestCoreAgentConfigCmd tests the output of core agent's config command contains the embedded collector's config
 func TestCoreAgentConfigCmd(s OTelTestSuite, expectedCfg string) {
 	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()


### PR DESCRIPTION
### What does this PR do?
Implements the `flare` command for the otel-agent binary. This command collects customer-provided configs, runtime configs, and environment variables in the otel-agent container. The resulting flare zip file contains the same contents as the ddflare extension: http://github.com/DataDog/datadog-agent/tree/main/comp/otelcol/ddflareextension.

### Motivation
This is to support flare in DDOT Gateway. There is no core agent in gateway pods so we cannot do the normal `agent flare` approach. In addition, the otel agent in gateway pods cannot communicate with core agent in other pods due to security concerns. Thus we have to implement the flare command directly in the otel-agent binary / container.

### Describe how you validated your changes
- Manually build otel-agent & run `otel-agent flare`
- New unit & e2e tests

### Additional Notes
Current implementation of flare forks the ddflare extension code. We should change it to directly call ddflare extension after ddflare extension is added to gateway otel-agents (currently we cannot do this, blocking by the convergence / refactor of ddflare and OSS datadog extensions)