### PR TITLE
[EBPF] gpu: store architecture in DeviceInfo

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -62,8 +62,9 @@ func (c *collector) getGPUDeviceInfo(device ddnvml.Device) (*workloadmeta.GPU, e
 			Major: int(devInfo.SMVersion / 10),
 			Minor: int(devInfo.SMVersion % 10),
 		},
-		TotalCores:  devInfo.CoreCount,
-		TotalMemory: devInfo.Memory,
+		TotalCores:   devInfo.CoreCount,
+		TotalMemory:  devInfo.Memory,
+		Architecture: gpuArchToString(devInfo.Architecture),
 	}
 
 	switch d := device.(type) {
@@ -89,15 +90,6 @@ func (c *collector) getGPUDeviceInfo(device ddnvml.Device) (*workloadmeta.GPU, e
 
 // fillNVMLAttributes fills the attributes of the GPU device by querying NVML API
 func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device ddnvml.Device) {
-	arch, err := device.GetArchitecture()
-	if err != nil {
-		if logLimiter.ShouldLog() {
-			log.Warnf("%v for %d", err, gpuDeviceInfo.Index)
-		}
-	} else {
-		gpuDeviceInfo.Architecture = gpuArchToString(arch)
-	}
-
 	virtMode, err := device.GetVirtualizationMode()
 	if err != nil {
 		if logLimiter.ShouldLog() {

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -65,6 +65,12 @@ func TestPull(t *testing.T) {
 	for _, uuid := range testutil.GPUUUIDs {
 		require.True(t, foundIDs[uuid], "GPU with UUID %s not found", uuid)
 	}
+
+	for _, migChildrenUUIDs := range testutil.MIGChildrenUUIDs {
+		for _, migChildUUID := range migChildrenUUIDs {
+			require.True(t, foundIDs[migChildUUID], "MIG child GPU %s not found", migChildUUID)
+		}
+	}
 }
 
 func TestGpuArchToString(t *testing.T) {

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -114,10 +114,11 @@ type DeviceEventData struct {
 
 // DeviceInfo holds common cached properties for a GPU device
 type DeviceInfo struct {
-	SMVersion uint32
-	UUID      string
-	Name      string
-	CoreCount int
+	SMVersion    uint32
+	UUID         string
+	Name         string
+	CoreCount    int
+	Architecture nvml.DeviceArchitecture
 
 	// Index of the device in the host. For MIG devices, this is the index of the MIG device in the parent device.
 	Index int
@@ -182,11 +183,9 @@ func NewPhysicalDevice(dev nvml.Device) (*PhysicalDevice, error) {
 		return nil, fmt.Errorf("error filling basic data from NVML: %w", err)
 	}
 
-	major, minor, err := device.SafeDevice.GetCudaComputeCapability()
-	if err != nil {
-		return nil, fmt.Errorf("error getting CUDA compute capability: %w", err)
+	if err := device.fillPhysicalDeviceData(safeDev); err != nil {
+		return nil, fmt.Errorf("error filling physical device data: %w", err)
 	}
-	device.SMVersion = uint32(major*10 + minor)
 
 	migEnabled, _, err := safeDev.GetMigMode()
 	if err == nil && migEnabled == nvml.DEVICE_MIG_ENABLE {
@@ -249,6 +248,7 @@ func (d *PhysicalDevice) fillMigChildren() error {
 		// for MIG devices.
 		migChildDevice.SMVersion = d.SMVersion
 		migChildDevice.Parent = d
+		migChildDevice.Architecture = d.Architecture
 
 		d.MIGChildren = append(d.MIGChildren, migChildDevice)
 	}
@@ -304,6 +304,23 @@ func (d *DeviceInfo) fillBasicDataFromNVML(dev SafeDevice) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// fillPhysicalDeviceData fills the device info for a physical device using NVML APIs
+func (d *DeviceInfo) fillPhysicalDeviceData(dev SafeDevice) error {
+	arch, err := dev.GetArchitecture()
+	if err != nil {
+		return fmt.Errorf("error getting physical device architecture: %w", err)
+	}
+	d.Architecture = arch
+
+	major, minor, err := dev.GetCudaComputeCapability()
+	if err != nil {
+		return fmt.Errorf("error getting CUDA compute capability: %w", err)
+	}
+	d.SMVersion = uint32(major*10 + minor)
 
 	return nil
 }

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -232,6 +232,14 @@ func GetMIGDeviceMock(deviceIdx int, migDeviceIdx int, opts ...func(*nvmlmock.De
 
 			return migSpecificAttributes, nvml.SUCCESS
 		}
+
+		// Override functions that return errors for MIG devices
+		d.GetArchitectureFunc = func() (nvml.DeviceArchitecture, nvml.Return) {
+			return nvml.DEVICE_ARCH_UNKNOWN, nvml.ERROR_INVALID_ARGUMENT
+		}
+		d.GetCudaComputeCapabilityFunc = func() (int, int, nvml.Return) {
+			return 0, 0, nvml.ERROR_INVALID_ARGUMENT
+		}
 	}
 
 	opts = append(opts, prepareMigDevice)
@@ -297,13 +305,12 @@ func WithProcessInfoCallback(callback func(uuid string) ([]nvml.ProcessInfo, nvm
 	}
 }
 
-// GetBasicNvmlMock returns a mock of the nvml.Interface with a single device with 10 cores,
-// useful for basic tests that need only the basic interaction with NVML to be working.
+// GetBasicNvmlMock returns a mock of the nvml.Interface with the default devices and options.
 func GetBasicNvmlMock() *nvmlmock.Interface {
 	return GetBasicNvmlMockWithOptions()
 }
 
-// GetBasicNvmlMockWithOptions returns a mock of the nvml.Interface with a single device with 10 cores,
+// GetBasicNvmlMockWithOptions returns a mock of the nvml.Interface with the default devices and options,
 // allowing additional configuration through functional options.
 // It's ideal for tests that need custom NVML behavior beyond the defaults.
 func GetBasicNvmlMockWithOptions(options ...NvmlMockOption) *nvmlmock.Interface {


### PR DESCRIPTION
### What does this PR do?

Stores the device architecture in the `DeviceInfo` struct so that it can be loaded easily into workloadmeta for MIG and non-MIG devices.

### Motivation

Emit `gpu_architecture` tag for MIG and non-MIG devices.

### Describe how you validated your changes

Fixed a test to ensure that `GetArchitecture` returns an error for MIG devices in the unit tests.

### Additional Notes
