### PR TITLE
fix(ci): Also run invoke task unit tests on buildimages bumps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -680,7 +680,6 @@ workflow:
       compare_to: $COMPARE_TO_BRANCH
     when: never
 
-
 .dynamic_tests:
   - changes:
       paths:
@@ -689,7 +688,6 @@ workflow:
         - comp/**/*
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
-
 
 .on_e2e_or_windows_installer_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -1165,6 +1163,7 @@ workflow:
   - changes:
       paths:
         - tasks/**/*
+        - .gitlab-ci.yml # A buildimage bump can also affect the invoke tasks
       compare_to: $COMPARE_TO_BRANCH
 
 .on_gpu_or_e2e_changes:


### PR DESCRIPTION
### What does this PR do?

Change the `.on_invoke_tasks_changes` template to also include `.gitlab-ci.yml`

### Motivation

A buildimage bump can also affect the invoke tasks

### Describe how you validated your changes

### Additional Notes
