### PR TITLE
[PROF-13359] agent API key recovery

### DIFF
--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -9,6 +9,9 @@
 package collectorimpl
 
 import (
+	"os"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	hostname "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -56,10 +59,22 @@ var _ ExtraFactories = (*extraFactoriesWithAgentCore)(nil)
 // NewExtraFactoriesWithAgentCore creates a new ExtraFactories instance when the Agent Core is available.
 func NewExtraFactoriesWithAgentCore(
 	tagger tagger.Component,
-	hostname hostname.Component, ipcComp ipc.Component,
+	hostname hostname.Component,
+	ipcComp ipc.Component,
 	traceAgent traceagent.Component,
 	log log.Component,
+	config config.Component,
 ) ExtraFactories {
+
+	// ensure an API key is present in the environment
+	// ad hoc & hacky
+	if os.Getenv("DD_API_KEY") == "" {
+		if apiKey := config.GetString("api_key"); apiKey != "" {
+			log.Debug("fetched api key from agent")
+			os.Setenv("DD_API_KEY", apiKey)
+		}
+	}
+
 	return extraFactoriesWithAgentCore{
 		tagger:     tagger,
 		hostname:   hostname,


### PR DESCRIPTION
### What does this PR do?

Enables the full-host profiler to fetch the API key from agent's config when unset in its environment.

### Motivation

Simplifies deployment.

### Describe how you validated your changes

1. Unset `DD_API_KEY` in environment
2. Launch profiler with command below
3. Check the log line appears

Full profiler launch command
```bash
sudo -E DD_LOG_LEVEL=DEBUG ./bin/full-host-profiler/full-host-profiler run  -c cmd/host-profiler/dist/host-profiler-config.yaml --core-config ./dev/dist/datadog.yaml 2>&1 | grep 'fetched api key from agent'
```

### Additional Notes
