### PR TITLE
verify config values not overwritten by defaults

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -232,6 +232,7 @@ new-e2e-installer-windows:
       # install-exe
       - EXTRA_PARAMS: --run "TestInstallExe$/TestInstallAgentPackage$"
       - EXTRA_PARAMS: --run "TestInstallExe$/TestInstallAgentFails$"
+      - EXTRA_PARAMS: --run "TestInstallExe$/TestConfigValuesNotOverwrittenByDefaults$"
       - EXTRA_PARAMS: --run "TestInstallExeWithProxy$/TestInstallAgentPackageWithProxy$"
       # install-script
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallAgentPackage$"

--- a/test/new-e2e/tests/installer/windows/suites/install-exe/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-exe/install_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"testing"
 
+	"gopkg.in/yaml.v2"
+
 	infraos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
@@ -110,6 +112,58 @@ func (s *testInstallExeSuite) TestInstallAgentFails() {
 	s.Require().Equal(wincommon.GetIdentityForSID(wincommon.AdministratorsSID).GetSID(), security.Group.GetSID(), "config dir should be grouped by Administrators group")
 	// Agent is not installed so we can't grab paths from the registry keys, must provide them manually
 	wincommonagent.TestHasNoWorldWritablePaths(s.T(), s.Env().RemoteHost, []string{configDir})
+}
+
+// TestConfigValuesNotOverwrittenByDefaults is a regression test for WINA-2118.
+// It verifies that when an empty datadog.yaml file exists before installation,
+// the installer does not overwrite it with default values from unset environment variables.
+func (s *testInstallExeSuite) TestConfigValuesNotOverwrittenByDefaults() {
+	// Arrange
+	host := s.Env().RemoteHost
+	configDir := `C:\ProgramData\Datadog`
+	configPath := `C:\ProgramData\Datadog\datadog.yaml`
+
+	// Create config directory and empty datadog.yaml
+	err := host.MkdirAll(configDir)
+	s.Require().NoError(err, "failed to create config directory")
+	_, err = host.WriteFile(configPath, []byte{})
+	s.Require().NoError(err, "failed to create empty datadog.yaml")
+
+	// Verify the file is empty before install
+	contentBefore, err := host.ReadFile(configPath)
+	s.Require().NoError(err, "failed to read datadog.yaml before install")
+	s.Require().Empty(contentBefore, "datadog.yaml should be empty before install")
+
+	// Act
+	// Run the installer without any config options to test that default env.Env values
+	// do not overwrite config values (WINA-2118).
+	output, err := s.InstallScript().Run(
+		// explicitly unset some values that are always set by this Run helper method
+		installerwindows.WithExtraEnvVars(map[string]string{
+			"DD_API_KEY":        "",
+			"DD_SITE":           "",
+			"DD_REMOTE_UPDATES": "",
+		}),
+	)
+
+	// Assert
+	s.Require().NoErrorf(err, "failed to run installer: %s", output)
+	s.Require().NoError(s.WaitForInstallerService("Running"))
+
+	// Verify the datadog.yaml file has no configuration values set.
+	// The installer may add comments or an empty YAML object ({}), but should not
+	// write any actual configuration keys when no options are provided.
+	// We use an empty config file to ensure we catch any/all options that may be written to the config
+	// if they are not provided to the installer, so the test should continue working as we add new options.
+	// If later we want to write defaults to the config we can update this test, but we must ensure that
+	// if the option exists in datadog.yaml that it takes precedence over the default value.
+	contentAfter, err := host.ReadFile(configPath)
+	s.Require().NoError(err, "failed to read datadog.yaml after install")
+
+	var configValues map[string]interface{}
+	err = yaml.Unmarshal(contentAfter, &configValues)
+	s.Require().NoError(err, "failed to parse datadog.yaml as YAML")
+	s.Require().Empty(configValues, "datadog.yaml should have no configuration values set - default env values should not overwrite config. Got: %v", configValues)
 }
 
 // proxyEnv provisions a Windows VM (for the installer) and a Linux VM (hosting a Squid proxy)


### PR DESCRIPTION
### What does this PR do?

Adds `TestConfigValuesNotOverwrittenByDefaults` to the install-exe test suite as a regression test for [WINA-2118](https://datadoghq.atlassian.net/browse/WINA-2118) / https://github.com/DataDog/datadog-agent/pull/44496.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2125
We had tests for the config_write code layer but not at the setup code layer. This test ensures that when `datadog.yaml` exists before installation, the installer does not overwrite it with default values from unset environment variables.

[WINA-2118]: https://datadoghq.atlassian.net/browse/WINA-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ