### PR TITLE
Add NotReady endpoints processing

### DIFF
--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
@@ -305,7 +305,7 @@ func (m *metadataController) syncEndpoints(key string) error {
 	case err != nil:
 		log.Debugf("Unable to retrieve endpoints %v from store: %v", key, err)
 	default:
-		err = m.mapEndpoints(endpoints)
+		m.mapEndpoints(endpoints)
 	}
 	return err
 }
@@ -331,7 +331,7 @@ func (m *metadataController) syncEndpointSlices(key string) error {
 }
 
 // mapEndpoints matches pods to services via endpoint TargetRef objects. It supports Kubernetes 1.4+.
-func (m *metadataController) mapEndpoints(endpoints *corev1.Endpoints) error {
+func (m *metadataController) mapEndpoints(endpoints *corev1.Endpoints) {
 	nodeToPods := make(map[string]map[string]sets.Set[string])
 	affectedNodes := sets.New[string]()
 
@@ -343,13 +343,11 @@ func (m *metadataController) mapEndpoints(endpoints *corev1.Endpoints) error {
 
 	m.cleanupStaleNodes(endpoints.Namespace, endpoints.Name, affectedNodes)
 	m.updateNodeMetadata(endpoints.Namespace, endpoints.Name, nodeToPods)
-
-	return nil
 }
 
 func (m *metadataController) mapEndpointAddresses(address []corev1.EndpointAddress, ns, name string,
 	nodeToPods map[string]map[string]sets.Set[string], affectedNodes sets.Set[string],
-) error {
+) {
 	for _, address := range address {
 		if address.TargetRef == nil {
 			// Endpoints are also used by the control plane as resource locks for leader election.
@@ -385,8 +383,6 @@ func (m *metadataController) mapEndpointAddresses(address []corev1.EndpointAddre
 		}
 		nodeToPods[nodeName][namespace].Insert(podName)
 	}
-
-	return nil
 }
 
 // mapEndpointSlice matches pods to services via endpoint TargetRef objects. It supports Kubernetes 1.19+.

--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
@@ -337,45 +337,54 @@ func (m *metadataController) mapEndpoints(endpoints *corev1.Endpoints) error {
 
 	// Loop over the subsets to create a mapping of nodes to pods running on the node.
 	for _, subset := range endpoints.Subsets {
-		for _, address := range subset.Addresses {
-			if address.TargetRef == nil {
-				// Endpoints are also used by the control plane as resource locks for leader election.
-				// These endpoints will not have a TargetRef and can be ignored.
-				log.Tracef("No TargetRef for endpoints %s/%s, skipping", endpoints.Namespace, endpoints.Name)
-				continue
-			}
-			if address.TargetRef.Kind != "Pod" {
-				continue
-			}
-			namespace := address.TargetRef.Namespace
-			podName := address.TargetRef.Name
-			if podName == "" || namespace == "" {
-				log.Tracef("Incomplete reference for object %s on service %s/%s, skipping",
-					address.TargetRef.UID, endpoints.Namespace, endpoints.Name)
-				continue
-			}
-
-			// TODO: Kubernetes 1.3.x does not include `NodeName`
-			if address.NodeName == nil {
-				continue
-			}
-
-			nodeName := *address.NodeName
-
-			affectedNodes.Insert(nodeName)
-
-			if _, ok := nodeToPods[nodeName]; !ok {
-				nodeToPods[nodeName] = make(map[string]sets.Set[string])
-			}
-			if _, ok := nodeToPods[nodeName][namespace]; !ok {
-				nodeToPods[nodeName][namespace] = sets.New[string]()
-			}
-			nodeToPods[nodeName][namespace].Insert(podName)
-		}
+		m.mapEndpointAddresses(subset.Addresses, endpoints.Namespace, endpoints.Name, nodeToPods, affectedNodes)
+		m.mapEndpointAddresses(subset.NotReadyAddresses, endpoints.Namespace, endpoints.Name, nodeToPods, affectedNodes)
 	}
 
 	m.cleanupStaleNodes(endpoints.Namespace, endpoints.Name, affectedNodes)
 	m.updateNodeMetadata(endpoints.Namespace, endpoints.Name, nodeToPods)
+
+	return nil
+}
+
+func (m *metadataController) mapEndpointAddresses(address []corev1.EndpointAddress, ns, name string,
+	nodeToPods map[string]map[string]sets.Set[string], affectedNodes sets.Set[string],
+) error {
+	for _, address := range address {
+		if address.TargetRef == nil {
+			// Endpoints are also used by the control plane as resource locks for leader election.
+			// These endpoints will not have a TargetRef and can be ignored.
+			log.Tracef("No TargetRef for endpoints %s/%s, skipping", ns, name)
+			continue
+		}
+		if address.TargetRef.Kind != "Pod" {
+			continue
+		}
+		namespace := address.TargetRef.Namespace
+		podName := address.TargetRef.Name
+		if podName == "" || namespace == "" {
+			log.Tracef("Incomplete reference for object %s on service %s/%s, skipping",
+				address.TargetRef.UID, ns, name)
+			continue
+		}
+
+		// TODO: Kubernetes 1.3.x does not include `NodeName`
+		if address.NodeName == nil {
+			continue
+		}
+
+		nodeName := *address.NodeName
+
+		affectedNodes.Insert(nodeName)
+
+		if _, ok := nodeToPods[nodeName]; !ok {
+			nodeToPods[nodeName] = make(map[string]sets.Set[string])
+		}
+		if _, ok := nodeToPods[nodeName][namespace]; !ok {
+			nodeToPods[nodeName][namespace] = sets.New[string]()
+		}
+		nodeToPods[nodeName][namespace].Insert(podName)
+	}
 
 	return nil
 }

--- a/releasenotes/notes/add-not-ready-endpoints-60082c731a70d317.yaml
+++ b/releasenotes/notes/add-not-ready-endpoints-60082c731a70d317.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add NotReady endpoint processing to be on par with EndpointSlices processing.
+


### PR DESCRIPTION
### What does this PR do?
Add not ready endpoint processing to be on par with endpoint slices.

### Motivation
One of the steps to fix `kube_service` tag behavior 

### Describe how you validated your changes

Deploy Agent using operator and check that kube_service tag behavior didn't change.

### Additional Notes
https://datadoghq.atlassian.net/browse/CONTINT-4939