### PR TITLE
Dont join key names for system_probe config

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -19,20 +19,6 @@ import (
 type transformerFunction func(string) []map[string]string
 
 const (
-	spNS                         = "system_probe_config"
-	netNS                        = "network_config"
-	smNS                         = "service_monitoring_config"
-	evNS                         = "event_monitoring_config"
-	compNS                       = "compliance_config"
-	ccmNS                        = "ccm_network_config"
-	diNS                         = "dynamic_instrumentation"
-	wcdNS                        = "windows_crash_detection"
-	pngNS                        = "ping"
-	tracerouteNS                 = "traceroute"
-	discoveryNS                  = "discovery"
-	gpuNS                        = "gpu_monitoring"
-	privilegedLogsNS             = "privileged_logs"
-	swNS                         = "software_inventory"
 	defaultConnsMessageBatchSize = 600
 
 	// defaultRuntimeCompilerOutputDir is the default path for output from the system-probe runtime compiler
@@ -73,7 +59,7 @@ var (
 func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("ignore_host_etc", false)
 	cfg.BindEnvAndSetDefault("go_core_dump", false)
-	cfg.BindEnvAndSetDefault(join(spNS, "disable_thp"), true)
+	cfg.BindEnvAndSetDefault("system_probe_config.disable_thp", true)
 
 	// SBOM configuration
 	cfg.BindEnvAndSetDefault("sbom.host.enabled", false)
@@ -95,8 +81,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("dogstatsd_port", 8125)
 
 	// logging
-	cfg.BindEnvAndSetDefault(join(spNS, "log_file"), "")
-	cfg.BindEnvAndSetDefault(join(spNS, "log_level"), "")
+	cfg.BindEnvAndSetDefault("system_probe_config.log_file", "")
+	cfg.BindEnvAndSetDefault("system_probe_config.log_level", "")
 	cfg.BindEnvAndSetDefault("log_file", defaultSystemProbeLogFilePath)
 	cfg.BindEnvAndSetDefault("log_level", "info", "DD_LOG_LEVEL", "LOG_LEVEL")
 	cfg.BindEnvAndSetDefault("syslog_uri", "")
@@ -119,300 +105,296 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("secret_backend_skip_checks", false)
 
 	// settings for system-probe in general
-	cfg.BindEnvAndSetDefault(join(spNS, "enabled"), false, "DD_SYSTEM_PROBE_ENABLED")
-	cfg.BindEnvAndSetDefault(join(spNS, "external"), false, "DD_SYSTEM_PROBE_EXTERNAL")
-	cfg.SetDefault(join(spNS, "adjusted"), false)
+	cfg.BindEnvAndSetDefault("system_probe_config.enabled", false, "DD_SYSTEM_PROBE_ENABLED")
+	cfg.BindEnvAndSetDefault("system_probe_config.external", false, "DD_SYSTEM_PROBE_EXTERNAL")
+	cfg.SetDefault("system_probe_config.adjusted", false)
 
-	cfg.BindEnvAndSetDefault(join(spNS, "sysprobe_socket"), DefaultSystemProbeAddress, "DD_SYSPROBE_SOCKET")
-	cfg.BindEnvAndSetDefault(join(spNS, "max_conns_per_message"), defaultConnsMessageBatchSize)
+	cfg.BindEnvAndSetDefault("system_probe_config.sysprobe_socket", DefaultSystemProbeAddress, "DD_SYSPROBE_SOCKET")
+	cfg.BindEnvAndSetDefault("system_probe_config.max_conns_per_message", defaultConnsMessageBatchSize)
 
-	cfg.BindEnvAndSetDefault(join(spNS, "debug_port"), 0)
-	cfg.BindEnvAndSetDefault(join(spNS, "telemetry_enabled"), false, "DD_TELEMETRY_ENABLED")
-	cfg.BindEnvAndSetDefault(join(spNS, "telemetry_perf_buffer_emit_per_cpu"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "health_port"), int64(0), "DD_SYSTEM_PROBE_HEALTH_PORT")
+	cfg.BindEnvAndSetDefault("system_probe_config.debug_port", 0)
+	cfg.BindEnvAndSetDefault("system_probe_config.telemetry_enabled", false, "DD_TELEMETRY_ENABLED")
+	cfg.BindEnvAndSetDefault("system_probe_config.telemetry_perf_buffer_emit_per_cpu", false)
+	cfg.BindEnvAndSetDefault("system_probe_config.health_port", int64(0), "DD_SYSTEM_PROBE_HEALTH_PORT")
 
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enabled"), false, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENABLED")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.site"), DefaultSite, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_SITE", "DD_SITE")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.profile_dd_url"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_DD_URL", "DD_APM_INTERNAL_PROFILING_DD_URL")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.api_key"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_API_KEY", "DD_API_KEY")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.env"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENV", "DD_ENV")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.period"), 5*time.Minute, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_PERIOD")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.cpu_duration"), 1*time.Minute, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_CPU_DURATION")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.mutex_profile_fraction"), 0)
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.block_profile_rate"), 0)
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enable_goroutine_stacktraces"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enable_block_profiling"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enable_mutex_profiling"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.delta_profiles"), true)
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.custom_attributes"), []string{"module", "rule_id"})
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.unix_socket"), "")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.extra_tags"), []string{})
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.enabled", false, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENABLED")
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.site", DefaultSite, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_SITE", "DD_SITE")
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.profile_dd_url", "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_DD_URL", "DD_APM_INTERNAL_PROFILING_DD_URL")
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.api_key", "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_API_KEY", "DD_API_KEY")
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.env", "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENV", "DD_ENV")
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.period", 5*time.Minute, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_PERIOD")
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.cpu_duration", 1*time.Minute, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_CPU_DURATION")
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.mutex_profile_fraction", 0)
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.block_profile_rate", 0)
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.enable_goroutine_stacktraces", false)
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.enable_block_profiling", false)
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.enable_mutex_profiling", false)
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.delta_profiles", true)
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.custom_attributes", []string{"module", "rule_id"})
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.unix_socket", "")
+	cfg.BindEnvAndSetDefault("system_probe_config.internal_profiling.extra_tags", []string{})
 
-	cfg.BindEnvAndSetDefault(join(spNS, "memory_controller.enabled"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "memory_controller.hierarchy"), "v1")
-	cfg.BindEnvAndSetDefault(join(spNS, "memory_controller.pressure_levels"), map[string]string{})
-	cfg.BindEnvAndSetDefault(join(spNS, "memory_controller.thresholds"), map[string]string{})
+	cfg.BindEnvAndSetDefault("system_probe_config.memory_controller.enabled", false)
+	cfg.BindEnvAndSetDefault("system_probe_config.memory_controller.hierarchy", "v1")
+	cfg.BindEnvAndSetDefault("system_probe_config.memory_controller.pressure_levels", map[string]string{})
+	cfg.BindEnvAndSetDefault("system_probe_config.memory_controller.thresholds", map[string]string{})
 
 	// ebpf general settings
-	cfg.BindEnvAndSetDefault(join(spNS, "bpf_debug"), false, "DD_SYSTEM_PROBE_CONFIG_BPF_DEBUG", "BPF_DEBUG")
-	cfg.BindEnvAndSetDefault(join(spNS, "bpf_dir"), defaultSystemProbeBPFDir, "DD_SYSTEM_PROBE_BPF_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "excluded_linux_versions"), []string{})
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_tracepoints"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_co_re"), true, "DD_ENABLE_CO_RE")
-	cfg.BindEnvAndSetDefault(join(spNS, "btf_path"), "", "DD_SYSTEM_PROBE_BTF_PATH")
-	cfg.BindEnvAndSetDefault(join(spNS, "btf_output_dir"), defaultBTFOutputDir, "DD_SYSTEM_PROBE_BTF_OUTPUT_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "remote_config_btf_enabled"), false, "DD_SYSTEM_PROBE_REMOTE_CONFIG_BTF_ENABLED")
-	cfg.BindEnv(join(spNS, "enable_runtime_compiler"), "DD_ENABLE_RUNTIME_COMPILER") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("system_probe_config.bpf_debug", false, "DD_SYSTEM_PROBE_CONFIG_BPF_DEBUG", "BPF_DEBUG")
+	cfg.BindEnvAndSetDefault("system_probe_config.bpf_dir", defaultSystemProbeBPFDir, "DD_SYSTEM_PROBE_BPF_DIR")
+	cfg.BindEnvAndSetDefault("system_probe_config.excluded_linux_versions", []string{})
+	cfg.BindEnvAndSetDefault("system_probe_config.enable_tracepoints", false)
+	cfg.BindEnvAndSetDefault("system_probe_config.enable_co_re", true, "DD_ENABLE_CO_RE")
+	cfg.BindEnvAndSetDefault("system_probe_config.btf_path", "", "DD_SYSTEM_PROBE_BTF_PATH")
+	cfg.BindEnvAndSetDefault("system_probe_config.btf_output_dir", defaultBTFOutputDir, "DD_SYSTEM_PROBE_BTF_OUTPUT_DIR")
+	cfg.BindEnvAndSetDefault("system_probe_config.remote_config_btf_enabled", false, "DD_SYSTEM_PROBE_REMOTE_CONFIG_BTF_ENABLED")
+	cfg.BindEnv("system_probe_config.enable_runtime_compiler", "DD_ENABLE_RUNTIME_COMPILER") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	// deprecated in favor of allow_prebuilt_fallback below
-	cfg.BindEnv(join(spNS, "allow_precompiled_fallback"), "DD_ALLOW_PRECOMPILED_FALLBACK") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnv(join(spNS, "allow_prebuilt_fallback"), "DD_ALLOW_PREBUILT_FALLBACK")       //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnvAndSetDefault(join(spNS, "allow_runtime_compiled_fallback"), true, "DD_ALLOW_RUNTIME_COMPILED_FALLBACK")
-	cfg.BindEnvAndSetDefault(join(spNS, "runtime_compiler_output_dir"), defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
-	cfg.BindEnv(join(spNS, "enable_kernel_header_download"), "DD_ENABLE_KERNEL_HEADER_DOWNLOAD") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_dirs"), []string{}, "DD_KERNEL_HEADER_DIRS")
-	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_download_dir"), defaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "apt_config_dir"), suffixHostEtc(defaultAptConfigDirSuffix), "DD_APT_CONFIG_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "yum_repos_dir"), suffixHostEtc(defaultYumReposDirSuffix), "DD_YUM_REPOS_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "zypper_repos_dir"), suffixHostEtc(defaultZypperReposDirSuffix), "DD_ZYPPER_REPOS_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "attach_kprobes_with_kprobe_events_abi"), false, "DD_ATTACH_KPROBES_WITH_KPROBE_EVENTS_ABI")
+	cfg.BindEnv("system_probe_config.allow_precompiled_fallback", "DD_ALLOW_PRECOMPILED_FALLBACK") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("system_probe_config.allow_prebuilt_fallback", "DD_ALLOW_PREBUILT_FALLBACK")       //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("system_probe_config.allow_runtime_compiled_fallback", true, "DD_ALLOW_RUNTIME_COMPILED_FALLBACK")
+	cfg.BindEnvAndSetDefault("system_probe_config.runtime_compiler_output_dir", defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
+	cfg.BindEnv("system_probe_config.enable_kernel_header_download", "DD_ENABLE_KERNEL_HEADER_DOWNLOAD") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("system_probe_config.kernel_header_dirs", []string{}, "DD_KERNEL_HEADER_DIRS")
+	cfg.BindEnvAndSetDefault("system_probe_config.kernel_header_download_dir", defaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
+	cfg.BindEnvAndSetDefault("system_probe_config.apt_config_dir", suffixHostEtc(defaultAptConfigDirSuffix), "DD_APT_CONFIG_DIR")
+	cfg.BindEnvAndSetDefault("system_probe_config.yum_repos_dir", suffixHostEtc(defaultYumReposDirSuffix), "DD_YUM_REPOS_DIR")
+	cfg.BindEnvAndSetDefault("system_probe_config.zypper_repos_dir", suffixHostEtc(defaultZypperReposDirSuffix), "DD_ZYPPER_REPOS_DIR")
+	cfg.BindEnvAndSetDefault("system_probe_config.attach_kprobes_with_kprobe_events_abi", false, "DD_ATTACH_KPROBES_WITH_KPROBE_EVENTS_ABI")
 
 	// Dynamic Instrumentation settings
-	cfg.BindEnvAndSetDefault(join(diNS, "enabled"), false, "DD_DYNAMIC_INSTRUMENTATION_ENABLED")
-	cfg.BindEnvAndSetDefault(join(diNS, "offline_mode"), false, "DD_DYNAMIC_INSTRUMENTATION_OFFLINE_MODE")
-	cfg.BindEnvAndSetDefault(join(diNS, "probes_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_PROBES_FILE_PATH")
-	cfg.BindEnvAndSetDefault(join(diNS, "snapshot_output_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_SNAPSHOT_FILE_PATH")
-	cfg.BindEnvAndSetDefault(join(diNS, "diagnostics_output_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_FILE_PATH")
-	cfg.BindEnvAndSetDefault(join(diNS, "symdb_upload_enabled"), true, "DD_SYMBOL_DATABASE_UPLOAD_ENABLED")
-	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "enabled"), true)
-	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "dir"), defaultDynamicInstrumentationDebugInfoDir)
-	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "max_total_bytes"), int64(2<<30 /* 2GiB */))
-	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "required_disk_space_bytes"), int64(512<<20 /* 512MiB */))
-	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "required_disk_space_percent"), float64(0.0))
-	cfg.BindEnvAndSetDefault(join(diNS, "circuit_breaker", "interval"), 1*time.Second)
-	cfg.BindEnvAndSetDefault(join(diNS, "circuit_breaker", "per_probe_cpu_limit"), 0.1)
-	cfg.BindEnvAndSetDefault(join(diNS, "circuit_breaker", "all_probes_cpu_limit"), 0.5)
-	cfg.BindEnvAndSetDefault(join(diNS, "circuit_breaker", "interrupt_overhead"), 5*time.Microsecond)
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.enabled", false, "DD_DYNAMIC_INSTRUMENTATION_ENABLED")
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.offline_mode", false, "DD_DYNAMIC_INSTRUMENTATION_OFFLINE_MODE")
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.probes_file_path", false, "DD_DYNAMIC_INSTRUMENTATION_PROBES_FILE_PATH")
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.snapshot_output_file_path", false, "DD_DYNAMIC_INSTRUMENTATION_SNAPSHOT_FILE_PATH")
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.diagnostics_output_file_path", false, "DD_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_FILE_PATH")
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.symdb_upload_enabled", true, "DD_SYMBOL_DATABASE_UPLOAD_ENABLED")
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.enabled", true)
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.dir", defaultDynamicInstrumentationDebugInfoDir)
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.max_total_bytes", int64(2<<30 /* 2GiB */))
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.required_disk_space_bytes", int64(512<<20 /* 512MiB */))
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.required_disk_space_percent", float64(0.0))
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.interval", 1*time.Second)
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.per_probe_cpu_limit", 0.1)
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.all_probes_cpu_limit", 0.5)
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breakerinterrupt_overhead", 5*time.Microsecond)
 
 	// network_tracer settings
 	// we cannot use BindEnvAndSetDefault for network_config.enabled because we need to know if it was manually set.
-	cfg.BindEnv(join(netNS, "enabled"), "DD_SYSTEM_PROBE_NETWORK_ENABLED") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv' //nolint:errcheck
-	cfg.BindEnvAndSetDefault(join(spNS, "disable_tcp"), false, "DD_DISABLE_TCP_TRACING")
-	cfg.BindEnvAndSetDefault(join(spNS, "disable_udp"), false, "DD_DISABLE_UDP_TRACING")
-	cfg.BindEnvAndSetDefault(join(spNS, "disable_ipv6"), false, "DD_DISABLE_IPV6_TRACING")
+	cfg.BindEnv("network_config.enabled", "DD_SYSTEM_PROBE_NETWORK_ENABLED") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv' //nolint:errcheck
+	cfg.BindEnvAndSetDefault("system_probe_config.disable_tcp", false, "DD_DISABLE_TCP_TRACING")
+	cfg.BindEnvAndSetDefault("system_probe_config.disable_udp", false, "DD_DISABLE_UDP_TRACING")
+	cfg.BindEnvAndSetDefault("system_probe_config.disable_ipv6", false, "DD_DISABLE_IPV6_TRACING")
 
-	cfg.SetDefault(join(netNS, "collect_tcp_v4"), true)
-	cfg.SetDefault(join(netNS, "collect_tcp_v6"), true)
-	cfg.SetDefault(join(netNS, "collect_udp_v4"), true)
-	cfg.SetDefault(join(netNS, "collect_udp_v6"), true)
+	cfg.SetDefault("network_config.collect_tcp_v4", true)
+	cfg.SetDefault("network_config.collect_tcp_v6", true)
+	cfg.SetDefault("network_config.collect_udp_v4", true)
+	cfg.SetDefault("network_config.collect_udp_v6", true)
 
-	cfg.BindEnvAndSetDefault(join(spNS, "offset_guess_threshold"), int64(defaultOffsetThreshold))
+	cfg.BindEnvAndSetDefault("system_probe_config.offset_guess_threshold", int64(defaultOffsetThreshold))
 
-	cfg.BindEnvAndSetDefault(join(spNS, "max_tracked_connections"), 65536)
-	cfg.BindEnv(join(spNS, "max_closed_connections_buffered"))    //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnv(join(netNS, "max_failed_connections_buffered"))   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnv(join(spNS, "closed_connection_flush_threshold"))  //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnv(join(netNS, "closed_connection_flush_threshold")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnv(join(spNS, "closed_channel_size"))                //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnv(join(netNS, "closed_channel_size"))               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnvAndSetDefault(join(netNS, "closed_buffer_wakeup_count"), 4)
-	cfg.BindEnvAndSetDefault(join(spNS, "max_connection_state_buffered"), 75000)
+	cfg.BindEnvAndSetDefault("system_probe_config.max_tracked_connections", 65536)
+	cfg.BindEnv("system_probe_config.max_closed_connections_buffered")   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("network_config.max_failed_connections_buffered")        //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("system_probe_config.closed_connection_flush_threshold") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("network_config.closed_connection_flush_threshold")      //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("system_probe_config.closed_channel_size")               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("network_config.closed_channel_size")                    //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("network_config.closed_buffer_wakeup_count", 4)
+	cfg.BindEnvAndSetDefault("system_probe_config.max_connection_state_buffered", 75000)
 
-	cfg.BindEnvAndSetDefault(join(spNS, "disable_dns_inspection"), false, "DD_DISABLE_DNS_INSPECTION")
-	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_stats"), true, "DD_COLLECT_DNS_STATS")
-	cfg.BindEnvAndSetDefault(join(spNS, "collect_local_dns"), false, "DD_COLLECT_LOCAL_DNS")
-	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_domains"), true, "DD_COLLECT_DNS_DOMAINS")
-	cfg.BindEnvAndSetDefault(join(spNS, "max_dns_stats"), 20000)
-	cfg.BindEnvAndSetDefault(join(spNS, "dns_timeout_in_s"), 15)
+	cfg.BindEnvAndSetDefault("system_probe_config.disable_dns_inspection", false, "DD_DISABLE_DNS_INSPECTION")
+	cfg.BindEnvAndSetDefault("system_probe_config.collect_dns_stats", true, "DD_COLLECT_DNS_STATS")
+	cfg.BindEnvAndSetDefault("system_probe_config.collect_local_dns", false, "DD_COLLECT_LOCAL_DNS")
+	cfg.BindEnvAndSetDefault("system_probe_config.collect_dns_domains", true, "DD_COLLECT_DNS_DOMAINS")
+	cfg.BindEnvAndSetDefault("system_probe_config.max_dns_stats", 20000)
+	cfg.BindEnvAndSetDefault("system_probe_config.dns_timeout_in_s", 15)
 
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_conntrack"), true)
-	cfg.BindEnvAndSetDefault(join(spNS, "conntrack_max_state_size"), 65536*2)
-	cfg.BindEnvAndSetDefault(join(spNS, "conntrack_rate_limit"), 500)
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_conntrack_all_namespaces"), true, "DD_SYSTEM_PROBE_ENABLE_CONNTRACK_ALL_NAMESPACES")
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_protocol_classification"), true, "DD_ENABLE_PROTOCOL_CLASSIFICATION")
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_ringbuffers"), true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_RINGBUFFERS")
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_custom_batching"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_CUSTOM_BATCHING")
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_tcp_failed_connections"), true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_FAILED_CONNS")
-	cfg.BindEnvAndSetDefault(join(netNS, "ignore_conntrack_init_failure"), false, "DD_SYSTEM_PROBE_NETWORK_IGNORE_CONNTRACK_INIT_FAILURE")
-	cfg.BindEnvAndSetDefault(join(netNS, "conntrack_init_timeout"), 10*time.Second)
-	cfg.BindEnvAndSetDefault(join(netNS, "allow_netlink_conntracker_fallback"), true)
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_ebpf_conntracker"), true)
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_cilium_lb_conntracker"), true)
+	cfg.BindEnvAndSetDefault("system_probe_config.enable_conntrack", true)
+	cfg.BindEnvAndSetDefault("system_probe_config.conntrack_max_state_size", 65536*2)
+	cfg.BindEnvAndSetDefault("system_probe_config.conntrack_rate_limit", 500)
+	cfg.BindEnvAndSetDefault("system_probe_config.enable_conntrack_all_namespaces", true, "DD_SYSTEM_PROBE_ENABLE_CONNTRACK_ALL_NAMESPACES")
+	cfg.BindEnvAndSetDefault("network_config.enable_protocol_classification", true, "DD_ENABLE_PROTOCOL_CLASSIFICATION")
+	cfg.BindEnvAndSetDefault("network_config.enable_ringbuffers", true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_RINGBUFFERS")
+	cfg.BindEnvAndSetDefault("network_config.enable_custom_batching", false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_CUSTOM_BATCHING")
+	cfg.BindEnvAndSetDefault("network_config.enable_tcp_failed_connections", true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_FAILED_CONNS")
+	cfg.BindEnvAndSetDefault("network_config.ignore_conntrack_init_failure", false, "DD_SYSTEM_PROBE_NETWORK_IGNORE_CONNTRACK_INIT_FAILURE")
+	cfg.BindEnvAndSetDefault("network_config.conntrack_init_timeout", 10*time.Second)
+	cfg.BindEnvAndSetDefault("network_config.allow_netlink_conntracker_fallback", true)
+	cfg.BindEnvAndSetDefault("network_config.enable_ebpf_conntracker", true)
+	cfg.BindEnvAndSetDefault("network_config.enable_cilium_lb_conntracker", true)
 
-	cfg.BindEnvAndSetDefault(join(spNS, "source_excludes"), map[string][]string{})
-	cfg.BindEnvAndSetDefault(join(spNS, "dest_excludes"), map[string][]string{})
+	cfg.BindEnvAndSetDefault("system_probe_config.source_excludes", map[string][]string{})
+	cfg.BindEnvAndSetDefault("system_probe_config.dest_excludes", map[string][]string{})
 
-	cfg.BindEnvAndSetDefault(join(spNS, "language_detection.enabled"), false)
+	cfg.BindEnvAndSetDefault("system_probe_config.language_detection.enabled", false)
 
-	cfg.BindEnvAndSetDefault(join(spNS, "process_service_inference", "use_improved_algorithm"), false)
-
-	// For backward compatibility
-	cfg.BindEnv(join(smNS, "process_service_inference", "enabled"), "DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_ENABLED") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnvAndSetDefault(join(spNS, "process_service_inference", "enabled"), runtime.GOOS == "windows")
+	cfg.BindEnvAndSetDefault("system_probe_config.process_service_inference.use_improved_algorithm", false)
 
 	// For backward compatibility
-	cfg.BindEnv(join(smNS, "process_service_inference", "use_windows_service_name"), "DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_USE_WINDOWS_SERVICE_NAME") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("service_monitoring_config.process_service_inference.enabled", "DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_ENABLED") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("system_probe_config.process_service_inference.enabled", runtime.GOOS == "windows")
+
+	// For backward compatibility
+	cfg.BindEnv("service_monitoring_config.process_service_inference.use_windows_service_name", "DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_USE_WINDOWS_SERVICE_NAME") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	// default on windows is now enabled; default on linux is still disabled
-	cfg.BindEnvAndSetDefault(join(spNS, "process_service_inference", "use_windows_service_name"), true)
+	cfg.BindEnvAndSetDefault("system_probe_config.process_service_inference.use_windows_service_name", true)
 
 	// network_config namespace only
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
+	cfg.BindEnvAndSetDefault("network_config.enable_gateway_lookup", true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
 
-	cfg.BindEnvAndSetDefault(join(spNS, "expected_tags_duration"), 30*time.Minute, "DD_SYSTEM_PROBE_EXPECTED_TAGS_DURATION")
+	cfg.BindEnvAndSetDefault("system_probe_config.expected_tags_duration", 30*time.Minute, "DD_SYSTEM_PROBE_EXPECTED_TAGS_DURATION")
 
 	// list of DNS query types to be recorded
-	cfg.BindEnvAndSetDefault(join(netNS, "dns_recorded_query_types"), []string{})
+	cfg.BindEnvAndSetDefault("network_config.dns_recorded_query_types", []string{})
 	// (temporary) enable submitting DNS stats by query type.
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_dns_by_querytype"), false)
+	cfg.BindEnvAndSetDefault("network_config.enable_dns_by_querytype", false)
 	// connection aggregation with port rollups
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_connection_rollup"), false)
+	cfg.BindEnvAndSetDefault("network_config.enable_connection_rollup", false)
 
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_ebpfless"), false, "DD_ENABLE_EBPFLESS", "DD_NETWORK_CONFIG_ENABLE_EBPFLESS")
+	cfg.BindEnvAndSetDefault("network_config.enable_ebpfless", false, "DD_ENABLE_EBPFLESS", "DD_NETWORK_CONFIG_ENABLE_EBPFLESS")
 
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_fentry"), false)
+	cfg.BindEnvAndSetDefault("network_config.enable_fentry", false)
 
 	// TLS cert collection
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_cert_collection"), false)
-	cfg.BindEnvAndSetDefault(join(netNS, "cert_collection_map_cleaner_interval"), 30*time.Second)
+	cfg.BindEnvAndSetDefault("network_config.enable_cert_collection", false)
+	cfg.BindEnvAndSetDefault("network_config.cert_collection_map_cleaner_interval", 30*time.Second)
 
 	// windows config
-	cfg.BindEnvAndSetDefault(join(spNS, "windows.enable_monotonic_count"), false)
+	cfg.BindEnvAndSetDefault("system_probe_config.windows.enable_monotonic_count", false)
 
 	// oom_kill module
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_oom_kill"), false)
+	cfg.BindEnvAndSetDefault("system_probe_config.enable_oom_kill", false)
 
 	// tcp_queue_length module
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_tcp_queue_length"), false)
+	cfg.BindEnvAndSetDefault("system_probe_config.enable_tcp_queue_length", false)
 	// process module
 	// nested within system_probe_config to not conflict with process-agent's process_config
-	cfg.BindEnvAndSetDefault(join(spNS, "process_config.enabled"), false, "DD_SYSTEM_PROBE_PROCESS_ENABLED")
+	cfg.BindEnvAndSetDefault("system_probe_config.process_config.enabled", false, "DD_SYSTEM_PROBE_PROCESS_ENABLED")
 	// ebpf module
-	cfg.BindEnvAndSetDefault(join("ebpf_check", "enabled"), false)
-	cfg.BindEnvAndSetDefault(join("ebpf_check", "kernel_bpf_stats"), false)
+	cfg.BindEnvAndSetDefault("ebpf_check.enabled", false)
+	cfg.BindEnvAndSetDefault("ebpf_check.kernel_bpf_stats", false)
 
 	// settings for the entry count of the ebpfcheck
 	// control the size of the buffers used for the batch lookups of the ebpf maps
-	cfg.BindEnvAndSetDefault(join("ebpf_check", "entry_count", "max_keys_buffer_size_bytes"), 512*1024)
-	cfg.BindEnvAndSetDefault(join("ebpf_check", "entry_count", "max_values_buffer_size_bytes"), 1024*1024)
+	cfg.BindEnvAndSetDefault("ebpf_check.entry_count.max_keys_buffer_size_bytes", 512*1024)
+	cfg.BindEnvAndSetDefault("ebpf_check.entry_count.max_values_buffer_size_bytes", 1024*1024)
 	// How many times we can restart the entry count of a map before we give up if we get an iteration restart
 	// due to the map changing while we look it up
-	cfg.BindEnvAndSetDefault(join("ebpf_check", "entry_count", "max_restarts"), 3)
+	cfg.BindEnvAndSetDefault("ebpf_check.entry_count.max_restarts", 3)
 	// How many entries we should keep track of in the entry count map to detect restarts in the
 	// single-item iteration
-	cfg.BindEnvAndSetDefault(join("ebpf_check", "entry_count", "entries_for_iteration_restart_detection"), 100)
+	cfg.BindEnvAndSetDefault("ebpf_check.entry_count.entries_for_iteration_restart_detection", 100)
 
 	// event monitoring
-	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "enabled"), true, "DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED")
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_all_probes"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_kernel_filters"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_approvers"), false)  // will be set to true by sanitize() if enable_kernel_filters is true
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_discarders"), false) // will be set to true by sanitize() if enable_kernel_filters is true
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "flush_discarder_window"), 3)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "pid_cache_size"), 10000)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "dns_resolution.cache_size"), 1024)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "dns_resolution.enabled"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "events_stats.tags_cardinality"), "high")
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "custom_sensitive_words"), []string{})
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "custom_sensitive_regexps"), []string{})
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "erpc_dentry_resolution_enabled"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "map_dentry_resolution_enabled"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "dentry_cache_size"), 8000)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.lazy_interface_prefixes"), []string{})
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.classifier_priority"), 10)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.classifier_handle"), 0)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.flow_monitor.enabled"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.flow_monitor.sk_storage.enabled"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.flow_monitor.period"), "10s")
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.raw_classifier_handle"), 0)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_ring_buffer"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_kprobe_fallback"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.buffer_size"), 0)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.kretprobe_max_active"), 512)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "envs_with_value"), []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES", "SSH_CLIENT"})
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "runtime_compilation.enabled"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.enabled"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.ingress.enabled"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.raw_packet.enabled"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.raw_packet.limiter_rate"), 10)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.raw_packet.filter"), "no_pid_tcp_syn")
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.private_ip_ranges"), DefaultPrivateIPCIDRs)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.extra_private_ip_ranges"), []string{})
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "events_stats.polling_interval"), 20)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "syscalls_monitor.enabled"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "span_tracking.enabled"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "span_tracking.cache_size"), 4096)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "capabilities_monitoring.enabled"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "capabilities_monitoring.period"), "5s")
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "snapshot_using_listmount"), false)
-	cfg.BindEnvAndSetDefault(join(evNS, "env_vars_resolution.enabled"), true)
+	cfg.BindEnvAndSetDefault("event_monitoring_config.network_process.enabled", true, "DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED")
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.enable_all_probes", false)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.enable_kernel_filters", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.enable_approvers", false)  // will be set to true by sanitize() if enable_kernel_filters is true
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.enable_discarders", false) // will be set to true by sanitize() if enable_kernel_filters is true
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.flush_discarder_window", 3)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.pid_cache_size", 10000)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.dns_resolution.cache_size", 1024)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.dns_resolution.enabled", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.events_stats.tags_cardinality", "high")
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.custom_sensitive_words", []string{})
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.custom_sensitive_regexps", []string{})
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.erpc_dentry_resolution_enabled", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.map_dentry_resolution_enabled", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.dentry_cache_size", 8000)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.lazy_interface_prefixes", []string{})
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.classifier_priority", 10)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.classifier_handle", 0)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.flow_monitor.enabled", false)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.flow_monitor.sk_storage.enabled", false)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.flow_monitor.period", "10s")
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.raw_classifier_handle", 0)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.event_stream.use_ring_buffer", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.event_stream.use_fentry", false)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.event_stream.use_kprobe_fallback", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.event_stream.buffer_size", 0)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.event_stream.kretprobe_max_active", 512)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.envs_with_value", []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES", "SSH_CLIENT"})
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.runtime_compilation.enabled", false)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.enabled", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.ingress.enabled", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.raw_packet.enabled", true)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.raw_packet.limiter_rate", 10)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.raw_packet.filter", "no_pid_tcp_syn")
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.private_ip_ranges", DefaultPrivateIPCIDRs)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.network.extra_private_ip_ranges", []string{})
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.events_stats.polling_interval", 20)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.syscalls_monitor.enabled", false)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.span_tracking.enabled", false)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.span_tracking.cache_size", 4096)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.capabilities_monitoring.enabled", false)
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.capabilities_monitoring.period", "5s")
+	eventMonitorBindEnvAndSetDefault(cfg, "event_monitoring_config.snapshot_using_listmount", false)
+	cfg.BindEnvAndSetDefault("event_monitoring_config.env_vars_resolution.enabled", true)
 
 	// process event monitoring data limits for network tracer
-	eventMonitorBindEnv(cfg, join(evNS, "network_process", "max_processes_tracked"))
+	eventMonitorBindEnv(cfg, "event_monitoring_config.network_process.max_processes_tracked")
 
-	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "container_store", "enabled"), true)
-	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "container_store", "max_containers_tracked"), 1024)
+	cfg.BindEnvAndSetDefault("event_monitoring_config.network_process.container_store.enabled", true)
+	cfg.BindEnvAndSetDefault("event_monitoring_config.network_process.container_store.max_containers_tracked", 1024)
 
-	cfg.BindEnvAndSetDefault(join(compNS, "enabled"), false)
+	cfg.BindEnvAndSetDefault("compliance_config.enabled", false)
 
 	// enable/disable use of root net namespace
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_root_netns"), true)
+	cfg.BindEnvAndSetDefault("network_config.enable_root_netns", true)
 
 	// Windows crash detection
-	cfg.BindEnvAndSetDefault(join(wcdNS, "enabled"), false)
+	cfg.BindEnvAndSetDefault("windows_crash_detection.enabled", false)
 
 	// Ping
-	cfg.BindEnvAndSetDefault(join(pngNS, "enabled"), false)
+	cfg.BindEnvAndSetDefault("ping.enabled", false)
 
 	// Traceroute
-	cfg.BindEnvAndSetDefault(join(tracerouteNS, "enabled"), false)
+	cfg.BindEnvAndSetDefault("traceroute.enabled", false)
 
 	// CCM config
-	cfg.BindEnvAndSetDefault(join(ccmNS, "enabled"), false)
+	cfg.BindEnvAndSetDefault("ccm_network_config.enabled", false)
 
 	// Discovery config
-	cfg.BindEnv(join(discoveryNS, "enabled")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnvAndSetDefault(join(discoveryNS, "cpu_usage_update_delay"), "60s")
-	cfg.BindEnvAndSetDefault(join(discoveryNS, "ignored_command_names"), []string{"chronyd", "cilium-agent", "containerd", "dhclient", "dockerd", "kubelet", "livenessprobe", "local-volume-pr", "sshd", "systemd"})
-	cfg.BindEnvAndSetDefault(join(discoveryNS, "service_collection_interval"), "60s")
+	cfg.BindEnv("discovery.enabled") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("discovery.cpu_usage_update_delay", "60s")
+	cfg.BindEnvAndSetDefault("discovery.ignored_command_names", []string{"chronyd", "cilium-agent", "containerd", "dhclient", "dockerd", "kubelet", "livenessprobe", "local-volume-pr", "sshd", "systemd"})
+	cfg.BindEnvAndSetDefault("discovery.service_collection_interval", "60s")
 
 	// Privileged Logs config
-	cfg.BindEnvAndSetDefault(join(privilegedLogsNS, "enabled"), false)
+	cfg.BindEnvAndSetDefault("privileged_logs.enabled", false)
 
 	// Fleet policies
 	cfg.BindEnv("fleet_policies_dir") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 
 	// GPU monitoring
-	cfg.BindEnvAndSetDefault(join(gpuNS, "enabled"), false)
-	cfg.BindEnv(join(gpuNS, "nvml_lib_path")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnvAndSetDefault(join(gpuNS, "process_scan_interval_seconds"), 5)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "initial_process_sync"), true)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "configure_cgroup_perms"), false)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "enable_fatbin_parsing"), false)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "fatbin_request_queue_size"), 100)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "ring_buffer_pages_per_device"), 32) // 32 pages = 128KB by default per device
-	cfg.BindEnvAndSetDefault(join(gpuNS, "ringbuffer_wakeup_size"), 3000)     // 3000 bytes is about ~10-20 events depending on the specific type
-	cfg.BindEnvAndSetDefault(join(gpuNS, "attacher_detailed_logs"), false)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "ringbuffer_flush_interval"), 1*time.Second)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "device_cache_refresh_interval"), 5*time.Second)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "cgroup_reapply_interval"), 30*time.Second)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "cgroup_reapply_infinitely"), false)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.enabled", false)
+	cfg.BindEnv("gpu_monitoring.nvml_lib_path") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("gpu_monitoring.process_scan_interval_seconds", 5)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.initial_process_sync", true)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.configure_cgroup_perms", false)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.enable_fatbin_parsing", false)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.fatbin_request_queue_size", 100)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.ring_buffer_pages_per_device", 32) // 32 pages = 128KB by default per device
+	cfg.BindEnvAndSetDefault("gpu_monitoring.ringbuffer_wakeup_size", 3000)     // 3000 bytes is about ~10-20 events depending on the specific type
+	cfg.BindEnvAndSetDefault("gpu_monitoring.attacher_detailed_logs", false)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.ringbuffer_flush_interval", 1*time.Second)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.device_cache_refresh_interval", 5*time.Second)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.cgroup_reapply_interval", 30*time.Second)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.cgroup_reapply_infinitely", false)
 
 	// gpu - stream config
-	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "max_kernel_launches"), 1000)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "max_mem_alloc_events"), 1000)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "max_pending_kernel_spans"), 1000)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "max_pending_memory_spans"), 1000)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "max_active"), 100)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "timeout_seconds"), 30) // 30 seconds by default, includes two checks at the default interval of 15 seconds
+	cfg.BindEnvAndSetDefault("gpu_monitoring.streams.max_kernel_launches", 1000)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.streams.max_mem_alloc_events", 1000)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.streams.max_pending_kernel_spans", 1000)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.streams.max_pending_memory_spans", 1000)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.streams.max_active", 100)
+	cfg.BindEnvAndSetDefault("gpu_monitoring.streams.timeout_seconds", 30) // 30 seconds by default, includes two checks at the default interval of 15 seconds
 
 	initCWSSystemProbeConfig(cfg)
 	initUSMSystemProbeConfig(cfg)
 
-	cfg.BindEnvAndSetDefault(join(netNS, "direct_send"), false)
-}
-
-func join(pieces ...string) string {
-	return strings.Join(pieces, ".")
+	cfg.BindEnvAndSetDefault("network_config.direct_send", false)
 }
 
 func suffixHostEtc(suffix string) string {

--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -16,70 +16,70 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// ========================================
 	// General USM Configuration
 	// ========================================
-	cfg.BindEnvAndSetDefault(join(smNS, "enabled"), false, "DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED")
-	cfg.BindEnv(join(smNS, "max_concurrent_requests"))  //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnv(join(smNS, "enable_quantization"))      //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnv(join(smNS, "enable_connection_rollup")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnvAndSetDefault(join(smNS, "enable_ring_buffers"), true)
-	cfg.BindEnvAndSetDefault(join(smNS, "enable_event_stream"), true)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.enabled", false, "DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED")
+	cfg.BindEnv("service_monitoring_config.max_concurrent_requests")  //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("service_monitoring_config.enable_quantization")      //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("service_monitoring_config.enable_connection_rollup") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("service_monitoring_config.enable_ring_buffers", true)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.enable_event_stream", true)
 	// kernel_buffer_pages determines the number of pages allocated *per CPU*
 	// for buffering kernel data, whether using a perf buffer or a ring buffer.
-	cfg.BindEnvAndSetDefault(join(smNS, "kernel_buffer_pages"), 16)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.kernel_buffer_pages", 16)
 	// data_channel_size defines the size of the Go channel that buffers events.
 	// Each event has a fixed size of approximately 4KB (sizeof(batch_data_t)).
 	// By setting this value to 100, the channel will buffer up to ~400KB of data in the Go heap memory.
-	cfg.BindEnvAndSetDefault(join(smNS, "data_channel_size"), 100)
-	cfg.BindEnvAndSetDefault(join(smNS, "disable_map_preallocation"), true)
-	cfg.BindEnvAndSetDefault(join(smNS, "direct_consumer", "buffer_wakeup_count_per_cpu"), 8)
-	cfg.BindEnvAndSetDefault(join(smNS, "direct_consumer", "channel_size"), 1000)
-	cfg.BindEnvAndSetDefault(join(smNS, "direct_consumer", "kernel_buffer_size_per_cpu"), 65536) // 64KB per CPU base size
+	cfg.BindEnvAndSetDefault("service_monitoring_config.data_channel_size", 100)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.disable_map_preallocation", true)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.direct_consumer.buffer_wakeup_count_per_cpu", 8)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.direct_consumer.channel_size", 1000)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.direct_consumer.kernel_buffer_size_per_cpu", 65536) // 64KB per CPU base size
 
 	// ========================================
 	// HTTP Protocol Configuration
 	// ========================================
 	// New tree structure with backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "enabled"), true)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.enabled", true)
 	// Deprecated flat keys for backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "enable_http_monitoring"), true)
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_http_monitoring"), true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
+	cfg.BindEnvAndSetDefault("service_monitoring_config.enable_http_monitoring", true)
+	cfg.BindEnvAndSetDefault("network_config.enable_http_monitoring", true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
 
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "max_stats_buffered"), 100000)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.max_stats_buffered", 100000)
 	// Deprecated flat keys for backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "max_http_stats_buffered"), 100000)
-	cfg.BindEnvAndSetDefault(join(netNS, "max_http_stats_buffered"), 100000, "DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED")
+	cfg.BindEnvAndSetDefault("service_monitoring_config.max_http_stats_buffered", 100000)
+	cfg.BindEnvAndSetDefault("network_config.max_http_stats_buffered", 100000, "DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED")
 
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "max_tracked_connections"), 1024)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.max_tracked_connections", 1024)
 	// Deprecated flat keys for backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "max_tracked_http_connections"), 1024)
-	cfg.BindEnvAndSetDefault(join(netNS, "max_tracked_http_connections"), 1024)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.max_tracked_http_connections", 1024)
+	cfg.BindEnvAndSetDefault("network_config.max_tracked_http_connections", 1024)
 
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "notification_threshold"), 512)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.notification_threshold", 512)
 	// Deprecated flat keys for backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "http_notification_threshold"), 512)
-	cfg.BindEnvAndSetDefault(join(netNS, "http_notification_threshold"), 512)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http_notification_threshold", 512)
+	cfg.BindEnvAndSetDefault("network_config.http_notification_threshold", 512)
 
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "max_request_fragment"), 512) // matches hard limit currently imposed in NPM driver
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.max_request_fragment", 512) // matches hard limit currently imposed in NPM driver
 	// Deprecated flat keys for backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "http_max_request_fragment"), 512)
-	cfg.BindEnvAndSetDefault(join(netNS, "http_max_request_fragment"), 512)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http_max_request_fragment", 512)
+	cfg.BindEnvAndSetDefault("network_config.http_max_request_fragment", 512)
 
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "map_cleaner_interval_seconds"), 300)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.map_cleaner_interval_seconds", 300)
 	// Deprecated flat keys for backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "http_map_cleaner_interval_in_s"), 300)
-	cfg.BindEnvAndSetDefault(join(spNS, "http_map_cleaner_interval_in_s"), 300)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http_map_cleaner_interval_in_s", 300)
+	cfg.BindEnvAndSetDefault("system_probe_config.http_map_cleaner_interval_in_s", 300)
 
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "idle_connection_ttl_seconds"), 30)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.idle_connection_ttl_seconds", 30)
 	// Deprecated flat keys for backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "http_idle_connection_ttl_in_s"), 30)
-	cfg.BindEnvAndSetDefault(join(spNS, "http_idle_connection_ttl_in_s"), 30)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http_idle_connection_ttl_in_s", 30)
+	cfg.BindEnvAndSetDefault("system_probe_config.http_idle_connection_ttl_in_s", 30)
 
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "use_direct_consumer"), false)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.use_direct_consumer", false)
 
 	// HTTP replace rules configuration
-	cfg.BindEnvAndSetDefault(join(smNS, "http", "replace_rules"), nil)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http.replace_rules", nil)
 	// Deprecated flat keys for backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "http_replace_rules"), nil)
-	cfg.BindEnvAndSetDefault(join(netNS, "http_replace_rules"), nil, "DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES")
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http_replace_rules", nil)
+	cfg.BindEnvAndSetDefault("network_config.http_replace_rules", nil, "DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES")
 
 	httpRulesTransformer := func(key string) transformerFunction {
 		return func(in string) []map[string]string {
@@ -91,9 +91,9 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 		}
 	}
 	replaceRules := []string{
-		join(smNS, "http", "replace_rules"),
-		join(smNS, "http_replace_rules"),
-		join(netNS, "http_replace_rules"),
+		"service_monitoring_config.http.replace_rules",
+		"service_monitoring_config.http_replace_rules",
+		"network_config.http_replace_rules",
 	}
 	for _, rule := range replaceRules {
 		cfg.ParseEnvAsSliceMapString(rule, httpRulesTransformer(rule))
@@ -103,61 +103,61 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// HTTP/2 Protocol Configuration
 	// ========================================
 	// Tree structure
-	cfg.BindEnvAndSetDefault(join(smNS, "http2", "enabled"), false)
-	cfg.BindEnvAndSetDefault(join(smNS, "http2", "dynamic_table_map_cleaner_interval_seconds"), 30)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.enabled", false)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http2.dynamic_table_map_cleaner_interval_seconds", 30)
 
 	// Legacy bindings for backward compatibility (deprecated)
-	cfg.BindEnvAndSetDefault(join(smNS, "enable_http2_monitoring"), false)
-	cfg.BindEnvAndSetDefault(join(smNS, "http2_dynamic_table_map_cleaner_interval_seconds"), 30)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.enable_http2_monitoring", false)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.http2_dynamic_table_map_cleaner_interval_seconds", 30)
 
 	// ========================================
 	// Kafka Protocol Configuration
 	// ========================================
-	cfg.BindEnvAndSetDefault(join(smNS, "kafka", "enabled"), false)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.kafka.enabled", false)
 	// For backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "enable_kafka_monitoring"), false)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.enable_kafka_monitoring", false)
 
-	cfg.BindEnvAndSetDefault(join(smNS, "kafka", "max_stats_buffered"), 100000)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.kafka.max_stats_buffered", 100000)
 	// For backward compatibility
-	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.max_kafka_stats_buffered", 100000)
 
 	// ========================================
 	// PostgreSQL Protocol Configuration
 	// ========================================
-	cfg.BindEnvAndSetDefault(join(smNS, "postgres", "enabled"), false)
-	cfg.BindEnvAndSetDefault(join(smNS, "postgres", "max_stats_buffered"), 100000)
-	cfg.BindEnvAndSetDefault(join(smNS, "postgres", "max_telemetry_buffer"), 160)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.postgres.enabled", false)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.postgres.max_stats_buffered", 100000)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.postgres.max_telemetry_buffer", 160)
 
 	// ========================================
 	// Redis Protocol Configuration
 	// ========================================
-	cfg.BindEnvAndSetDefault(join(smNS, "redis", "enabled"), false)
-	cfg.BindEnvAndSetDefault(join(smNS, "redis", "track_resources"), false)
-	cfg.BindEnvAndSetDefault(join(smNS, "redis", "max_stats_buffered"), 100000)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.redis.enabled", false)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.redis.track_resources", false)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.redis.max_stats_buffered", 100000)
 
 	// ========================================
 	// Native TLS Configuration
 	// ========================================
-	cfg.BindEnvAndSetDefault(join(smNS, "tls", "native", "enabled"), true)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.tls.native.enabled", true)
 	// For backward compatibility
-	cfg.BindEnv(join(netNS, "enable_https_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("network_config.enable_https_monitoring", "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 
 	// ========================================
 	// Go TLS Configuration
 	// ========================================
-	cfg.BindEnvAndSetDefault(join(smNS, "tls", "go", "enabled"), true)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.tls.go.enabled", true)
 	// For backward compatibility
-	cfg.BindEnv(join(smNS, "enable_go_tls_support")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	cfg.BindEnvAndSetDefault(join(smNS, "tls", "go", "exclude_self"), true)
+	cfg.BindEnv("service_monitoring_config.enable_go_tls_support") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnvAndSetDefault("service_monitoring_config.tls.go.exclude_self", true)
 
 	// ========================================
 	// Istio TLS Configuration
 	// ========================================
-	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "enabled"), true)
-	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "envoy_path"), defaultEnvoyPath)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.tls.istio.enabled", true)
+	cfg.BindEnvAndSetDefault("service_monitoring_config.tls.istio.envoy_path", defaultEnvoyPath)
 
 	// ========================================
 	// Node.js TLS Configuration
 	// ========================================
-	cfg.BindEnv(join(smNS, "tls", "nodejs", "enabled")) //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	cfg.BindEnv("service_monitoring_config.tls.nodejs.enabled") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 }


### PR DESCRIPTION
### What does this PR do?

Using literal strings for config keys, instead of joining prefixes, reduces the binary size due to less code generation. The savings are not huge (~50kb) but should help ease the pressure on the static_quality_gates.

### Motivation

Help the static_quality_gates by giving more wiggle room.

### Describe how you validated your changes

### Additional Notes
