### PR TITLE
Introduce ComputedServiceName field for agent-side service naming

### DIFF
--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -114,6 +114,9 @@ const (
 
 	// SourceKubeAPIServer represents metadata collected from the Kubernetes API Server
 	SourceKubeAPIServer Source = "kubeapiserver"
+
+	// SourceServiceNaming represents the service name computed by the service naming collector
+	SourceServiceNaming Source = "service_naming"
 )
 
 // ContainerRuntime is the container runtime used by a container.
@@ -652,6 +655,9 @@ type Container struct {
 	// Linux only.
 	CgroupPath   string
 	RestartCount int
+
+	// ComputedServiceName is the service name computed by the service naming collector
+	ComputedServiceName string
 }
 
 // GetID implements Entity#GetID.
@@ -744,6 +750,11 @@ func (c Container) String(verbose bool) string {
 
 	if c.ECSContainer != nil {
 		_, _ = fmt.Fprint(&sb, c.ECSContainer.String(verbose))
+	}
+
+	if c.ComputedServiceName != "" {
+		_, _ = fmt.Fprintln(&sb, "----------- Computed Service Name -----------")
+		_, _ = fmt.Fprintln(&sb, "Service:", c.ComputedServiceName)
 	}
 
 	return sb.String()


### PR DESCRIPTION
### What does this PR do?
This PR introduces the data model changes required for agent-side service name configuration. It adds a ComputedServiceName field to the Container workloadmeta entity, along with a dedicated source (SourceServiceNaming) to represent service names computed by the Agent. No behavior changes are introduced in this PR, it is a first step to implement the complete unified service name renaming. 

### Motivation
[DSCVR-316](https://datadoghq.atlassian.net/browse/DSCVR-316)

Datadog strives to provide a consistent cross-product experience through unified service tagging. However, customers using configuration-as-code and GitOps workflows can still encounter inconsistencies due to different precedence rules across products. This PR helps close that gap by improving tag consistency.

### Describe how you validated your changes

All test pass and new test have been added.

### Additional Notes

This PR focuses exclusively on configuration loading and validation. Runtime evaluation and agent integration are handled in follow-up PRs as defined in the [RFC](https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/5664243759/Service+Name+Configuration). Also this PR is related with the existing one in [here ](https://github.com/DataDog/datadog-agent/pull/44722).

[DSCVR-316]: https://datadoghq.atlassian.net/browse/DSCVR-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ