### PR TITLE
Fix flaky softwareinventory status tests by waiting for async init

### DIFF
--- a/comp/softwareinventory/impl/status_test.go
+++ b/comp/softwareinventory/impl/status_test.go
@@ -27,7 +27,7 @@ func TestGetPayloadRefreshesCachedValues(t *testing.T) {
 		{DisplayName: "FooApp", ProductCode: "foo"},
 		{DisplayName: "BarApp", ProductCode: "bar"},
 	})
-	is := f.sut()
+	is := f.sut().WaitForSystemProbe()
 
 	// Status JSON should trigger a refresh of cached values
 	stats := make(map[string]interface{})
@@ -108,7 +108,7 @@ func TestStatusTemplates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFixtureWithData(t, true, tt.mockData)
-			is := f.sut()
+			is := f.sut().WaitForSystemProbe()
 
 			// Test Text template
 			var buf bytes.Buffer
@@ -133,7 +133,7 @@ func TestStatusTemplates(t *testing.T) {
 
 func TestStatusTemplateWithNoSoftwareInventoryMetadata(t *testing.T) {
 	f := newFixtureWithData(t, true, []software.Entry{})
-	is := f.sut()
+	is := f.sut().WaitForSystemProbe()
 
 	// Test Text template
 	var buf bytes.Buffer


### PR DESCRIPTION
### What does this PR do?

Fixes flaky tests in the softwareinventory component by adding `WaitForSystemProbe()` to ensure the async goroutine has completed populating the cache before assertions.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2124

The tests were failing intermittently because they would read from `cachedInventory` before the background goroutine (started in `startSoftwareInventoryCollection`) had a chance to populate it. This caused 'Detected 0 installed software entries' instead of the expected count.

