### PR TITLE
remove package entry from packages.db in Purge()

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -594,6 +594,13 @@ func (i *installerImpl) Purge(ctx context.Context) {
 		if err != nil {
 			log.Warnf("could not remove package %s: %v", pkg.Name, err)
 		}
+		// Delete the package entry from the database.
+		// This ensures the entry is removed even if os.Remove(packages.db) fails later
+		// due to file locking race conditions on Windows.
+		err = i.db.DeletePackage(pkg.Name)
+		if err != nil {
+			log.Warnf("could not delete package %s from db: %v", pkg.Name, err)
+		}
 	}
 	// NOTE: On Windows, purge must be called from a copy of the installer that
 	//       exists outside of the install directory. If purge is called from


### PR DESCRIPTION
### What does this PR do?
This PR removes package entry from packages.db before removing packages.db. On Windows platform, it's observed that packages.db could still be in a "locked" state after it's closed, resulting in file removal failure. In such a case, if a package entry is not removed from the database, the next package installation may be incorrectly skipped when it finds the stale entry in packages.db.

### Motivation
We have seen about 7% failure rate with new-e2e/tests/installer/windows/suites/ddot-package.TestAgentMSIInstallsDDOTPackage. The issue is tracked by [WINA-2094](https://datadoghq.atlassian.net/browse/WINA-2094).

### Describe how you validated your changes
Ensure all pipelines pass and the issue no longer happens with stress e2e tests.

### Additional Notes


[WINA-2094]: https://datadoghq.atlassian.net/browse/WINA-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ