### PR TITLE
Bump secret-generic-connector to 1.5.0.

### DIFF
--- a/deps/secret_connector/secret_connector.MODULE.bazel
+++ b/deps/secret_connector/secret_connector.MODULE.bazel
@@ -2,7 +2,7 @@
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "1.4.2"
+VERSION = "1.5.0"
 
 # Define URLs for each platform
 secret_generic_urls = {
@@ -24,16 +24,16 @@ secret_generic_urls = {
 # Note: These should be updated for each version
 secret_generic_sha256 = {
     "linux": {
-        "x86_64": "91962d9c683b591769c60c09f34e5211124a703545e40a2fa5286f79fd3f2ddc",
-        "arm64": "c7aabfdf0b14ee263304104058b0b98e2bf68d22fcc88e8df53d2b83fdb80f0e",
+        "x86_64": "932d78686207f4d428e266c7afcea0fe4cba26fbad9f3b5e6686ef510bcc985c",
+        "arm64": "f20c043af96d8982283ee065e3fe5eca527656916d5e2e79e308a51e959fba10",
     },
     "windows": {
-        "x86_64": "06483a4a3f6a2d18ae20bfa1cce791e30d43997941cbff9c64ca2ce09bb249d0",
-        "arm64": "0c45c233ef2b0a5c7433684dae1306c9b290327a3d9e2f257348a45549caf20d",
+        "x86_64": "2b1fc0523cb9e5ff48f70a779b4cdc3d0b5d58ef929e41a0935e35dd01c6b636",
+        "arm64": "5d28d6db8663e3e428a702608caf4e5ac4008ed901f46d0feb2965e7f7603146",
     },
     "macos": {
-        "x86_64": "9b198a301e82ff796d82ea08315777ee58dd4e684684158c29030196864b52d5",
-        "arm64": "a2d5e0cd931f9e5b8cc572af6a2b3271714c179d21c30266bbf5ce67909df265",
+        "x86_64": "583fac3054ba1630fc115bda45dd3aceb93f3c4bcebf366dcad17f39320b2d91",
+        "arm64": "1bc6998789553aa26d2b248d1b2aac5b6a1807d51865eca495065fb44be047f6",
     },
 }
 

--- a/releasenotes/notes/bump-sgc-1.5.0-7cceec6b59620a6c.yaml
+++ b/releasenotes/notes/bump-sgc-1.5.0-7cceec6b59620a6c.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The datadog-agent now uses datadog-secret-backend v1.5.0 which added support for Kubernetes secrets via the Secrets API, Kubernetes file-based secrets, support for Docker secrets, and support for plaintext file secrets. 
+enhancements:
+  - |
+    The datadog-secret-backend now allows implicit Vault authentication to be set as a config option or an env var
+    Added a configurable max_file_read_size config option to file.yaml, file.json, & file.text to prevent OOM reads
+other:
+  - |
+    For up-to-date docs, check out the secret-backend `changelog <https://github.com/DataDog/datadog-secret-backend/blob/v1/CHANGELOG.md>`_, and the Datadog Secrets Management `documentation <https://docs.datadoghq.com/agent/configuration/secrets-management/>`_


### PR DESCRIPTION
### What does this PR do?
Bump secret-generic-connector to 1.5.0. See [changelog](https://github.com/DataDog/datadog-secret-backend/blob/v1/CHANGELOG.md)

### Motivation

### Describe how you validated your changes

### Additional Notes
