### PR TITLE
[INCIDENT-47540] Add `.bazeliskrc` with instructions to download from GitHub

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,2 @@
+# Use GitHub Releases as the Bazel download source
+BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download


### PR DESCRIPTION
### What does this PR do?

Adds a `.bazeliskrc` config file with a setting instructing bazelisk to download Bazel versions from GitHub instead of `releases.bazel.com`

### Motivation

The default source, `releases.bazel.com` is currently down due to an expired TLS certificate

### Describe how you validated your changes

### Additional Notes
