### PR TITLE
[VULN-13388] Correct possible overflow / underflow vulnerability

### DIFF
--- a/comp/core/ipc/httphelpers/client.go
+++ b/comp/core/ipc/httphelpers/client.go
@@ -48,7 +48,7 @@ func NewClient(authToken string, clientTLSConfig *tls.Config, config pkgconfigmo
 				return nil, err
 			}
 
-			port, err := strconv.Atoi(sPort)
+			port, err := strconv.ParseUint(sPort, 10, 16)
 			if err != nil {
 				return nil, fmt.Errorf("invalid port for vsock listener: %v", err)
 			}


### PR DESCRIPTION
### What does this PR do?
When converting a string to an integer which will be used as a port, restrict the range from 0 - 65535.

### Motivation
This was identified as a potential vulnerability in the code.

### Describe how you validated your changes
CI
