### PR TITLE
Disk Go Check: Improve diskv2 check test coverage for edge cases and platform-specific paths

### DIFF
--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"slices"
 	"testing"
 
 	gopsutil_disk "github.com/shirou/gopsutil/v4/disk"
@@ -1603,12 +1604,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturn
 	assert.Nil(t, err)
 	// Partition with device "none" should be excluded
 	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), "", mock.MatchedBy(func(tags []string) bool {
-		for _, tag := range tags {
-			if tag == "device:none" {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(tags, "device:none")
 	}))
 	// Regular partition should still be reported
 	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{"device:/dev/sda1", "device_name:sda1"})

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -1572,6 +1572,8 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndInodesIsZero_ThenInode
 	m.AssertNotCalled(t, "Gauge", "system.fs.inodes.total", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "Gauge", "system.fs.inodes.used", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "Gauge", "system.fs.inodes.free", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+	m.AssertNotCalled(t, "Gauge", "system.fs.inodes.utilized", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+	m.AssertNotCalled(t, "Gauge", "system.fs.inodes.in_use", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 }
 
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturnsNoneDevice_ThenNoUsageMetricsAreReportedForThatPartition(t *testing.T) {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -1439,21 +1440,11 @@ mount_point_exclude:
 	assert.Nil(t, err)
 	// The partition with "(deleted)" suffix should be excluded
 	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), "", mock.MatchedBy(func(tags []string) bool {
-		for _, tag := range tags {
-			if tag == "device:/dev/sda1" {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(tags, "device:/dev/sda1")
 	}))
 	// The other partition should still be reported
 	m.AssertCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), "", mock.MatchedBy(func(tags []string) bool {
-		for _, tag := range tags {
-			if tag == "device:/dev/sda2" {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(tags, "device:/dev/sda2")
 	}))
 }
 
@@ -1498,20 +1489,8 @@ device_tag_re:
 	assert.Nil(t, err)
 	// Verify all three tags are present on the metrics
 	m.AssertCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), "", mock.MatchedBy(func(tags []string) bool {
-		hasRole := false
-		hasType := false
-		hasTier := false
-		for _, tag := range tags {
-			if tag == "role:primary" {
-				hasRole = true
-			}
-			if tag == "type:ssd" {
-				hasType = true
-			}
-			if tag == "tier:fast" {
-				hasTier = true
-			}
-		}
-		return hasRole && hasType && hasTier
+		return slices.Contains(tags, "role:primary") &&
+			slices.Contains(tags, "type:ssd") &&
+			slices.Contains(tags, "tier:fast")
 	}))
 }

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	gopsutil_disk "github.com/shirou/gopsutil/v4/disk"
@@ -745,12 +746,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionHasCdromInOpts_ThenPartit
 	assert.Nil(t, err)
 	// CD-ROM partition should be excluded due to "cdrom" in opts
 	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), "", mock.MatchedBy(func(tags []string) bool {
-		for _, tag := range tags {
-			if tag == "device:d:" {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(tags, "device:d:")
 	}))
 	// Regular partition should still be reported
 	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{`device:?\volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}`, `device_name:?\volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}`})
@@ -785,12 +781,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionHasEmptyFstype_ThenPartit
 	assert.Nil(t, err)
 	// Partition with empty Fstype should be excluded
 	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), "", mock.MatchedBy(func(tags []string) bool {
-		for _, tag := range tags {
-			if tag == "device:e:" {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(tags, "device:e:")
 	}))
 	// Regular partition should still be reported
 	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{`device:?\volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}`, `device_name:?\volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}`})


### PR DESCRIPTION
### What does this PR do?
Adds comprehensive test coverage for previously untested code paths in the `diskv2` check, including edge cases, fallback mechanisms, and platform-specific exclusion logic.
### Motivation
While reviewing the `diskv2` codebase, several test gaps were identified for important code paths that handle edge cases and error scenarios. This PR addresses those gaps to ensure the disk check behaves correctly across different environments and configurations.
### Describe how you validated your changes
Added new tests and checked no regressions
### Additional Notes
- All tests follow existing patterns and naming conventions
- Tests verify both positive and negative cases where applicable
- No production code changes - tests only