### PR TITLE
[EBPF] gpu: add unit test to ensure MatchContainerDevices works with MIG

### DIFF
--- a/pkg/gpu/containers/containers_test.go
+++ b/pkg/gpu/containers/containers_test.go
@@ -310,6 +310,8 @@ func TestMatchContainerDevices(t *testing.T) {
 		require.True(t, ok)
 		physicalDevice2, ok := devices[1].(*ddnvml.PhysicalDevice)
 		require.True(t, ok)
+		require.Len(t, physicalDevice1.MIGChildren, 2)
+		require.Len(t, physicalDevice2.MIGChildren, 2)
 		mig1 := physicalDevice1.MIGChildren[0]
 		mig2 := physicalDevice1.MIGChildren[1]
 		mig3 := physicalDevice2.MIGChildren[0]

--- a/pkg/gpu/containers/containers_test.go
+++ b/pkg/gpu/containers/containers_test.go
@@ -310,8 +310,8 @@ func TestMatchContainerDevices(t *testing.T) {
 		require.True(t, ok)
 		physicalDevice2, ok := devices[1].(*ddnvml.PhysicalDevice)
 		require.True(t, ok)
-		require.Len(t, physicalDevice1.MIGChildren, 2)
-		require.Len(t, physicalDevice2.MIGChildren, 2)
+		require.GreaterOrEqual(t, len(physicalDevice1.MIGChildren), 2)
+		require.GreaterOrEqual(t, len(physicalDevice2.MIGChildren), 2)
 		mig1 := physicalDevice1.MIGChildren[0]
 		mig2 := physicalDevice1.MIGChildren[1]
 		mig3 := physicalDevice2.MIGChildren[0]


### PR DESCRIPTION
### What does this PR do?

Adds a unit test that ensures that MatchContainerDevices works with MIG setups.

### Motivation

Increase test coverage

### Describe how you validated your changes

Test-only changes

### Additional Notes