### PR TITLE
[TEEP-3981] feat(agentprofiling check): add agent termination option to agentprofiling check

### DIFF
--- a/cmd/agent/dist/conf.d/agentprofiling.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/agentprofiling.d/conf.yaml.example
@@ -4,15 +4,15 @@
 
 init_config: {}
 instances:
-  - 
+  -
 
     ## @param memory_threshold - string - optional - default: "0"
     ## Set to either a size (e.g., 10MB) or an exact byte value (e.g., 10485760).
     ## When this check runs, it will check if the Core Agent's RSS memory usage is above this threshold.
     ## If the threshold is exceeded, the check will generate a flare with memory and CPU profiles.
     ## Flare generation can only be triggered once per Agent lifecycle.
-    ## 
-    ## If this value is set to "0", the check will not run. 
+    ##
+    ## If this value is set to "0", the check will not run.
     #
     # memory_threshold: "0"
 
@@ -21,7 +21,7 @@ instances:
     ## a flare with memory and CPU profiles will be generated.
     ## Flare generation can only be triggered once per Agent lifecycle.
     ##
-    ## If this value is set to 0, the check will not run. 
+    ## If this value is set to 0, the check will not run.
     #
     # cpu_threshold: 0
 
@@ -32,7 +32,19 @@ instances:
     # ticket_id: ""
 
     ## @param user_email - string - required - default: ""
-    ## Set to the email address associated with the ticket. 
+    ## Set to the email address associated with the ticket.
     ## If not specified, the Agent will be unable to associate the flare with the ticket.
     #
     # user_email: ""
+
+    ## @param terminate_agent_on_threshold - boolean - optional - default: false
+    ## When set to true, the agent process will be terminated after successfully generating a flare
+    ## when memory or CPU thresholds are exceeded.
+    ##
+    ## WARNING: This will cause the agent to exit. Ensure your process manager is configured to restart
+    ## the agent automatically. Use with caution.
+    ##
+    ## The agent will attempt graceful shutdown via SIGINT, allowing cleanup before exit. If signal
+    ## delivery fails, it will fall back to immediate termination.
+    #
+    # terminate_agent_on_threshold: false

--- a/pkg/collector/corechecks/agentprofiling/agentprofiling.go
+++ b/pkg/collector/corechecks/agentprofiling/agentprofiling.go
@@ -10,8 +10,7 @@ package agentprofiling
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
+	"testing"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -201,26 +200,9 @@ func (m *Check) Run() error {
 // via stopAgent(). Termination is skipped when running in test mode to avoid killing the test process.
 func (m *Check) terminateAgent() {
 	// Skip termination when running in test mode
-	// Check if we're running under go test by looking for test-related arguments
-	// Go test passes arguments like "-test.v=true" or "-test.run=TestName", so we use HasPrefix
-	for _, arg := range os.Args {
-		if strings.HasPrefix(arg, "-test.") {
-			log.Info("Skipping agent termination: running in test mode")
-			return
-		}
-	}
-	// Also check if binary name indicates a test binary
-	// On Windows, test binaries are named like "foo.test.exe", so we check for ".test" suffix
-	// after removing the ".exe" extension if present
-	if len(os.Args) > 0 {
-		binName := filepath.Base(os.Args[0])
-		// Remove .exe extension on Windows to handle "foo.test.exe" case
-		binName = strings.TrimSuffix(binName, ".exe")
-		// Check if binary name starts with "test" or ends with ".test"
-		if strings.HasPrefix(binName, "test") || strings.HasSuffix(binName, ".test") {
-			log.Info("Skipping agent termination: running in test mode")
-			return
-		}
+	if testing.Testing() {
+		log.Info("Skipping agent termination: running in test mode")
+		return
 	}
 
 	log.Warnf("Terminating agent process due to threshold exceeded (terminate_agent_on_threshold is enabled)")

--- a/pkg/collector/corechecks/agentprofiling/agentprofiling_test.go
+++ b/pkg/collector/corechecks/agentprofiling/agentprofiling_test.go
@@ -149,7 +149,7 @@ func TestTerminateAgentOnThresholdConfig(t *testing.T) {
 	assert.Equal(t, uint(1), check.memoryThreshold)
 
 	// Verify that when threshold is exceeded, flare is generated
-	// Note: Termination is skipped in test mode (detected via os.Args), so we can't test
+	// Note: Termination is skipped in test mode (detected via testing.Testing()), so we can't test
 	// the actual shutdown behavior. However, we verify that the config is parsed correctly
 	// and that the check would attempt termination in a non-test environment.
 	err := check.Run()

--- a/pkg/collector/corechecks/agentprofiling/agentprofiling_test.go
+++ b/pkg/collector/corechecks/agentprofiling/agentprofiling_test.go
@@ -149,8 +149,9 @@ func TestTerminateAgentOnThresholdConfig(t *testing.T) {
 	assert.Equal(t, uint(1), check.memoryThreshold)
 
 	// Verify that when threshold is exceeded, flare is generated
-	// Note: We can't actually test os.Exit() in unit tests, but we can verify
-	// that the config is set correctly and the check would attempt termination
+	// Note: Termination is skipped in test mode (detected via os.Args), so we can't test
+	// the actual shutdown behavior. However, we verify that the config is parsed correctly
+	// and that the check would attempt termination in a non-test environment.
 	err := check.Run()
 	require.NoError(t, err)
 	assert.True(t, check.flareGenerated)

--- a/releasenotes/notes/agentprofiling-check-terminate-threshold-feat-6f35b801e1ace36e.yaml
+++ b/releasenotes/notes/agentprofiling-check-terminate-threshold-feat-6f35b801e1ace36e.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The Agent Profiling check now supports automatic agent termination after flare generation when memory or CPU thresholds are exceeded. This feature is useful in resource-constrained environments where the agent needs to be restarted after generating diagnostic information.
+
+    Enable this feature by setting ``terminate_agent_on_threshold: true`` in the Agent Profiling check configuration. When enabled, the agent will attempt a graceful shutdown via SIGINT after successfully generating a flare, allowing cleanup before exit. If signal delivery fails, it will fall back to immediate termination.
+
+    **Warning**: This feature will cause the agent to exit. This feature is disabled by default and should be used with caution.

--- a/releasenotes/notes/agentprofiling-check-terminate-threshold-feat-6f35b801e1ace36e.yaml
+++ b/releasenotes/notes/agentprofiling-check-terminate-threshold-feat-6f35b801e1ace36e.yaml
@@ -8,8 +8,8 @@
 ---
 features:
   - |
-    The Agent Profiling check now supports automatic agent termination after flare generation when memory or CPU thresholds are exceeded. This feature is useful in resource-constrained environments where the agent needs to be restarted after generating diagnostic information.
+    The Agent Profiling check now supports automatic Agent termination after flare generation when memory or CPU thresholds are exceeded. This feature is useful in resource-constrained environments where the Agent needs to be restarted after generating diagnostic information.
 
-    Enable this feature by setting `terminate_agent_on_threshold: true` in the Agent Profiling check configuration. When enabled, the agent will attempt a graceful shutdown via SIGINT after successfully generating a flare, allowing cleanup before exit. If signal delivery fails, it will fall back to immediate termination.
+    Enable this feature by setting `terminate_agent_on_threshold: true` in the Agent Profiling check configuration. When enabled, the Agent uses its established shutdown mechanism to trigger graceful shutdown after successfully generating a flare, ensuring proper cleanup before exit.
 
     **Warning**: This feature will cause the agent to exit. This feature is disabled by default and should be used with caution.

--- a/releasenotes/notes/agentprofiling-check-terminate-threshold-feat-6f35b801e1ace36e.yaml
+++ b/releasenotes/notes/agentprofiling-check-terminate-threshold-feat-6f35b801e1ace36e.yaml
@@ -12,4 +12,4 @@ features:
 
     Enable this feature by setting `terminate_agent_on_threshold: true` in the Agent Profiling check configuration. When enabled, the Agent uses its established shutdown mechanism to trigger graceful shutdown after successfully generating a flare, ensuring proper cleanup before exit.
 
-    **Warning**: This feature will cause the agent to exit. This feature is disabled by default and should be used with caution.
+    **Warning**: This feature will cause the Agent to exit. This feature is disabled by default and should be used with caution.

--- a/releasenotes/notes/agentprofiling-check-terminate-threshold-feat-6f35b801e1ace36e.yaml
+++ b/releasenotes/notes/agentprofiling-check-terminate-threshold-feat-6f35b801e1ace36e.yaml
@@ -10,6 +10,6 @@ features:
   - |
     The Agent Profiling check now supports automatic agent termination after flare generation when memory or CPU thresholds are exceeded. This feature is useful in resource-constrained environments where the agent needs to be restarted after generating diagnostic information.
 
-    Enable this feature by setting ``terminate_agent_on_threshold: true`` in the Agent Profiling check configuration. When enabled, the agent will attempt a graceful shutdown via SIGINT after successfully generating a flare, allowing cleanup before exit. If signal delivery fails, it will fall back to immediate termination.
+    Enable this feature by setting `terminate_agent_on_threshold: true` in the Agent Profiling check configuration. When enabled, the agent will attempt a graceful shutdown via SIGINT after successfully generating a flare, allowing cleanup before exit. If signal delivery fails, it will fall back to immediate termination.
 
     **Warning**: This feature will cause the agent to exit. This feature is disabled by default and should be used with caution.


### PR DESCRIPTION
## What does this PR do?
This PR adds a new configuration option `terminate_agent_on_threshold` to the agentprofiling check that allows the agent process to be automatically terminated after generating a flare when memory or CPU thresholds are exceeded. The termination is opt-in (defaults to false) and uses the agent's established graceful shutdown mechanism (`signals.Stopper`) to ensure proper cleanup via `stopAgent()`. Termination is automatically skipped when running in test mode to prevent test failures.

## Changes:
- Add `terminate_agent_on_threshold` boolean config field
- Implement termination logic using the agent's graceful shutdown mechanism (`signals.Stopper`)
- Update example config with documentation and warnings
- Add unit tests for config parsing and termination logic
- Refactor to use `signals.Stopper` instead of direct signal handling for better integration with agent shutdown flow

## Motivation
This feature helps prevent OOM errors and CPU throttling by automatically terminating the agent when resource thresholds are exceeded. This allows process managers to restart the agent before it consumes excessive system resources, making it useful for troubleshooting memory and CPU issues in production environments.

## Describe how you validated your changes
Ran the changes locally in a dev environment and tested with the agentprofiling check:

```
instances:
  - memory_threshold: "1MB"
    cpu_threshold: 1000
    ticket_id: "2427230"
    user_email: "morgan.wang@datadoghq.com"
    terminate_agent_on_threshold: true
```

Verified that the Agent was shutdown successfully:
```
026-01-06 17:20:34 UTC | CORE | INFO | (pkg/collector/corechecks/agentprofiling/agentprofiling.go:254 in generateFlare) | Flare sent with case ID "2427230"
2026-01-06 17:20:34 UTC | CORE | INFO | (pkg/collector/corechecks/agentprofiling/agentprofiling.go:261 in generateFlare) | Flare generation complete. No more flares will be generated until the Agent is restarted.
2026-01-06 17:20:34 UTC | CORE | WARN | (pkg/collector/corechecks/agentprofiling/agentprofiling.go:208 in terminateAgent) | Terminating agent process due to threshold exceeded (terminate_agent_on_threshold is enabled)
2026-01-06 17:20:34 UTC | CORE | INFO | (pkg/collector/corechecks/agentprofiling/agentprofiling.go:219 in terminateAgent) | Agent Profiling check: Graceful shutdown requested. Agent will exit after cleanup.
2026-01-06 17:20:34 UTC | CORE | INFO | (cmd/agent/subcommands/run/command.go:323 in func2) | Received stop command, shutting down...
2026-01-06 17:20:34 UTC | CORE | INFO | (cmd/agent/subcommands/run/command.go:752 in stopAgent) | See ya!
```
Manually QAed on Linux container, local macOS machine, and local Windows machine. The Agent successfully sent flares and terminated with proper cleanup. Flares can be found here: https://datadog.zendesk.com/agent/tickets/2427230.