### PR TITLE
chore: bump default kube version to 1.34 in tests

### DIFF
--- a/test/e2e-framework/common/config/environment.go
+++ b/test/e2e-framework/common/config/environment.go
@@ -231,7 +231,7 @@ func (e *CommonEnvironment) InfraOSImageIDUseLatest() bool {
 }
 
 func (e *CommonEnvironment) KubernetesVersion() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraKubernetesVersion, "1.32")
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraKubernetesVersion, "1.34")
 }
 
 func (e *CommonEnvironment) KindVersion() string {

--- a/test/e2e-framework/components/kubernetes/kind.go
+++ b/test/e2e-framework/components/kubernetes/kind.go
@@ -74,9 +74,9 @@ func NewKindClusterWithConfig(env config.Env, vm *remote.Host, name string, kube
 			versions from the mirror - although it should be noted the sha is required. So sometimes the version is
 			just the tag, and sometimes it's the tag with the sha.
 		*/
-		kindVersionConfig, err := GetKindVersionConfig(kubeVersion)
+		kindVersionConfig, err := GetKindVersionConfig(env, kubeVersion)
 		if err != nil {
-			log.Printf("[WARN] Could not find version %s in our static map, using default kind version and the provided k8s version as node image", kubeVersion)
+			log.Printf("[WARN] Could not find version %s in our static map, error: %s\n using default kind version and the provided k8s version as node image", kubeVersion, err)
 
 			// Validate the kubeVersion format when not in static map
 			if err := validateKubeVersionFormat(kubeVersion); err != nil {
@@ -156,7 +156,7 @@ func NewLocalKindCluster(env config.Env, name string, kubeVersion string, opts .
 		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
 		commonEnvironment := env
 
-		kindVersionConfig, err := GetKindVersionConfig(kubeVersion)
+		kindVersionConfig, err := GetKindVersionConfig(env, kubeVersion)
 		if err != nil {
 			return err
 		}

--- a/test/e2e-framework/components/kubernetes/nvidia/nvidia.go
+++ b/test/e2e-framework/components/kubernetes/nvidia/nvidia.go
@@ -180,7 +180,7 @@ func installNvkind(env config.Env, vm *remote.Host, kindVersion string, clusterO
 func initNvkindCluster(env config.Env, vm *remote.Host, name string, clusterOpts *KindClusterOptions, opts ...pulumi.ResourceOption) (*kubernetes.Cluster, error) {
 	return components.NewComponent(env, name, func(clusterComp *kubernetes.Cluster) error {
 		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
-		kindVersionConfig, err := kubernetes.GetKindVersionConfig(clusterOpts.kubeVersion)
+		kindVersionConfig, err := kubernetes.GetKindVersionConfig(env, clusterOpts.kubeVersion)
 		if err != nil {
 			return err
 		}

--- a/test/e2e-framework/tasks/doc.py
+++ b/test/e2e-framework/tasks/doc.py
@@ -40,3 +40,4 @@ local_package: str = "Path to a local package to install, it can be either a fol
 pull_secret_path: str = "Path to the OpenShift pull secret file (required for OpenShift cluster creation)."
 local_chart_path: str = "Path to a local helm chart to install the Datadog Agent."
 latest_ami: str = "Use the latest AMI for the OS and architecture (default False)."
+kube_version: str = "The Kubernetes version for the GKE cluster (default to 1.34)"

--- a/test/e2e-framework/tasks/gcp/gke.py
+++ b/test/e2e-framework/tasks/gcp/gke.py
@@ -24,6 +24,7 @@ scenario_name = "gcp/gke"
         "agent_flavor": doc.agent_flavor,
         "helm_config": doc.helm_config,
         "local_chart_path": doc.local_chart_path,
+        "kube_version": doc.kube_version,
     }
 )
 def create_gke(
@@ -43,6 +44,7 @@ def create_gke(
     agent_flavor: Optional[str] = None,
     helm_config: Optional[str] = None,
     local_chart_path: Optional[str] = None,
+    kube_version: Optional[str] = None,
 ) -> None:
     """
     Create a new GKE environment.
@@ -58,6 +60,7 @@ def create_gke(
         "ddinfra:gcp/defaultPublicKeyPath": cfg.get_gcp().publicKeyPath,
         "ddinfra:gcp/gke/enableAutopilot": use_autopilot,
         "ddagent:localChartPath": local_chart_path,
+        "ddinfra:kubernetesVersion": kube_version,
     }
 
     full_stack_name = deploy(


### PR DESCRIPTION
### What does this PR do?

add a new option to e2e-framework for gke cluster to specify the kubernetes version.

Bump default version in Pulumi defaults to 1.34

### Motivation

allow testing of latest kube version using gcp.gke

### Describe how you validated your changes

run the command

```
dda inv gcp.deploy-gke -k 1.35
```

cluster successfully deployed.

### Additional Notes

**This bumps default kubernetes version in tests**
