### PR TITLE
Mark domain controller tests as flaky

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/agent-package/domain_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/domain_test.go
@@ -136,6 +136,8 @@ type testUpgradeWithMissingPasswordSuite struct {
 //  3. Upgrade to current version, expect it to fail
 //  4. Assert missing password error is reported and Agent+Installer are still running
 func TestUpgradeWithMissingPassword(t *testing.T) {
+	// TODO(WINA-2078): domain controller promotion is flaky
+	flake.Mark(t)
 	s := &testUpgradeWithMissingPasswordSuite{}
 	s.testAgentUpgradeSuite.BaseSuite.CreateStableAgent = s.createStableAgent
 	e2e.Run(t, s,
@@ -261,6 +263,8 @@ type testAgentUpgradesAfterDCPromotionSuite struct {
 // This converts all accounts from local accounts to domain accounts, i.e. hostname\username -> domain\username,
 // so we test that our username code handles this change appropriately.
 func TestAgentUpgradesAfterDCPromotion(t *testing.T) {
+	// TODO(WINA-2055): domain controller promotion is flaky
+	flake.Mark(t)
 	e2e.Run(t, &testAgentUpgradesAfterDCPromotionSuite{},
 		e2e.WithProvisioner(
 			winawshost.ProvisionerNoAgentNoFakeIntake(),


### PR DESCRIPTION

### What does this PR do?
Mark TestUpgradeWithMissingPassword and TestAgentUpgradesAfterDCPromotion as flaky due to domain controller promotion instability.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2055
https://datadoghq.atlassian.net/browse/WINA-2078
xref https://github.com/DataDog/datadog-agent/pull/44490
