### PR TITLE
Add support for running Rust tests with `dda inv test`

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/rust/BUILD.bazel
+++ b/pkg/collector/corechecks/servicediscovery/module/rust/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
-load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 rust_binary(
     name = "sd-agent",
@@ -20,4 +20,23 @@ pkg_files(
 pkg_install(
     name = "install",
     srcs = [":sd-agent_pkg"],
+)
+
+rust_test(
+    name = "sd-agent_test",
+    crate = ":sd-agent",
+    edition = "2021",
+    visibility = ["//visibility:public"],
+)
+
+pkg_files(
+    name = "sd-agent_test_pkg",
+    testonly = True,
+    srcs = [":sd-agent_test"],
+)
+
+pkg_install(
+    name = "install_test",
+    testonly = True,
+    srcs = [":sd-agent_test_pkg"],
 )

--- a/pkg/collector/corechecks/servicediscovery/module/rust/src/main.rs
+++ b/pkg/collector/corechecks/servicediscovery/module/rust/src/main.rs
@@ -1,3 +1,30 @@
 fn main() {
     println!("Hello from Rust test binary!");
 }
+
+// Testable functions
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        assert_eq!(add(2, 2), 4);
+        assert_eq!(add(-1, 1), 0);
+        assert_eq!(add(0, 0), 0);
+    }
+
+    #[test]
+    fn test_greet() {
+        assert_eq!(greet("Rust"), "Hello, Rust!");
+        assert_eq!(greet("World"), "Hello, World!");
+    }
+}

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -219,7 +219,7 @@ def process_test_result(
     success = process_result(flavor=flavor, result=test_result)
 
     if success:
-        print(color_message("All tests passed", "green"))
+        print(color_message("All Go tests passed", "green"))
         return True
 
     if test_washer or running_in_ci():
@@ -441,7 +441,7 @@ def test(
             print(color_message(f"Rust tests failed: {', '.join(rust_result.failures)}", "red"))
             rust_success = False
         else:
-            print(color_message(f"All {rust_result.test_count} Rust tests passed", "green"))
+            print(color_message("All Rust tests passed", "green"))
 
         # Include Rust JUnit files in the list
         if rust_result.junit_files:

--- a/tasks/libs/testing/rust_test_utils.py
+++ b/tasks/libs/testing/rust_test_utils.py
@@ -39,11 +39,8 @@ def discover_rust_tests(target_paths: list[str]) -> dict[str, str]:
 
     rust_tests = {}
 
-    # Check if bazelisk is available
-    try:
-        subprocess.run(["which", "bazelisk"], capture_output=True, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        # Bazelisk not available - return empty dict (graceful degradation)
+    # Skip on Windows and macOS
+    if sys.platform == 'win32' or sys.platform == 'darwin':
         return rust_tests
 
     for target in target_paths:
@@ -119,16 +116,6 @@ def run_rust_tests(
     # Skip on Windows and macOS
     if sys.platform == 'win32' or sys.platform == 'darwin':
         print(color_message("Rust tests are only supported on Linux, skipping", "yellow"))
-        return RustTestResult(success=True, failures=[], test_count=0, junit_files=[])
-
-    # Check if bazelisk is available
-    check_bazel = ctx.run("which bazelisk", warn=True, hide=True)
-    if check_bazel.exited != 0:
-        print(
-            color_message(
-                "Warning: bazelisk not found, skipping Rust tests. Install with: brew install bazelisk", "yellow"
-            )
-        )
         return RustTestResult(success=True, failures=[], test_count=0, junit_files=[])
 
     if not rust_tests:

--- a/tasks/libs/testing/rust_test_utils.py
+++ b/tasks/libs/testing/rust_test_utils.py
@@ -1,0 +1,249 @@
+"""
+Utilities for discovering and running Rust tests via Bazel
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+
+from invoke.context import Context
+
+from tasks.libs.common.color import color_message
+from tasks.libs.types.arch import Arch
+
+
+@dataclass
+class RustTestResult:
+    """Result of running Rust tests"""
+
+    success: bool
+    failures: list[str]
+    test_count: int
+    junit_files: list[str]  # Paths to generated JUnit XML files
+
+
+def discover_rust_tests(target_paths: list[str]) -> dict[str, str]:
+    """
+    Discover Rust tests in the given target paths using Bazel query.
+
+    Args:
+        target_paths: List of paths to scan for Rust tests (e.g., ["./pkg", "./cmd/..."])
+
+    Returns:
+        Dictionary mapping test_name -> source_path
+        Example: {"sd-agent_test": "pkg/collector/corechecks/servicediscovery/module/rust"}
+    """
+    import subprocess
+
+    rust_tests = {}
+
+    # Check if bazelisk is available
+    try:
+        subprocess.run(["which", "bazelisk"], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Bazelisk not available - return empty dict (graceful degradation)
+        return rust_tests
+
+    for target in target_paths:
+        # Convert "./pkg/" -> "//pkg/..." or "./pkg/..." -> "//pkg/..."
+        # Strip leading "./" and trailing "/" to avoid double slashes
+        clean_target = target.lstrip('./').rstrip('/')
+        # Also strip "..." to normalize (we'll add it back)
+        clean_target = clean_target.rstrip('.')
+        clean_target = clean_target.rstrip('/')
+        # Add wildcard pattern
+        bazel_pattern = f"//{clean_target}/..."
+
+        # Query Bazel for rust_test targets
+        try:
+            result = subprocess.run(
+                ["bazelisk", "query", f"kind(rust_test, {bazel_pattern})", "--output=label"],
+                capture_output=True,
+                text=True,
+                check=False,  # Don't raise on non-zero exit (no targets = exit 7)
+            )
+
+            # Exit code 7 means "no targets found" - this is OK, just skip
+            # Exit code 3 means "partial success" - also OK
+            if result.returncode == 7 or result.returncode == 3:
+                continue
+            elif result.returncode != 0:
+                # Other errors should be logged but not fail discovery
+                print(color_message(f"Warning: bazel query failed for {bazel_pattern}: {result.stderr}", "yellow"))
+                continue
+
+            # Parse output: "//path/to/package:test_name"
+            for line in result.stdout.strip().split('\n'):
+                # Skip empty lines and loading messages
+                if not line or line.startswith('Loading:'):
+                    continue
+
+                # Split on last ':' to separate package from target
+                if ':' in line:
+                    package_path = line.split(':')[0].lstrip('/')
+                    test_name = line.split(':')[1]
+                    rust_tests[test_name] = package_path
+
+        except Exception as e:
+            print(color_message(f"Warning: Failed to query Bazel for {bazel_pattern}: {e}", "yellow"))
+            continue
+
+    return rust_tests
+
+
+def run_rust_tests(
+    ctx: Context,
+    rust_tests: dict[str, str],
+    arch: Arch,
+    junit_base_name: str | None = None,
+    flavor=None,
+) -> RustTestResult:
+    """
+    Run Rust tests using Bazel with CI visibility support.
+
+    Args:
+        ctx: Invoke context
+        rust_tests: Dictionary mapping test_name -> source_path
+        arch: Architecture to run tests for
+        junit_base_name: Base name for JUnit XML files (e.g., "junit-rust-base")
+        flavor: Agent flavor for JUnit XML enrichment
+
+    Returns:
+        RustTestResult with success status, failures, and JUnit file paths
+    """
+    import shutil
+    from datetime import datetime, timezone
+
+    # Skip on Windows and macOS
+    if sys.platform == 'win32' or sys.platform == 'darwin':
+        print(color_message("Rust tests are only supported on Linux, skipping", "yellow"))
+        return RustTestResult(success=True, failures=[], test_count=0, junit_files=[])
+
+    # Check if bazelisk is available
+    check_bazel = ctx.run("which bazelisk", warn=True, hide=True)
+    if check_bazel.exited != 0:
+        print(
+            color_message(
+                "Warning: bazelisk not found, skipping Rust tests. Install with: brew install bazelisk", "yellow"
+            )
+        )
+        return RustTestResult(success=True, failures=[], test_count=0, junit_files=[])
+
+    if not rust_tests:
+        return RustTestResult(success=True, failures=[], test_count=0, junit_files=[])
+
+    # Platform mapping for Bazel
+    platform_map = {
+        "x86_64": "//bazel/platforms:linux_x86_64",
+        "arm64": "//bazel/platforms:linux_arm64",
+    }
+
+    platform_flag = ""
+    if arch.kmt_arch in platform_map:
+        platform_flag = f"--platforms={platform_map[arch.kmt_arch]}"
+
+    test_results = []
+    test_count = len(rust_tests)
+
+    for test_name, source_path in rust_tests.items():
+        print(f"Running Rust test: {test_name} ({source_path})")
+        start_time = datetime.now(timezone.utc)
+
+        # Run Bazel test - it automatically generates test.xml in bazel-testlogs
+        result = ctx.run(
+            f"bazelisk test {platform_flag} --test_output=errors -- @//{source_path}:{test_name}", warn=True
+        )
+
+        end_time = datetime.now(timezone.utc)
+
+        # Bazel creates test.xml in bazel-testlogs/{source_path}/{test_name}/test.xml
+        bazel_xml_path = f"bazel-testlogs/{source_path}/{test_name}/test.xml"
+
+        test_results.append(
+            {
+                'test_name': test_name,
+                'source_path': source_path,
+                'start_time': start_time,
+                'end_time': end_time,
+                'xml_path': bazel_xml_path if os.path.exists(bazel_xml_path) else None,
+                'exit_code': result.exited if result.exited is not None else 1,
+            }
+        )
+
+    # Collect JUnit XML files
+    junit_files = []
+    if junit_base_name and flavor:
+        from tasks.libs.common.junit_upload_core import enrich_junitxml
+
+        for result in test_results:
+            if result['xml_path'] and os.path.exists(result['xml_path']):
+                # Copy Bazel's test.xml to our output location with consistent naming
+                output_xml = f"{junit_base_name}-{result['test_name']}.xml"
+                shutil.copy2(result['xml_path'], output_xml)
+
+                # Enhance error message with full test output from system-out
+                _enhance_junit_error_message(output_xml, result['source_path'], result['test_name'])
+
+                # Enrich JUnit XML with flavor info (same as Go tests)
+                enrich_junitxml(output_xml, flavor)
+
+                junit_files.append(output_xml)
+
+    # Determine success/failure
+    failed_tests = [f"{r['source_path']}:{r['test_name']}" for r in test_results if r['exit_code'] != 0]
+
+    return RustTestResult(
+        success=len(failed_tests) == 0, failures=failed_tests, test_count=test_count, junit_files=junit_files
+    )
+
+
+def _enhance_junit_error_message(xml_path: str, source_path: str, test_name: str):
+    """
+    Enhance Bazel's JUnit XML by replacing the generic error message with full test output.
+
+    Bazel generates a generic "exited with error code 101" message, but the actual test
+    output is in <system-out>. This function copies that output into the error message
+    so it's visible in Datadog Test Visibility.
+
+    Also restructures the names so that:
+    - Test suite name = source_path (e.g., "pkg/collector/.../rusthello")
+    - Test case name = test_name (e.g., "rusthello_test")
+
+    Args:
+        xml_path: Path to the JUnit XML file to enhance
+        source_path: Source path for the test (used as test suite name and classname)
+        test_name: Name of the test (used as test case name)
+    """
+    import xml.etree.ElementTree as ET
+
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    for testsuite in root.findall('.//testsuite'):
+        # Set testsuite name to just the source path
+        testsuite.set('name', source_path)
+
+        # Get the testcase, error element, and system-out
+        testcase = testsuite.find('testcase')
+        system_out = testsuite.find('system-out')
+
+        if testcase is None:
+            continue
+
+        # Set testcase name to just the test name (not the full path)
+        testcase.set('name', test_name)
+
+        # Set classname to the source path
+        testcase.set('classname', source_path)
+
+        # If there's an error element and system-out, replace error message with full output
+        error = testcase.find('error')
+        if error is not None and system_out is not None and system_out.text:
+            # Replace the generic error message with the full test output
+            error.set('message', 'Rust test suite failed')
+            error.text = system_out.text.strip()
+
+    # Write back the enhanced XML
+    tree.write(xml_path, encoding='UTF-8', xml_declaration=True)

--- a/tasks/unit_tests/rust_test_utils_tests.py
+++ b/tasks/unit_tests/rust_test_utils_tests.py
@@ -1,0 +1,290 @@
+import shutil
+import subprocess
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tasks.libs.testing.rust_test_utils import (
+    _enhance_junit_error_message,
+    discover_rust_tests,
+)
+
+
+class TestDiscoverRustTests(unittest.TestCase):
+    """Tests for discover_rust_tests() function using Bazel query"""
+
+    @patch('subprocess.run')
+    def test_discover_single_rust_test(self, mock_run):
+        """Test discovering a single Rust test via Bazel query"""
+        # Mock 'which bazelisk' check - success
+        mock_which = MagicMock()
+        mock_which.returncode = 0
+
+        # Mock bazel query output
+        mock_query = MagicMock()
+        mock_query.returncode = 0
+        mock_query.stdout = "//pkg/collector/test:my_test\n"
+        mock_query.stderr = ""
+
+        mock_run.side_effect = [mock_which, mock_query]
+
+        result = discover_rust_tests(["./pkg"])
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("my_test", result)
+        self.assertEqual(result["my_test"], "pkg/collector/test")
+
+    @patch('subprocess.run')
+    def test_discover_multiple_rust_tests(self, mock_run):
+        """Test discovering multiple Rust tests from different packages"""
+        mock_which = MagicMock()
+        mock_which.returncode = 0
+
+        mock_query = MagicMock()
+        mock_query.returncode = 0
+        mock_query.stdout = "//pkg/module1:test_one\n//pkg/module2:test_two\n"
+        mock_query.stderr = ""
+
+        mock_run.side_effect = [mock_which, mock_query]
+
+        result = discover_rust_tests(["./pkg"])
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("test_one", result)
+        self.assertIn("test_two", result)
+        self.assertEqual(result["test_one"], "pkg/module1")
+        self.assertEqual(result["test_two"], "pkg/module2")
+
+    @patch('subprocess.run')
+    def test_discover_no_tests_exit_code_7(self, mock_run):
+        """Test handling bazel query exit code 7 (no targets found)"""
+        mock_which = MagicMock()
+        mock_which.returncode = 0
+
+        mock_query = MagicMock()
+        mock_query.returncode = 7  # No targets found
+        mock_query.stdout = ""
+        mock_query.stderr = "ERROR: no targets found beneath 'pkg'"
+
+        mock_run.side_effect = [mock_which, mock_query]
+
+        result = discover_rust_tests(["./pkg"])
+
+        self.assertEqual(len(result), 0)
+
+    @patch('subprocess.run')
+    def test_discover_multiple_paths(self, mock_run):
+        """Test discovering tests from multiple target paths"""
+        mock_which = MagicMock()
+        mock_which.returncode = 0
+
+        # First query returns one test
+        mock_query1 = MagicMock()
+        mock_query1.returncode = 0
+        mock_query1.stdout = "//pkg/test:test1\n"
+        mock_query1.stderr = ""
+
+        # Second query returns exit code 7 (no tests)
+        mock_query2 = MagicMock()
+        mock_query2.returncode = 7
+        mock_query2.stdout = ""
+        mock_query2.stderr = ""
+
+        mock_run.side_effect = [mock_which, mock_query1, mock_query2]
+
+        result = discover_rust_tests(["./pkg", "./cmd"])
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("test1", result)
+
+    @patch('subprocess.run')
+    def test_bazelisk_not_available(self, mock_run):
+        """Test graceful handling when bazelisk is not available"""
+        mock_which = MagicMock()
+        mock_which.side_effect = subprocess.CalledProcessError(1, 'which')
+
+        mock_run.side_effect = [mock_which]
+
+        result = discover_rust_tests(["./pkg"])
+
+        self.assertEqual(len(result), 0)
+
+    @patch('subprocess.run')
+    def test_query_output_with_loading_messages(self, mock_run):
+        """Test parsing bazel query output that includes loading messages"""
+        mock_which = MagicMock()
+        mock_which.returncode = 0
+
+        mock_query = MagicMock()
+        mock_query.returncode = 0
+        mock_query.stdout = "Loading: 0 packages loaded\n//pkg/test:my_test\n"
+        mock_query.stderr = ""
+
+        mock_run.side_effect = [mock_which, mock_query]
+
+        result = discover_rust_tests(["./pkg"])
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("my_test", result)
+
+    @patch('subprocess.run')
+    def test_query_error_handling(self, mock_run):
+        """Test handling of bazel query errors (non-7 exit codes)"""
+        mock_which = MagicMock()
+        mock_which.returncode = 0
+
+        mock_query = MagicMock()
+        mock_query.returncode = 1  # Some other error
+        mock_query.stdout = ""
+        mock_query.stderr = "ERROR: some other error"
+
+        mock_run.side_effect = [mock_which, mock_query]
+
+        # Should not raise, just return empty dict
+        result = discover_rust_tests(["./pkg"])
+
+        self.assertEqual(len(result), 0)
+
+    @patch('subprocess.run')
+    def test_path_normalization_trailing_slash(self, mock_run):
+        """Test that trailing slashes in paths are handled correctly"""
+        mock_which = MagicMock()
+        mock_which.returncode = 0
+
+        mock_query = MagicMock()
+        mock_query.returncode = 0
+        mock_query.stdout = "//pkg/test:my_test\n"
+        mock_query.stderr = ""
+
+        mock_run.side_effect = [mock_which, mock_query]
+
+        # Path with trailing slash should work
+        result = discover_rust_tests(["./pkg/"])
+
+        self.assertEqual(len(result), 1)
+        # Verify the query was called with correct pattern (no double slashes)
+        query_call = mock_run.call_args_list[1]
+        query_cmd = query_call[0][0]
+        self.assertIn("//pkg/...", query_cmd[2])
+        self.assertNotIn("//pkg//", query_cmd[2])
+
+    @patch('subprocess.run')
+    def test_path_normalization_with_ellipsis(self, mock_run):
+        """Test that paths ending with ... are normalized correctly"""
+        mock_which = MagicMock()
+        mock_which.returncode = 0
+
+        mock_query = MagicMock()
+        mock_query.returncode = 0
+        mock_query.stdout = "//pkg/test:my_test\n"
+        mock_query.stderr = ""
+
+        mock_run.side_effect = [mock_which, mock_query]
+
+        # Path already with ... should work
+        result = discover_rust_tests(["./pkg/..."])
+
+        self.assertEqual(len(result), 1)
+        # Verify the query was called with correct pattern
+        query_call = mock_run.call_args_list[1]
+        query_cmd = query_call[0][0]
+        self.assertIn("//pkg/...", query_cmd[2])
+
+
+class TestEnhanceJunitErrorMessage(unittest.TestCase):
+    """Tests for _enhance_junit_error_message() function"""
+
+    def setUp(self):
+        """Set up test XML files"""
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.test_data_dir = Path(__file__).parent / "testdata" / "rust"
+
+    def tearDown(self):
+        """Clean up temp files"""
+        if self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir)
+
+    def test_enhance_error_with_full_output(self):
+        """Test enhancing error message with full system-out content"""
+        # Copy sample failing XML
+        sample_xml = self.test_data_dir / "sample_junit_fail.xml"
+        test_xml = self.temp_dir / "test.xml"
+        shutil.copy2(sample_xml, test_xml)
+
+        _enhance_junit_error_message(str(test_xml), "pkg/test", "test_name")
+
+        # Verify changes
+        tree = ET.parse(test_xml)
+        root = tree.getroot()
+        error = root.find('.//error')
+
+        self.assertIsNotNone(error)
+        self.assertEqual(error.get('message'), 'Rust test suite failed')
+        self.assertIn('test result: FAILED', error.text)
+        self.assertIn('assertion `left == right` failed', error.text)
+
+    def test_set_classname_and_suite_name(self):
+        """Test setting proper test suite and test case names"""
+        sample_xml = self.test_data_dir / "sample_junit_fail.xml"
+        test_xml = self.temp_dir / "test.xml"
+        shutil.copy2(sample_xml, test_xml)
+
+        source_path = "pkg/collector/module/rusthello"
+        test_name = "rusthello_test"
+
+        _enhance_junit_error_message(str(test_xml), source_path, test_name)
+
+        tree = ET.parse(test_xml)
+        root = tree.getroot()
+        testsuite = root.find('.//testsuite')
+        testcase = root.find('.//testcase')
+
+        # Check that suite name is just the source path
+        self.assertEqual(testsuite.get('name'), source_path)
+
+        # Check that testcase name is just the test name
+        self.assertEqual(testcase.get('name'), test_name)
+
+        # Check that classname is the source path
+        self.assertEqual(testcase.get('classname'), source_path)
+
+    def test_handle_missing_system_out(self):
+        """Test handling XML without system-out element"""
+        xml_content = '''<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="test_suite" tests="1" failures="0" errors="1">
+    <testcase name="test_case" time="0.001">
+      <error message="test error"></error>
+    </testcase>
+  </testsuite>
+</testsuites>'''
+
+        test_xml = self.temp_dir / "test.xml"
+        test_xml.write_text(xml_content)
+
+        # Should not raise an exception
+        _enhance_junit_error_message(str(test_xml), "pkg/test", "test_name")
+
+        # Verify classname is still set
+        tree = ET.parse(test_xml)
+        testcase = tree.find('.//testcase')
+        self.assertEqual(testcase.get('classname'), "pkg/test")
+
+    def test_handle_passing_test(self):
+        """Test enhancing XML for passing tests"""
+        sample_xml = self.test_data_dir / "sample_junit_pass.xml"
+        test_xml = self.temp_dir / "test.xml"
+        shutil.copy2(sample_xml, test_xml)
+
+        _enhance_junit_error_message(str(test_xml), "pkg/test", "test_name")
+
+        # Should complete without errors
+        tree = ET.parse(test_xml)
+        testcase = tree.find('.//testcase')
+        self.assertEqual(testcase.get('classname'), "pkg/test")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/unit_tests/testdata/rust/sample_build.bazel
+++ b/tasks/unit_tests/testdata/rust/sample_build.bazel
@@ -1,0 +1,9 @@
+rust_test(
+    name = "rusthello_test",
+    srcs = ["src/main.rs"],
+)
+
+rust_test(
+    name = "another_test",
+    srcs = ["src/lib.rs"],
+)

--- a/tasks/unit_tests/testdata/rust/sample_junit_fail.xml
+++ b/tasks/unit_tests/testdata/rust/sample_junit_fail.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="pkg/collector/module/rusthello/test-789012/rusthello_test" tests="1" failures="0" errors="1">
+    <testcase name="pkg/collector/module/rusthello/test-789012/rusthello_test" status="run" duration="0" time="0">
+      <error message="exited with error code 101"></error>
+    </testcase>
+    <system-out><![CDATA[
+running 2 tests
+test tests::test_add ... FAILED
+test tests::test_greet ... ok
+
+failures:
+
+---- tests::test_add stdout ----
+
+thread 'tests::test_add' panicked at src/main.rs:21:9:
+assertion `left == right` failed
+  left: 5
+ right: 4
+
+failures:
+    tests::test_add
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+    ]]></system-out>
+  </testsuite>
+</testsuites>

--- a/tasks/unit_tests/testdata/rust/sample_junit_pass.xml
+++ b/tasks/unit_tests/testdata/rust/sample_junit_pass.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="pkg/collector/module/rusthello/test-123456/rusthello_test" tests="1" failures="0" errors="0">
+    <testcase name="pkg/collector/module/rusthello/test-123456/rusthello_test" time="0.001" />
+    <system-out><![CDATA[
+running 2 tests
+test tests::test_add ... ok
+test tests::test_greet ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+    ]]></system-out>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
### What does this PR do?

Add support for running Rust (Bazel) tests with `dda inv test`.

While Bazel tests can already be easily run with `bazel test //pkg/...` or similar,
the reason for this integration is to have the tests run in CI and reported to 
Datadog Test Optimization similar to existing tests, and to have the Rust
code living inside a Go module be automatically tested when developers
use `dda inv test --targets=./foo/bar` locally.

Note that Rust test runner's JSON/XML output is not stabilized as of writing
and is only available on nightly. Since we don't use nightly and we don't want
to parse the unstructured output from the test runner we use Bazel's built-in
JUnit support. This is perhaps not ideal since the Bazel JUnit does not include
information about the indiviudal unit tests, only each suite as a whole, but
it should be good enough for an initial version.

Some massaging of the Bazel JUnit file was required to have the error messages
from the actual tests properly visible on Datadog.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-313

### Describe how you validated your changes

CI.
Checked [test runs of the Rust tests on this branch in Datadog Test Optimization](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Avitkyrka%2Frust-test%20%40test.suite%3A%22pkg%2Fcollector%2Fcorechecks%2Fservicediscovery%2Fmodule%2Frust%22&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&top_n=10&top_o=top&viz=stream&x_missing=true&start=1767005594292&end=1767610394292&paused=false)

### Additional information

The tests are currently skipped on Windows and macOS due to missing toolchains.

We don't currently generate `test_output.json` files so things like the test
washer won't work with these tests.