### PR TITLE
dyninst: add an id tying together chunks of a SymDB upload

### DIFF
--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	container "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/uuid"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
@@ -232,13 +233,23 @@ func run() (retErr error) {
 	bufferFuncs := 0
 	// Flush every so ofter in order to not store too many scopes in memory.
 	const maxBufferFuncs = 10000
-	maybeFlush := func(force bool) error {
+	uploadID := uuid.New()
+	batchNum := 0
+	maybeFlush := func(final bool) error {
 		if len(uploadBuffer) == 0 {
 			return nil
 		}
-		if force || bufferFuncs >= maxBufferFuncs {
+		if final || bufferFuncs >= maxBufferFuncs {
 			log.Tracef("SymDB: uploading symbols chunk: %d packages, %d functions", len(uploadBuffer), bufferFuncs)
-			if err := up.Upload(context.Background(), uploadBuffer); err != nil {
+			err := up.UploadBatch(
+				context.Background(),
+				uploader.UploadInfo{
+					UploadID: uploadID,
+					BatchNum: batchNum,
+					Final:    final,
+				},
+				uploadBuffer)
+			if err != nil {
 				return fmt.Errorf("upload failed: %w", err)
 			}
 			uploadBuffer = uploadBuffer[:0]
@@ -254,25 +265,21 @@ func run() (retErr error) {
 		}
 
 		if up != nil {
-			scope := uploader.ConvertPackageToScope(pkg, "cli" /* agentVersion */)
+			scope := uploader.ConvertPackageToScope(pkg.Package, "cli" /* agentVersion */)
 			uploadBuffer = append(uploadBuffer, scope)
 			bufferFuncs += pkg.Stats().NumFunctions
-			if err := maybeFlush(false /* force */); err != nil {
+			if err := maybeFlush(pkg.Final); err != nil {
 				return err
 			}
 		}
 
-		stats.addPackage(pkg)
+		stats.addPackage(pkg.Package)
 
 		if !*silent {
 			pkg.Serialize(out)
 		}
 	}
-	if err := maybeFlush(true /* force */); err != nil {
-		log.Errorf("Failed to upload symbols: %v", err)
-	} else {
-		log.Info("Upload completed")
-	}
+	log.Info("Upload completed")
 
 	trace.Stop()
 	log.Infof("Symbol extraction completed in %s.", time.Since(start))

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -37,9 +37,12 @@ var loclistErrorLogLimiter = rate.NewLimiter(rate.Every(1*time.Minute), 1)
 
 // PackagesIterator returns an iterator over the packages in the binary.
 //
+// The last package yielded by the iterator has its Final field set to true. No
+// more packages will be yielded after that, but an error may still be yielded.
+//
 // PackagesIterator can only be used if the packagesIterator was configured with
 // ExtractOptions.AccumulateInlineInfoAcrossCompileUnits=false.
-func PackagesIterator(binaryPath string, loader object.Loader, opt ExtractOptions) (iter.Seq2[Package, error], error) {
+func PackagesIterator(binaryPath string, loader object.Loader, opt ExtractOptions) (iter.Seq2[PackageWithFinal, error], error) {
 	bin, err := openBinary(binaryPath, loader, opt)
 	if err != nil {
 		return nil, err
@@ -70,7 +73,7 @@ func ExtractSymbols(binaryPath string, loader object.Loader, opt ExtractOptions)
 				existingPkg.Types[name] = t
 			}
 		} else {
-			packages[pkg.Name] = &pkg
+			packages[pkg.Name] = &pkg.Package
 		}
 	}
 
@@ -737,12 +740,59 @@ func (b *packagesIterator) close() {
 	}
 }
 
+type PackageWithFinal struct {
+	Package
+	// Final is set if this is the last package in the binary.
+	Final bool
+}
+
 // iterator returns a Go iterator that yields packages one by one. The returned
 // iterator takes ownership of the Elf file, so it must be called (or used in a
 // range loop) in order to eventually release resources.
 //
-// Packages with no types or functions not yielded.
-func (b *packagesIterator) iterator() iter.Seq2[Package, error] {
+// Packages with no types or functions are not yielded.
+//
+// For simplicity, the iterator never returns both a package and an error.
+//
+// The implementation wraps innerIterator() and yields packages with a delay of
+// one so that it can set the Final field of the last package.
+func (b *packagesIterator) iterator() iter.Seq2[PackageWithFinal, error] {
+	return func(yield func(pkg PackageWithFinal, err error) bool) {
+		var prev *Package
+		var err error
+		for pkg, err := range b.innerIterator() {
+			if err != nil {
+				break
+			}
+			if prev != nil {
+				if !yield(PackageWithFinal{Package: *prev, Final: false}, nil /* err */) {
+					return
+				}
+			}
+			prev = &pkg
+		}
+		if prev != nil {
+			yield(PackageWithFinal{
+				Package: *prev,
+				// NOTE: We set the Final field even if the iteration terminated
+				// because of an error.
+				Final: true,
+			}, nil /* err */)
+		}
+		if err != nil {
+			yield(PackageWithFinal{}, err)
+		}
+	}
+}
+
+// iterator returns a Go iterator that yields packages one by one. The returned
+// iterator takes ownership of the Elf file, so it must be called (or used in a
+// range loop) in order to eventually release resources.
+//
+// Packages with no types or functions are not yielded.
+//
+// For simplicity, the iterator never returns both a package and an error.
+func (b *packagesIterator) innerIterator() iter.Seq2[Package, error] {
 	var err error
 	// Keep track of packages we've seen so that we ignore compile units
 	// belonging to packages we've already yielded. This happens for packages

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -18,9 +18,11 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
+	"github.com/google/uuid"
 )
 
 // ScopeType represents the type of scope in the SymDB schema
@@ -116,14 +118,33 @@ func NewSymDBUploader(
 	}
 }
 
-// Upload uploads a batch of packages to SymDB.
-func (s *SymDBUploader) Upload(ctx context.Context, packages []Scope) error {
+// UploadInfo contains metadata about a batch of packages to be uploaded to
+// SymDB.
+type UploadInfo struct {
+	// UploadID identifies which logical upload this batch is part of: if packages
+	// are split into multiple batches because of size limits, they will all share
+	// the same uploadID.
+	UploadID uuid.UUID
+	// BatchNum is the number of the batch relative to the other batches in this
+	// upload. First batch has number 1.
+	BatchNum int
+	// Final is set if this is the final (or the only) batch of packages for
+	// this upload.
+	Final bool
+}
+
+// UploadBatch uploads a batch the symbols for a batch of packages to SymDB (via
+// the trace-agent).
+func (s *SymDBUploader) UploadBatch(ctx context.Context, info UploadInfo, packages []Scope) error {
 	// Wrap the data in an envelope expected by the debugger backend.
 	var buf bytes.Buffer
 	buf.WriteString(`{
 "service": "` + s.service + `",
 "version": "` + s.version + `",
 "language": "go",
+"upload_id": "` + info.UploadID.String() + `",
+"batch_num": ` + strconv.Itoa(info.BatchNum) + `,
+"final": ` + strconv.FormatBool(info.Final) + `,
 "scopes": `)
 
 	jsonBytes, err := json.Marshal(packages)


### PR DESCRIPTION
Tag the different chunks (i.e. batches for packages) of a SymDB upload
with a common id so that the backend can recognize them as part of the
same upload. The backend needs to do that when trying to identify
duplicate uploads, and without this ID it has to use a heuristic based
on upload time.

Also tag the final chunk with a `final` bit so that the backend can
recognize the upload as complete.
