### PR TITLE
[AGENTRUN-951] Shared library check e2e test: Don't remove the shlib after the test

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/checks/shared-library/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/shared-library/common.go
@@ -8,11 +8,13 @@ package sharedlibrary
 
 import (
 	_ "embed"
+	"path"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	osVM "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
@@ -22,7 +24,7 @@ import (
 )
 
 //go:embed files/conf.yaml
-var exampleCheckYaml string
+var exampleCheckConfig string
 
 type sharedLibrarySuite struct {
 	e2e.BaseSuite[environments.Host]
@@ -32,7 +34,7 @@ type sharedLibrarySuite struct {
 }
 
 func (v *sharedLibrarySuite) getSuiteOptions() []e2e.SuiteOption {
-	config := `shared_library_check:
+	agentConfig := `shared_library_check:
   enabled: "true"
   library_folder_path: ` + v.checksdPath
 
@@ -41,8 +43,8 @@ func (v *sharedLibrarySuite) getSuiteOptions() []e2e.SuiteOption {
 		awshost.Provisioner(
 			awshost.WithRunOptions(
 				ec2.WithAgentOptions(
-					agentparams.WithIntegration("example.d", exampleCheckYaml),
-					agentparams.WithAgentConfig(config),
+					agentparams.WithAgentConfig(agentConfig),
+					agentparams.WithIntegration("example.d", exampleCheckConfig),
 				),
 				ec2.WithEC2InstanceOptions(ec2.WithOS(v.descriptor)),
 			),
@@ -50,6 +52,29 @@ func (v *sharedLibrarySuite) getSuiteOptions() []e2e.SuiteOption {
 	))
 
 	return suiteOptions
+}
+
+func (v *sharedLibrarySuite) init() {
+	// copy the lib with the right permissions
+	sourceLibPath := path.Join(".", "files", v.libraryName)
+	v.Env().RemoteHost.CopyFile(sourceLibPath, v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
+
+	// verify that the library has been successfully copied
+	res, err := v.Env().RemoteHost.FileExists(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
+	require.NoError(v.T(), err)
+	require.True(v.T(), res)
+}
+
+func (v *sharedLibrarySuite) clean() {
+	// remove lib after the test
+	out := v.Env().RemoteHost.Remove(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
+	// should not output anything, otherwise it's an error
+	require.NoError(v.T(), out)
+
+	// verify that the library has been successfully deleted
+	res, err := v.Env().RemoteHost.FileExists(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
+	require.NoError(v.T(), err)
+	require.False(v.T(), res)
 }
 
 // Test the shared library code and check it returns the right metrics
@@ -62,25 +87,33 @@ func (v *sharedLibrarySuite) testCheckExecutionAndVerifyMetrics() {
 
 	// metric
 	metrics := data[0].Aggregator.Metrics
-	assert.Equal(v.T(), 1, len(metrics))
+	require.Len(v.T(), metrics, 1)
+
 	metric := metrics[0]
 	assert.Equal(v.T(), "hello.gauge", metric.Metric)
 	assert.Equal(v.T(), 1.0, metric.Points[0][1])
 
 	// service check
 	serviceChecks := data[0].Aggregator.ServiceChecks
-	assert.Equal(v.T(), 1, len(serviceChecks))
+	require.Len(v.T(), serviceChecks, 1)
+
 	serviceCheck := serviceChecks[0]
 	assert.Equal(v.T(), "hello.service_check", serviceCheck.Name)
 	assert.Equal(v.T(), 0, serviceCheck.Status)
 
 	// event
 	events := data[0].Aggregator.Events
-	assert.Equal(v.T(), 1, len(events))
+	require.Len(v.T(), events, 1)
+
 	event := events[0]
 	assert.Equal(v.T(), "hello.event", event.Title)
 	assert.Equal(v.T(), "hello.text", event.Text)
 	assert.Equal(v.T(), "normal", event.Priority)
 	assert.Equal(v.T(), "info", event.AlertType)
+}
 
+func (v *sharedLibrarySuite) testCheckExample() {
+	v.init()
+	v.testCheckExecutionAndVerifyMetrics()
+	v.clean()
 }

--- a/test/new-e2e/tests/agent-runtimes/checks/shared-library/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/shared-library/common.go
@@ -65,18 +65,6 @@ func (v *sharedLibrarySuite) init() {
 	require.True(v.T(), res)
 }
 
-func (v *sharedLibrarySuite) clean() {
-	// remove lib after the test
-	out := v.Env().RemoteHost.Remove(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
-	// should not output anything, otherwise it's an error
-	require.NoError(v.T(), out)
-
-	// verify that the library has been successfully deleted
-	res, err := v.Env().RemoteHost.FileExists(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
-	require.NoError(v.T(), err)
-	require.False(v.T(), res)
-}
-
 // Test the shared library code and check it returns the right metrics
 func (v *sharedLibrarySuite) testCheckExecutionAndVerifyMetrics() {
 	v.T().Log("Running Shared Library Check Example test")
@@ -115,5 +103,4 @@ func (v *sharedLibrarySuite) testCheckExecutionAndVerifyMetrics() {
 func (v *sharedLibrarySuite) testCheckExample() {
 	v.init()
 	v.testCheckExecutionAndVerifyMetrics()
-	v.clean()
 }

--- a/test/new-e2e/tests/agent-runtimes/checks/shared-library/example_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/shared-library/example_nix_test.go
@@ -7,11 +7,9 @@
 package sharedlibrary
 
 import (
-	"path"
 	"testing"
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 )
@@ -33,28 +31,6 @@ func TestLinuxCheckImplementationSuite(t *testing.T) {
 	e2e.Run(t, suite, suite.getSuiteOptions()...)
 }
 
-func (v *linuxSharedLibrarySuite) copyLibrary(sourceLibPath string) {
-	v.Env().RemoteHost.CopyFile(sourceLibPath, v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
-}
-
-func (v *linuxSharedLibrarySuite) removeLibrary() {
-	out := v.Env().RemoteHost.Remove(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
-	// should not output anything, otherwise it's an error
-	require.Empty(v.T(), out)
-}
-
-func (v *linuxSharedLibrarySuite) TestLinuxCheckExampleRun() {
-	// copy the lib with the right permissions
-	sourceLibPath := path.Join(".", "files", v.libraryName)
-	v.copyLibrary(sourceLibPath)
-
-	res, err := v.Env().RemoteHost.FileExists(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
-	require.Nil(v.T(), err)
-	require.True(v.T(), res)
-
-	// execute the check and verify the metrics
-	v.testCheckExecutionAndVerifyMetrics()
-
-	// clean the lib after the test
-	v.removeLibrary()
+func (v *linuxSharedLibrarySuite) TestLinuxCheckExample() {
+	v.testCheckExample()
 }

--- a/test/new-e2e/tests/agent-runtimes/checks/shared-library/example_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/shared-library/example_win_test.go
@@ -7,11 +7,9 @@
 package sharedlibrary
 
 import (
-	"path"
 	"testing"
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 )
@@ -33,28 +31,6 @@ func TestWindowsCheckImplementationSuite(t *testing.T) {
 	e2e.Run(t, suite, suite.getSuiteOptions()...)
 }
 
-func (v *windowsSharedLibrarySuite) copyLibrary(sourceLibPath string) {
-	v.Env().RemoteHost.CopyFile(sourceLibPath, v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
-}
-
-func (v *windowsSharedLibrarySuite) removeLibrary() {
-	out := v.Env().RemoteHost.Remove(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
-	// should not output anything, otherwise it's an error
-	require.Empty(v.T(), out)
-}
-
 func (v *windowsSharedLibrarySuite) TestWindowsCheckExample() {
-	// copy the lib with the right permissions
-	sourceLibPath := path.Join(".", "files", v.libraryName)
-	v.copyLibrary(sourceLibPath)
-
-	res, err := v.Env().RemoteHost.FileExists(v.Env().RemoteHost.JoinPath(v.checksdPath, v.libraryName))
-	require.Nil(v.T(), err)
-	require.True(v.T(), res)
-
-	// execute the check and verify the metrics
-	v.testCheckExecutionAndVerifyMetrics()
-
-	// remove the lib after the test
-	v.removeLibrary()
+	v.testCheckExample()
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue by not trying to remove the shlib. Having it removed would have cause issues to the Agent because the shlib check would still be scheduled.

Also. the e2e has been refactored to reduce code duplication between Linux and Windows

### Motivation

Fix the flakiness of the shlib check e2e test caused by the lock of the shlib during its removal.

### Describe how you validated your changes

e2e test in the CI.

### Additional Notes
