### PR TITLE
chore: test framework deploy on ecs fargate only

### DIFF
--- a/test/e2e-framework/scenarios/aws/ecs/run.go
+++ b/test/e2e-framework/scenarios/aws/ecs/run.go
@@ -17,12 +17,20 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/tracegen"
 	fakeintakeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
 
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ssm"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 	resourcesAws "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ssm"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+// isEC2ProviderSet checks whether at least one EC2 capacity provider is set in the given params
+// An EC2 provider is considered set if at least one of its node groups is enabled.
+func isEC2ProviderSet(params *Params) bool {
+	return params.LinuxNodeGroup || params.LinuxARMNodeGroup || params.WindowsNodeGroup || params.LinuxBottleRocketNodeGroup
+
+}
 
 func Run(ctx *pulumi.Context) error {
 	awsEnv, err := resourcesAws.NewEnvironment(ctx)
@@ -59,7 +67,7 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resourcesAws.Environment, env *envir
 	var apiKeyParam *ssm.Parameter
 	var fakeIntake *fakeintakeComp.Fakeintake
 
-	if params.agentOptions != nil {
+	if awsEnv.AgentDeploy() {
 		if params.fakeintakeOptions != nil {
 			if fakeIntake, err = fakeintake.NewECSFargateInstance(awsEnv, "ecs", params.fakeintakeOptions...); err != nil {
 				return err
@@ -97,8 +105,8 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resourcesAws.Environment, env *envir
 		env.FakeIntake = nil
 	}
 
-	// Testing workload
-	if params.testingWorkload {
+	// Testing workload if at least one EC2 node group is present
+	if params.testingWorkload && isEC2ProviderSet(clusterParams) {
 		if _, err := nginx.EcsAppDefinition(awsEnv, cluster.ClusterArn); err != nil {
 			return err
 		}
@@ -127,7 +135,7 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resourcesAws.Environment, env *envir
 	}
 
 	// Deploy Fargate test apps when enabled
-	if params.testingWorkload && params.agentOptions != nil && clusterParams.FargateCapacityProvider {
+	if params.testingWorkload && clusterParams.FargateCapacityProvider {
 		if _, err := redis.FargateAppDefinition(awsEnv, cluster.ClusterArn, apiKeyParam.Name, fakeIntake); err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

The ecs scenario should be able to deploy the test workloads on fargate nodes only.
For that: check if agent is enabled and if so deploy a fakeintake. When checking for fargate deployment check only if test workload is enabled and if fargate is provided, then deploy the fargate specific workloads.

### Motivation

allow me to deploy on ECS fargate nodes only for QA validation

### Describe how you validated your changes

run the scenario with the command and it worked:

```
dda inv -e aws.create-ecs -i -n -a '<agent version to test>' -u --no-bottlerocket-node-group --no-linux-node-group -s <your stack name>
```

### Additional Notes
