### PR TITLE
[CWS] Improved event zeroer

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/bpf.h
+++ b/pkg/security/ebpf/c/include/helpers/bpf.h
@@ -5,7 +5,7 @@
 #include "events_definition.h"
 #include "maps.h"
 
-__attribute__((always_inline)) void save_obj_fd(struct syscall_cache_t *syscall) {
+static __attribute__((always_inline)) void save_obj_fd(struct syscall_cache_t *syscall) {
     struct bpf_tgid_fd_t key = {
         .tgid = bpf_get_current_pid_tgid() >> 32,
         .fd = syscall->bpf.retval,
@@ -27,7 +27,7 @@ __attribute__((always_inline)) void save_obj_fd(struct syscall_cache_t *syscall)
     }
 }
 
-__attribute__((always_inline)) u32 fetch_map_id(int fd) {
+static __attribute__((always_inline)) u32 fetch_map_id(int fd) {
     struct bpf_tgid_fd_t key = {
         .tgid = bpf_get_current_pid_tgid() >> 32,
         .fd = fd,
@@ -40,7 +40,7 @@ __attribute__((always_inline)) u32 fetch_map_id(int fd) {
     return *map_id;
 }
 
-__attribute__((always_inline)) u32 fetch_prog_id(int fd) {
+static __attribute__((always_inline)) u32 fetch_prog_id(int fd) {
     struct bpf_tgid_fd_t key = {
         .tgid = bpf_get_current_pid_tgid() >> 32,
         .fd = fd,
@@ -53,7 +53,7 @@ __attribute__((always_inline)) u32 fetch_prog_id(int fd) {
     return *map_id;
 }
 
-__attribute__((always_inline)) void populate_map_id_and_prog_id(struct syscall_cache_t *syscall) {
+static __attribute__((always_inline)) void populate_map_id_and_prog_id(struct syscall_cache_t *syscall) {
     int fd = 0;
 
     switch (syscall->bpf.cmd) {
@@ -130,7 +130,7 @@ __attribute__((always_inline)) void populate_map_id_and_prog_id(struct syscall_c
     }
 }
 
-__attribute__((always_inline)) void fill_from_syscall_args(struct syscall_cache_t *syscall, struct bpf_event_t *event) {
+static __attribute__((always_inline)) void fill_from_syscall_args(struct syscall_cache_t *syscall, struct bpf_event_t *event) {
     switch (event->cmd) {
     case BPF_MAP_CREATE:
         bpf_probe_read(&event->map.map_type, sizeof(event->map.map_type), &syscall->bpf.attr->map_type);

--- a/pkg/security/ebpf/c/include/helpers/caps.h
+++ b/pkg/security/ebpf/c/include/helpers/caps.h
@@ -1,7 +1,7 @@
 #ifndef _HELPERS_CAPS_H_
 #define _HELPERS_CAPS_H_
 
-__attribute__((always_inline)) void send_capabilities_usage_event(void *ctx, struct capabilities_usage_key_t *key, struct capabilities_usage_entry_t *entry) {
+static __attribute__((always_inline)) void send_capabilities_usage_event(void *ctx, struct capabilities_usage_key_t *key, struct capabilities_usage_entry_t *entry) {
     u64 now = bpf_ktime_get_ns();
     int should_send = is_dirty(entry) && period_reached_or_new_entry(entry, now);
     if (!should_send) {
@@ -38,7 +38,7 @@ __attribute__((always_inline)) void send_capabilities_usage_event(void *ctx, str
     send_event(ctx, EVENT_CAPABILITIES, event);
 }
 
-__attribute__((always_inline)) void flush_capabilities_usage(void *ctx, u32 tgid, u64 cookie) {
+static __attribute__((always_inline)) void flush_capabilities_usage(void *ctx, u32 tgid, u64 cookie) {
     u64 capabilities_monitoring_enabled = 0;
     LOAD_CONSTANT("capabilities_monitoring_enabled", capabilities_monitoring_enabled);
     if (!capabilities_monitoring_enabled) {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -157,7 +157,39 @@ func NewEventZeroer() func(*Event) {
 	var eventZero = Event{BaseEvent: BaseEvent{Os: runtime.GOOS}}
 
 	return func(e *Event) {
-		*e = eventZero
+		switch e.GetEventType() {
+		case PrCtlEventType:
+
+			e.PrCtl = eventZero.PrCtl
+			e.BaseEvent = eventZero.BaseEvent
+		case FileOpenEventType:
+			e.Open = eventZero.Open
+			e.BaseEvent = eventZero.BaseEvent
+		case SetSockOptEventType:
+			e.SetSockOpt = eventZero.SetSockOpt
+			e.BaseEvent = eventZero.BaseEvent
+		case ArgsEnvsEventType:
+			e.ArgsEnvs = eventZero.ArgsEnvs
+			e.BaseEvent = eventZero.BaseEvent
+		case ConnectEventType:
+			e.Connect = eventZero.Connect
+			e.BaseEvent = eventZero.BaseEvent
+		case MMapEventType:
+			e.MMap = eventZero.MMap
+			e.BaseEvent = eventZero.BaseEvent
+		case DNSEventType:
+			e.DNS = eventZero.DNS
+			e.BaseEvent = eventZero.BaseEvent
+		case FileUnlinkEventType:
+			e.Unlink = eventZero.Unlink
+			e.BaseEvent = eventZero.BaseEvent
+		case AcceptEventType:
+			e.Accept = eventZero.Accept
+			e.BaseEvent = eventZero.BaseEvent
+		default:
+			*e = eventZero
+		}
+
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

According to our profiler, the event zeroer is a hot path that consumes a lot of CPU, which slows down the handling of events and might result in event losses, this is especially true when the GC is active.

This PR makes the zeroing operation less costly by selectively zeroing only the fields that need it.

### Motivation

Avoiding event loss

### Describe how you validated your changes

Deploying to a cluster

### Additional Notes
