### PR TITLE
Fix: APM instrumentation field lost during heartbeat updates

### DIFF
--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1767,7 +1767,7 @@ func (p *Process) Merge(e Entity) error {
 	if otherProcess.Service != nil && p.Service != nil {
 		otherProcess.Service.APMInstrumentation =
 			otherProcess.Service.APMInstrumentation ||
-			p.Service.APMInstrumentation
+				p.Service.APMInstrumentation
 	}
 
 	// If the source has service data, remove the one from destination so merge() takes service data from the source

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1761,6 +1761,15 @@ func (p *Process) Merge(e Entity) error {
 		return fmt.Errorf("cannot merge ProcessMetadata with different kind %T", e)
 	}
 
+	// Preserve APMInstrumentation from destination if source has it as false
+	// This prevents losing instrumentation state when a collector that doesn't detect APM
+	// (e.g., service discovery) updates the service data in a later heartbeat
+	if otherProcess.Service != nil && p.Service != nil {
+		otherProcess.Service.APMInstrumentation =
+			otherProcess.Service.APMInstrumentation ||
+			p.Service.APMInstrumentation
+	}
+
 	// If the source has service data, remove the one from destination so merge() takes service data from the source
 	if otherProcess.Service != nil {
 		p.Service = nil

--- a/comp/core/workloadmeta/def/types_test.go
+++ b/comp/core/workloadmeta/def/types_test.go
@@ -413,11 +413,11 @@ func TestMergeGPU(t *testing.T) {
 
 func TestProcessMergePreservesAPMInstrumentation(t *testing.T) {
 	tests := []struct {
-		name                          string
-		destinationProcess            *Process
-		sourceProcess                 *Process
-		expectedAPMInstrumentation    bool
-		description                   string
+		name                       string
+		destinationProcess         *Process
+		sourceProcess              *Process
+		expectedAPMInstrumentation bool
+		description                string
 	}{
 		{
 			name: "preserve APMInstrumentation when source has false and destination has true",
@@ -445,7 +445,7 @@ func TestProcessMergePreservesAPMInstrumentation(t *testing.T) {
 				},
 			},
 			expectedAPMInstrumentation: true,
-			description:               "APM state should be preserved when non-APM collector updates service",
+			description:                "APM state should be preserved when non-APM collector updates service",
 		},
 		{
 			name: "overwrite APMInstrumentation when source explicitly sets it to true",
@@ -472,7 +472,7 @@ func TestProcessMergePreservesAPMInstrumentation(t *testing.T) {
 				},
 			},
 			expectedAPMInstrumentation: true,
-			description:               "APM collector should be able to set instrumentation to true",
+			description:                "APM collector should be able to set instrumentation to true",
 		},
 		{
 			name: "both false stays false",
@@ -499,7 +499,7 @@ func TestProcessMergePreservesAPMInstrumentation(t *testing.T) {
 				},
 			},
 			expectedAPMInstrumentation: false,
-			description:               "Should stay false if both collectors report false",
+			description:                "Should stay false if both collectors report false",
 		},
 		{
 			name: "source has no service - destination service preserved",
@@ -523,7 +523,7 @@ func TestProcessMergePreservesAPMInstrumentation(t *testing.T) {
 				Service: nil,
 			},
 			expectedAPMInstrumentation: true,
-			description:               "Destination service should be preserved if source has no service",
+			description:                "Destination service should be preserved if source has no service",
 		},
 		{
 			name: "destination has no service - source service used",
@@ -547,7 +547,7 @@ func TestProcessMergePreservesAPMInstrumentation(t *testing.T) {
 				},
 			},
 			expectedAPMInstrumentation: true,
-			description:               "Source service should be used if destination has no service",
+			description:                "Source service should be used if destination has no service",
 		},
 	}
 
@@ -562,4 +562,3 @@ func TestProcessMergePreservesAPMInstrumentation(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
### What does this PR do?
This PR introduces a simple condition to check whether the original process already had APM instrumentation set to true when it is updated via a heartbeat. This ensures that the APM instrumentation flag remains true if it was originally enabled.

### Motivation
[DSCVR-302](https://datadoghq.atlassian.net/browse/DSCVR-302) 
The previous (incorrect) behavior was discovered during the [investigation](https://datadoghq.atlassian.net/wiki/spaces/~712020cd09e734c2ad4306ab09c6b04ef5c99d/pages/edit-v2/5967610152) of a bug.

### Validation
All test pass. It also adds comprehensive test coverage with 5 APM instrumentation merge preservation test cases.


### Additional Notes


[DSCVR-302]: https://datadoghq.atlassian.net/browse/DSCVR-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ