### PR TITLE
APM: Prevent flakes in testServer for trace writer (APMSP-2499)

### DIFF
--- a/pkg/trace/writer/testserver.go
+++ b/pkg/trace/writer/testserver.go
@@ -26,6 +26,8 @@ import (
 // create payload IDs for the test server.
 var uid = atomic.NewUint64(0)
 
+const payloadSplitter = "|special_payload|"
+
 // expectResponses creates a new payload for the test server. The test server will
 // respond with the given status codes, in the given order, for each subsequent
 // request, in rotation.
@@ -35,7 +37,7 @@ func expectResponses(codes ...int) *payload {
 	}
 	p := newPayload(nil)
 	p.body.WriteString(strconv.FormatUint(uid.Inc(), 10))
-	p.body.WriteString("|")
+	p.body.WriteString(payloadSplitter)
 	for i, code := range codes {
 		if i > 0 {
 			p.body.WriteString(",")
@@ -175,7 +177,7 @@ func (ts *testServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // to the given request body. If the request body does not originate from a
 // payload created with expectResponse, it returns http.StatusOK.
 func (ts *testServer) getNextCode(reqBody []byte) int {
-	parts := strings.Split(string(reqBody), "|")
+	parts := strings.Split(string(reqBody), payloadSplitter)
 	if len(parts) != 2 {
 		// not a special body
 		return http.StatusOK

--- a/pkg/trace/writer/testserver_test.go
+++ b/pkg/trace/writer/testserver_test.go
@@ -21,14 +21,14 @@ func TestExpectResponses(t *testing.T) {
 		codes      []int
 		bodySuffix string
 	}{
-		{nil, "|200"},
-		{[]int{}, "|200"},
-		{[]int{200}, "|200"},
-		{[]int{200, 300}, "|200,300"},
-		{[]int{403, 403, 200, 100}, "|403,403,200,100"},
+		{nil, "|special_payload|200"},
+		{[]int{}, "|special_payload|200"},
+		{[]int{200}, "|special_payload|200"},
+		{[]int{200, 300}, "|special_payload|200,300"},
+		{[]int{403, 403, 200, 100}, "|special_payload|403,403,200,100"},
 	} {
 		body := expectResponses(tt.codes...).body.String()
-		parts := strings.Split(body, "|")
+		parts := strings.Split(body, payloadSplitter)
 		if len(parts) != 2 {
 			t.Fatalf("malformed body: %s", body)
 		}
@@ -133,7 +133,7 @@ func TestTestServer(t *testing.T) {
 			http.StatusLoopDetected,
 			http.StatusTooManyRequests,
 		} {
-			resp, err := http.Post(ts.URL, "text/plain", strings.NewReader("1|200,508,429"))
+			resp, err := http.Post(ts.URL, "text/plain", strings.NewReader("1|special_payload|200,508,429"))
 			assert.NoError(err)
 			assert.Equal(code, resp.StatusCode)
 			resp.Body.Close()


### PR DESCRIPTION
### What does this PR do?
Prevent stray `|` characters from potentially panic-ing the TestServer implementation.

### Motivation
The test server uses incoming requests to setup expectations but incoming payloads can potentially include `|`, see testutil/span.go where we use the pipe char as a potential resource name for spans. To prevent a stray pipe from crashing the TestServer (and avoid completely re-writing how it handles expectations since this is just a test server) I modified the separator to be more unique. 

### Describe how you validated your changes
This flake seems to be _ultra_ rare (it only can happen when there is exactly 1 pipe character and when the value to the right happens to be a valid int, my best guess is that this can happen due to protobuf) I had a hard time reproducing it but given the stack trace this has to be it. I validated the test passes afterwards and didn't cause any regressions, this is all only test code too.

### Additional Notes
