### PR TITLE
[Backport 7.74.x] [EBPF-995] gpu: fix metric type for errors metric 

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -102,7 +102,7 @@ func (c *deviceEventsCollector) Collect() ([]Metric, error) {
 			}
 			c.metricsByXidCode[evt.EventData] = &Metric{
 				Name:     "errors.xid.total",
-				Type:     metrics.CountType,
+				Type:     metrics.GaugeType,
 				Priority: High,
 				Tags: []string{
 					"type:" + strconv.Itoa(int(evt.EventData)),

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -205,7 +205,7 @@ func TestDeviceEventsCollector(t *testing.T) {
 	assert.Equal(t, Metric{
 		Name:     xidErrorsMetricName,
 		Value:    1,
-		Type:     metrics.CountType,
+		Type:     metrics.GaugeType,
 		Priority: High,
 		Tags:     []string{"type:31", "origin:hardware"},
 	}, mm[0])
@@ -230,14 +230,14 @@ func TestDeviceEventsCollector(t *testing.T) {
 		{
 			Name:     xidErrorsMetricName,
 			Value:    1,
-			Type:     metrics.CountType,
+			Type:     metrics.GaugeType,
 			Priority: High,
 			Tags:     []string{"type:12", "origin:driver"},
 		},
 		{
 			Name:     xidErrorsMetricName,
 			Value:    2,
-			Type:     metrics.CountType,
+			Type:     metrics.GaugeType,
 			Priority: High,
 			Tags:     []string{"type:31", "origin:hardware"},
 		},

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -413,7 +413,7 @@ func createStatelessAPIs() []apiCallInfo {
 					return []Metric{{
 						Name:  fmt.Sprintf("errors.ecc.%s.total", errorTypeName),
 						Value: float64(count),
-						Type:  metrics.CountType,
+						Type:  metrics.GaugeType,
 						Tags: []string{
 							fmt.Sprintf("memory_location:%s", memoryLocationName),
 						},


### PR DESCRIPTION
Backports dc7372385e6cc93698d1ca2addfed65b243836f0 from https://github.com/DataDog/datadog-agent/pull/44583

### What does this PR do?

Fixes the type being used for `gpu.errors` metrics, which should be emitted as gauge and not as a count, as we're emitting absolute values and not increases.

### Motivation


Ensure that metrics are presented correctly in the UI.


### Describe how you validated your changes


Unit tests passing.


### Additional Notes


(cherry picked from commit dc7372385e6cc93698d1ca2addfed65b243836f0)



