### PR TITLE
fix(service-catalog): Remove pagerduty

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -206,7 +206,10 @@ metadata:
   displayName: Datadog-agent CI
   tags:
     - datadog-agent-ci
-  owner: agent-devx
+  owner: agent-supply-chain
+  additionalOwners:
+    - name: agent-devx
+    - name: agent-build
   links:
     - name: datadog-agent
       type: repo
@@ -263,9 +266,6 @@ metadata:
     - name: datadog-agent-pipelines
       type: slack
       contact: https://dd.enterprise.slack.com/archives/CR5TV8QBY
-integrations:
-  pagerduty:
-    serviceURL: https://datadog.pagerduty.com/service-directory/P9SGXPT
 datadog:
   pipelines:
     fingerprints:


### PR DESCRIPTION
### What does this PR do?
As we migrated out of pagerduty I remove this as integration in the service definition and use the agent-supply-chain as default team for this service as it's the team in charge of the on-call.

### Motivation
Fix this [failure](https://app.datadoghq.com/dashboard/ebi-u94-22h/service-metadata-validation-failures?fromUser=false&refresh_mode=sliding&tpl_var_team_handle=agent-devx&from_ts=1766736548716&to_ts=1767341348716&live=true)

### Describe how you validated your changes
Modified the schema according to its [definition](https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/v3/metadata.schema.json)

### Additional Notes
