### PR TITLE
DJM Installation - Databricks worker logs improvements

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -104,7 +104,7 @@ var (
 	workerLogsStandardAccessMode = []config.IntegrationConfigLogs{
 		{
 			Type:                   "file",
-			Path:                   "/var/log/databricks_privileged/*/*stderr",
+			Path:                   "/var/log/databricks_privileged/*/*/stderr",
 			Source:                 "worker_stderr",
 			Service:                "databricks",
 			AutoMultiLineDetection: config.BoolToPtr(true),

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -111,7 +111,7 @@ var (
 		},
 		{
 			Type:                   "file",
-			Path:                   "/var/log/databricks_privileged/*/*stdout",
+			Path:                   "/var/log/databricks_privileged/*/*/stdout",
 			Source:                 "worker_stdout",
 			Service:                "databricks",
 			AutoMultiLineDetection: config.BoolToPtr(true),

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -88,13 +88,6 @@ var (
 	workerLogs = []config.IntegrationConfigLogs{
 		{
 			Type:                   "file",
-			Path:                   "/databricks/spark/work/*/*/*.log",
-			Source:                 "worker_logs",
-			Service:                "databricks",
-			AutoMultiLineDetection: config.BoolToPtr(true),
-		},
-		{
-			Type:                   "file",
 			Path:                   "/databricks/spark/work/*/*/stderr",
 			Source:                 "worker_stderr",
 			Service:                "databricks",


### PR DESCRIPTION
### What does this PR do?

- stop collection from `worker_logs` source that now appears to be stale
- finish configuration of privileged worker logs collection on Standard Access Mode clusters: mount the correct logs dir in `/var/log` and specify where the stdout & stderr are located with ` var workerLogsStandardAccessMode`

### Motivation

### Describe how you validated your changes

### Additional Notes
