### PR TITLE
[ACTP] add time suffix on runner enrollment

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -112,10 +113,13 @@ func performSelfEnrollment(log log.Component, ddConfig config.Component, cfg *pa
 	appKey := ddConfig.GetString("app_key")
 
 	env.DetectFeatures(ddConfig)
-	runnerName, err := hostname.Get(context.Background())
+	runnerHostname, err := hostname.Get(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
+	now := time.Now().UTC()
+	formattedTime := now.Format("20060102150405")
+	runnerName := runnerHostname + "-" + formattedTime
 
 	enrollmentResult, err := enrollment.SelfEnroll(ddSite, runnerName, apiKey, appKey)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Add a suffix with the current time when self enrolling a PAR

### Motivation

Avoid collision on runner names

### Describe how you validated your changes

### Additional Notes

PAR in agent is not GA yet